### PR TITLE
[WIP] Demo to wire up DTCoreText NSAtrributedStrings to native views.

### DIFF
--- a/Wikipedia/Categories/NSAttributedString+WMFHTMLForSite.m
+++ b/Wikipedia/Categories/NSAttributedString+WMFHTMLForSite.m
@@ -28,7 +28,8 @@
                DTDefaultLinkDecoration: @NO, // disable decoration for links
                DTDefaultLinkColor: [UIColor wmf_logoBlue],
                DTDocumentPreserveTrailingSpaces: @YES,
-               DTDefaultStyleSheet: defaultStyleSheet
+               DTDefaultStyleSheet: defaultStyleSheet,
+               DTUseiOS6Attributes: @YES
     };
 }
 

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -21,6 +21,8 @@
 // Other
 #import "SessionSingleton.h"
 
+#import "NSURL+WMFLinkParsing.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WMFArticleContainerViewController ()
@@ -300,6 +302,11 @@ NS_ASSUME_NONNULL_BEGIN
                                                           savedPages:self.savedPageList];
     vc.article = article;
     [self.navigationController pushViewController:vc animated:YES];
+}
+
+- (BOOL)textView:(UITextView*)textView shouldInteractWithURL:(NSURL*)URL inRange:(NSRange)characterRange {
+    [URL wmf_informNavigationDelegate:self withSender:nil];
+    return NO;
 }
 
 @end

--- a/Wikipedia/UI-V5/WMFArticleViewController.h
+++ b/Wikipedia/UI-V5/WMFArticleViewController.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) MWKDataStore* dataStore;
 @property (nonatomic, strong, readonly) MWKSavedPageList* savedPages;
 
-@property (nonatomic, weak) id<WMFArticleViewControllerDelegate> delegate;
+@property (nonatomic, weak) id<WMFArticleViewControllerDelegate, UITextViewDelegate> delegate;
 
 - (void)updateUI;
 


### PR DESCRIPTION
So after the talk - I whipped this up in 20 minutes. 

This gets all the auto layout for free and has "native-looking" text rendering. It also supports all the links. And it is just a plain UITextView.

Like I said earlier… The view parts of DTCoreText were made before we could display NSAttributedStrings in standard UIControls. I think the HTML->AttributedString conversion stuff is really all we need for iOS 7 and up.