### PR TITLE
Search bar styling

### DIFF
--- a/Wikipedia/UI-V5/WMFSearchViewController.m
+++ b/Wikipedia/UI-V5/WMFSearchViewController.m
@@ -131,6 +131,14 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
     [self.searchBar becomeFirstResponder];
+    [self configureSearchBar:self.searchBar];
+}
+
+-(void)configureSearchBar:(UISearchBar*)searchBar {
+    [searchBar setPlaceholder:@"Search Wikipedia"];
+    searchBar.tintColor = [UIColor darkGrayColor];
+    searchBar.searchBarStyle  = UISearchBarStyleMinimal;
+    searchBar.backgroundColor = [UIColor colorWithRed:0.9294 green:0.9294 blue:0.9294 alpha:1.0];
 }
 
 - (void)prepareForSegue:(UIStoryboardSegue*)segue sender:(id)sender {

--- a/Wikipedia/UI-V5/WMFSearchViewController.m
+++ b/Wikipedia/UI-V5/WMFSearchViewController.m
@@ -134,9 +134,9 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
     [self configureSearchBar:self.searchBar];
 }
 
--(void)configureSearchBar:(UISearchBar*)searchBar {
+- (void)configureSearchBar:(UISearchBar*)searchBar {
     [searchBar setPlaceholder:@"Search Wikipedia"];
-    searchBar.tintColor = [UIColor darkGrayColor];
+    searchBar.tintColor       = [UIColor darkGrayColor];
     searchBar.searchBarStyle  = UISearchBarStyleMinimal;
     searchBar.backgroundColor = [UIColor colorWithRed:0.9294 green:0.9294 blue:0.9294 alpha:1.0];
 }

--- a/Wikipedia/View Controllers/RecentSearches/RecentSearchCell.m
+++ b/Wikipedia/View Controllers/RecentSearches/RecentSearchCell.m
@@ -7,7 +7,7 @@
 #import "UIView+WMFShadow.h"
 #import "UIColor+WMFHexColor.h"
 
-static CGFloat const magnifyIconSize    = 28.f;
+static CGFloat const magnifyIconSize    = 26.f;
 static NSInteger const magnifyIconColor = 0x777777;
 
 @interface RecentSearchCell ()

--- a/Wikipedia/View Controllers/RecentSearches/RecentSearchCell.xib
+++ b/Wikipedia/View Controllers/RecentSearches/RecentSearchCell.xib
@@ -19,7 +19,7 @@
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wta-pq-kUh">
                                 <rect key="frame" x="40" y="0.0" width="278" height="60"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>

--- a/Wikipedia/View Controllers/RecentSearches/RecentSearchesViewController.m
+++ b/Wikipedia/View Controllers/RecentSearches/RecentSearchesViewController.m
@@ -12,7 +12,7 @@
 #import "Wikipedia-Swift.h"
 #import "UIColor+WMFHexColor.h"
 
-static CGFloat const cellHeight           = 70.f;
+static CGFloat const cellHeight           = 68.f;
 static CGFloat const trashFontSize        = 30.f;
 static NSInteger const trashColor         = 0x777777;
 static NSString* const pListFileName      = @"Recent.plist";


### PR DESCRIPTION
https://phabricator.wikimedia.org/T110726

Updates to search bar styling. Differs from mock because of navigation bar issues.

Will definitely need follow-on styling but that will have to wait until further design direction.

In *before/after* screenshots below notice the following:
- Search bar background color changed to match view background (eliminates weird color banding)
- Search term magnifying glass icon sized reduced
- Search term text size reduced to better match other text size
- Cancel button text color no longer blue
- "Search Wikipedia" search box placeholder text added

**Before:**
<img width="487" alt="screen shot 2015-09-02 at 5 06 30 pm" src="https://cloud.githubusercontent.com/assets/3143487/9647750/1a98c992-5195-11e5-9236-bb26c9e8f668.png">

**After:**
<img width="487" alt="screen shot 2015-09-02 at 5 05 29 pm" src="https://cloud.githubusercontent.com/assets/3143487/9647752/1fca06ba-5195-11e5-9d37-d54d4adfd94a.png">