### PR TITLE
Fix for cell shadows extending down too far and not resizing properly.

### DIFF
--- a/Wikipedia/UI-V5/UIView+WMFShadow.h
+++ b/Wikipedia/UI-V5/UIView+WMFShadow.h
@@ -15,10 +15,4 @@
  */
 - (void)wmf_setupShadow;
 
-/**
- *  Update the shadow based on bounds changes
- *  Call this whenever the bounds of the view changes to update the shadow
- */
-- (void)wmf_updateShadowPathBasedOnBounds;
-
 @end

--- a/Wikipedia/UI-V5/UIView+WMFShadow.m
+++ b/Wikipedia/UI-V5/UIView+WMFShadow.m
@@ -11,16 +11,11 @@
 @implementation UIView (WMFShadow)
 
 - (void)wmf_setupShadow {
-    self.clipsToBounds       = NO;
+    self.layer.masksToBounds = NO;
     self.layer.shadowColor   = [UIColor blackColor].CGColor;
-    self.layer.shadowOpacity = 0.15;
-    self.layer.shadowRadius  = 3.0;
+    self.layer.shadowOpacity = 0.2;
+    self.layer.shadowRadius  = 4.0;
     self.layer.shadowOffset  = CGSizeZero;
-    [self wmf_updateShadowPathBasedOnBounds];
-}
-
-- (void)wmf_updateShadowPathBasedOnBounds {
-    self.layer.shadowPath = [UIBezierPath bezierPathWithRect:CGRectInset(self.bounds, -1.0, -1.0)].CGPath;
 }
 
 @end

--- a/Wikipedia/UI-V5/WMFHomeSectionFooter.m
+++ b/Wikipedia/UI-V5/WMFHomeSectionFooter.m
@@ -10,9 +10,4 @@
     [self.backgroundView wmf_setupShadow];
 }
 
-- (void)setBounds:(CGRect)bounds {
-    [super setBounds:bounds];
-    [self.backgroundView wmf_updateShadowPathBasedOnBounds];
-}
-
 @end

--- a/Wikipedia/UI-V5/WMFShadowCell.m
+++ b/Wikipedia/UI-V5/WMFShadowCell.m
@@ -22,9 +22,4 @@
     [self.contentView wmf_setupShadow];
 }
 
-- (void)setBounds:(CGRect)bounds {
-    [super setBounds:bounds];
-    [self.contentView wmf_updateShadowPathBasedOnBounds];
-}
-
 @end


### PR DESCRIPTION
https://phabricator.wikimedia.org/T110442

**Before:** *Note: shadows are bright red for easy comparison.*
 
- Shadow doesn't extend to bottom of cell:
![screen shot 2015-09-01 at 5 59 36 pm](https://cloud.githubusercontent.com/assets/3143487/9620761/9e467356-50d3-11e5-82de-74c482c26e0f.png)
- Shadow wonky width after rotate:
![screen shot 2015-09-01 at 5 59 46 pm](https://cloud.githubusercontent.com/assets/3143487/9620763/9e4c951a-50d3-11e5-977b-2615e12d0bed.png)
-Moar wonk after rotating back to portrait:
![screen shot 2015-09-01 at 5 59 56 pm](https://cloud.githubusercontent.com/assets/3143487/9620762/9e49e4aa-50d3-11e5-89e2-455b9b14e593.png)

**After:**
![screen shot 2015-09-01 at 5 57 37 pm](https://cloud.githubusercontent.com/assets/3143487/9620772/ab75994e-50d3-11e5-921a-77d24f8c8293.png)
![screen shot 2015-09-01 at 5 57 49 pm](https://cloud.githubusercontent.com/assets/3143487/9620771/ab752d38-50d3-11e5-993d-36897d029773.png)
![screen shot 2015-09-01 at 5 57 32 pm](https://cloud.githubusercontent.com/assets/3143487/9620770/ab7288f8-50d3-11e5-9959-6f1067ef37eb.png)
^ I scrolled around on this last one - that's why it's not in same position as pre-rotation image.