### PR TITLE
Fix underlying issue of the bounds error

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 		0E94AFF31B209857000BC5EA /* WMFSearchViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E94AFF21B209857000BC5EA /* WMFSearchViewController.m */; };
 		0E94AFF61B209882000BC5EA /* WMFArticleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E94AFF51B209882000BC5EA /* WMFArticleViewController.m */; };
 		0E94AFFB1B20A22C000BC5EA /* WMFStyleManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E94AFFA1B20A22C000BC5EA /* WMFStyleManager.m */; };
+		0E9824981B8FF618003F9B84 /* WMFSelfSizingWaterfallCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E9824971B8FF618003F9B84 /* WMFSelfSizingWaterfallCollectionViewLayout.m */; };
 		0EA0BF3C1B8AAB6300BA423E /* WMFShadowCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EA0BF3B1B8AAB6300BA423E /* WMFShadowCell.m */; };
 		0EA35C4A1B6BB85100D9CFE6 /* WMFArticleContainerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EA35C491B6BB85100D9CFE6 /* WMFArticleContainerViewController.m */; };
 		0EA4402E1AA6281200B09DBA /* NSDateFormatter+WMFExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EA4402D1AA6281200B09DBA /* NSDateFormatter+WMFExtensions.m */; };
@@ -900,6 +901,8 @@
 		0E94AFF51B209882000BC5EA /* WMFArticleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFArticleViewController.m; sourceTree = "<group>"; };
 		0E94AFF91B20A22C000BC5EA /* WMFStyleManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFStyleManager.h; sourceTree = "<group>"; };
 		0E94AFFA1B20A22C000BC5EA /* WMFStyleManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFStyleManager.m; sourceTree = "<group>"; };
+		0E9824961B8FF618003F9B84 /* WMFSelfSizingWaterfallCollectionViewLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFSelfSizingWaterfallCollectionViewLayout.h; sourceTree = "<group>"; };
+		0E9824971B8FF618003F9B84 /* WMFSelfSizingWaterfallCollectionViewLayout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFSelfSizingWaterfallCollectionViewLayout.m; sourceTree = "<group>"; };
 		0EA0BF3A1B8AAB6300BA423E /* WMFShadowCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFShadowCell.h; sourceTree = "<group>"; };
 		0EA0BF3B1B8AAB6300BA423E /* WMFShadowCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFShadowCell.m; sourceTree = "<group>"; };
 		0EA35C481B6BB85100D9CFE6 /* WMFArticleContainerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFArticleContainerViewController.h; sourceTree = "<group>"; };
@@ -2495,6 +2498,8 @@
 				0E03E2921B84392100C1FBD7 /* WMFHomeSectionController.h */,
 				0E03E2971B845F2F00C1FBD7 /* SSSectionedDataSource+WMFSectionConvenience.h */,
 				0E03E2981B845F2F00C1FBD7 /* SSSectionedDataSource+WMFSectionConvenience.m */,
+				0E9824961B8FF618003F9B84 /* WMFSelfSizingWaterfallCollectionViewLayout.h */,
+				0E9824971B8FF618003F9B84 /* WMFSelfSizingWaterfallCollectionViewLayout.m */,
 				0E2691031B86BBC0009B8605 /* Related Section */,
 				0ED6897C1B8246F400B30427 /* Nearby Section */,
 				0E03E2861B83948B00C1FBD7 /* Views */,
@@ -3705,6 +3710,7 @@
 				0449E63918AAA26A00D51524 /* NSHTTPCookieStorage+CloneCookie.m in Sources */,
 				04C695CE18ED08D900D9F2DA /* UIView+WMFSearchSubviews.m in Sources */,
 				0487048E19F8262600B7D307 /* WikipediaZeroMessageFetcher.m in Sources */,
+				0E9824981B8FF618003F9B84 /* WMFSelfSizingWaterfallCollectionViewLayout.m in Sources */,
 				BC092BA21B19135700093C59 /* WMFApiJsonResponseSerializer.m in Sources */,
 				0EFB0F221B31EE2D00D05C08 /* Image.m in Sources */,
 				D4F277FB194235A00032BA38 /* ProtectedEditAttemptFunnel.m in Sources */,

