### PR TITLE
Search crash fix

### DIFF
--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -155,7 +155,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+    [coordinator animateAlongsideTransition:^(id < UIViewControllerTransitionCoordinatorContext > context) {
         [self updateInsetsForArticleViewController];
         [self.previewController updatePreviewWithSizeChange:size];
     } completion:NULL];
@@ -272,19 +272,18 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Popup
 
 - (void)presentPopupForTitle:(MWKTitle*)title {
-    
     MWKArticle* article = [self.dataStore articleWithTitle:title];
 
     WMFArticleContainerViewController* vc =
         [[WMFArticleContainerViewController alloc] initWithDataStore:self.dataStore
                                                           savedPages:self.savedPageList];
     vc.article = article;
-    
+
     //TODO: Disabling pop ups until Popup VC is redesigned.
     //Renable preview when this true
-    
+
     [self.navigationController pushViewController:vc animated:YES];
-    
+
     return;
 
     WMFPreviewController* previewController = [[WMFPreviewController alloc] initWithPreviewViewController:vc containingViewController:self tabBarController:self.navigationController.tabBarController];

--- a/Wikipedia/UI-V5/WMFArticleViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleViewController.m
@@ -390,7 +390,7 @@ NS_ASSUME_NONNULL_BEGIN
     [super viewDidLoad];
 
     self.automaticallyAdjustsScrollViewInsets = NO;
-    self.tableView.scrollsToTop = YES;
+    self.tableView.scrollsToTop               = YES;
 
     UICollectionViewFlowLayout* galleryLayout = (UICollectionViewFlowLayout*)_headerGalleryViewController.collectionViewLayout;
     galleryLayout.minimumInteritemSpacing = 0;

--- a/Wikipedia/UI-V5/WMFSearchViewController.m
+++ b/Wikipedia/UI-V5/WMFSearchViewController.m
@@ -203,8 +203,8 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
         return [self.fetcher searchArticleTitlesForSearchTerm:searchTerm];
     }).then((id) ^ (WMFSearchResults * results){
         /*
-         HAX: must set dataSource before starting the animation since dataSource is _unsafely_ assigned to the
-         collection view, meaning there's a chance the collectionView accesses deallocated memory during an animation
+           HAX: must set dataSource before starting the animation since dataSource is _unsafely_ assigned to the
+           collection view, meaning there's a chance the collectionView accesses deallocated memory during an animation
          */
         self.resultsListController.dataSource = results;
 
@@ -234,7 +234,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 
 - (void)updateSearchSuggestion:(NSString*)searchSuggestion {
     NSAttributedString* title =
-        [searchSuggestion length] ? [self getAttributedStringForSuggestion: searchSuggestion] : nil;
+        [searchSuggestion length] ? [self getAttributedStringForSuggestion : searchSuggestion] : nil;
     [self.searchSuggestionButton setAttributedTitle:title forState:UIControlStateNormal];
     [self.view setNeedsUpdateConstraints];
     [self.view layoutIfNeeded];
@@ -244,8 +244,8 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
     [super updateViewConstraints];
     self.suggestionButtonHeightConstraint.constant =
         [self.searchSuggestionButton attributedTitleForState:UIControlStateNormal] ?
-            [self.searchSuggestionButton wmf_heightAccountingForMultiLineText]
-            : 0;
+        [self.searchSuggestionButton wmf_heightAccountingForMultiLineText]
+        : 0;
 }
 
 - (NSAttributedString*)getAttributedStringForSuggestion:(NSString*)suggestion {

--- a/Wikipedia/UI-V5/WMFSearchViewController.m
+++ b/Wikipedia/UI-V5/WMFSearchViewController.m
@@ -202,11 +202,15 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
     dispatch_promise(^{
         return [self.fetcher searchArticleTitlesForSearchTerm:searchTerm];
     }).then((id) ^ (WMFSearchResults * results){
+        /*
+         HAX: must set dataSource before starting the animation since dataSource is _unsafely_ assigned to the
+         collection view, meaning there's a chance the collectionView accesses deallocated memory during an animation
+         */
+        self.resultsListController.dataSource = results;
+
         [UIView animateWithDuration:0.25 animations:^{
             [self updateUIWithResults:results];
         }];
-
-        self.resultsListController.dataSource = results;
 
         if ([results.articles count] < kWMFMinResultsBeforeAutoFullTextSearch) {
             return [self.fetcher searchFullArticleTextForSearchTerm:searchTerm appendToPreviousResults:results];
@@ -224,13 +228,14 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 }
 
 - (void)updateUIWithResults:(WMFSearchResults*)results {
-    [self updateSearchButtonWithResults:results.searchSuggestion];
+    [self updateSearchSuggestion:results.searchSuggestion];
     [self updateRecentSearchesVisibility];
 }
 
-- (void)updateSearchButtonWithResults:(NSString*)searchSuggestion {
-    [self.searchSuggestionButton setAttributedTitle:([searchSuggestion length] ? [self getAttributedStringForSuggestion : searchSuggestion] : nil)
-                                           forState:UIControlStateNormal];
+- (void)updateSearchSuggestion:(NSString*)searchSuggestion {
+    NSAttributedString* title =
+        [searchSuggestion length] ? [self getAttributedStringForSuggestion: searchSuggestion] : nil;
+    [self.searchSuggestionButton setAttributedTitle:title forState:UIControlStateNormal];
     [self.view setNeedsUpdateConstraints];
     [self.view layoutIfNeeded];
 }
@@ -238,7 +243,9 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 - (void)updateViewConstraints {
     [super updateViewConstraints];
     self.suggestionButtonHeightConstraint.constant =
-        [self.searchSuggestionButton attributedTitleForState:UIControlStateNormal] ? [self.searchSuggestionButton wmf_heightAccountingForMultiLineText] : 0;
+        [self.searchSuggestionButton attributedTitleForState:UIControlStateNormal] ?
+            [self.searchSuggestionButton wmf_heightAccountingForMultiLineText]
+            : 0;
 }
 
 - (NSAttributedString*)getAttributedStringForSuggestion:(NSString*)suggestion {
@@ -261,7 +268,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 - (IBAction)searchForSuggestion:(id)sender {
     self.searchBar.text = [self searchSuggestion];
     [UIView animateWithDuration:0.25 animations:^{
-        [self updateSearchButtonWithResults:nil];
+        [self updateSearchSuggestion:nil];
     }];
 
     [self searchForSearchTerm:self.searchBar.text];


### PR DESCRIPTION
If we had to change constraints between search queries (e.g. if one had a suggestion and the other didn't), then we would trigger an animated layout pass, causing the collectionView to access it's **now deallocated** dataSource.  Step by step:

- Get new search results
- Start animating new search suggestion (or lack thereof)
- Before animation actually starts, set new dataSource, causing old one to be released
- Old dataSource is queried for numberOfSections
:boom: EXC_BAD_ACCESS

Actual bug repro steps (now fixed):
- Search for something w/o a suggestion (e.g. Rocky)
- Wait until results arrive
- Search for something w/ a suggestion (e.g. Appa)
- Quickly switch between the two, and you'll eventually hit the race condition & crash