### PR TITLE
Make native links interactive

### DIFF
--- a/MediaWikiKit/MediaWikiKit/MWKArticle.h
+++ b/MediaWikiKit/MediaWikiKit/MWKArticle.h
@@ -100,7 +100,7 @@ static const NSInteger kMWKArticleSectionNone = -1;
 ///
 
 /**
- * @return Summary of the receiver as an attributd string built from HTML.
+ * @return Summary of the receiver as an attributed string built from HTML.
  */
 - (NSAttributedString*)summaryHTML;
 

--- a/MediaWikiKit/MediaWikiKit/MWKArticle.h
+++ b/MediaWikiKit/MediaWikiKit/MWKArticle.h
@@ -67,6 +67,15 @@ static const NSInteger kMWKArticleSectionNone = -1;
 @property (readonly, strong, nonatomic) MWKImage* thumbnail;
 @property (readonly, strong, nonatomic) MWKImage* image;
 
+/**
+ *  Array of `MWKCitation` objects parsed from the receiver's reference list.
+ *
+ *  Might be `nil` if the section containing the reference list hasn't been downloaded, be sure to check `isCached`
+ *  and fetch the full article contents if necessary.  Might also be `nil` if an error occurred, in which case the
+ *  citations should be viewed in the webview.
+ */
+@property (readonly, strong, nonatomic /*, nullable*/) NSArray* citations;
+
 - (instancetype)initWithTitle:(MWKTitle*)title dataStore:(MWKDataStore*)dataStore;
 - (instancetype)initWithTitle:(MWKTitle*)title dataStore:(MWKDataStore*)dataStore dict:(NSDictionary*)dict;
 - (instancetype)initWithTitle:(MWKTitle*)title dataStore:(MWKDataStore*)dataStore searchResultsDict:(NSDictionary*)dict;

--- a/MediaWikiKit/MediaWikiKit/MWKArticle.m
+++ b/MediaWikiKit/MediaWikiKit/MWKArticle.m
@@ -459,6 +459,9 @@ static MWKArticleSchemaVersion const MWKArticleCurrentSchemaVersion = MWKArticle
 
 static NSString* const WMFParagraphSelector = @"/html/body/p";
 
+/**
+ * @return An XPath selector used to select children of top-level paragraphs of an article's HTML.
+ */
 + (NSString*)paragraphChildSelector {
     static NSString* paragraphChildSelector;
     static dispatch_once_t onceToken;

--- a/MediaWikiKit/MediaWikiKit/MWKArticle.m
+++ b/MediaWikiKit/MediaWikiKit/MWKArticle.m
@@ -14,6 +14,7 @@
 #import "NSString+WMFHTMLParsing.h"
 #import "NSAttributedString+WMFHTMLForSite.h"
 #import "MWKSection.h"
+#import "MWKCitation.h"
 
 typedef NS_ENUM (NSUInteger, MWKArticleSchemaVersion) {
     /**
@@ -49,6 +50,7 @@ static MWKArticleSchemaVersion const MWKArticleCurrentSchemaVersion = MWKArticle
 @property (readwrite, strong, nonatomic) MWKImageList* images;
 @property (readwrite, strong, nonatomic) MWKImage* thumbnail;
 @property (readwrite, strong, nonatomic) MWKImage* image;
+@property (readwrite, strong, nonatomic /*, nullable*/) NSArray* citations;
 
 @end
 
@@ -456,6 +458,36 @@ static MWKArticleSchemaVersion const MWKArticleCurrentSchemaVersion = MWKArticle
 }
 
 #pragma mark - Extraction
+
+#pragma mark Citations
+
+static NSString* const WMFArticleReflistColumnSelector = @"/html/body/*[contains(@class,'reflist')]//*[contains(@class, 'references')]/li";
+
+- (NSArray*)citations {
+    if (!_citations) {
+        __block NSArray* referenceListItems;
+        [self.sections.entries enumerateObjectsWithOptions:NSEnumerationReverse
+                                                usingBlock:^(MWKSection* section, NSUInteger idx, BOOL* stop) {
+            referenceListItems = [section elementsInTextMatchingXPath:WMFArticleReflistColumnSelector];
+            if (referenceListItems.count > 0) {
+                *stop = YES;
+            }
+        }];
+        if (!referenceListItems) {
+            DDLogWarn(@"Failed to parse reflist for %@ cached article: %@", self.isCached ? @"" : @"not", self);
+            return nil;
+        }
+        _citations = [[referenceListItems bk_map:^MWKCitation*(TFHppleElement* el) {
+            return [[MWKCitation alloc] initWithCitationIdentifier:el.attributes[@"id"]
+                                                           rawHTML:el.raw];
+        }] bk_reject:^BOOL (id obj) {
+            return WMF_IS_EQUAL(obj, [NSNull null]);
+        }];
+    }
+    return _citations;
+}
+
+#pragma mark Section Paragraphs
 
 static NSString* const WMFParagraphSelector = @"/html/body/p";
 

