### PR TITLE
Some small style tweaks.

### DIFF
--- a/Wikipedia/UI-V5/WMFArticlePreviewCell.m
+++ b/Wikipedia/UI-V5/WMFArticlePreviewCell.m
@@ -24,7 +24,7 @@ static CGFloat const WMFImageHeight = 160;
 - (void)prepareForReuse {
     [super prepareForReuse];
     [[WMFImageController sharedInstance] cancelFetchForURL:self.imageURL];
-    self.imageView.image = [UIImage imageNamed:@"logo-placeholder-nearby.png"];
+    self.imageView.image = [UIImage imageNamed:@"lead-default.png"];
     _imageURL            = nil;
     _titleLabel.text     = nil;
     _titleText           = nil;
@@ -33,7 +33,7 @@ static CGFloat const WMFImageHeight = 160;
 
 - (void)awakeFromNib {
     [super awakeFromNib];
-    self.imageView.image             = [UIImage imageNamed:@"logo-placeholder-nearby.png"];
+    self.imageView.image             = [UIImage imageNamed:@"lead-default.png"];
     self.backgroundColor             = [UIColor whiteColor];
     self.contentView.backgroundColor = [UIColor whiteColor];
 }

--- a/Wikipedia/UI-V5/WMFArticlePreviewCell.xib
+++ b/Wikipedia/UI-V5/WMFArticlePreviewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="15A244d" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
@@ -27,8 +27,8 @@
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.20000000000000001" colorSpace="calibratedRGB"/>
                         <gestureRecognizers/>
                     </view>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pEK-59-fwO">
-                        <rect key="frame" x="8" y="81" width="345" height="39"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pEK-59-fwO" userLabel="Title Label">
+                        <rect key="frame" x="16" y="85" width="329" height="39"/>
                         <animations/>
                         <fontDescription key="fontDescription" name="TimesNewRomanPSMT" family="Times New Roman" pointSize="34"/>
                         <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -36,8 +36,8 @@
                         <color key="shadowColor" white="0.0" alpha="0.5" colorSpace="calibratedWhite"/>
                         <size key="shadowOffset" width="0.0" height="1"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbF-9q-HIn">
-                        <rect key="frame" x="8" y="130" width="345" height="20"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbF-9q-HIn" userLabel="Description Label">
+                        <rect key="frame" x="16" y="124" width="329" height="20"/>
                         <animations/>
                         <fontDescription key="fontDescription" name="TimesNewRomanPSMT" family="Times New Roman" pointSize="17"/>
                         <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -45,8 +45,8 @@
                         <color key="shadowColor" white="0.0" alpha="0.5" colorSpace="calibratedWhite"/>
                         <size key="shadowOffset" width="0.0" height="1"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AVJ-4N-Dr6">
-                        <rect key="frame" x="8" y="168" width="345" height="20"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AVJ-4N-Dr6" userLabel="Summary Label">
+                        <rect key="frame" x="16" y="168" width="329" height="20"/>
                         <animations/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -59,17 +59,17 @@
             <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="pEK-59-fwO" secondAttribute="trailing" constant="8" id="5bK-Ct-E22"/>
-                <constraint firstItem="vbF-9q-HIn" firstAttribute="bottom" secondItem="kPi-wU-UzV" secondAttribute="bottom" constant="-10" id="7DI-C8-Ce9"/>
+                <constraint firstAttribute="trailing" secondItem="pEK-59-fwO" secondAttribute="trailing" constant="16" id="5bK-Ct-E22"/>
+                <constraint firstItem="vbF-9q-HIn" firstAttribute="bottom" secondItem="kPi-wU-UzV" secondAttribute="bottom" constant="-16" id="7DI-C8-Ce9"/>
                 <constraint firstItem="kPi-wU-UzV" firstAttribute="leading" secondItem="4oB-M2-f0E" secondAttribute="leading" id="8cS-b1-6Cf"/>
                 <constraint firstItem="vbF-9q-HIn" firstAttribute="trailing" secondItem="pEK-59-fwO" secondAttribute="trailing" id="Bwg-G1-AHL"/>
                 <constraint firstItem="AVJ-4N-Dr6" firstAttribute="top" secondItem="kPi-wU-UzV" secondAttribute="bottom" constant="8" id="JLS-oe-btW"/>
                 <constraint firstItem="DHn-dQ-BBy" firstAttribute="leading" secondItem="kPi-wU-UzV" secondAttribute="leading" id="N3Z-Or-18E"/>
                 <constraint firstItem="DHn-dQ-BBy" firstAttribute="top" secondItem="kPi-wU-UzV" secondAttribute="top" id="TEC-wc-uVA"/>
                 <constraint firstItem="vbF-9q-HIn" firstAttribute="leading" secondItem="pEK-59-fwO" secondAttribute="leading" id="VP5-MT-WVV"/>
-                <constraint firstItem="vbF-9q-HIn" firstAttribute="top" secondItem="pEK-59-fwO" secondAttribute="bottom" constant="10" id="a4q-aQ-EEg"/>
+                <constraint firstItem="vbF-9q-HIn" firstAttribute="top" secondItem="pEK-59-fwO" secondAttribute="bottom" id="a4q-aQ-EEg"/>
                 <constraint firstItem="DHn-dQ-BBy" firstAttribute="trailing" secondItem="kPi-wU-UzV" secondAttribute="trailing" id="aYN-Wp-RZG"/>
-                <constraint firstItem="pEK-59-fwO" firstAttribute="leading" secondItem="4oB-M2-f0E" secondAttribute="leading" constant="8" id="cbI-rk-WYN"/>
+                <constraint firstItem="pEK-59-fwO" firstAttribute="leading" secondItem="4oB-M2-f0E" secondAttribute="leading" constant="16" id="cbI-rk-WYN"/>
                 <constraint firstItem="kPi-wU-UzV" firstAttribute="top" secondItem="4oB-M2-f0E" secondAttribute="top" id="gqX-Rl-5tH"/>
                 <constraint firstItem="vbF-9q-HIn" firstAttribute="trailing" secondItem="AVJ-4N-Dr6" secondAttribute="trailing" id="jet-NL-aB8"/>
                 <constraint firstAttribute="trailing" secondItem="kPi-wU-UzV" secondAttribute="trailing" id="xDh-kd-k8A"/>

--- a/Wikipedia/UI-V5/WMFArticleViewController.storyboard
+++ b/Wikipedia/UI-V5/WMFArticleViewController.storyboard
@@ -26,8 +26,12 @@
                                         <segue destination="7Or-9F-7Br" kind="embed" id="HdJ-OF-Rfg"/>
                                     </connections>
                                 </containerView>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aRr-YL-vMe" userLabel="Gray Overlay">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="250"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.20000000000000001" colorSpace="calibratedWhite"/>
+                                </view>
                                 <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pfp-fe-IJA" userLabel="Title Label">
-                                    <rect key="frame" x="20" y="134" width="374" height="60"/>
+                                    <rect key="frame" x="20" y="144" width="374" height="60"/>
                                     <animations/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <constraints>
@@ -65,19 +69,29 @@
                             <animations/>
                             <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             <constraints>
+                                <constraint firstItem="aRr-YL-vMe" firstAttribute="top" secondItem="fN6-15-6k9" secondAttribute="top" id="8d1-83-weB"/>
+                                <constraint firstItem="NaE-rZ-0jM" firstAttribute="top" secondItem="aRr-YL-vMe" secondAttribute="bottom" id="AHd-pY-zhe"/>
                                 <constraint firstItem="7Lr-kU-lXN" firstAttribute="top" secondItem="fN6-15-6k9" secondAttribute="top" constant="10" id="AIP-LN-XUw"/>
                                 <constraint firstAttribute="bottom" secondItem="N3F-xg-lcP" secondAttribute="bottom" id="CD2-kI-NCt"/>
                                 <constraint firstItem="NaE-rZ-0jM" firstAttribute="leading" secondItem="fN6-15-6k9" secondAttribute="leading" constant="20" symbolic="YES" id="D0Q-Xt-uMD"/>
+                                <constraint firstItem="aRr-YL-vMe" firstAttribute="leading" secondItem="fN6-15-6k9" secondAttribute="leading" id="EPg-eJ-eXU"/>
                                 <constraint firstAttribute="bottom" secondItem="NaE-rZ-0jM" secondAttribute="bottom" constant="20" symbolic="YES" id="F0s-h0-85m"/>
                                 <constraint firstItem="Pfp-fe-IJA" firstAttribute="leading" secondItem="fN6-15-6k9" secondAttribute="leading" constant="20" symbolic="YES" id="JQ5-YK-uKU"/>
+                                <constraint firstAttribute="bottom" secondItem="aRr-YL-vMe" secondAttribute="bottom" id="LbF-QT-aeI"/>
                                 <constraint firstItem="N3F-xg-lcP" firstAttribute="top" secondItem="fN6-15-6k9" secondAttribute="top" id="Mpl-Ow-U0n"/>
+                                <constraint firstAttribute="trailing" secondItem="aRr-YL-vMe" secondAttribute="trailing" id="PlI-Qz-yr0"/>
                                 <constraint firstAttribute="trailing" secondItem="N3F-xg-lcP" secondAttribute="trailing" id="RMB-Db-paF"/>
-                                <constraint firstItem="NaE-rZ-0jM" firstAttribute="top" secondItem="Pfp-fe-IJA" secondAttribute="bottom" constant="10" id="SA0-IK-ch8"/>
+                                <constraint firstItem="NaE-rZ-0jM" firstAttribute="top" secondItem="Pfp-fe-IJA" secondAttribute="bottom" id="SA0-IK-ch8"/>
                                 <constraint firstAttribute="trailing" secondItem="7Lr-kU-lXN" secondAttribute="trailing" constant="10" id="V8a-5S-mA5"/>
                                 <constraint firstAttribute="trailing" secondItem="Pfp-fe-IJA" secondAttribute="trailing" constant="20" symbolic="YES" id="bh8-Wu-2e1"/>
                                 <constraint firstAttribute="trailing" secondItem="NaE-rZ-0jM" secondAttribute="trailing" constant="20" symbolic="YES" id="s2t-ri-FTC"/>
                                 <constraint firstItem="N3F-xg-lcP" firstAttribute="leading" secondItem="fN6-15-6k9" secondAttribute="leading" id="xAt-od-Qyd"/>
                             </constraints>
+                            <variation key="default">
+                                <mask key="constraints">
+                                    <exclude reference="AHd-pY-zhe"/>
+                                </mask>
+                            </variation>
                             <connections>
                                 <outlet property="descriptionLabel" destination="NaE-rZ-0jM" id="9QH-pj-Yr0"/>
                                 <outlet property="descriptionTopConstraint" destination="SA0-IK-ch8" id="oMK-pl-5fi"/>

--- a/Wikipedia/UI-V5/WMFArticleViewController.storyboard
+++ b/Wikipedia/UI-V5/WMFArticleViewController.storyboard
@@ -67,7 +67,7 @@
                                 </button>
                             </subviews>
                             <animations/>
-                            <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             <constraints>
                                 <constraint firstItem="aRr-YL-vMe" firstAttribute="top" secondItem="fN6-15-6k9" secondAttribute="top" id="8d1-83-weB"/>
                                 <constraint firstItem="NaE-rZ-0jM" firstAttribute="top" secondItem="aRr-YL-vMe" secondAttribute="bottom" id="AHd-pY-zhe"/>
@@ -320,6 +320,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="250"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <animations/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <collectionViewLayout key="collectionViewLayout" id="s93-Y9-at2" customClass="WMFCollectionViewPageLayout"/>
                         <cells>
                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" placeholderIntrinsicWidth="50" placeholderIntrinsicHeight="50" reuseIdentifier="WMFImageCollectionViewCell" id="BsT-fo-lkV" customClass="WMFImageCollectionViewCell">


### PR DESCRIPTION
- Switched placeholder image on article preview cell to use same
image used on the native article card.

- Small adjustments to title and description spacing.

- Added gray overlay to native article card for contrast with
title/description when image has white area(s). Used same
black w alpha as article preview cell.

- Fix for native article card transparent images showing black through transparent areas.