### PR TITLE
Update recent searches screen layout according to new mocks.

### DIFF
--- a/Wikipedia/UI-V5/WMFHomeSectionHeader.xib
+++ b/Wikipedia/UI-V5/WMFHomeSectionHeader.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="15A244d" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
@@ -8,11 +8,11 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionReusableView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="WMFHomeSectionHeader" id="DH9-hh-2Hp" customClass="WMFHomeSectionHeader">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="50"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Text" translatesAutoresizingMaskIntoConstraints="NO" id="Bj8-RH-fPG">
-                    <rect key="frame" x="2" y="7" width="590" height="37"/>
+                    <rect key="frame" x="2" y="12" width="310" height="37"/>
                     <animations/>
                     <constraints>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="Abw-0C-Eqo"/>
@@ -33,6 +33,7 @@
             <connections>
                 <outlet property="titleView" destination="Bj8-RH-fPG" id="kLd-uI-lUi"/>
             </connections>
+            <point key="canvasLocation" x="198.5" y="358"/>
         </collectionReusableView>
     </objects>
 </document>

--- a/Wikipedia/UI-V5/iPhone_Root.storyboard
+++ b/Wikipedia/UI-V5/iPhone_Root.storyboard
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="15A244d" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="O8j-Xm-zXE">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="O8j-Xm-zXE">
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
@@ -262,51 +263,51 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="507"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="ka6-Dy-C8P">
-                                <rect key="frame" x="0.0" y="50" width="600" height="457"/>
-                                <animations/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <connections>
-                                    <outlet property="dataSource" destination="Rqy-g9-mNA" id="5go-DG-2bZ"/>
-                                    <outlet property="delegate" destination="Rqy-g9-mNA" id="qWP-b9-11L"/>
-                                </connections>
-                            </tableView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bGx-k7-AQ1" userLabel="Title Label" customClass="PaddedLabel">
-                                <rect key="frame" x="0.0" y="0.0" width="525" height="50"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bGx-k7-AQ1" userLabel="Title Label">
+                                <rect key="frame" x="25" y="8" width="492" height="40"/>
                                 <animations/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="50" placeholder="YES" id="MJn-Fv-Xfk"/>
+                                    <constraint firstAttribute="height" constant="40" id="MJn-Fv-Xfk"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7SS-UN-pgW" userLabel="Trash Button" customClass="WikiGlyphButton">
-                                <rect key="frame" x="525" y="0.0" width="75" height="50"/>
+                                <rect key="frame" x="525" y="8" width="75" height="40"/>
                                 <animations/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="75" id="1mE-o0-SnE"/>
                                 </constraints>
                             </view>
+                            <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="ka6-Dy-C8P">
+                                <rect key="frame" x="0.0" y="48" width="600" height="459"/>
+                                <animations/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="Rqy-g9-mNA" id="5go-DG-2bZ"/>
+                                    <outlet property="delegate" destination="Rqy-g9-mNA" id="qWP-b9-11L"/>
+                                </connections>
+                            </tableView>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="0.94509803921568625" green="0.94509803921568625" blue="0.94509803921568625" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="U8y-aI-ssO" firstAttribute="top" secondItem="ka6-Dy-C8P" secondAttribute="bottom" id="0eP-KB-sYM"/>
-                            <constraint firstItem="bGx-k7-AQ1" firstAttribute="top" secondItem="wQU-Qf-hyW" secondAttribute="bottom" id="8g7-OL-dpp"/>
-                            <constraint firstItem="ka6-Dy-C8P" firstAttribute="top" secondItem="7SS-UN-pgW" secondAttribute="bottom" id="Hea-Em-Lo4"/>
+                            <constraint firstItem="bGx-k7-AQ1" firstAttribute="top" secondItem="wQU-Qf-hyW" secondAttribute="bottom" constant="8" id="8g7-OL-dpp"/>
                             <constraint firstAttribute="trailing" secondItem="ka6-Dy-C8P" secondAttribute="trailing" id="Nxp-8p-jAo"/>
-                            <constraint firstItem="bGx-k7-AQ1" firstAttribute="leading" secondItem="un9-Tr-mR7" secondAttribute="leading" id="Rqc-W8-ezB"/>
+                            <constraint firstItem="bGx-k7-AQ1" firstAttribute="leading" secondItem="un9-Tr-mR7" secondAttribute="leading" constant="25" id="Rqc-W8-ezB"/>
                             <constraint firstItem="ka6-Dy-C8P" firstAttribute="leading" secondItem="un9-Tr-mR7" secondAttribute="leading" id="T76-im-h7m"/>
                             <constraint firstItem="ka6-Dy-C8P" firstAttribute="top" secondItem="bGx-k7-AQ1" secondAttribute="bottom" id="YB4-03-c48"/>
