### PR TITLE
format using flag instead of level

### DIFF
--- a/Wikipedia/mw-utils/WMFLogFormatter.m
+++ b/Wikipedia/mw-utils/WMFLogFormatter.m
@@ -20,21 +20,21 @@ static NSString* cachedApplicationName;
 }
 
 - (NSString*)formatLogMessage:(DDLogMessage*)logMessage {
-    NSString* level;
-    switch (logMessage->_level) {
-        case DDLogLevelDebug:
+    NSString* level = @"";
+    switch (logMessage->_flag) {
+        case DDLogFlagDebug:
             level = @"DEBUG";
             break;
-        case DDLogLevelVerbose:
+        case DDLogFlagVerbose:
             level = @"VERBOSE";
             break;
-        case DDLogLevelInfo:
+        case DDLogFlagInfo:
             level = @"INFO";
             break;
-        case DDLogLevelWarning:
+        case DDLogFlagWarning:
             level = @"WARN";
             break;
-        case DDLogLevelError:
+        case DDLogFlagError:
             level = @"ERROR";
             break;
         default:
@@ -45,7 +45,7 @@ static NSString* cachedApplicationName;
             cachedApplicationName,
             [self queueThreadLabelForLogMessage:logMessage],
             logMessage->_function,
-            logMessage->_line,
+            (unsigned long)logMessage->_line,
             level,
             logMessage->_message];
 }


### PR DESCRIPTION
All logs were mistakenly formatted w/ the current log level instead of the flag corresponding to that message. Now formats correctly:

> 2015-08-13 16:04:26:676 Wikipedia Debug[main] -[AppDelegate application:didFinishLaunchingWithOptions:]#L68 **INFO**:
I'm an info log!
> 2015-08-13 16:04:26:676 Wikipedia Debug[main] -[AppDelegate application:didFinishLaunchingWithOptions:]#L69 **WARN**:
I'm a warning log!
