### PR TITLE
Fix code coverage data generation when running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ DerivedData
 *.dSYM.zip
 *.gcno
 *.gcda
+*.gcov
+*.profdata
+*.xccoverage
 
 # Icons
 Wikipedia/Images.xcassets/AppIcon.appiconset/*.png

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ group :dev do
 end
 
 group :ci do
-  gem 'fastlane', '~> 1.26.0'
+  gem 'fastlane', :git => "https://github.com/bgerstle/fastlane.git", :branch => "feature/enable_code_coverage"
   gem 'git', '~> 1.2'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ group :dev do
 end
 
 group :ci do
-  gem 'fastlane', :git => "https://github.com/bgerstle/fastlane.git", :ref => '401f5562fafb553a9dd900b6fbcc15da074f6f01'
+  gem 'fastlane'#, :git => "https://github.com/bgerstle/fastlane.git", :ref => '401f5562fafb553a9dd900b6fbcc15da074f6f01'
   gem 'git', '~> 1.2'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ group :dev do
 end
 
 group :ci do
-  gem 'fastlane', :git => "https://github.com/bgerstle/fastlane.git", :branch => "feature/enable_code_coverage"
+  gem 'fastlane', :git => "https://github.com/bgerstle/fastlane.git", :ref => '401f5562fafb553a9dd900b6fbcc15da074f6f01'
   gem 'git', '~> 1.2'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/bgerstle/fastlane.git
-  revision: a1a14a2a36e260217bf93b79a2025b6109013c9f
-  branch: feature/enable_code_coverage
+  revision: 401f5562fafb553a9dd900b6fbcc15da074f6f01
+  ref: 401f5562fafb553a9dd900b6fbcc15da074f6f01
   specs:
     fastlane (1.27.0)
       addressable (~> 2.3.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,3 @@
-GIT
-  remote: https://github.com/bgerstle/fastlane.git
-  revision: 401f5562fafb553a9dd900b6fbcc15da074f6f01
-  ref: 401f5562fafb553a9dd900b6fbcc15da074f6f01
-  specs:
-    fastlane (1.27.0)
-      addressable (~> 2.3.8)
-      aws-sdk (~> 1.0)
-      cert (>= 0.3.2, < 1.0.0)
-      credentials_manager (>= 0.8.1, < 1.0.0)
-      deliver (>= 0.13.4, < 1.0.0)
-      fastlane_core (>= 0.16.2, < 1.0.0)
-      frameit (>= 2.2.1, < 3.0.0)
-      gym (>= 0.6.2, < 1.0.0)
-      krausefx-shenzhen (>= 0.14.5)
-      nokogiri (~> 1.6)
-      pbxplorer (~> 1.0.0)
-      pem (>= 0.8.0, < 1.0.0)
-      pilot (>= 0.2.0, < 1.0.0)
-      plist (~> 3.1.0)
-      produce (>= 0.6.2, < 1.0.0)
-      rest-client (~> 1.8.0)
-      sigh (>= 0.10.7, < 1.0.0)
-      slack-notifier (~> 1.0)
-      snapshot (>= 0.10.0, < 1.0.0)
-      spaceship (>= 0.6.0, < 1.0.0)
-      terminal-notifier (~> 1.6.2)
-      terminal-table (~> 1.4.5)
-      xcodeproj (>= 0.20, < 1.0.0)
-      xcpretty (>= 0.1.11)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -109,6 +78,31 @@ GEM
       faraday (>= 0.7.4, < 0.10)
     fastimage (1.6.8)
       addressable (~> 2.3, >= 2.3.5)
+    fastlane (1.26.0)
+      addressable (~> 2.3.8)
+      aws-sdk (~> 1.0)
+      cert (>= 0.3.2, < 1.0.0)
+      credentials_manager (>= 0.8.1, < 1.0.0)
+      deliver (>= 0.13.4, < 1.0.0)
+      fastlane_core (>= 0.16.1, < 1.0.0)
+      frameit (>= 2.2.0, < 3.0.0)
+      gym (>= 0.4.6, < 1.0.0)
+      krausefx-shenzhen (>= 0.14.5)
+      nokogiri (~> 1.6)
+      pbxplorer (~> 1.0.0)
+      pem (>= 0.8.0, < 1.0.0)
+      pilot (>= 0.1.7, < 1.0.0)
+      plist (~> 3.1.0)
+      produce (>= 0.6.2, < 1.0.0)
+      rest-client (~> 1.8.0)
+      sigh (>= 0.10.7, < 1.0.0)
+      slack-notifier (~> 1.0)
+      snapshot (>= 0.9.3, < 1.0.0)
+      spaceship (>= 0.6.0, < 1.0.0)
+      terminal-notifier (~> 1.6.2)
+      terminal-table (~> 1.4.5)
+      xcodeproj (>= 0.20, < 1.0.0)
+      xcpretty (>= 0.1.11)
     fastlane_core (0.17.0)
       babosa
       capybara (~> 2.4.3)
@@ -235,5 +229,5 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 0.38.2)
-  fastlane!
+  fastlane
   git (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,34 @@
+GIT
+  remote: https://github.com/bgerstle/fastlane.git
+  revision: a1a14a2a36e260217bf93b79a2025b6109013c9f
+  branch: feature/enable_code_coverage
+  specs:
+    fastlane (1.27.0)
+      addressable (~> 2.3.8)
+      aws-sdk (~> 1.0)
+      cert (>= 0.3.2, < 1.0.0)
+      credentials_manager (>= 0.8.1, < 1.0.0)
+      deliver (>= 0.13.4, < 1.0.0)
+      fastlane_core (>= 0.16.2, < 1.0.0)
+      frameit (>= 2.2.1, < 3.0.0)
+      gym (>= 0.6.2, < 1.0.0)
+      krausefx-shenzhen (>= 0.14.5)
+      nokogiri (~> 1.6)
+      pbxplorer (~> 1.0.0)
+      pem (>= 0.8.0, < 1.0.0)
+      pilot (>= 0.2.0, < 1.0.0)
+      plist (~> 3.1.0)
+      produce (>= 0.6.2, < 1.0.0)
+      rest-client (~> 1.8.0)
+      sigh (>= 0.10.7, < 1.0.0)
+      slack-notifier (~> 1.0)
+      snapshot (>= 0.10.0, < 1.0.0)
+      spaceship (>= 0.6.0, < 1.0.0)
+      terminal-notifier (~> 1.6.2)
+      terminal-table (~> 1.4.5)
+      xcodeproj (>= 0.20, < 1.0.0)
+      xcpretty (>= 0.1.11)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -78,32 +109,7 @@ GEM
       faraday (>= 0.7.4, < 0.10)
     fastimage (1.6.8)
       addressable (~> 2.3, >= 2.3.5)
-    fastlane (1.26.0)
-      addressable (~> 2.3.8)
-      aws-sdk (~> 1.0)
-      cert (>= 0.3.2, < 1.0.0)
-      credentials_manager (>= 0.8.1, < 1.0.0)
-      deliver (>= 0.13.4, < 1.0.0)
-      fastlane_core (>= 0.16.1, < 1.0.0)
-      frameit (>= 2.2.0, < 3.0.0)
-      gym (>= 0.4.6, < 1.0.0)
-      krausefx-shenzhen (>= 0.14.5)
-      nokogiri (~> 1.6)
-      pbxplorer (~> 1.0.0)
-      pem (>= 0.8.0, < 1.0.0)
-      pilot (>= 0.1.7, < 1.0.0)
-      plist (~> 3.1.0)
-      produce (>= 0.6.2, < 1.0.0)
-      rest-client (~> 1.8.0)
-      sigh (>= 0.10.7, < 1.0.0)
-      slack-notifier (~> 1.0)
-      snapshot (>= 0.9.3, < 1.0.0)
-      spaceship (>= 0.6.0, < 1.0.0)
-      terminal-notifier (~> 1.6.2)
-      terminal-table (~> 1.4.5)
-      xcodeproj (>= 0.20, < 1.0.0)
-      xcpretty (>= 0.1.11)
-    fastlane_core (0.16.2)
+    fastlane_core (0.17.0)
       babosa
       capybara (~> 2.4.3)
       colored
@@ -124,12 +130,13 @@ GEM
       mini_magick (~> 4.0.2)
     fuzzy_match (2.0.4)
     git (1.2.9.1)
-    gym (0.5.0)
-      fastlane_core (>= 0.16.1, < 1.0.0)
+    gym (0.6.2)
+      fastlane_core (>= 0.17.0, < 1.0.0)
+      plist
       rubyzip (>= 1.1.7)
       terminal-table
       xcpretty
-    highline (1.7.5)
+    highline (1.7.6)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -228,5 +235,5 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 0.38.2)
-  fastlane (~> 1.26.0)
+  fastlane!
   git (~> 1.2)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,7 +27,11 @@ platform :ios do
       workspace: 'Wikipedia.xcworkspace',
       scheme: 'Wikipedia',
       destination: 'platform=iOS Simulator,name=iPhone 6,OS=9.0',
-      build_settings: {'GCC_INSTRUMENT_PROGRAM_FLOW_ARCS' => 'YES', 'GCC_GENERATE_TEST_COVERAGE_FILES' => 'YES'}
+      build_settings: {
+        'GCC_INSTRUMENT_PROGRAM_FLOW_ARCS' => 'YES', 
+        'GCC_GENERATE_TEST_COVERAGE_FILES' => 'YES'
+      },
+      '-enableCodeCoverage' => 'YES'
     )
 
     # xctool isn't 100% happy w/ Xcode 7

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,8 +26,7 @@ platform :ios do
     xctest(
       workspace: 'Wikipedia.xcworkspace',
       scheme: 'Wikipedia',
-      destination: 'platform=iOS Simulator,name=iPhone 6,OS=9.0',
-      enable_code_coverage: 'YES'
+      destination: 'platform=iOS Simulator,name=iPhone 6,OS=9.0'
     )
 
     # xctool isn't 100% happy w/ Xcode 7

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,11 +27,7 @@ platform :ios do
       workspace: 'Wikipedia.xcworkspace',
       scheme: 'Wikipedia',
       destination: 'platform=iOS Simulator,name=iPhone 6,OS=9.0',
-      build_settings: {
-        'GCC_INSTRUMENT_PROGRAM_FLOW_ARCS' => 'YES', 
-        'GCC_GENERATE_TEST_COVERAGE_FILES' => 'YES'
-      },
-      '-enableCodeCoverage' => 'YES'
+      enable_code_coverage: 'YES'
     )
 
     # xctool isn't 100% happy w/ Xcode 7


### PR DESCRIPTION
Code coverage was only being generated when run via Xcode. Removing all coverage parameters allows the defaults to kick in, generating `profdata` files needed by @codecov.