+                            <constraint firstItem="7SS-UN-pgW" firstAttribute="top" secondItem="bGx-k7-AQ1" secondAttribute="top" id="cHr-cY-eOK"/>
+                            <constraint firstItem="7SS-UN-pgW" firstAttribute="bottom" secondItem="bGx-k7-AQ1" secondAttribute="bottom" id="ehK-vH-ktM"/>
                             <constraint firstAttribute="trailing" secondItem="7SS-UN-pgW" secondAttribute="trailing" id="hBO-Jx-cJe"/>
-                            <constraint firstItem="7SS-UN-pgW" firstAttribute="leading" secondItem="bGx-k7-AQ1" secondAttribute="trailing" id="hC9-Qy-49A"/>
-                            <constraint firstItem="7SS-UN-pgW" firstAttribute="top" secondItem="wQU-Qf-hyW" secondAttribute="bottom" id="rcG-1H-QW3"/>
+                            <constraint firstItem="7SS-UN-pgW" firstAttribute="leading" secondItem="bGx-k7-AQ1" secondAttribute="trailing" constant="8" symbolic="YES" id="hC9-Qy-49A"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="headingLabel" destination="bGx-k7-AQ1" id="jiB-LK-Nd9"/>
+                        <outlet property="headingLabel" destination="bGx-k7-AQ1" id="c8h-qY-42y"/>
                         <outlet property="table" destination="ka6-Dy-C8P" id="ONG-nR-ET1"/>
                         <outlet property="trashButton" destination="7SS-UN-pgW" id="svA-sm-1IW"/>
                     </connections>

--- a/Wikipedia/View Controllers/RecentSearches/RecentSearchCell.h
+++ b/Wikipedia/View Controllers/RecentSearches/RecentSearchCell.h
@@ -3,10 +3,8 @@
 
 #import <UIKit/UIKit.h>
 
-@class PaddedLabel;
-
 @interface RecentSearchCell : UITableViewCell
 
-@property (weak, nonatomic) IBOutlet PaddedLabel* label;
+@property (weak, nonatomic) IBOutlet UILabel* label;
 
 @end

--- a/Wikipedia/View Controllers/RecentSearches/RecentSearchCell.m
+++ b/Wikipedia/View Controllers/RecentSearches/RecentSearchCell.m
@@ -2,59 +2,43 @@
 //  Copyright (c) 2014 Wikimedia Foundation. Provided under MIT-style license; please copy and modify!
 
 #import "RecentSearchCell.h"
-#import "PaddedLabel.h"
-#import "NSObject+ConstraintsScale.h"
-#import "Defines.h"
 #import "WikiGlyph_Chars.h"
 #import "UIFont+WMFStyle.h"
+#import "UIView+WMFShadow.h"
+#import "UIColor+WMFHexColor.h"
 