--- a/MediaWikiKit/MediaWikiKit/MWKCitation.h
+++ b/MediaWikiKit/MediaWikiKit/MWKCitation.h
@@ -1,0 +1,54 @@
+//
+//  MWKCitation.h
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 8/6/15.
+//  Copyright (c) 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import "MTLModel.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Individual citation (aka reference), parsed from a page's reflist HTML.
+ */
+@interface MWKCitation : MTLModel
+
+/**
+ * Identifier for the citation element in the reference list.
+ */
+@property (nonatomic, copy, readonly) NSString* citationIdentifier;
+
+/**
+ *  HTML representation of the receiver, as parsed from the reference list.
+ */
+@property (nonatomic, copy, readonly) NSString* rawHTML;
+
+/**
+ *  Lazily computed property containing "id" attributes of backlinks from the receiver.
+ *
+ *  Used to allow users to jump back to one of the locations where the receiver was cited.
+ */
+@property (nonatomic, copy, readonly) NSArray* backlinkIdentifiers;
+
+/**
+ *  Lazily computed property which returns the HTML inside the citation element, excluding the back-links.
+ *
+ *  This can be anything from a simple span of text with a link, but could also be a list of links.
+ *
+ *  @see rawHTML
+ */
+@property (nonatomic, copy, readonly) NSString* citationHTML;
+
+
+- (MWKCitation* __nullable)initWithCitationIdentifier:(NSString*)citationIdentifier
+                                              rawHTML:(NSString*)rawHTML;
+
+- (MWKCitation* __nullable)initWithCitationIdentifier:(NSString*)citationIdentifier
+                                              rawHTML:(NSString*)rawHTML
+                                                error:(out NSError* __autoreleasing* __nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MediaWikiKit/MediaWikiKit/MWKCitation.m
+++ b/MediaWikiKit/MediaWikiKit/MWKCitation.m
@@ -1,0 +1,95 @@
+//
+//  MWKCitation.m
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 8/6/15.
+//  Copyright (c) 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import "MWKCitation.h"
+#import <hpple/TFHpple.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MWKCitation ()
+@property (nonatomic, copy) NSString* citationIdentifier;
+@property (nonatomic, copy) NSArray* backlinkIdentifiers;
+@property (nonatomic, copy) NSString* rawHTML;
+@end
+
+@implementation MWKCitation
+@synthesize citationHTML        = _citationHTML;
+@synthesize backlinkIdentifiers = _backlinkIdentifiers;
+
++ (MTLPropertyStorage)storageBehaviorForPropertyWithKey:(NSString*)propertyKey {
+    if ([propertyKey isEqualToString:WMF_SAFE_KEYPATH([MWKCitation new], citationHTML)]
+        || [propertyKey isEqualToString:WMF_SAFE_KEYPATH([MWKCitation new], backlinkIdentifiers)]) {
+        return MTLPropertyStorageTransitory;
+    }
+    return MTLPropertyStoragePermanent;
+}
+
+- (MWKCitation* __nullable)initWithCitationIdentifier:(NSString* __nonnull)citationIdentifier
+                                              rawHTML:(NSString* __nonnull)rawHTML {
+    return [self initWithCitationIdentifier:citationIdentifier
+                                    rawHTML:rawHTML
+                                      error:nil];
+}
+
+- (MWKCitation* __nullable)initWithCitationIdentifier:(NSString* __nonnull)citationIdentifier
+                                              rawHTML:(NSString* __nonnull)rawHTML
+                                                error:(out NSError* __nullable __autoreleasing* __nullable)error {
+    self = [super init];
+    if (self) {
+        self.rawHTML            = rawHTML;
+        self.citationIdentifier = citationIdentifier;
+    }
+    if ([self validate:error]) {
+        return self;
+    } else {
+        DDLogError(@"Failed to create citation object with identifier %@ and rawHTML %@", citationIdentifier, rawHTML);
+        return nil;
+    }
+}
+
+- (BOOL)validateCitationIdentfier:(inout NSString* __autoreleasing*)inoutCitationIdentifier
+                            error:(out NSError* __autoreleasing*)error {
+    return [(*inoutCitationIdentifier) length] > 0;
+}
+
+- (BOOL)validateRawHTML:(inout NSString* __autoreleasing*)inoutRawHTML
+                  error:(out NSError* __autoreleasing*)error {
+    return [(*inoutRawHTML) length] > 0;
+}
+
+- (NSString*)citationHTML {
+    if (_citationHTML) {
+        _citationHTML = [[[[TFHpple hppleWithHTMLData:[self.rawHTML dataUsingEncoding:NSUTF8StringEncoding]]
+                           searchWithXPathQuery:@"/html/body/*[not(contains(@class, 'mw-cite-backlink')]"]
+                          valueForKey:WMF_SAFE_KEYPATH(TFHppleElement.new, raw)] componentsJoinedByString:@""] ? : @"";
+        NSAssert(_citationHTML.length, @"Failed to parse citation from raw HTML: %@", self.rawHTML);
+    }
+    return _citationHTML;
+}
+
+- (NSArray*)backlinkIdentifiers {
+    if (_backlinkIdentifiers) {
+        _backlinkIdentifiers = [[[[TFHpple hppleWithHTMLData:[self.rawHTML dataUsingEncoding:NSUTF8StringEncoding]]
+                                  searchWithXPathQuery:@"/html/body//*[contains(@class,'mw-cite-backlink')]//a"]
+                                 bk_map:^NSString*(TFHppleElement* el) {
+            return el.attributes[@"id"];
+        }]
+                                bk_reject:^BOOL (id obj) {
+            return WMF_IS_EQUAL(obj, [NSNull null]);
+        }];
+        if (!_backlinkIdentifiers) {
+            _backlinkIdentifiers = @[];
+        }
+        NSAssert(_backlinkIdentifiers.count, @"Failed to parse backlinks from raw HTML: %@", self.rawHTML);
+    }
+    return _backlinkIdentifiers;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MediaWikiKit/MediaWikiKit/MWKSectionList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKSectionList.h
@@ -33,6 +33,8 @@
 
 @property (readonly, weak, nonatomic) MWKArticle* article;
 
+@property (readonly, strong, nonatomic) NSArray* entries;
+
 - (NSUInteger) count;
 - (MWKSection*)objectAtIndexedSubscript:(NSUInteger)idx;
 

--- a/MediaWikiKit/MediaWikiKit/MWKSectionList.m
+++ b/MediaWikiKit/MediaWikiKit/MWKSectionList.m
@@ -136,4 +136,8 @@
     return nil;
 }
 
+- (NSArray*)entries {
+    return self.sections;
+}
+
 @end

--- a/MediaWikiKit/MediaWikiKit/MWKSite.h
+++ b/MediaWikiKit/MediaWikiKit/MWKSite.h
@@ -37,6 +37,15 @@ extern NSString* const WMFDefaultSiteDomain;
 /// Create a site using @c language and the default domain.
 - (instancetype)initWithLanguage:(NSString*)language;
 
+/**
+ * Initialize a site with components of a URL.
+ *
+ * @param url URL pointing to a Wikipedia site (e.g. https://en.wikipedia.org).
+ *
+ * @return A site with properties parsed from the given URL, or `nil` if parsing failed.
+ */
+- (MWKSite* __nullable)initWithURL:(NSURL*)url;
+
 + (instancetype)siteWithDomain:(NSString*)domain language:(NSString*)language;
 
 + (instancetype)siteWithLanguage:(NSString*)language;

--- a/MediaWikiKit/MediaWikiKit/MWKSite.m
+++ b/MediaWikiKit/MediaWikiKit/MWKSite.m
@@ -36,6 +36,22 @@ typedef NS_ENUM (NSUInteger, MWKSiteNSCodingSchemaVersion) {
     return [self initWithDomain:WMFDefaultSiteDomain language:language];
 }
 
+- (MWKSite* __nullable)initWithURL:(NSURL* __nonnull)url {
+    NSArray* hostComponents = [url.host componentsSeparatedByString:@"."];
+    if (hostComponents.count < 3) {
+        DDLogError(@"Can't form site from incomplete URL: %@", url);
+        return nil;
+    }
+    NSString* language = [hostComponents firstObject];
+    if (!language.length) {
+        DDLogError(@"Can't form site empty language URL component: %@", url);
+        return nil;
+    }
+    NSString* domain =
+        [[hostComponents subarrayWithRange:NSMakeRange(1, hostComponents.count - 1)] componentsJoinedByString:@"."];
+    return [self initWithDomain:domain language:language];
+}
+
 + (instancetype)siteWithLanguage:(NSString*)language {
     return [[self alloc] initWithLanguage:language];
 }

--- a/MediaWikiKit/MediaWikiKit/MWKTitle.h
+++ b/MediaWikiKit/MediaWikiKit/MWKTitle.h
@@ -58,6 +58,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// Initialize a new title with `relativeInternalLink`, which is parsed after removing the `/wiki/` prefix.
 - (instancetype)initWithInternalLink:(NSString*)relativeInternalLink site:(MWKSite*)site;
 
+/**
+ * Initialize a new title with a URL, using its path and and host as the title's `text` and `site`.
+ *
+ * @param url URL pointing to a Wikipedia page (i.e. an internal link).
+ *
+ * @return A new title with properties parsed from the given URL, or `nil` if an error occurred.
+ */
+- (MWKTitle* __nullable)initWithURL:(NSURL*)url;
+
 /// Convenience factory method wrapping `initWithString:site:`.
 + (MWKTitle*)titleWithString:(NSString*)str site:(MWKSite*)site;
 

--- a/MediaWikiKit/MediaWikiKit/MWKTitle.m
+++ b/MediaWikiKit/MediaWikiKit/MWKTitle.m
@@ -5,6 +5,8 @@
 #import "NSString+WMFPageUtilities.h"
 #import "NSArray+WMFExtensions.h"
 #import "NSObjectUtilities.h"
+#import "NSURL+WMFLinkParsing.h"
+#import "NSString+WMFPageUtilities.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -41,6 +43,16 @@ NS_ASSUME_NONNULL_BEGIN
     NSAssert(relativeInternalLink.length == 0 || [relativeInternalLink wmf_isInternalLink],
              @"Expected string with internal link prefix but got: %@", relativeInternalLink);
     return [self initWithString:[relativeInternalLink wmf_internalLinkPath] site:site];
+}
+
+- (MWKTitle* __nullable)initWithURL:(NSURL* __nonnull)url {
+    MWKSite* site = [[MWKSite alloc] initWithURL:url];
+    if (!site) {
+        return nil;
+    }
+    return [self initWithSite:site
+              normalizedTitle:[[url wmf_internalLinkPath] wmf_normalizedPageTitle]
+                     fragment:url.fragment];
 }
 
 - (instancetype)initWithString:(NSString*)string site:(MWKSite*)site {

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 		BC56209D1B6BAB910013FFB0 /* Exoplanet.mobileview.json in Resources */ = {isa = PBXBuildFile; fileRef = BC56209C1B6BAB910013FFB0 /* Exoplanet.mobileview.json */; };
 		BC5620A81B6BEDAD0013FFB0 /* UIColor+WMFStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = BC5620A71B6BEDAD0013FFB0 /* UIColor+WMFStyle.m */; };
 		BC5FA1771B72859B005BE5BA /* NSURL+WMFLinkParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = BC5FA1761B72859B005BE5BA /* NSURL+WMFLinkParsing.m */; };
+		BC5FA1821B738DFB005BE5BA /* MWKCitation.m in Sources */ = {isa = PBXBuildFile; fileRef = BC5FA1811B738DFB005BE5BA /* MWKCitation.m */; };
 		BC5FE5701B1DF02900273BC0 /* ENWikiSiteInfo.json in Resources */ = {isa = PBXBuildFile; fileRef = BC5FE56F1B1DF02900273BC0 /* ENWikiSiteInfo.json */; };
 		BC5FE5721B1DF38A00273BC0 /* NOWikiSiteInfo.json in Resources */ = {isa = PBXBuildFile; fileRef = BC5FE5711B1DF38A00273BC0 /* NOWikiSiteInfo.json */; };
 		BC5FE5751B1DFF5400273BC0 /* ArticleFetcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC5FE5741B1DFF5400273BC0 /* ArticleFetcherTests.m */; };
