### PR TITLE
Fix bottom article inset

### DIFF
--- a/MediaWikiKit/MediaWikiKit/MWKArticle.m
+++ b/MediaWikiKit/MediaWikiKit/MWKArticle.m
@@ -608,7 +608,7 @@ static NSString* const WMFParagraphSelector = @"/html/body/p";
 
     NSMutableArray* superScripts = [NSMutableArray array];
     [summary enumerateAttribute:(NSString*)kCTSuperscriptAttributeName inRange:NSMakeRange(0, summary.length) options:0 usingBlock:^(id value, NSRange range, BOOL* stop) {
-        if([value integerValue] == 1){
+        if ([value integerValue] == 1) {
             [superScripts addObject:[NSValue valueWithRange:range]];
         }
     }];

--- a/Wikipedia/UI-V5/UIView+WMFShadow.m
+++ b/Wikipedia/UI-V5/UIView+WMFShadow.m
@@ -19,7 +19,7 @@
     [self wmf_updateShadowPathBasedOnBounds];
 }
 
-- (void)wmf_updateShadowPathBasedOnBounds{
+- (void)wmf_updateShadowPathBasedOnBounds {
     self.layer.shadowPath = [UIBezierPath bezierPathWithRect:CGRectInset(self.bounds, -1.0, -1.0)].CGPath;
 }
 

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -109,6 +109,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)viewDidLoad {
     [super viewDidLoad];
 
+    // Manually adjusting scrollview offsets to compensate for embedded navigation controller
+    self.automaticallyAdjustsScrollViewInsets = NO;
+
     [self updateInsetsForArticleViewController];
 
     UINavigationController* nav = [[UINavigationController alloc] initWithRootViewController:self.articleViewController];
@@ -134,8 +137,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)updateInsetsForArticleViewController {
-    CGFloat navHeight = [self.navigationController.navigationBar frame].size.height + [[UIApplication sharedApplication] statusBarFrame].size.height;
-    self.articleViewController.tableView.contentInset = UIEdgeInsetsMake(navHeight, 0.0, 0.0, 0.0);
+    self.articleViewController.tableView.contentInset =
+        UIEdgeInsetsMake([self.navigationController.navigationBar frame].size.height
+                         + [[UIApplication sharedApplication] statusBarFrame].size.height,
+                         0.0,
+                         self.tabBarController.tabBar.frame.size.height,
+                         0.0);
 }
 
 #pragma mark - WebView Transition

--- a/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
@@ -97,7 +97,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
+
     self.collectionView.dataSource = self.dataSource;
 
     self.extendedLayoutIncludesOpaqueBars     = YES;

--- a/Wikipedia/UI-V5/WMFArticlePreviewCell.m
+++ b/Wikipedia/UI-V5/WMFArticlePreviewCell.m
@@ -91,13 +91,13 @@ static CGFloat const WMFImageHeight = 160;
 
     summaryAttributedText = [summaryAttributedText wmf_attributedStringChangingAttribute:NSParagraphStyleAttributeName
                                                                                withBlock:^NSParagraphStyle*(NSParagraphStyle* paragraphStyle){
-                                                                                   NSMutableParagraphStyle* style = paragraphStyle.mutableCopy;
-                                                                                   style.alignment     = NSTextAlignmentNatural;
-                                                                                   style.lineSpacing = 12;
-                                                                                   style.lineBreakMode = NSLineBreakByTruncatingTail;
-                                                                                   
-                                                                                   return style;
-                                                                               }];
+        NSMutableParagraphStyle* style = paragraphStyle.mutableCopy;
+        style.alignment = NSTextAlignmentNatural;
+        style.lineSpacing = 12;
+        style.lineBreakMode = NSLineBreakByTruncatingTail;
+
+        return style;
+    }];
 
 
     self.summaryLabel.attributedText = summaryAttributedText;

--- a/Wikipedia/UI-V5/WMFArticleViewController.storyboard
+++ b/Wikipedia/UI-V5/WMFArticleViewController.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Btv-Tg-s8D">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Btv-Tg-s8D">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>

--- a/Wikipedia/UI-V5/WMFHomeViewController.m
+++ b/Wikipedia/UI-V5/WMFHomeViewController.m
@@ -157,6 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
     CGFloat width = self.view.bounds.size.width - self.collectionView.contentInset.left - self.collectionView.contentInset.right;
     return width;
 }
+
 #pragma mark - Actions
 
 - (void)didTapSettingsButton:(UIBarButtonItem*)sender {

--- a/Wikipedia/UI-V5/WMFRelatedSectionController.m
+++ b/Wikipedia/UI-V5/WMFRelatedSectionController.m
@@ -78,10 +78,10 @@ static NSUInteger const WMFRelatedSectionMaxResults = 3;
     if ([cell isKindOfClass:[WMFArticlePreviewCell class]]) {
         WMFArticlePreviewCell* previewCell = (id)cell;
         MWKLocationSearchResult* result    = object;
-        previewCell.titleText       = result.displayTitle;
-        previewCell.descriptionText = result.wikidataDescription;
-        previewCell.imageURL        = result.thumbnailURL;
-        previewCell.summaryAttributedText     = nil;
+        previewCell.titleText             = result.displayTitle;
+        previewCell.descriptionText       = result.wikidataDescription;
+        previewCell.imageURL              = result.thumbnailURL;
+        previewCell.summaryAttributedText = nil;
     }
 }
 


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/444217/9481052/24befcca-4b55-11e5-84ed-600552877f21.png)


After:
![image](https://cloud.githubusercontent.com/assets/444217/9481038/08df854c-4b55-11e5-9525-6431198c2b51.png)


Still not underlapping navBar ✅
![image](https://cloud.githubusercontent.com/assets/444217/9481029/fcf7e706-4b54-11e5-8f79-741642ee4ea1.png)


Still rendered below translucent tabBar ✅
![image](https://cloud.githubusercontent.com/assets/444217/9481022/e9d5f442-4b54-11e5-8c37-23e73ba029f2.png)
