### PR TITLE
Made default MWKTitle equality check exclude fragment.

### DIFF
--- a/MediaWikiKit/MediaWikiKit/MWKArticle.m
+++ b/MediaWikiKit/MediaWikiKit/MWKArticle.m
@@ -103,7 +103,7 @@ static MWKArticleSchemaVersion const MWKArticleCurrentSchemaVersion = MWKArticle
 }
 
 - (BOOL)isEqualToArticle:(MWKArticle*)other {
-    return WMF_EQUAL(self.title, isEqualToTitleExcludingFragment:, other.title)
+    return WMF_EQUAL(self.title, isEqualToTitle:, other.title)
            && WMF_EQUAL(self.redirected, isEqual:, other.redirected)
            && WMF_EQUAL(self.lastmodified, isEqualToDate:, other.lastmodified)
            && WMF_IS_EQUAL(self.lastmodifiedby, other.lastmodifiedby)

--- a/MediaWikiKit/MediaWikiKit/MWKTitle.h
+++ b/MediaWikiKit/MediaWikiKit/MWKTitle.h
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)isEqualToTitle:(MWKTitle*)title;
 
-- (BOOL)isEqualToTitleExcludingFragment:(MWKTitle*)title;
+- (BOOL)isEqualToTitleIncludingFragment:(MWKTitle*)title;
 
 @end
 

--- a/MediaWikiKit/MediaWikiKit/MWKTitle.m
+++ b/MediaWikiKit/MediaWikiKit/MWKTitle.m
@@ -119,13 +119,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)isEqualToTitle:(MWKTitle*)otherTitle {
     return WMF_IS_EQUAL_PROPERTIES(self, site, otherTitle)
-           && WMF_EQUAL_PROPERTIES(self, text, isEqualToString:, otherTitle)
-           && WMF_EQUAL_PROPERTIES(self, fragment, isEqualToString:, otherTitle);
+           && WMF_EQUAL_PROPERTIES(self, text, isEqualToString:, otherTitle);
 }
 
-- (BOOL)isEqualToTitleExcludingFragment:(MWKTitle*)otherTitle {
+- (BOOL)isEqualToTitleIncludingFragment:(MWKTitle*)otherTitle {
     return WMF_IS_EQUAL_PROPERTIES(self, site, otherTitle)
-           && WMF_EQUAL_PROPERTIES(self, text, isEqualToString:, otherTitle);
+           && WMF_EQUAL_PROPERTIES(self, text, isEqualToString:, otherTitle)
+           && WMF_EQUAL_PROPERTIES(self, fragment, isEqualToString:, otherTitle);
 }
 
 - (NSString*)description {


### PR DESCRIPTION
Was causeing problems with "memoryCachedArticleWithTitle" thinking
it didn't have a cached article if the title's fragment was set.