### PR TITLE
Change MWKDataStore article cache behavior to prevent side effects

### DIFF
--- a/MediaWikiKit/MediaWikiKit/MWKDataStore.h
+++ b/MediaWikiKit/MediaWikiKit/MWKDataStore.h
@@ -91,9 +91,45 @@ extern NSString* const MWKArticleKey;
  */
 - (void)saveImageInfo:(NSArray*)imageInfo forArticle:(MWKArticle*)article;
 
-// Raw load methods
+///
+/// @name Article Load Methods
+///
+
+/**
+ *  Retrieves an existing article from the receiver.
+ *
+ *  This will check memory cache first, falling back to disk if necessary. If data is read from disk, it is inserted
+ *  into the memory cache before returning, allowing subsequent calls to this method to hit the memory cache.
+ *
+ *  @param title The title under which article data was previously stored.
+ *
+ *  @return An article, or @c nil if none was found.
+ */
 - (MWKArticle*)existingArticleWithTitle:(MWKTitle*)title;
+
+/**
+ *  Attempt to create an article object from data on disk.
+ *
+ *  @param title The title under which article data was previously stored.
+ *
+ *  @return An article, or @c nil if none was found.
+ */
+- (MWKArticle*)articleFromDiskWithTitle:(MWKTitle*)title;
+
+/**
+ *  Get or create an article with a given title.
+ *
+ *  If an article already exists for this title return it. Otherwise, create a new object and return it without saving
+ *  it.
+ *
+ *  @param title The title related to the article data.
+ *
+ *  @return An article object with the given title.
+ *
+ *  @see -existingArticleWithTitle:
+ */
 - (MWKArticle*)articleWithTitle:(MWKTitle*)title;
+
 - (MWKSection*)sectionWithId:(NSUInteger)sectionId article:(MWKArticle*)article;
 - (NSString*)sectionTextWithId:(NSUInteger)sectionId article:(MWKArticle*)article;
 - (MWKImage*)imageWithURL:(NSString*)url article:(MWKArticle*)article;