@@ -939,6 +940,8 @@
 		BC5620A71B6BEDAD0013FFB0 /* UIColor+WMFStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIColor+WMFStyle.m"; sourceTree = "<group>"; };
 		BC5FA1751B72859B005BE5BA /* NSURL+WMFLinkParsing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+WMFLinkParsing.h"; sourceTree = "<group>"; };
 		BC5FA1761B72859B005BE5BA /* NSURL+WMFLinkParsing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+WMFLinkParsing.m"; sourceTree = "<group>"; };
+		BC5FA1801B738DFB005BE5BA /* MWKCitation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MWKCitation.h; sourceTree = "<group>"; };
+		BC5FA1811B738DFB005BE5BA /* MWKCitation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MWKCitation.m; sourceTree = "<group>"; };
 		BC5FE56F1B1DF02900273BC0 /* ENWikiSiteInfo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ENWikiSiteInfo.json; sourceTree = "<group>"; };
 		BC5FE5711B1DF38A00273BC0 /* NOWikiSiteInfo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = NOWikiSiteInfo.json; sourceTree = "<group>"; };
 		BC5FE5741B1DFF5400273BC0 /* ArticleFetcherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArticleFetcherTests.m; sourceTree = "<group>"; };
@@ -2573,6 +2576,8 @@
 				BCB669A01A83F6C300C7B1FE /* MWKSectionList.h */,
 				BCCED2D21AE041BD0094EB7E /* MWKSectionList_Private.h */,
 				BCB669A11A83F6C300C7B1FE /* MWKSectionList.m */,
+				BC5FA1801B738DFB005BE5BA /* MWKCitation.h */,
+				BC5FA1811B738DFB005BE5BA /* MWKCitation.m */,
 			);
 			name = "Data i/o";
 			sourceTree = "<group>";
@@ -3592,6 +3597,7 @@
 				BC6E8B9F1B5FE0C9003D9A39 /* UICollectionView+WMFKVOUpdatableList.m in Sources */,
 				BC50C37F1A83C784006DC7AF /* WMFNetworkUtilities.m in Sources */,
 				BCB58F441A890D9700465627 /* MWKImageInfo+MWKImageComparison.m in Sources */,
+				BC5FA1821B738DFB005BE5BA /* MWKCitation.m in Sources */,
 				BCB669AD1A83F6C400C7B1FE /* MWKSavedPageList.m in Sources */,
 				BCC185E81A9FA498005378F8 /* UICollectionViewLayout+AttributeUtils.m in Sources */,
 				04D686F81AB2949C0009B44A /* PaddedLabel.m in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		BC56209A1B6B92CF0013FFB0 /* WMFLinkButtonFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = BC5620991B6B92CF0013FFB0 /* WMFLinkButtonFactory.m */; };
 		BC56209D1B6BAB910013FFB0 /* Exoplanet.mobileview.json in Resources */ = {isa = PBXBuildFile; fileRef = BC56209C1B6BAB910013FFB0 /* Exoplanet.mobileview.json */; };
 		BC5620A81B6BEDAD0013FFB0 /* UIColor+WMFStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = BC5620A71B6BEDAD0013FFB0 /* UIColor+WMFStyle.m */; };
+		BC5FA1771B72859B005BE5BA /* NSURL+WMFLinkParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = BC5FA1761B72859B005BE5BA /* NSURL+WMFLinkParsing.m */; };
 		BC5FE5701B1DF02900273BC0 /* ENWikiSiteInfo.json in Resources */ = {isa = PBXBuildFile; fileRef = BC5FE56F1B1DF02900273BC0 /* ENWikiSiteInfo.json */; };
 		BC5FE5721B1DF38A00273BC0 /* NOWikiSiteInfo.json in Resources */ = {isa = PBXBuildFile; fileRef = BC5FE5711B1DF38A00273BC0 /* NOWikiSiteInfo.json */; };
 		BC5FE5751B1DFF5400273BC0 /* ArticleFetcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC5FE5741B1DFF5400273BC0 /* ArticleFetcherTests.m */; };
@@ -936,6 +937,8 @@
 		BC56209C1B6BAB910013FFB0 /* Exoplanet.mobileview.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Exoplanet.mobileview.json; sourceTree = "<group>"; };
 		BC5620A61B6BEDAD0013FFB0 /* UIColor+WMFStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIColor+WMFStyle.h"; sourceTree = "<group>"; };
 		BC5620A71B6BEDAD0013FFB0 /* UIColor+WMFStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIColor+WMFStyle.m"; sourceTree = "<group>"; };
+		BC5FA1751B72859B005BE5BA /* NSURL+WMFLinkParsing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+WMFLinkParsing.h"; sourceTree = "<group>"; };
+		BC5FA1761B72859B005BE5BA /* NSURL+WMFLinkParsing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+WMFLinkParsing.m"; sourceTree = "<group>"; };
 		BC5FE56F1B1DF02900273BC0 /* ENWikiSiteInfo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ENWikiSiteInfo.json; sourceTree = "<group>"; };
 		BC5FE5711B1DF38A00273BC0 /* NOWikiSiteInfo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = NOWikiSiteInfo.json; sourceTree = "<group>"; };
 		BC5FE5741B1DFF5400273BC0 /* ArticleFetcherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArticleFetcherTests.m; sourceTree = "<group>"; };
@@ -1808,6 +1811,8 @@
 				04C43ABA183442FC006C643B /* NSString+Extras.h */,
 				04C43ABB183442FC006C643B /* NSString+Extras.m */,
 				045AB8C11B1E15D9002839D7 /* NSURL+Extras.h */,
+				BC5FA1751B72859B005BE5BA /* NSURL+WMFLinkParsing.h */,
+				BC5FA1761B72859B005BE5BA /* NSURL+WMFLinkParsing.m */,
 				045AB8C21B1E15D9002839D7 /* NSURL+Extras.m */,
 				04B91AA918E3D9E200FFAA1C /* NSString+FormattedAttributedString.h */,
 				04B91AAA18E3D9E200FFAA1C /* NSString+FormattedAttributedString.m */,
@@ -3581,6 +3586,7 @@
 				BCB669B71A83F6C400C7B1FE /* MWKSectionList.m in Sources */,
 				0EE768811AFD25CC00A5D046 /* WMFSearchFunnel.m in Sources */,
 				046A4B9D1B38DC5400440F67 /* UIView+WMFRTLMirroring.m in Sources */,
+				BC5FA1771B72859B005BE5BA /* NSURL+WMFLinkParsing.m in Sources */,
 				BCB66A0C1A85183000C7B1FE /* NSString+WMFHTMLParsing.m in Sources */,
 				BCB669AF1A83F6C400C7B1FE /* MWKHistoryList.m in Sources */,
 				BC6E8B9F1B5FE0C9003D9A39 /* UICollectionView+WMFKVOUpdatableList.m in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -270,6 +270,7 @@
 		BC32A1D71B4B14C000A286DE /* WMFBackgroundTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC32A1D61B4B14C000A286DE /* WMFBackgroundTaskManager.swift */; };
 		BC32A1D91B4B1B8A00A286DE /* WMFLegacyImageDataMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC32A1D81B4B1B8A00A286DE /* WMFLegacyImageDataMigration.swift */; };
 		BC34E46A1B31AD8B00258928 /* MWKLanguageLinkController.m in Sources */ = {isa = PBXBuildFile; fileRef = BC34E4691B31AD8B00258928 /* MWKLanguageLinkController.m */; };
+		BC3863491B73E056003A2D38 /* NSURL+WMFLinkParsingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC3863481B73E056003A2D38 /* NSURL+WMFLinkParsingTests.m */; };
 		BC49B3641AEECFD8009F55BE /* ArticleLoadingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC49B3631AEECFD8009F55BE /* ArticleLoadingTests.m */; };
 		BC505EEB1B59461400537006 /* WMFCollectionViewPageLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = BC505EEA1B59461400537006 /* WMFCollectionViewPageLayout.m */; };
 		BC505EEE1B594B5700537006 /* WMFImageCollectionViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BC505EED1B594B5700537006 /* WMFImageCollectionViewCell.m */; };
@@ -909,6 +910,7 @@
 		BC34E4681B31AD8B00258928 /* MWKLanguageLinkController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MWKLanguageLinkController.h; sourceTree = "<group>"; };
 		BC34E4691B31AD8B00258928 /* MWKLanguageLinkController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MWKLanguageLinkController.m; sourceTree = "<group>"; };
 		BC34E4721B31D92100258928 /* LangaugeSelectionDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LangaugeSelectionDelegate.h; sourceTree = "<group>"; };
+		BC3863481B73E056003A2D38 /* NSURL+WMFLinkParsingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+WMFLinkParsingTests.m"; sourceTree = "<group>"; };
 		BC4273521A7C736800068882 /* WikipediaUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WikipediaUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC49B3631AEECFD8009F55BE /* ArticleLoadingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArticleLoadingTests.m; sourceTree = "<group>"; };
 		BC505EE91B59461400537006 /* WMFCollectionViewPageLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFCollectionViewPageLayout.h; sourceTree = "<group>"; };
@@ -2442,6 +2444,7 @@
 				BC725EC91B617E1A00E0A64C /* WMFSafeAssignTests.m */,
 				BC725ED11B62DADD00E0A64C /* MWKLanguageLinkResponseSerializerTests.m */,
 				0E9008E61B715E2E001A600A /* WMFCollectionViewExtensionTests.m */,
