### PR TITLE
add custom log formatter

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		BC32A1D91B4B1B8A00A286DE /* WMFLegacyImageDataMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC32A1D81B4B1B8A00A286DE /* WMFLegacyImageDataMigration.swift */; };
 		BC34E46A1B31AD8B00258928 /* MWKLanguageLinkController.m in Sources */ = {isa = PBXBuildFile; fileRef = BC34E4691B31AD8B00258928 /* MWKLanguageLinkController.m */; };
 		BC3863491B73E056003A2D38 /* NSURL+WMFLinkParsingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC3863481B73E056003A2D38 /* NSURL+WMFLinkParsingTests.m */; };
+		BC38635A1B77EAC1003A2D38 /* WMFLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = BC3863591B77EAC1003A2D38 /* WMFLogFormatter.m */; };
 		BC49B3641AEECFD8009F55BE /* ArticleLoadingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC49B3631AEECFD8009F55BE /* ArticleLoadingTests.m */; };
 		BC505EEB1B59461400537006 /* WMFCollectionViewPageLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = BC505EEA1B59461400537006 /* WMFCollectionViewPageLayout.m */; };
 		BC505EEE1B594B5700537006 /* WMFImageCollectionViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BC505EED1B594B5700537006 /* WMFImageCollectionViewCell.m */; };
@@ -908,6 +909,8 @@
 		BC34E4691B31AD8B00258928 /* MWKLanguageLinkController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MWKLanguageLinkController.m; sourceTree = "<group>"; };
 		BC34E4721B31D92100258928 /* LangaugeSelectionDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LangaugeSelectionDelegate.h; sourceTree = "<group>"; };
 		BC3863481B73E056003A2D38 /* NSURL+WMFLinkParsingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+WMFLinkParsingTests.m"; sourceTree = "<group>"; };
+		BC3863581B77EAC1003A2D38 /* WMFLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFLogFormatter.h; sourceTree = "<group>"; };
+		BC3863591B77EAC1003A2D38 /* WMFLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFLogFormatter.m; sourceTree = "<group>"; };
 		BC4273521A7C736800068882 /* WikipediaUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WikipediaUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC49B3631AEECFD8009F55BE /* ArticleLoadingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArticleLoadingTests.m; sourceTree = "<group>"; };
 		BC505EE91B59461400537006 /* WMFCollectionViewPageLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFCollectionViewPageLayout.h; sourceTree = "<group>"; };
@@ -2754,6 +2757,8 @@
 				BC7E4A491B34A26A00EECD8B /* WMFLogging.h */,
 				BCBDC88D1B3A42E7003A6D17 /* SwiftUtilities.swift */,
 				BC725EC81B61255400E0A64C /* WMFOutParamUtils.h */,
+				BC3863581B77EAC1003A2D38 /* WMFLogFormatter.h */,
+				BC3863591B77EAC1003A2D38 /* WMFLogFormatter.m */,
 			);
 			path = "mw-utils";
 			sourceTree = "<group>";
@@ -3619,6 +3624,7 @@
 				BC505EF71B59643400537006 /* WMFPageCollectionViewController.m in Sources */,
 				BCE24FDF1B0CF0C7003F054B /* LegacyPhoneGapDataMigrator.m in Sources */,
 				042950D41A9D3BA7009BE784 /* UIColor+WMFHexColor.m in Sources */,
+				BC38635A1B77EAC1003A2D38 /* WMFLogFormatter.m in Sources */,
 				BCBDC88C1B3A0715003A6D17 /* Cancellable.swift in Sources */,
 				0439317619FB092600386E8F /* UIWebView+LoadAssetsHtml.m in Sources */,
 				04B91AA718E34BBC00FFAA1C /* UIView+TemporaryAnimatedXF.m in Sources */,

--- a/Wikipedia/AppDelegate.m
+++ b/Wikipedia/AppDelegate.m
@@ -4,6 +4,7 @@
 #import "BITHockeyManager+WMFExtensions.h"
 #import "WMFAppViewController.h"
 #import "Wikipedia-Swift.h"
+#import "WMFLogFormatter.h"
 
 @interface AppDelegate ()
 
@@ -33,7 +34,9 @@
      }];
 
 #if DEBUG