--- a/MediaWikiKit/MediaWikiKit/MWKDataStore.m
+++ b/MediaWikiKit/MediaWikiKit/MWKDataStore.m
@@ -292,26 +292,26 @@ static NSString* const MWKImageInfoFilename = @"ImageInfo.plist";
 }
 
 - (MWKArticle*)existingArticleWithTitle:(MWKTitle*)title {
+    MWKArticle* existingArticle =
+        [self memoryCachedArticleWithTitle:title] ?: [self articleFromDiskWithTitle:title];
+    if (existingArticle) {
+        [self.articleCache setObject:existingArticle forKey:existingArticle.title];
+    }
+    return existingArticle;
+}
+
+- (MWKArticle*)articleFromDiskWithTitle:(MWKTitle*)title {
     NSString* path     = [self pathForTitle:title];
     NSString* filePath = [path stringByAppendingPathComponent:@"Article.plist"];
     NSDictionary* dict = [NSDictionary dictionaryWithContentsOfFile:filePath];
-    return dict ? [[MWKArticle alloc] initWithTitle : title dataStore:self dict:dict] : nil;
+    if (!dict) {
+        return nil;
+    }
+    return [[MWKArticle alloc] initWithTitle:title dataStore:self dict:dict];
 }
 
 - (MWKArticle*)articleWithTitle:(MWKTitle*)title {
-    MWKArticle* article = [self memoryCachedArticleWithTitle:title];
-
-    if (!article) {
-        article = [self existingArticleWithTitle:title];
-        if (!article) {
-            article = [[MWKArticle alloc] initWithTitle:title dataStore:self];
-        }
-        if (article) {
-            [self.articleCache setObject:article forKey:article.title];
-        }
-    }
-
-    return article;
+    return [self existingArticleWithTitle:title] ?: [[MWKArticle alloc] initWithTitle:title dataStore:self];
 }
 
 - (MWKSection*)sectionWithId:(NSUInteger)sectionId article:(MWKArticle*)article {

--- a/MediaWikiKit/MediaWikiKit/MWKDataStore.m
+++ b/MediaWikiKit/MediaWikiKit/MWKDataStore.m
@@ -293,7 +293,7 @@ static NSString* const MWKImageInfoFilename = @"ImageInfo.plist";
 
 - (MWKArticle*)existingArticleWithTitle:(MWKTitle*)title {
     MWKArticle* existingArticle =
-        [self memoryCachedArticleWithTitle:title] ?: [self articleFromDiskWithTitle:title];
+        [self memoryCachedArticleWithTitle:title] ? : [self articleFromDiskWithTitle:title];
     if (existingArticle) {
         [self.articleCache setObject:existingArticle forKey:existingArticle.title];
     }
@@ -311,7 +311,7 @@ static NSString* const MWKImageInfoFilename = @"ImageInfo.plist";
 }
 
 - (MWKArticle*)articleWithTitle:(MWKTitle*)title {
-    return [self existingArticleWithTitle:title] ?: [[MWKArticle alloc] initWithTitle:title dataStore:self];
+    return [self existingArticleWithTitle:title] ? : [[MWKArticle alloc] initWithTitle:title dataStore:self];
 }
 
 - (MWKSection*)sectionWithId:(NSUInteger)sectionId article:(MWKArticle*)article {

--- a/Wikipedia/UI-V5/WMFArticleFetcher.m
+++ b/Wikipedia/UI-V5/WMFArticleFetcher.m
@@ -198,7 +198,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (id)serializedArticleWithTitle:(MWKTitle*)title response:(NSDictionary*)response {
-    MWKArticle* article = [self.dataStore articleWithTitle:title];
+    MWKArticle* article = [[MWKArticle alloc] initWithTitle:title dataStore:self.dataStore dict:response];
     @try {
         [article importMobileViewJSON:response];
         [article save];

--- a/Wikipedia/UI-V5/WMFArticleViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleViewController.m
@@ -125,7 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
     _article = article;
 
     [self.headerGalleryViewController setImagesFromArticle:article];
-    [self updateSectionHierarchy];
+    self.topLevelSections = [_article.sections.topLevelSections wmf_tail];
 
     [self updateUI];
 
@@ -142,10 +142,6 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     [self observeAndFetchArticleIfNeeded];
-}
-
-- (void)updateSectionHierarchy {
-    self.topLevelSections = [_article.sections.topLevelSections wmf_tail];
 }
 
 - (void)setMode:(WMFArticleControllerMode)mode animated:(BOOL)animated {
@@ -213,6 +209,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (MWKSection*)parentSectionForTableSection:(NSUInteger)section {
     NSParameterAssert([self isTOCSection:section]);
+    NSParameterAssert(self.indexSetOfTOCSections.count > 0);
     return self.topLevelSections[section - self.indexSetOfTOCSections.firstIndex];
 }
 
@@ -306,15 +303,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)fetchArticleForTitle:(MWKTitle*)title {
     @weakify(self)
-    [self.articlePreviewFetcher fetchArticlePreviewForPageTitle : title progress : NULL].then(^(MWKArticlePreview* articlePreview){
+    [self.articlePreviewFetcher fetchArticlePreviewForPageTitle: title progress: NULL].then(^(MWKArticlePreview* articlePreview){
         @strongify(self)
         AnyPromise * fullArticlePromise = [self.articleFetcher fetchArticleForPageTitle:title progress:NULL];
         self.articleFetcherPromise = fullArticlePromise;
         return fullArticlePromise;
     }).then(^(MWKArticle* article){
         @strongify(self)
-        [self.headerGalleryViewController setImagesFromArticle : article];
-        [self updateSectionHierarchy];
         self.article = article;
     }).catch(^(NSError* error){
         @strongify(self)

--- a/Wikipedia/UI-V5/WMFArticleViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleViewController.m
@@ -302,17 +302,17 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)fetchArticleForTitle:(MWKTitle*)title {
-    @weakify(self)
-    [self.articlePreviewFetcher fetchArticlePreviewForPageTitle: title progress: NULL].then(^(MWKArticlePreview* articlePreview){
-        @strongify(self)
-        AnyPromise * fullArticlePromise = [self.articleFetcher fetchArticleForPageTitle:title progress:NULL];
+    @weakify(self);
+    [self.articlePreviewFetcher fetchArticlePreviewForPageTitle:title progress:NULL].then(^(MWKArticlePreview* articlePreview){
+        @strongify(self);
+        AnyPromise* fullArticlePromise = [self.articleFetcher fetchArticleForPageTitle:title progress:NULL];
         self.articleFetcherPromise = fullArticlePromise;
         return fullArticlePromise;
     }).then(^(MWKArticle* article){
-        @strongify(self)
+        @strongify(self);
         self.article = article;
     }).catch(^(NSError* error){
-        @strongify(self)
+        @strongify(self);
         if ([error wmf_isWMFErrorOfType:WMFErrorTypeRedirected]) {
             [self fetchArticleForTitle:[[error userInfo] wmf_redirectTitle]];
         } else if (!self.presentingViewController) {


### PR DESCRIPTION
Phab: [T110381](https://phabricator.wikimedia.org/T110381)

---

In a nutshell, we were putting "empty" articles in the data store's memory cache, which resulted in the article fetcher filling them with new data, when *then* resulted in view controllers getting false positives on equality checks which they were using to only set new data.  In other words:

- Create an "empty" article and put it in the cache
- Fetch the "full" article. populating the previously "empty" article w/ data
- Try to set the new "full" article in your view controller's in the completion block, but fail because it's the same object: `self.article == article` is true.

To fix it, I changed (and documented) the behaviors for the data store's article loading methods:

- `articleWithTitle:(MWKTitle*)`: high-level API, "just give me an article." if we have an **existing article** (see below), you'll get that. otherwise we'll create a new one
- `existingArticleWithTitle:(MWKTitle*)` similar pattern to the one employed by SDWebImage: give me an article from memory, or read from disk. if we get it from disk, we'll put it in memory so you'll hit the cache next time
- `articleFromDiskWithTitle:(MWKTitle*)` I think you see where this is going... 

On top of this, the fetcher now *always* creates new article objects and saves them.  The main benefit of this is that it doesn't touch the cache (multi-threading problems) or read data from disk (unnecessary).

Now that all of this is fixed, `WMFArticleViewController` can _actually_ rely on equality checks to determine if it got new data. Phew! 😌

In a separate patch, I'd like to look into whether or not we always end up with the new data we get from the server.  I have a hunch that old sections might be able to linger since we're not removing old data on a new download.  