--- a/Wikipedia/UI-V5/WMFSelfSizingWaterfallCollectionViewLayout.h
+++ b/Wikipedia/UI-V5/WMFSelfSizingWaterfallCollectionViewLayout.h
@@ -1,0 +1,6 @@
+
+#import "SelfSizingWaterfallCollectionViewLayout.h"
+
+@interface WMFSelfSizingWaterfallCollectionViewLayout : SelfSizingWaterfallCollectionViewLayout
+
+@end

--- a/Wikipedia/UI-V5/WMFSelfSizingWaterfallCollectionViewLayout.m
+++ b/Wikipedia/UI-V5/WMFSelfSizingWaterfallCollectionViewLayout.m
@@ -1,0 +1,14 @@
+
+#import "WMFSelfSizingWaterfallCollectionViewLayout.h"
+
+@implementation WMFSelfSizingWaterfallCollectionViewLayout
+
+- (CGSize)collectionViewContentSize {
+    if ([self.collectionView numberOfSections] == 1 && [self.collectionView numberOfItemsInSection:0] == 0) {
+        return self.collectionView.bounds.size;
+    }
+
+    return [super collectionViewContentSize];
+}
+
+@end

--- a/Wikipedia/UI-V5/iPhone_Root.storyboard
+++ b/Wikipedia/UI-V5/iPhone_Root.storyboard
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="15A244d" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="O8j-Xm-zXE">
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
@@ -216,7 +215,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <animations/>
-                        <collectionViewLayout key="collectionViewLayout" id="OM6-RR-VUO" customClass="SelfSizingWaterfallCollectionViewLayout"/>
+                        <collectionViewLayout key="collectionViewLayout" id="OM6-RR-VUO" customClass="WMFSelfSizingWaterfallCollectionViewLayout"/>
                         <cells/>
                         <connections>
                             <outlet property="dataSource" destination="qVm-oc-aaW" id="oec-qb-SMc"/>
@@ -239,7 +238,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <animations/>
                         <color key="backgroundColor" red="0.94499534368515015" green="0.94515722990036011" blue="0.94498521089553833" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <collectionViewLayout key="collectionViewLayout" id="PEa-JF-GrQ" customClass="SelfSizingWaterfallCollectionViewLayout"/>
+                        <collectionViewLayout key="collectionViewLayout" id="PEa-JF-GrQ" customClass="WMFSelfSizingWaterfallCollectionViewLayout"/>
                         <cells/>
                         <connections>
                             <outlet property="delegate" destination="ijM-Cp-AID" id="SC7-eq-goH"/>
@@ -324,7 +323,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="477"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <animations/>
-                        <collectionViewLayout key="collectionViewLayout" id="ic4-TR-7Nt" customClass="SelfSizingWaterfallCollectionViewLayout"/>
+                        <collectionViewLayout key="collectionViewLayout" id="ic4-TR-7Nt" customClass="WMFSelfSizingWaterfallCollectionViewLayout"/>
                         <cells/>
                         <connections>
                             <outlet property="dataSource" destination="4Pn-cn-DIj" id="bps-am-g8F"/>
@@ -345,7 +344,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <animations/>
-                        <collectionViewLayout key="collectionViewLayout" id="ETy-nN-umd" customClass="SelfSizingWaterfallCollectionViewLayout"/>
+                        <collectionViewLayout key="collectionViewLayout" id="ETy-nN-umd" customClass="WMFSelfSizingWaterfallCollectionViewLayout"/>
                         <cells/>
                         <connections>
                             <outlet property="dataSource" destination="2yz-KN-V6a" id="dqQ-eP-Tyk"/>


### PR DESCRIPTION
Also found this while working on the pop up

Following up on:
https://phabricator.wikimedia.org/T110381

The collection view layout is attempting to make calculations using Key Value Coding when the height of the cells is 0
(This occurs when there is a section, but not cells in the section)

This was still happening before the section was loaded when launching in landscape.
Launching in landscape causes the view to rotate prematurely kicking off layout logic.