-#define FONT_SIZE (16.0f * MENUS_SCALE_MULTIPLIER)
-#define FONT_COLOR [UIColor grayColor]
-#define ICON_SIZE (20.0f * MENUS_SCALE_MULTIPLIER)
-#define ICON_GLYPH WIKIGLYPH_MAGNIFY_BOLD
-#define BORDER_COLOR [UIColor colorWithWhite:0.9 alpha:1.0]
-#define MAGNIFY_ICON_COLOR [UIColor colorWithWhite:0.8 alpha:1.0]
+static CGFloat const magnifyIconSize    = 28.f;
+static NSInteger const magnifyIconColor = 0x777777;
 
 @interface RecentSearchCell ()
 
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint* topBorderHeightConstraint;
-@property (weak, nonatomic) IBOutlet UIView* topBorderView;
-@property (strong, nonatomic) NSAttributedString* magnifyIconString;
-@property (weak, nonatomic) IBOutlet PaddedLabel* iconLabel;
+@property (strong, nonatomic) IBOutlet UIView* shadowView;
+@property (strong, nonatomic) IBOutlet UILabel* iconLabel;
 
 @end
 
 @implementation RecentSearchCell
 
 - (void)awakeFromNib {
-    self.selectionStyle = UITableViewCellSelectionStyleNone;
-
-    self.iconLabel.attributedText           = [self getAttributedIconString];
-    self.topBorderView.backgroundColor      = BORDER_COLOR;
-    self.topBorderHeightConstraint.constant = 1.0f / [UIScreen mainScreen].scale;
-    self.label.font                         = [UIFont systemFontOfSize:FONT_SIZE];
-
-    self.label.numberOfLines = 1;
-    self.label.lineBreakMode = NSLineBreakByTruncatingTail; // <-- Don't make truncating a habit! :) Is bad.
-
-    self.label.textColor = FONT_COLOR;
-
-    [self adjustConstraintsScaleForViews:@[self.label, self.iconLabel]];
+    self.iconLabel.attributedText = [RecentSearchCell attributedIconString];
+    [self.shadowView wmf_setupShadow];
+    self.contentView.backgroundColor = [UIColor clearColor];
+    self.backgroundColor             = [UIColor clearColor];
 }
 
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
-    [super setSelected:selected animated:animated];
-
-    // Configure the view for the selected state
-}
-
-- (NSAttributedString*)getAttributedIconString {
-    return [[NSAttributedString alloc] initWithString:ICON_GLYPH
-                                           attributes:@{
-                NSFontAttributeName: [UIFont wmf_glyphFontOfSize:ICON_SIZE],
-                NSForegroundColorAttributeName: MAGNIFY_ICON_COLOR,
-                NSBaselineOffsetAttributeName: @1
-            }];
++ (NSAttributedString*)attributedIconString {
+    static dispatch_once_t once;
+    static NSAttributedString* sharedString;
+    dispatch_once(&once, ^{
+        sharedString =
+            [[NSAttributedString alloc] initWithString:WIKIGLYPH_MAGNIFY_BOLD
+                                            attributes:@{
+                 NSFontAttributeName: [UIFont wmf_glyphFontOfSize:magnifyIconSize],
+                 NSForegroundColorAttributeName: [UIColor wmf_colorWithHex:magnifyIconColor alpha:1.0f],
+                 NSBaselineOffsetAttributeName: @1
+             }];
+    });
+    return sharedString;
 }
 
 @end

--- a/Wikipedia/View Controllers/RecentSearches/RecentSearchCell.xib
+++ b/Wikipedia/View Controllers/RecentSearches/RecentSearchCell.xib
@@ -1,60 +1,61 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6250" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="76" id="KGk-i7-Jjw" customClass="RecentSearchCell">
+        <tableViewCell opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="76" id="KGk-i7-Jjw" customClass="RecentSearchCell">
             <rect key="frame" x="0.0" y="0.0" width="338" height="76"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wta-pq-kUh" customClass="PaddedLabel">
-                        <rect key="frame" x="46" y="5" width="276" height="65"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WF0-wK-GT2" userLabel="Top Border View">
-                        <rect key="frame" x="0.0" y="0.0" width="338" height="1"/>
-                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZeT-gY-dY9" userLabel="Shadow View">
+                        <rect key="frame" x="10" y="8" width="318" height="60"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wta-pq-kUh">
+                                <rect key="frame" x="40" y="0.0" width="278" height="60"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F9j-lW-tit" userLabel="Icon Label">
+                                <rect key="frame" x="0.0" y="0.0" width="40" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="40" id="T4U-j3-9Dg"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="1" id="UG4-bJ-juH"/>
+                            <constraint firstAttribute="bottom" secondItem="F9j-lW-tit" secondAttribute="bottom" id="CG2-jC-HeJ"/>
+                            <constraint firstAttribute="trailing" secondItem="wta-pq-kUh" secondAttribute="trailing" id="HLR-ja-9NW"/>
+                            <constraint firstItem="F9j-lW-tit" firstAttribute="leading" secondItem="ZeT-gY-dY9" secondAttribute="leading" id="IzT-4c-fln"/>
+                            <constraint firstItem="F9j-lW-tit" firstAttribute="top" secondItem="ZeT-gY-dY9" secondAttribute="top" id="m2P-6a-nsE"/>
+                            <constraint firstItem="wta-pq-kUh" firstAttribute="top" secondItem="ZeT-gY-dY9" secondAttribute="top" id="pwE-wd-51E"/>
+                            <constraint firstAttribute="bottom" secondItem="wta-pq-kUh" secondAttribute="bottom" id="vry-V1-SGI"/>
+                            <constraint firstItem="wta-pq-kUh" firstAttribute="leading" secondItem="F9j-lW-tit" secondAttribute="trailing" id="ywH-RS-s6P"/>
                         </constraints>
                     </view>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F9j-lW-tit" userLabel="Icon Label" customClass="PaddedLabel">
-                        <rect key="frame" x="4" y="1" width="42" height="74"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="42" id="T4U-j3-9Dg"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="F9j-lW-tit" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="4" id="JZH-iR-XHj"/>
-                    <constraint firstAttribute="trailing" secondItem="wta-pq-kUh" secondAttribute="trailing" constant="16" id="MV9-8w-9zF"/>
-                    <constraint firstAttribute="bottom" secondItem="wta-pq-kUh" secondAttribute="bottom" constant="5" id="PAe-5m-TPy"/>
-                    <constraint firstItem="F9j-lW-tit" firstAttribute="top" secondItem="WF0-wK-GT2" secondAttribute="bottom" id="bo9-ya-ZLL"/>
-                    <constraint firstItem="wta-pq-kUh" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="5" id="bpt-P4-5gw"/>
-                    <constraint firstAttribute="bottom" secondItem="F9j-lW-tit" secondAttribute="bottom" id="bwU-R8-o2O"/>
-                    <constraint firstItem="wta-pq-kUh" firstAttribute="leading" secondItem="F9j-lW-tit" secondAttribute="trailing" id="cpq-KU-YXd"/>
-                    <constraint firstItem="WF0-wK-GT2" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="dxN-m0-hNz"/>
-                    <constraint firstAttribute="trailing" secondItem="WF0-wK-GT2" secondAttribute="trailing" id="hx6-pp-9Dy"/>
-                    <constraint firstItem="WF0-wK-GT2" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="o4x-vq-EsY"/>
+                    <constraint firstAttribute="trailing" secondItem="ZeT-gY-dY9" secondAttribute="trailing" constant="10" id="dPF-8J-XNe"/>
+                    <constraint firstItem="ZeT-gY-dY9" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="10" id="eIV-IX-zEd"/>
+                    <constraint firstItem="ZeT-gY-dY9" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="ha6-5Q-xEV"/>
+                    <constraint firstAttribute="bottom" secondItem="ZeT-gY-dY9" secondAttribute="bottom" constant="8" id="uaE-aR-rDd"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
                 <outlet property="iconLabel" destination="F9j-lW-tit" id="xhd-Oy-3St"/>
                 <outlet property="label" destination="wta-pq-kUh" id="jn4-Gb-08f"/>
-                <outlet property="topBorderHeightConstraint" destination="UG4-bJ-juH" id="S5E-cW-8wo"/>
-                <outlet property="topBorderView" destination="WF0-wK-GT2" id="V8V-gw-Ee3"/>
+                <outlet property="shadowView" destination="ZeT-gY-dY9" id="9qk-ge-JIC"/>
             </connections>
             <point key="canvasLocation" x="250" y="323"/>
         </tableViewCell>

--- a/Wikipedia/View Controllers/RecentSearches/RecentSearchesViewController.m
+++ b/Wikipedia/View Controllers/RecentSearches/RecentSearchesViewController.m
@@ -3,8 +3,6 @@
 
 #import "RecentSearchesViewController.h"
 #import "RecentSearchCell.h"
-#import "PaddedLabel.h"
-#import "NSObject+ConstraintsScale.h"
 #import "WikiGlyphButton.h"
 #import "WikiGlyphLabel.h"
 #import "WikiGlyph_Chars.h"
@@ -12,22 +10,19 @@
 #import "UIViewController+WMFHideKeyboard.h"
 #import "UIView+TemporaryAnimatedXF.h"
 #import "Wikipedia-Swift.h"
+#import "UIColor+WMFHexColor.h"
 
-#define CELL_HEIGHT (48.0 * MENUS_SCALE_MULTIPLIER)
-#define HEADING_FONT_SIZE (16.0 * MENUS_SCALE_MULTIPLIER)
-#define HEADING_COLOR [UIColor blackColor]
-#define HEADING_PADDING UIEdgeInsetsMake(22.0f, 16.0f, 22.0f, 16.0f)
-#define TRASH_FONT_SIZE (30.0 * MENUS_SCALE_MULTIPLIER)
-#define TRASH_COLOR [UIColor grayColor]
-#define TRASH_DISABLED_COLOR [UIColor lightGrayColor]
-#define PLIST_FILE_NAME @"Recent.plist"
-#define LIMIT 100
+static CGFloat const cellHeight           = 70.f;
+static CGFloat const trashFontSize        = 30.f;
+static NSInteger const trashColor         = 0x777777;
+static NSString* const pListFileName      = @"Recent.plist";
+static NSUInteger const recentSearchLimit = 100.f;
 
 @interface RecentSearchesViewController ()
 
-@property (weak, nonatomic) IBOutlet UITableView* table;
-@property (weak, nonatomic) IBOutlet PaddedLabel* headingLabel;
-@property (weak, nonatomic) IBOutlet WikiGlyphButton* trashButton;
+@property (strong, nonatomic) IBOutlet UITableView* table;
+@property (strong, nonatomic) IBOutlet UILabel* headingLabel;
+@property (strong, nonatomic) IBOutlet WikiGlyphButton* trashButton;
 
 @property (strong, nonatomic) NSMutableArray* tableDataArray;
 
@@ -46,9 +41,10 @@
 
     [self loadDataArrayFromFile];
 
-    [self adjustConstraintsScaleForViews:@[self.headingLabel, self.trashButton]];
-
     [self updateTrashButtonEnabledState];
+
+    [self.table setBackgroundColor:[UIColor clearColor]];
+    self.table.backgroundView.backgroundColor = [UIColor clearColor];
 }
 
 - (NSUInteger)recentSearchesItemCount {
@@ -62,16 +58,13 @@
 }
 
 - (void)setupHeadingLabel {
-    self.headingLabel.padding   = HEADING_PADDING;
-    self.headingLabel.font      = [UIFont boldSystemFontOfSize:HEADING_FONT_SIZE];
-    self.headingLabel.textColor = HEADING_COLOR;
-    self.headingLabel.text      = MWLocalizedString(@"search-recent-title", nil);
+    self.headingLabel.text = MWLocalizedString(@"search-recent-title", nil);
 }
 
 - (void)setupTrashButton {
     self.trashButton.backgroundColor = [UIColor clearColor];
-    [self.trashButton.label setWikiText:WIKIGLYPH_TRASH color:TRASH_COLOR
-                                   size:TRASH_FONT_SIZE
+    [self.trashButton.label setWikiText:WIKIGLYPH_TRASH color:[UIColor wmf_colorWithHex:trashColor alpha:1.0f]
+                                   size:trashFontSize
                          baselineOffset:1];
 
     self.trashButton.accessibilityLabel  = MWLocalizedString(@"menu-trash-accessibility-label", nil);
@@ -103,8 +96,8 @@
          @"type": @(searchType)
      } atIndex:0];
 
