### PR TITLE
Onboarding follow on

### DIFF
--- a/Wikipedia/UI-V5/WMFAppViewController.m
+++ b/Wikipedia/UI-V5/WMFAppViewController.m
@@ -164,9 +164,8 @@ typedef NS_ENUM (NSUInteger, WMFAppTabType) {
 
         [self runDataMigrationIfNeededWithCompletion:^{
             [self loadMainUI];
-            [self presentOnboardingIfNeededWithCompletion:^(BOOL didShowOnboarding){
-                [self hideSplashViewAnimated:!didShowOnboarding];
-            }];
+            BOOL didShowOnboarding = [self presentOnboardingIfNeeded];
+            [self hideSplashViewAnimated:!didShowOnboarding];
         }];
     });
 }
@@ -193,22 +192,16 @@ typedef NS_ENUM (NSUInteger, WMFAppTabType) {
     return showOnboarding.boolValue;
 }
 
-- (void)presentOnboardingIfNeededWithCompletion:(void (^)(BOOL didShowOnboarding))completion {
+- (BOOL)presentOnboardingIfNeeded {
     if ([self shouldShowOnboarding]) {
         [self presentViewController:[OnboardingViewController wmf_initialViewControllerFromClassStoryboard]
                            animated:NO
-                         completion:^{
-            if (completion) {
-                completion(YES);
-            }
-        }];
+                         completion:NULL];
         [[NSUserDefaults standardUserDefaults] setObject:@NO forKey:@"ShowOnboarding"];
         [[NSUserDefaults standardUserDefaults] synchronize];
-        return;
+        return YES;
     }
-    if (completion) {
-        completion(NO);
-    }
+    return NO;
 }
 
 #pragma mark - Splash


### PR DESCRIPTION
I asked @montehurd to follow my completion block example without understanding that the on boarding does not call back when it is Complete. Instead it calls back when the presentation is complete, which is not useful for flow control.

Because of this we do not need a completion block to know when the on boarding is presented, we can just return a bool synchronously. This commit does just that.

This was my fault for not understanding the on boarding flow so correcting it here. If we do want to report back when onboarding is complete, we can re-introduce a completion block for this then.

