### PR TITLE
Fix search site (T113735)

### DIFF
--- a/Wikipedia/UI-V5/WMFAppViewController.m
+++ b/Wikipedia/UI-V5/WMFAppViewController.m
@@ -359,7 +359,7 @@ static NSUInteger const WMFAppTabCount = WMFAppTabTypeRecent + 1;
 
 - (void)searchLanguageDidChangeWithNotification:(NSNotification*)note {
     [self configureHomeViewController];
-    [self configureSavedViewController];
+    [self configureSearchViewController];
 }
 
 @end

--- a/Wikipedia/View Controllers/Languages/MWKLanguageLinkController.m
+++ b/Wikipedia/View Controllers/Languages/MWKLanguageLinkController.m
@@ -35,7 +35,11 @@ NSArray* WMFReadPreviouslySelectedLanguages() {
 
 /// Get the union of OS preferred languages & previously selected languages.
 static NSArray* WMFReadPreviousAndPreferredLanguages() {
-    NSMutableSet* preferredLanguages = [NSMutableSet setWithArray:[NSLocale preferredLanguages]];
+    NSMutableSet* preferredLanguages = [NSMutableSet setWithArray:[[NSLocale preferredLanguages] bk_map:^NSString*(NSString* languageCode) {
+        NSLocale* locale = [NSLocale localeWithLocaleIdentifier:languageCode];
+        // use language code when determining if a langauge is preferred (e.g. "en_US" is preferred if "en" was selected)
+        return [locale objectForKey:NSLocaleLanguageCode];
+    }]];
     [preferredLanguages addObjectsFromArray:WMFReadPreviouslySelectedLanguages()];
     return [preferredLanguages allObjects];
 }

--- a/Wikipedia/assets/languages.json
+++ b/Wikipedia/assets/languages.json
@@ -5,11 +5,6 @@
         "name": "English"
     },
     {
-        "canonical_name": "English",
-        "code": "en-US",
-        "name": "English"
-    },
-    {
         "canonical_name": "Dutch",
         "code": "nl", 
         "name": "Nederlands"

--- a/WikipediaUnitTests/MWKLanguageLinkControllerTests.m
+++ b/WikipediaUnitTests/MWKLanguageLinkControllerTests.m
@@ -36,16 +36,11 @@
 }
 
 - (void)testDefaultsToDevicePreferredLanguages {
-    NSParameterAssert(self.controller.filteredPreferredLanguageCodes.count > 0);
-
     /*
-       using weaker "intersection" test since there might be a case where the sim preferred languages have
-       more than what's defined in the static language data
+       since we've asserted above that "en" or "en-US" is one of the OS preferred languages, we can assert that our
+       controller contains a language link for "en"
      */
-    XCTAssertTrue([[NSSet setWithArray:self.controller.filteredPreferredLanguageCodes]
-                   intersectsSet:
-                   [NSSet setWithArray:[NSLocale preferredLanguages]]]);
-
+    assertThat(self.controller.filteredPreferredLanguageCodes, contains(@"en", nil));
     [self verifyAllLanguageArrayProperties];
 }
 

--- a/www/languages.json
+++ b/www/languages.json
@@ -5,11 +5,6 @@
         "name": "English"
     },
     {
-        "canonical_name": "English",
-        "code": "en-US",
-        "name": "English"
-    },
-    {
         "canonical_name": "Dutch",
         "code": "nl", 
         "name": "Nederlands"


### PR DESCRIPTION
Classic case of DYAC: we were updating saved pages instead of search when the search site changed 😣.

Also remove the `en_US` language in `languages.json` since it was:
- Causing two "English" entries to show up in the language picker :confounded: 
- Causing "host not found errors" when the user selected the "en-US" version of "English" (there isn't a en-us.wikipedia.org)