-    if (self.tableDataArray.count > LIMIT) {
-        self.tableDataArray = [self.tableDataArray subarrayWithRange:NSMakeRange(0, LIMIT)].mutableCopy;
+    if (self.tableDataArray.count > recentSearchLimit) {
+        self.tableDataArray = [self.tableDataArray subarrayWithRange:NSMakeRange(0, recentSearchLimit)].mutableCopy;
     }
 
     [self saveDataArrayToFile];
@@ -139,7 +132,7 @@
 - (NSString*)getFilePath {
     NSArray* paths               = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString* documentsDirectory = [paths objectAtIndex:0];
-    return [documentsDirectory stringByAppendingPathComponent:PLIST_FILE_NAME];
+    return [documentsDirectory stringByAppendingPathComponent:pListFileName];
 }
 
 - (void)saveDataArrayToFile {
@@ -205,7 +198,7 @@
 }
 
 - (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {
-    return CELL_HEIGHT;
+    return cellHeight;
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView*)tableView {

--- a/Wikipedia/View Controllers/RecentSearches/RecentSearchesViewController.m
+++ b/Wikipedia/View Controllers/RecentSearches/RecentSearchesViewController.m
@@ -97,7 +97,7 @@ static NSUInteger const recentSearchLimit = 100.f;
      } atIndex:0];
 
     if (self.tableDataArray.count > recentSearchLimit) {
-        self.tableDataArray = [self.tableDataArray subarrayWithRange:NSMakeRange(0, recentSearchLimit)].mutableCopy;
+        self.tableDataArray = [self.tableDataArray wmf_safeSubarrayWithRange:NSMakeRange(0, recentSearchLimit)].mutableCopy;
     }
 
     [self saveDataArrayToFile];


### PR DESCRIPTION
https://phabricator.wikimedia.org/T110724

Note: ended up diverging from mock a bit based on conversations
with Corey. For now the individual recent search terms are styled
more like small cards with their own shadow.

(reminder: this ticket doesn't address the search box itself)

**Before:**
![screen shot 2015-09-02 at 2 18 56 pm](https://cloud.githubusercontent.com/assets/3143487/9644948/ba017abe-517d-11e5-8feb-b22fab0748e8.png)

**After:**
![screen shot 2015-09-02 at 2 14 21 pm](https://cloud.githubusercontent.com/assets/3143487/9644954/c0ca3aac-517d-11e5-9f77-60929410b5b9.png)