-    [DDLog addLogger:[DDTTYLogger sharedInstance]];
+    id<DDLogger> consoleLogger = [DDTTYLogger sharedInstance];
+    [consoleLogger setLogFormatter:[WMFLogFormatter new]];
+    [DDLog addLogger:consoleLogger];
 #endif
 }
 

--- a/Wikipedia/Categories/NSBundle+WMFInfoUtils.h
+++ b/Wikipedia/Categories/NSBundle+WMFInfoUtils.h
@@ -10,6 +10,8 @@
 
 @interface NSBundle (WMFInfoUtils)
 
+- (NSString*)wmf_bundleName;
+
 ///
 /// @name App Version Information
 ///

--- a/Wikipedia/Categories/NSBundle+WMFInfoUtils.m
+++ b/Wikipedia/Categories/NSBundle+WMFInfoUtils.m
@@ -10,6 +10,10 @@
 
 @implementation NSBundle (WMFInfoUtils)
 
+- (NSString*)wmf_bundleName {
+    return [self objectForInfoDictionaryKey:@"CFBundleName"];
+}
+
 #pragma mark - Version Info
 
 - (NSString*)wmf_bundleIdentifier {

--- a/Wikipedia/mw-utils/WMFLogFormatter.h
+++ b/Wikipedia/mw-utils/WMFLogFormatter.h
@@ -1,0 +1,14 @@
+//
+//  WMFLogFormatter.h
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 8/9/15.
+//  Copyright (c) 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CocoaLumberjack/DDDispatchQueueLogFormatter.h>
+
+@interface WMFLogFormatter : DDDispatchQueueLogFormatter
+
+@end

--- a/Wikipedia/mw-utils/WMFLogFormatter.m
+++ b/Wikipedia/mw-utils/WMFLogFormatter.m
@@ -1,0 +1,53 @@
+//
+//  WMFLogFormatter.m
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 8/9/15.
+//  Copyright (c) 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import "WMFLogFormatter.h"
+#import "NSBundle+WMFInfoUtils.h"
+
+static NSString* cachedApplicationName;
+
+@implementation WMFLogFormatter
+
++ (void)initialize {
+    if (self == [WMFLogFormatter class]) {
+        cachedApplicationName = [[NSBundle mainBundle] wmf_bundleName];
+    }
+}
+
+- (NSString*)formatLogMessage:(DDLogMessage*)logMessage {
+    NSString* level;
+    switch (logMessage->_level) {
+        case DDLogLevelDebug:
+            level = @"DEBUG";
+            break;
+        case DDLogLevelVerbose:
+            level = @"VERBOSE";
+            break;
+        case DDLogLevelInfo:
+            level = @"INFO";
+            break;
+        case DDLogLevelWarning:
+            level = @"WARN";
+            break;
+        case DDLogLevelError:
+            level = @"ERROR";
+            break;
+        default:
+            break;
+    }
+    return [NSString stringWithFormat:@"%@ %@[%@] %@#L%lu %@:\n%@",
+            [self stringFromDate:logMessage->_timestamp],
+            cachedApplicationName,
+            [self queueThreadLabelForLogMessage:logMessage],
+            logMessage->_function,
+            logMessage->_line,
+            level,
+            logMessage->_message];
+}
+
+@end


### PR DESCRIPTION
Format is: 

```
timestamp Bundle_name[gcd_queue_name] function#line log_level:
message
```

Example:

> 2015-08-11 14:09:09:007 Wikipedia Debug[main] -[CommunicationBridge webView:didFailLoadWithError:]#L137 DEBUG:
webView failed to load: Error Domain=NSURLErrorDomain Code=-999 "The operation couldn’t be completed. (NSURLErrorDomain error -999.)" UserInfo=0x7f84f7d28f30 {NSErrorFailingURLStringKey=file:///Users/bgerstle/Library/Developer/CoreSimulator/Devices/E074AFFF-8EBC-4DE7-B58F-8BCFDCB05516/data/Containers/Data/Application/CA7874B7-7B1F-4D6E-801F-689F00029CA1/Documents/assets/index.html, NSErrorFailingURLKey=file:///Users/bgerstle/Library/Developer/CoreSimulator/Devices/E074AFFF-8EBC-4DE7-B58F-8BCFDCB05516/data/Containers/Data/Application/CA7874B7-7B1F-4D6E-801F-689F00029CA1/Documents/assets/index.html}