### PR TITLE
don't allow selection of placeholder items in header gallery

### DIFF
--- a/Wikipedia/UI-V5/WMFArticleHeaderImageGalleryViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleHeaderImageGalleryViewController.m
@@ -80,6 +80,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - UICollectionView Protocols
 
+- (BOOL)collectionView:(UICollectionView*)collectionView shouldSelectItemAtIndexPath:(nonnull NSIndexPath*)indexPath {
+    // prevent selection of placeholder image
+    return self.images.count > 0;
+}
+
 - (void)collectionView:(UICollectionView*)collectionView didSelectItemAtIndexPath:(NSIndexPath*)indexPath {
     [self.delegate headerImageGallery:self didSelectImageAtIndex:indexPath.item];
 }


### PR DESCRIPTION
## Repro steps
1. Search for "List of agriculture ministries"
2. Tap titular result
3. Try to select image

## Expected results
Nothing happens

## Actual results
Crash

Now fixed!