### PR TITLE
move build/cov badges & add "prebuild" to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,11 @@ lint:
 submodules: ##Install or update submodules
 	git submodule update --init --recursive
 
-check-deps: ##Make sure system prerequisites are installed
-check-deps: xcode-cltools-check exec-check node-check
+prebuild: ##Install dependencies needed to build the project
+prebuild: submodules
+
+check-deps: ##Make sure dev prerequisites are installed
+check-deps: xcode-cltools-check exec-check node-check bundle-check
 
 #!!!!!
 #!!!!! Travis

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Wikipedia iOS
 The official Wikipedia iOS client.
+
 [![Build Status](https://travis-ci.org/wikimedia/wikipedia-ios.svg)](https://travis-ci.org/wikimedia/wikipedia-ios) [![codecov.io](http://codecov.io/github/wikimedia/wikipedia-ios/coverage.svg?branch=master)](http://codecov.io/github/wikimedia/wikipedia-ios?branch=master)
 
 * OS target: iOS 6.0 or higher


### PR DESCRIPTION
I mentioned a `prebuild` goal in the `Makefile` when updating the README, but forgot to add it :disappointed:.  This adds the goal, which is intended to install dependencies needed to build the project—only submodules for now.  

I also moved badges to the next line in the README, because it looks better :art:.