### PR TITLE
use a protocol to ensure image requests never start during tests

### DIFF
--- a/Wikipedia/Images/WMFImageController.swift
+++ b/Wikipedia/Images/WMFImageController.swift
@@ -305,15 +305,13 @@ public class WMFImageController : NSObject {
     }
 
     public func cancelAllFetches() {
-        weak var wself = self;
-        dispatch_async(self.cancellingQueue) {
-            let sself = wself
-            let currentCancellables = sself?.cancellables.objectEnumerator()!.allObjects as! [Cancellable]
-            sself?.cancellables.removeAllObjects()
-            dispatch_async(dispatch_get_global_queue(0, 0)) {
-                for cancellable in currentCancellables {
-                    cancellable.cancel()
-                }
+        var currentCancellables: [Cancellable]!
+        dispatch_sync(self.cancellingQueue) {
+            currentCancellables = self.cancellables.objectEnumerator()!.allObjects as! [Cancellable]
+        }
+        dispatch_async(dispatch_get_global_queue(0, 0)) {
+            for cancellable in currentCancellables {
+                cancellable.cancel()
             }
         }
     }

--- a/WikipediaUnitTests/Utilities/WMFImageController+Testing.swift
+++ b/WikipediaUnitTests/Utilities/WMFImageController+Testing.swift
@@ -10,8 +10,7 @@ import Foundation
 import Wikipedia
 
 extension WMFImageController {
-    public class func temporaryController() -> WMFImageController {
-        let downloader = SDWebImageDownloader()
+    public class func temporaryController(downloader: SDWebImageDownloader = SDWebImageDownloader()) -> WMFImageController {
         let cache = SDImageCache(namespace: "temp", inDirectory: WMFRandomTemporaryPath())
         return WMFImageController(manager: SDWebImageManager(downloader: downloader, cache: cache),
                                   namespace: "temp")


### PR DESCRIPTION
also fixes interesting crash on deinit due to attempting to make a weak reference