### PR TITLE
Search messages

### DIFF
--- a/Wikipedia/Categories/NSString+Extras.h
+++ b/Wikipedia/Categories/NSString+Extras.h
@@ -42,4 +42,6 @@
 
 - (BOOL)wmf_isEqualToStringIgnoringCase:(NSString*)string;
 
+- (NSString*)wmf_trim;
+
 @end

--- a/Wikipedia/Categories/NSString+Extras.m
+++ b/Wikipedia/Categories/NSString+Extras.m
@@ -140,4 +140,8 @@
     return (NSOrderedSame == [self caseInsensitiveCompare:string]);
 }
 
+- (NSString*)wmf_trim {
+    return [self stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+}
+
 @end

--- a/Wikipedia/UI-V5/WMFSearchViewController.m
+++ b/Wikipedia/UI-V5/WMFSearchViewController.m
@@ -245,14 +245,12 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
         return [AnyPromise promiseWithValue:results];
     }).then(^(WMFSearchResults* results){
         if ([searchTerm isEqualToString:results.searchTerm]) {
-
             if (results.articles.count == 0) {
                 [self showAlert:MWLocalizedString(@"search-no-matches", nil) type:ALERT_TYPE_TOP duration:2.0];
             }
             self.resultsListController.dataSource = results;
         }
     }).catch(^(NSError* error){
-
         [self showAlert:error.userInfo[NSLocalizedDescriptionKey] type:ALERT_TYPE_TOP duration:2.0];
 
         NSLog(@"%@", [error description]);

--- a/Wikipedia/UI-V5/WMFSearchViewController.m
+++ b/Wikipedia/UI-V5/WMFSearchViewController.m
@@ -15,6 +15,7 @@
 
 
 #import "NSString+FormattedAttributedString.h"
+#import "UIViewController+Alert.h"
 
 static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 
@@ -244,9 +245,16 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
         return [AnyPromise promiseWithValue:results];
     }).then(^(WMFSearchResults* results){
         if ([searchTerm isEqualToString:results.searchTerm]) {
+
+            if (results.articles.count == 0) {
+                [self showAlert:MWLocalizedString(@"search-no-matches", nil) type:ALERT_TYPE_TOP duration:2.0];
+            }
             self.resultsListController.dataSource = results;
         }
     }).catch(^(NSError* error){
+
+        [self showAlert:error.userInfo[NSLocalizedDescriptionKey] type:ALERT_TYPE_TOP duration:2.0];
+
         NSLog(@"%@", [error description]);
     });
 }

--- a/Wikipedia/UI-V5/WMFSearchViewController.m
+++ b/Wikipedia/UI-V5/WMFSearchViewController.m
@@ -216,6 +216,9 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 }
 
 - (void)searchForSearchTerm:(NSString*)searchTerm {
+    if ([searchTerm wmf_trim].length == 0) {
+        return;
+    }
     @weakify(self);
     [self.fetcher searchArticleTitlesForSearchTerm:searchTerm]
     .thenOn(dispatch_get_main_queue(), ^id (WMFSearchResults* results){

--- a/Wikipedia/UI-V5/WMFSearchViewController.m
+++ b/Wikipedia/UI-V5/WMFSearchViewController.m
@@ -77,7 +77,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 
 - (void)updateRecentSearchesVisibility:(BOOL)animated {
     BOOL hideRecentSearches =
-        [self.searchBar.text length] > 0 || [self.recentSearches countOfEntries] == 0;
+        [self.searchBar.text wmf_trim].length > 0 || [self.recentSearches countOfEntries] == 0;
 
     [self setRecentSearchesHidden:hideRecentSearches animated:animated];
 }
@@ -174,7 +174,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 }
 
 - (void)searchBar:(UISearchBar*)searchBar textDidChange:(NSString*)searchText {
-    if ([searchText length] == 0) {
+    if ([searchText wmf_trim].length == 0) {
         [self didCancelSearch];
         return;
     }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T104858

Temporarily show old-style alerts for search until we can restyle alerts.

**Show alert when no search results were found:**
![screen shot 2015-09-18 at 1 33 07 pm](https://cloud.githubusercontent.com/assets/3143487/9970477/3dfd832e-5e0a-11e5-9e4c-c79d67de0550.png)
**Show alert relaying any error messages, such as connectivity problems:**
(this should also cause the *"Search is currently too busy.  Please try again later."* message from the phab ticket to be shown properly)
![screen shot 2015-09-18 at 1 33 22 pm](https://cloud.githubusercontent.com/assets/3143487/9970478/3e032bc6-5e0a-11e5-97b4-4840eaad7b17.png)