+				BC3863481B73E056003A2D38 /* NSURL+WMFLinkParsingTests.m */,
 			);
 			name = Tests;
 			path = WikipediaUnitTests;
@@ -3315,6 +3318,7 @@
 				BC6BFC611B684EF70074D0DA /* WMFArticleSummaryVisualTests.m in Sources */,
 				0EBC56971AD5B69300E82CDD /* BITHockeyManager+WMFExtensions.m in Sources */,
 				BCF1E20D1B4C5C7300B10877 /* WMFBackgroundTestManagerTests.swift in Sources */,
+				BC3863491B73E056003A2D38 /* NSURL+WMFLinkParsingTests.m in Sources */,
 				BCFE02781B41FA12003752B7 /* MWKHistoryListPerformanceTests.m in Sources */,
 				BC2375C11ABB14CC00B0BAA8 /* WMFArticleImageInjectionTests.m in Sources */,
 				043B6E8F1ACDE0CF0005C60B /* NSAttributedString+WMFSavedPagesAttributedStrings.m in Sources */,

--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
@@ -92,6 +92,10 @@
             argument = "-WMFFixtureRecordingEnabled NO"
             isEnabled = "YES">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-FakeZeroOn NO"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable

--- a/Wikipedia/Categories/NSURL+Extras.h
+++ b/Wikipedia/Categories/NSURL+Extras.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)wmf_urlByPrependingSchemeIfSchemeless;
 
-- (id)wmf_valueForQueryKey:(NSString*)queryKey;
+- (NSString*)wmf_valueForQueryKey:(NSString*)queryKey;
 
 @end
 

--- a/Wikipedia/Categories/NSURL+Extras.m
+++ b/Wikipedia/Categories/NSURL+Extras.m
@@ -41,7 +41,7 @@
     return [self wmf_urlByPrependingSchemeIfSchemeless:@"https"];
 }
 
-- (id)wmf_valueForQueryKey:(NSString*)queryKey {
+- (NSString*)wmf_valueForQueryKey:(NSString*)queryKey {
     #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
     #error Backwards-compatible iOS 7 implementation not necessary, delete it.
     #endif
@@ -64,10 +64,11 @@
             return queryDict;
         }] objectForKey:queryKey];
     } else {
-        return [(NSURLQueryItem*)[[[NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:YES] queryItems]
-                                  bk_match:^BOOL (NSURLQueryItem* q) {
+        NSURLQueryItem* queryItem = [[[NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:YES] queryItems]
+                                     bk_match:^BOOL (NSURLQueryItem* q) {
             return [q.name isEqualToString:@"page"];
-        }] value];
+        }];
+        return queryItem ? (queryItem.value ? : @"") : nil;
     }
 }
 

--- a/Wikipedia/Categories/NSURL+WMFLinkParsing.h
+++ b/Wikipedia/Categories/NSURL+WMFLinkParsing.h
@@ -1,0 +1,27 @@
+//
+//  NSURL+WMFLinkParsing.h
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 8/5/15.
+//  Copyright (c) 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "WMFArticleNavigationDelegate.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSURL (WMFLinkParsing)
+
+- (BOOL)wmf_isInternalLink;
+
+- (BOOL)wmf_isCitation;
+
+- (NSString*)wmf_internalLinkPath;
+
+- (void)wmf_informNavigationDelegate:(id<WMFArticleNavigationDelegate>)delegate
+                          withSender:(id<WMFArticleNavigation> __nullable)articleNavigator;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Wikipedia/Categories/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Categories/NSURL+WMFLinkParsing.m
@@ -1,0 +1,45 @@
+//
+//  NSURL+WMFLinkParsing.m
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 8/5/15.
+//  Copyright (c) 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import "NSURL+WMFLinkParsing.h"
+#import "NSString+Extras.h"
+#import "NSString+WMFPageUtilities.h"
+#import "MWKTitle.h"
+#import "NSURL+Extras.h"
+
+@implementation NSURL (WMFLinkParsing)
+
+- (BOOL)wmf_isInternalLink {
+    return [self.path wmf_isInternalLink];
+}
+
+- (BOOL)wmf_isCitation {
+    return [self.fragment wmf_isCitationFragment];
+}
+
+- (NSString*)wmf_internalLinkPath {
+    return [self.path wmf_internalLinkPath];
+}
+
+- (void)wmf_informNavigationDelegate:(id<WMFArticleNavigationDelegate>)delegate
+                          withSender:(id<WMFArticleNavigation> __nullable)articleNavigator {
+    if ([self wmf_isInternalLink]) {
+        MWKTitle* title = [[MWKTitle alloc] initWithURL:self];
+        if ([self wmf_isCitation]) {
+            [delegate articleNavigator:articleNavigator
+                    didTapCitationLink:self.fragment
+                                onPage:title];
+        } else {
+            [delegate articleNavigator:articleNavigator didTapLinkToPage:title];
+        }
+    } else {
+        [delegate articleNavigator:articleNavigator didTapExternalLink:[self wmf_urlByPrependingSchemeIfSchemeless]];
+    }
+}
+
+@end

