### PR TITLE
fix alpha HockeyAppID

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -4228,7 +4228,7 @@
 					"-Werror=incomplete-implementation",
 					"-Werror=nonnull",
 				);
-				WMF_HOCKEYAPP_IDENTIFIER = 35ef86a164e10f9c01c634c640ec2f0a;
+				WMF_HOCKEYAPP_IDENTIFIER = 95e2f42fa3eadeb025f319b58ef86aeb;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Alpha;


### PR DESCRIPTION
We had the following mixup:

- App was being uploaded to Wikipedia Alpha (beta) on HockeyApp
- Crash reports were being sent to Wikipedia Alpha (alpha) on HockeyApp

I had already deleted Wikipedia Alpha (alpha) since builds weren't being uploaded there, this change tells the app to upload reports to the correct HockeyApp ID.

Proof: https://rink.hockeyapp.net/manage/apps/206527/app_versions/42/crash_reasons/44189601?type=crashes