--- a/Wikipedia/Categories/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Categories/NSURL+WMFLinkParsing.m
@@ -28,15 +28,11 @@
 
 - (void)wmf_informNavigationDelegate:(id<WMFArticleNavigationDelegate>)delegate
                           withSender:(id<WMFArticleNavigation> __nullable)articleNavigator {
-    if ([self wmf_isInternalLink]) {
+    if ([self wmf_isCitation]) {
+        [delegate articleNavigator:articleNavigator didTapCitationLink:self.fragment];
+    } else if ([self wmf_isInternalLink]) {
         MWKTitle* title = [[MWKTitle alloc] initWithURL:self];
-        if ([self wmf_isCitation]) {
-            [delegate articleNavigator:articleNavigator
-                    didTapCitationLink:self.fragment
-                                onPage:title];
-        } else {
-            [delegate articleNavigator:articleNavigator didTapLinkToPage:title];
-        }
+        [delegate articleNavigator:articleNavigator didTapLinkToPage:title];
     } else {
         [delegate articleNavigator:articleNavigator didTapExternalLink:[self wmf_urlByPrependingSchemeIfSchemeless]];
     }

--- a/Wikipedia/UI-V5/WMFArticleNavigation.h
+++ b/Wikipedia/UI-V5/WMFArticleNavigation.h
@@ -12,9 +12,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol WMFArticleNavigation <NSObject>
 
-- (void)wmf_scrollToLink:(NSURL*)linkURL animated:(BOOL)animated;
+- (void)scrollToLink:(NSURL*)linkURL animated:(BOOL)animated;
 
-- (void)wmf_scrollToFragment:(NSString*)fragment animated:(BOOL)animated;
+- (void)scrollToFragment:(NSString*)fragment animated:(BOOL)animated;
 
 @end
 

--- a/Wikipedia/UI-V5/WMFArticleNavigationDelegate.h
+++ b/Wikipedia/UI-V5/WMFArticleNavigationDelegate.h
@@ -15,19 +15,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol WMFArticleNavigationDelegate <NSObject>
 
-- (void)articleView:(UIView<WMFArticleNavigation>*)sender didTapLinkToPage:(MWKTitle*)title;
+- (void)articleNavigator:(id<WMFArticleNavigation>)sender didTapLinkToPage:(MWKTitle*)pageTitle;
 
-- (void)articleView:(UIView<WMFArticleNavigation>*)sender didTapCitationLink:(NSString*)citationFragment;
+- (void)articleNavigator:(id<WMFArticleNavigation>)sender
+      didTapCitationLink:(NSString*)citationFragment
+                  onPage:(MWKTitle*)pageTitle;
 
-- (void)articleView:(UIView<WMFArticleNavigation>*)sender didTapSectionLink:(NSString*)sectionAnchorFragment;
+- (void)articleNavigator:(id<WMFArticleNavigation>)sender didTapExternalLink:(NSURL*)externalURL;
 
-- (void)articleView:(UIView<WMFArticleNavigation>*)sender didTapExternalLink:(NSURL*)externalURL;
+//- (void)articleNavigator:(id)sender didTapImage:(NSString*)sourceURL;
 
-//- (void)articleView:(id)sender didTapImage:(NSString*)sourceURL;
+//- (void)articleNavigatorDidTapEdit:(id)sender
 
-//- (void)articleViewDidTapEdit:(id)sender
-
-//- (void)articleView:(id)sender didTapEditForSection:(NSString*)sectionAnchorFragment;
+//- (void)articleNavigator:(id)sender didTapEditForSection:(NSString*)sectionAnchorFragment;
 
 @end
 

--- a/Wikipedia/UI-V5/WMFArticleNavigationDelegate.h
+++ b/Wikipedia/UI-V5/WMFArticleNavigationDelegate.h
@@ -23,9 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)articleNavigator:(id<WMFArticleNavigation> __nullable)sender didTapLinkToPage:(MWKTitle*)pageTitle;
 
-- (void)articleNavigator:(id<WMFArticleNavigation> __nullable)sender
-      didTapCitationLink:(NSString*)citationFragment
-                  onPage:(MWKTitle*)pageTitle;
+- (void)articleNavigator:(id<WMFArticleNavigation> __nullable)sender didTapCitationLink:(NSString*)citationFragment;
 
 - (void)articleNavigator:(id<WMFArticleNavigation> __nullable)sender didTapExternalLink:(NSURL*)externalURL;
 

--- a/Wikipedia/UI-V5/WMFArticleNavigationDelegate.h
+++ b/Wikipedia/UI-V5/WMFArticleNavigationDelegate.h
@@ -15,14 +15,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol WMFArticleNavigationDelegate <NSObject>
 
-- (void)articleNavigator:(id<WMFArticleNavigation>)sender didTapLinkToPage:(MWKTitle*)pageTitle;
+/*
+   TODO: remove __nullable, as it's only nullable to allow edge cases where there's no sender at the call site
+   which conforms to the protocol. Most delegates won't see `nil` since a "proxy" object will forward the delegate
+   callback, passing themselves as the sender.
+ */
 
-- (void)articleNavigator:(id<WMFArticleNavigation>)sender
+- (void)articleNavigator:(id<WMFArticleNavigation> __nullable)sender didTapLinkToPage:(MWKTitle*)pageTitle;
+
+- (void)articleNavigator:(id<WMFArticleNavigation> __nullable)sender
       didTapCitationLink:(NSString*)citationFragment
                   onPage:(MWKTitle*)pageTitle;
 
-- (void)articleNavigator:(id<WMFArticleNavigation>)sender didTapExternalLink:(NSURL*)externalURL;
+- (void)articleNavigator:(id<WMFArticleNavigation> __nullable)sender didTapExternalLink:(NSURL*)externalURL;
 
+/*
+   Note for the future: gallery presentation should be based on:
+   - article (or maybe section)
+   - current image
+   - rect of tapped image in screen bounds (for "zoom in" transition to modal)
+ */
 //- (void)articleNavigator:(id)sender didTapImage:(NSString*)sourceURL;
 
 //- (void)articleNavigatorDidTapEdit:(id)sender

--- a/Wikipedia/UI-V5/WMFArticleViewController.h
+++ b/Wikipedia/UI-V5/WMFArticleViewController.h
@@ -1,5 +1,6 @@
 
 #import <UIKit/UIKit.h>
+#import "WMFArticleNavigationDelegate.h"
 
 @class MWKDataStore;
 @class MWKSavedPageList;
@@ -13,6 +14,7 @@ typedef NS_ENUM (NSUInteger, WMFArticleControllerMode) {
 };
 
 @interface WMFArticleViewController : UITableViewController
+<WMFArticleNavigation>
 
 + (instancetype)articleViewControllerWithDataStore:(MWKDataStore*)dataStore savedPages:(MWKSavedPageList*)savedPages;
 
@@ -21,6 +23,9 @@ typedef NS_ENUM (NSUInteger, WMFArticleControllerMode) {
 @property (nonatomic, strong, nullable) MWKArticle* article;
 
 @property (nonatomic, assign, readonly) WMFArticleControllerMode mode;
+
+@property (nonatomic, weak, nullable) id<WMFArticleNavigationDelegate> articleNavigationDelegate;
+
 - (void)setMode:(WMFArticleControllerMode)mode animated:(BOOL)animated;
 
 - (void)updateUI;

--- a/Wikipedia/UI-V5/WMFArticleViewController.h
+++ b/Wikipedia/UI-V5/WMFArticleViewController.h
@@ -14,7 +14,7 @@ typedef NS_ENUM (NSUInteger, WMFArticleControllerMode) {
 };
 
 @interface WMFArticleViewController : UITableViewController
-<WMFArticleNavigation>
+    <UINavigationControllerDelegate>
 
 + (instancetype)articleViewControllerWithDataStore:(MWKDataStore*)dataStore savedPages:(MWKSavedPageList*)savedPages;
 

--- a/Wikipedia/UI-V5/WMFArticleViewController.h
+++ b/Wikipedia/UI-V5/WMFArticleViewController.h
@@ -24,8 +24,6 @@ typedef NS_ENUM (NSUInteger, WMFArticleControllerMode) {
 
 @property (nonatomic, assign, readonly) WMFArticleControllerMode mode;
 
-@property (nonatomic, weak, nullable) id<WMFArticleNavigationDelegate> articleNavigationDelegate;
-
 - (void)setMode:(WMFArticleControllerMode)mode animated:(BOOL)animated;
 
 - (void)updateUI;

--- a/Wikipedia/UI-V5/WMFArticleViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleViewController.m
@@ -587,21 +587,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)articleNavigator:(id<WMFArticleNavigation> __nullable)sender
       didTapCitationLink:(NSString* __nonnull)citationFragment {
-    [self showCitationWithFragment:citationFragment];
-}
-
-- (void)showCitationWithFragment:(NSString*)fragment {
-    if (!self.article.isCached) {
+    if (self.article.isCached) {
+        [self showCitationWithFragment:citationFragment];
+    } else {
         if (!self.articleFetcherPromise) {
             [self fetchArticle];
         }
         @weakify(self);
         self.articleFetcherPromise.then(^(MWKArticle* _) {
             @strongify(self);
-            [self showCitationWithFragment:fragment];
+            [self showCitationWithFragment:citationFragment];
         });
-        return;
     }
+}
+
+- (void)showCitationWithFragment:(NSString*)fragment {
+    NSParameterAssert(self.article.isCached);
     MWKCitation* tappedCitation = [self.article.citations bk_match:^BOOL (MWKCitation* citation) {
         return [citation.citationIdentifier isEqualToString:fragment];
     }];

--- a/Wikipedia/UI-V5/WMFArticleViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleViewController.m
@@ -26,7 +26,7 @@
 #import "WMFArticleNavigationDelegate.h"
 
 // Categories
-#import "NSString+Extras.h"
+#import "NSString+WMFUtilities.h"
 #import "UIButton+WMFButton.h"
 #import "UIStoryboard+WMFExtensions.h"
 #import "UIViewController+WMFStoryboardUtilities.h"
@@ -49,7 +49,8 @@ NS_ASSUME_NONNULL_BEGIN
  UITableViewDelegate,
  WMFArticleHeaderImageGalleryViewControllerDelegate,
  WMFImageGalleryViewControllerDelegate,
- WMFWebViewControllerDelegate>
+ WMFWebViewControllerDelegate,
+ WMFArticleNavigationDelegate>
 
 @property (nonatomic, weak) IBOutlet UIView* galleryContainerView;
 @property (nonatomic, weak) IBOutlet WMFArticleTableHeaderView* headerView;
@@ -435,6 +436,7 @@ NS_ASSUME_NONNULL_BEGIN
     WMFMinimalArticleContentCell* cell =
         [self.tableView dequeueReusableCellWithIdentifier:[WMFMinimalArticleContentCell wmf_nibName]];
     cell.attributedString = self.article.summaryHTML;
+    cell.articleNavigationDelegate = self;
     return cell;
 }
 
@@ -491,13 +493,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Article Link Presentation
 
-- (BOOL)titleIsTheSameAsCurrentArticle:(MWKTitle*)title {
+- (BOOL)isTitleReferenceToCurrentArticle:(MWKTitle*)title {
     return [[self.article title] isEqualToTitleExcludingFragment:title];
 }
 
 - (void)presentArticleScrolledToSectionForIndexPath:(NSIndexPath*)indexPath {
     MWKTitle* titleWithFragment = [self titleForSelectedIndexPath:indexPath];
-    if ([self titleIsTheSameAsCurrentArticle:titleWithFragment]) {
+    if ([self isTitleReferenceToCurrentArticle:titleWithFragment]) {
         [self.webViewController scrollToFragment:titleWithFragment.fragment];
         [self presentViewController:[[UINavigationController alloc] initWithRootViewController:self.webViewController] animated:YES completion:NULL];
     } else {
@@ -567,6 +569,29 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)willDismissGalleryController:(WMFImageGalleryViewController* __nonnull)gallery {
     self.headerGalleryViewController.currentPage = gallery.currentPage;
     [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+
+#pragma mark - WMFArticleNavigation
+
+- (void)scrollToFragment:(NSString * __nonnull)fragment animated:(BOOL)animated {
+}
+
+- (void)scrollToLink:(NSURL * __nonnull)linkURL animated:(BOOL)animated {
+}
+
+#pragma mark - WMFArticleNavigationDelegate
+
+- (void)articleNavigator:(id<WMFArticleNavigation> __nonnull)sender
+      didTapCitationLink:(NSString * __nonnull)citationFragment {
+}
+
+- (void)articleNavigator:(id<WMFArticleNavigation> __nonnull)sender
+        didTapLinkToPage:(MWKTitle * __nonnull)title {
+}
+
+- (void)articleNavigator:(id<WMFArticleNavigation> __nonnull)sender
+      didTapExternalLink:(NSURL * __nonnull)externalURL {
 }
 
 @end

--- a/Wikipedia/UI-V5/WMFArticleViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleViewController.m
@@ -1,5 +1,7 @@
 #import "WMFArticleViewController_Private.h"
 
+#import "SessionSingleton.h"
+
 // Frameworks
 #import <Masonry/Masonry.h>
 #import <BlocksKit/BlocksKit+UIKit.h>
@@ -596,7 +598,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)articleNavigator:(id<WMFArticleNavigation> __nullable)sender
       didTapExternalLink:(NSURL* __nonnull)externalURL {
-    // TODO: show zero warning if necesary, or directly open in safari
+    [[[SessionSingleton sharedInstance] zeroConfigState] showWarningIfNeededBeforeOpeningURL:externalURL];
 }
 
 #pragma mark - UINavigationControllerDelegate

--- a/Wikipedia/UI-V5/WMFArticleViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleViewController.m
@@ -607,6 +607,14 @@ NS_ASSUME_NONNULL_BEGIN
         return [citation.citationIdentifier isEqualToString:fragment];
     }];
     DDLogInfo(@"Tapped citation %@", tappedCitation);
+//    if (!tappedCitation) {
+//        DDLogWarn(@"Failed to parse citation for article %@", self.article);
+    // TEMP: show webview until we figure out what to do w/ ReferencesVC
+    [self.webViewController scrollToFragment:fragment];
+    [self presentViewController:[[UINavigationController alloc] initWithRootViewController:self.webViewController]
+                       animated:YES
+                     completion:NULL];
+//    }
 }
 
 - (void)articleNavigator:(id<WMFArticleNavigation> __nullable)sender

--- a/Wikipedia/UI-V5/WMFArticleViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleViewController.m
@@ -26,7 +26,7 @@
 #import "WMFArticleNavigationDelegate.h"
 
 // Categories
-#import "NSString+WMFUtilities.h"
+#import "NSString+Extras.h"
 #import "UIButton+WMFButton.h"
 #import "UIStoryboard+WMFExtensions.h"
 #import "UIViewController+WMFStoryboardUtilities.h"
@@ -435,8 +435,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (WMFMinimalArticleContentCell*)contentCellAtIndexPath:(NSIndexPath*)indexPath {
     WMFMinimalArticleContentCell* cell =
         [self.tableView dequeueReusableCellWithIdentifier:[WMFMinimalArticleContentCell wmf_nibName]];
-    cell.attributedString = self.article.summaryHTML;
-    cell.articleNavigationDelegate = self;
+    cell.attributedString          = self.article.summaryHTML;
+    cell.articleNavigationDelegate = self.articleNavigationDelegate;
     return cell;
 }
 
@@ -571,28 +571,37 @@ NS_ASSUME_NONNULL_BEGIN
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
-
 #pragma mark - WMFArticleNavigation
 
-- (void)scrollToFragment:(NSString * __nonnull)fragment animated:(BOOL)animated {
+- (void)scrollToFragment:(NSString* __nonnull)fragment animated:(BOOL)animated {
 }
 
-- (void)scrollToLink:(NSURL * __nonnull)linkURL animated:(BOOL)animated {
+- (void)scrollToLink:(NSURL* __nonnull)linkURL animated:(BOOL)animated {
 }
 
 #pragma mark - WMFArticleNavigationDelegate
 
-- (void)articleNavigator:(id<WMFArticleNavigation> __nonnull)sender
-      didTapCitationLink:(NSString * __nonnull)citationFragment {
+- (void)articleNavigator:(id<WMFArticleNavigation> __nullable)sender
+      didTapCitationLink:(NSString* __nonnull)citationFragment
+                  onPage:(MWKTitle* __nonnull)pageTitle {
+    if ([self isTitleReferenceToCurrentArticle:pageTitle]) {
+        [self scrollToFragment:citationFragment animated:YES];
+    }
 }
 
-- (void)articleNavigator:(id<WMFArticleNavigation> __nonnull)sender
-        didTapLinkToPage:(MWKTitle * __nonnull)title {
+- (void)articleNavigator:(id<WMFArticleNavigation> __nullable)sender
+        didTapLinkToPage:(MWKTitle* __nonnull)title {
+    [self presentPopupForTitle:title];
 }
 
-- (void)articleNavigator:(id<WMFArticleNavigation> __nonnull)sender
-      didTapExternalLink:(NSURL * __nonnull)externalURL {
+- (void)articleNavigator:(id<WMFArticleNavigation> __nullable)sender
+      didTapExternalLink:(NSURL* __nonnull)externalURL {
+    // TODO: show zero warning if necesary, or directly open in safari
 }
+
+#pragma mark - UINavigationControllerDelegate
+
+// placeholder
 
 @end
 

--- a/Wikipedia/UI-V5/WMFArticleViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleViewController.m
@@ -436,7 +436,7 @@ NS_ASSUME_NONNULL_BEGIN
     WMFMinimalArticleContentCell* cell =
         [self.tableView dequeueReusableCellWithIdentifier:[WMFMinimalArticleContentCell wmf_nibName]];
     cell.attributedString          = self.article.summaryHTML;
-    cell.articleNavigationDelegate = self.articleNavigationDelegate;
+    cell.articleNavigationDelegate = self;
     return cell;
 }
 

--- a/Wikipedia/UI-V5/WMFLinkButtonFactory.m
+++ b/Wikipedia/UI-V5/WMFLinkButtonFactory.m
@@ -9,28 +9,6 @@
 #import "WMFLinkButtonFactory.h"
 #import <BlocksKit/BlocksKit+UIKit.h>
 #import <DTCoreText/DTAttributedTextContentView.h>
-#import <DTCoreText/DTAttributedTextCell.h>
-#import <DTCoreText/DTLinkButton.h>
-#import <DTFoundation/DTTiledLayerWithoutFade.h>
-
-@interface DTAttributedTextContentView (WMFOverrideLayerClass)
-
-@end
-
-@implementation DTAttributedTextContentView (WMFOverrideLayerClass)
-
-+ (void)load {
-    /*
-       Set tiled layers for all attributed text content views. This prevents rendering all attributed text at once, but
-       might require unnecessary overrhead for smaller layers.
-
-       If there's a situation where the amount of text to shown is likely to be small most of the time, consider using
-       a custom subclass of DTAttributedTextContentView which returns `CALayer` from `layerClass` w/o checking super.
-     */
-    [DTAttributedTextContentView setLayerClass:[DTTiledLayerWithoutFade class]];
-}
-
-@end
 
 @implementation WMFLinkButtonFactory
 
@@ -46,6 +24,7 @@
     [linkButton bk_addEventHandler:^(DTLinkButton* sender) {
 //        @strongify(self);
 //        @strongify(attributedTextContentView);
+//        NSURL* URL = sender.URL;
 //        [self.articleNavigationDelegate articleView:attributedTextContentView didTapLinkToPage:sender.URL];
         DDLogVerbose(@"link tapped: %@", sender.URL);
     } forControlEvents:UIControlEventTouchUpInside];

--- a/Wikipedia/UI-V5/WMFLinkButtonFactory.m
+++ b/Wikipedia/UI-V5/WMFLinkButtonFactory.m
@@ -10,6 +10,8 @@
 #import <BlocksKit/BlocksKit+UIKit.h>
 #import <DTCoreText/DTAttributedTextContentView.h>
 
+#import "NSURL+WMFLinkParsing.h"
+
 @implementation WMFLinkButtonFactory
 
 - (UIView*)attributedTextContentView:(DTAttributedTextContentView*)attributedTextContentView
@@ -19,14 +21,11 @@
     DTLinkButton* linkButton = [[DTLinkButton alloc] initWithFrame:frame];
     linkButton.GUID = identifier;
     linkButton.URL  = url;
-//    @weakify(attributedTextContentView);
-//    @weakify(self);
+    @weakify(self);
     [linkButton bk_addEventHandler:^(DTLinkButton* sender) {
-//        @strongify(self);
-//        @strongify(attributedTextContentView);
-//        NSURL* URL = sender.URL;
-//        [self.articleNavigationDelegate articleView:attributedTextContentView didTapLinkToPage:sender.URL];
-        DDLogVerbose(@"link tapped: %@", sender.URL);
+        @strongify(self);
+        // TODO: pass text content view as sender once DTAttributedTextContentView conforms to the protocol
+        [sender.URL wmf_informNavigationDelegate:self.articleNavigationDelegate withSender:nil];
     } forControlEvents:UIControlEventTouchUpInside];
     return linkButton;
 }

--- a/Wikipedia/UI-V5/WMFMinimalArticleContentCell.m
+++ b/Wikipedia/UI-V5/WMFMinimalArticleContentCell.m
@@ -3,7 +3,29 @@
 
 #import "WMFMinimalArticleContentCell.h"
 #import "WMFLinkButtonFactory.h"
+
 #import <Masonry/Masonry.h>
+#import <DTFoundation/DTTiledLayerWithoutFade.h>
+
+@interface DTAttributedTextContentView (WMFOverrideLayerClass)
+
+@end
+
+@implementation DTAttributedTextContentView (WMFOverrideLayerClass)
+
++ (void)load {
+    /*
+     Set tiled layers for all attributed text content views. This prevents rendering all attributed text at once, but
+     might require unnecessary overrhead for smaller layers.
+
+     If there's a situation where the amount of text to shown is likely to be small most of the time, consider using
+     a custom subclass of DTAttributedTextContentView which returns `CALayer` from `layerClass` w/o checking super.
+     */
+    [DTAttributedTextContentView setLayerClass:[DTTiledLayerWithoutFade class]];
+}
+
+@end
+
 
 @interface WMFMinimalArticleContentCell ()
 <DTAttributedTextContentViewDelegate>

--- a/Wikipedia/UI-V5/WMFMinimalArticleContentCell.m
+++ b/Wikipedia/UI-V5/WMFMinimalArticleContentCell.m
@@ -15,11 +15,11 @@
 
 + (void)load {
     /*
-     Set tiled layers for all attributed text content views. This prevents rendering all attributed text at once, but
-     might require unnecessary overrhead for smaller layers.
+       Set tiled layers for all attributed text content views. This prevents rendering all attributed text at once, but
+       might require unnecessary overrhead for smaller layers.
 
-     If there's a situation where the amount of text to shown is likely to be small most of the time, consider using
-     a custom subclass of DTAttributedTextContentView which returns `CALayer` from `layerClass` w/o checking super.
+       If there's a situation where the amount of text to shown is likely to be small most of the time, consider using
+       a custom subclass of DTAttributedTextContentView which returns `CALayer` from `layerClass` w/o checking super.
      */
     [DTAttributedTextContentView setLayerClass:[DTTiledLayerWithoutFade class]];
 }

--- a/Wikipedia/View Controllers/WebView/WebViewController.m
+++ b/Wikipedia/View Controllers/WebView/WebViewController.m
@@ -793,31 +793,16 @@ typedef NS_ENUM (NSInteger, WMFWebViewAlertType) {
             if ([href wmf_isInternalLink]) {
                 MWKTitle* pageTitle = [strSelf.session.currentArticleSite titleWithInternalLink:href];
                 [weakSelf.delegate webViewController:weakSelf didTapOnLinkForTitle:pageTitle];
-            } else if ([href hasPrefix:@"http:"] || [href hasPrefix:@"https:"] || [href hasPrefix:@"//"]) {
+            } else {
                 // A standard external link, either explicitly http(s) or left protocol-relative on web meaning http(s)
                 if ([href hasPrefix:@"//"]) {
                     // Expand protocol-relative link to https -- secure by default!
                     href = [@"https:" stringByAppendingString:href];
                 }
-
-                // TODO: make all of the stuff above parse the URL into parts
-                // unless it's /wiki/ or #anchor style.
-                // Then validate if it's still in Wikipedia land and branch appropriately.
-                if ([SessionSingleton sharedInstance].zeroConfigState.disposition &&
-                    [[NSUserDefaults standardUserDefaults] boolForKey:@"ZeroWarnWhenLeaving"]) {
-                    strSelf.externalUrl = href;
-                    UIAlertView* dialog = [[UIAlertView alloc]
-                                           initWithTitle:MWLocalizedString(@"zero-interstitial-title", nil)
-                                                     message:MWLocalizedString(@"zero-interstitial-leave-app", nil)
-                                                    delegate:strSelf
-                                           cancelButtonTitle:MWLocalizedString(@"zero-interstitial-cancel", nil)
-                                           otherButtonTitles:MWLocalizedString(@"zero-interstitial-continue", nil)
-                                           , nil];
-                    dialog.tag = WMFWebViewAlertZeroInterstitial;
-                    [dialog show];
-                } else {
-                    NSURL* url = [NSURL URLWithString:href];
-                    [[UIApplication sharedApplication] openURL:url];
+                NSURL* url = [NSURL URLWithString:href];
+                NSCAssert(url, @"Failed to from URL from link %@", href);
+                if (url) {
+                    [[[SessionSingleton sharedInstance] zeroConfigState] showWarningIfNeededBeforeOpeningURL:url];
                 }
             }
         }];

--- a/Wikipedia/Zero/ZeroConfigState.h
+++ b/Wikipedia/Zero/ZeroConfigState.h
@@ -3,11 +3,14 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ZeroConfigState : NSObject
 
-@property (strong, nonatomic) NSString* partnerXcs;
-@property (nonatomic) BOOL disposition;
-@property (nonatomic) BOOL sentMCCMNC;
+@property (atomic, copy, nullable) NSString* partnerXcs;
+@property (atomic) BOOL disposition;
+@property (atomic) BOOL sentMCCMNC;
+
 @property (nonatomic, readonly) BOOL zeroOnDialogShownOnce;
 @property (nonatomic, readonly) BOOL warnWhenLeaving;
 @property (nonatomic, readonly) BOOL fakeZeroOn;
@@ -16,4 +19,8 @@
 - (void)toggleWarnWhenLeaving;
 - (void)toggleFakeZeroOn;
 
+- (void)showWarningIfNeededBeforeOpeningURL:(NSURL*)url;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wikipedia/Zero/ZeroConfigState.m
+++ b/Wikipedia/Zero/ZeroConfigState.m
@@ -2,6 +2,7 @@
 //  Copyright (c) 2013 Wikimedia Foundation. Provided under MIT-style license; please copy and modify!
 
 #import "ZeroConfigState.h"
+#import <BlocksKit/BlocksKit+UIKit.h>
 
 @implementation ZeroConfigState
 
@@ -33,6 +34,25 @@
 
 - (BOOL)fakeZeroOn {
     return [[NSUserDefaults standardUserDefaults] boolForKey:@"FakeZeroOn"];
+}
+
+- (void)showWarningIfNeededBeforeOpeningURL:(NSURL*)url {
+    NSParameterAssert(url);
+    if (self.disposition && [[NSUserDefaults standardUserDefaults] boolForKey:@"ZeroWarnWhenLeaving"]) {
+        NSString* messageWithHost = [NSString stringWithFormat:@"%@\n\n%@",
+                                     MWLocalizedString(@"zero-interstitial-leave-app", nil),
+                                     url.host];
+        UIAlertView* zeroAlert = [UIAlertView bk_alertViewWithTitle:MWLocalizedString(@"zero-interstitial-title", nil)
+                                                            message:messageWithHost];
+        [zeroAlert bk_setCancelButtonWithTitle:MWLocalizedString(@"zero-interstitial-cancel", nil)
+                                       handler:nil];
+        [zeroAlert bk_addButtonWithTitle:MWLocalizedString(@"zero-interstitial-continue", nil) handler:^{
+            [[UIApplication sharedApplication] openURL:url];
+        }];
+        [zeroAlert show];
+    } else {
+        [[UIApplication sharedApplication] openURL:url];
+    }
 }
 
 @end

--- a/Wikipedia/mw-utils/NSString+WMFPageUtilities.h
+++ b/Wikipedia/mw-utils/NSString+WMFPageUtilities.h
@@ -38,10 +38,15 @@ extern NSString* const WMFCitationFragmentSubstring;
 
 /**
  * Strips the internal link prefix from the receiver, if present.
+ *
+ * @warning If you need to be sure any query or fragment are also stripped, use this same category on `NSURL`.
  */
 - (NSString*)wmf_internalLinkPath;
 
-/// Normalizes page titles extracted from URLs, replacing percent escapes and underscores.
+/**
+ *  @return Copy of the receiver after normalizing page titles extracted from URLs, replacing percent escapes
+ *          and underscores.
+ */
 - (NSString*)wmf_normalizedPageTitle;
 
 @end

--- a/Wikipedia/mw-utils/NSString+WMFPageUtilities.h
+++ b/Wikipedia/mw-utils/NSString+WMFPageUtilities.h
@@ -11,15 +11,34 @@
 /// Expected prefix for links to pages from the wiki that the link's page belongs to.
 extern NSString* const WMFInternalLinkPathPrefix;
 
+/// Substring within a URL fragment that indicates whether or not it is a citation.
+extern NSString* const WMFCitationFragmentSubstring;
+
 @interface NSString (WMFPageUtilities)
 
 /**
- * @return Whether a URL is an internal link.
+ * Determine if a URL-like string is an internal link.
+ *
+ * The receiver can either be a relative or absolute URL, or the path component of a URL.
+ *
+ * @return `YES` if the receiver contains a substring indicating it is an internal-wiki link, otherwise `NO`.
+ *
  * @see WMFInternalLinkPrefix
  */
 - (BOOL)wmf_isInternalLink;
 
-/// Strips the internal link prefix from @c urlString, if present.
+/**
+ * Determine if a fragment points to a citation.
+ *
+ * The receiver is usually obtained from the fragment of a link tapped by the user.
+ *
+ * @return `YES` if the receiver contains a substring indicating that it is a citation, otherwise `NO`.
+ */
+- (BOOL)wmf_isCitationFragment;
+
+/**
+ * Strips the internal link prefix from the receiver, if present.
+ */
 - (NSString*)wmf_internalLinkPath;
 
 /// Normalizes page titles extracted from URLs, replacing percent escapes and underscores.

--- a/Wikipedia/mw-utils/NSString+WMFPageUtilities.m
+++ b/Wikipedia/mw-utils/NSString+WMFPageUtilities.m
@@ -12,10 +12,16 @@
 
 NSString* const WMFInternalLinkPathPrefix = @"/wiki/";
 
+NSString* const WMFCitationFragmentSubstring = @"cite_note";
+
 @implementation NSString (WMFPageUtilities)
 
 - (BOOL)wmf_isInternalLink {
-    return [self rangeOfString:WMFInternalLinkPathPrefix].location != NSNotFound;
+    return [self containsString:WMFInternalLinkPathPrefix];
+}
+
+- (BOOL)wmf_isCitationFragment {
+    return [self containsString:WMFCitationFragmentSubstring];
 }
 
 - (NSString*)wmf_internalLinkPath {

--- a/WikipediaUnitTests/NSURL+WMFLinkParsingTests.m
+++ b/WikipediaUnitTests/NSURL+WMFLinkParsingTests.m
@@ -1,0 +1,94 @@
+//
+//  NSURL+WMFLinkParsingTests.m
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 8/6/15.
+//  Copyright (c) 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import "NSURL+WMFLinkParsing.h"
+#import "NSString+WMFPageUtilities.h"
+#import "MWKTitle.h"
+
+#define MOCKITO_SHORTHAND 1
+#import <OCMockito/OCMockito.h>
+
+#define HC_SHORTHAND 1
+#import <OCHamcrest/OCHamcrest.h>
+
+@interface NSURL_WMFLinkParsingTests : XCTestCase
+
+@end
+
+@implementation NSURL_WMFLinkParsingTests
+
+- (void)testCitationURL {
+    XCTAssertTrue(([[NSURL URLWithString:[NSString stringWithFormat:@"#%@-0", WMFCitationFragmentSubstring]] wmf_isCitation]));
+}
+
+- (void)testURLWithoutFragmentIsNotCitation {
+    XCTAssertFalse([[NSURL URLWithString:@"/wiki/Foo"] wmf_isCitation]);
+}
+
+- (void)testURLWithFragmentNotContainingCitaitonSubstringIsNotCitation {
+    XCTAssertFalse([[NSURL URLWithString:@"/wiki/Foo#bar"] wmf_isCitation]);
+}
+
+- (void)testRelativeInternalLink {
+    XCTAssertTrue([[NSURL URLWithString:@"/wiki/Foo"] wmf_isInternalLink]);
+}
+
+- (void)testAbsoluteInternalLink {
+    XCTAssertTrue([[NSURL URLWithString:@"https://en.wikipedia.org/wiki/Foo"] wmf_isInternalLink]);
+}
+
+- (void)testAbsoluteInternalLinkWithOtherComponents {
+    XCTAssertTrue([[NSURL URLWithString:@"https://en.wikipedia.org/wiki/Foo?query=&string=value#fragment"] wmf_isInternalLink]);
+}
+
+- (void)testRelativeExternalLink {
+    XCTAssertFalse([[NSURL URLWithString:@"/Foo"] wmf_isInternalLink]);
+}
+
+- (void)testAbsoluteExternalLink {
+    XCTAssertFalse([[NSURL URLWithString:@"https://www.foo.com/bar"] wmf_isInternalLink]);
+}
+
+- (void)testInternalLinkPath {
+    NSString* testPath = @"foo/bar";
+    NSURL* testURL     = [[NSURL URLWithString:WMFInternalLinkPathPrefix]
+                      URLByAppendingPathComponent:testPath];
+    assertThat([testURL wmf_internalLinkPath], is(testPath));
+}
+
+- (void)testInternalLinkPathForURLExcludesFragmentAndQuery {
+    NSString* testPath                     = @"foo/bar";
+    NSString* testPathWithQueryAndFragment = [WMFInternalLinkPathPrefix stringByAppendingFormat:@"%@?baz#buz", testPath];
+    assertThat([[NSURL URLWithString:testPathWithQueryAndFragment] wmf_internalLinkPath], is(testPath));
+}
+
+- (void)testInformingDelegateOfCitationTap {
+    id<WMFArticleNavigationDelegate> mockDelegate = mockProtocol(@protocol(WMFArticleNavigationDelegate));
+    NSURL* testURL                                = [NSURL URLWithString:[NSString stringWithFormat:@"#%@-0", WMFCitationFragmentSubstring]];
+    [testURL wmf_informNavigationDelegate:mockDelegate withSender:nil];
+    [MKTVerify(mockDelegate) articleNavigator:nil didTapCitationLink:testURL.fragment];
+}
+
+- (void)testInformingDelegateOfExternalLinkTap {
+    id<WMFArticleNavigationDelegate> mockDelegate = mockProtocol(@protocol(WMFArticleNavigationDelegate));
+    NSURL* testURL                                = [NSURL URLWithString:@"https://www.google.com"];
+    [testURL wmf_informNavigationDelegate:mockDelegate withSender:nil];
+    [MKTVerify(mockDelegate) articleNavigator:nil didTapExternalLink:testURL];
+}
+
+- (void)testInformingDelegateOfInternalLinkTap {
+    id<WMFArticleNavigationDelegate> mockDelegate = mockProtocol(@protocol(WMFArticleNavigationDelegate));
+    NSURL* testURL                                = [NSURL URLWithString:[NSString stringWithFormat:@"https://en.wikipedia.org%@Foo", WMFInternalLinkPathPrefix]];
+    [testURL wmf_informNavigationDelegate:mockDelegate withSender:nil];
+    MWKTitle* titleFromTestURL = [[MWKTitle alloc] initWithURL:testURL];
+    [MKTVerify(mockDelegate) articleNavigator:nil didTapLinkToPage:titleFromTestURL];
+}
+
+@end


### PR DESCRIPTION
Last bit of work for [T106115](https://phabricator.wikimedia.org/T106115)

### Design notes
Abstracting away & encapsulating link parsing and handling behind a couple protocols & categories:

##### `WMFArticleNavigationDelegate`
Protocol for handlers of link events originating from an article's content, whether from web or native (eventually). See the checklist for all the interactions.

##### `NSURL+WMFLinkParsing`
If you have link that you want to tell your `WMFArticleNavigationDelegate` about, this is your category. Uses `-[MWKTitle initWithURL:]` to create titles from itself and call the correct delegate method for the type of URL it is.

As a user, I can:
- [x] Tap links in the native article view
- [x] Tap citations, and see the "references popup"
- [x] Tap external links, and see the MWZero warning if necessary

###### Easter Eggs 🐇🐣
Added the host to the warning users see when leaving WikiZero.
