### PR TITLE
Fix history

### DIFF
--- a/MediaWikiKit/MediaWikiKit/MWKHistoryEntry.m
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryEntry.m
@@ -70,7 +70,7 @@
             "\ttitle: %@,\n"
             "\tdate: %@,\n"
             "\tdiscoveryMethod: %@,\n"
-            "\tscrollPosition: %d\n"
+            "\tscrollPosition: %f\n"
             "}",
             [super description],
             self.title,

--- a/MediaWikiKit/MediaWikiKit/MWKHistoryList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryList.h
@@ -1,13 +1,13 @@
 
 #import "MWKList.h"
+#import "MWKHistoryEntry.h"
 
 @class MWKTitle;
-@class MWKHistoryEntry;
 @class MWKDataStore;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MWKHistoryList : MWKList
+@interface MWKHistoryList : MWKList<MWKHistoryEntry*>
 
 /**
  *  Create history list and connect with data store.
@@ -21,7 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak, readonly) MWKDataStore* dataStore;
 
-- (MWKHistoryEntry*)entryAtIndex:(NSUInteger)index;
 - (MWKHistoryEntry* __nullable)entryForTitle:(MWKTitle*)title;
 
 - (NSUInteger)indexForEntry:(MWKHistoryEntry*)entry;
@@ -37,15 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param discoveryMethod The method of discovery. MWKHistoryDiscoveryMethodUnknown is ignored if updating an existing                 
  *                         entry.
  */
-- (void)addPageToHistoryWithTitle:(MWKTitle*)title discoveryMethod:(MWKHistoryDiscoveryMethod)discoveryMethod;
-
-/**
- *  Add an entry to the the user history
- *  Use this method if you needed to create an entry directly.
- *
- *  @param entry The entry to add
- */
-- (void)addEntry:(MWKHistoryEntry*)entry;
+- (void)addPageToHistoryWithTitle:(MWKTitle*)title
+                  discoveryMethod:(MWKHistoryDiscoveryMethod)discoveryMethod;
 
 /**
  *  Save the scroll position of a page
@@ -75,7 +67,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  Remove all history items.
  */
 - (void)removeAllEntriesFromHistory;
-
 
 - (NSArray*)dataExport;
 

--- a/MediaWikiKit/MediaWikiKit/MWKHistoryList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryList.h
@@ -30,26 +30,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  Add a page to the user history.
- *  Calling this on a page already in the history will simply update its date.
+ *
+ *  Calling this on a page already in the history will simply update its @c date.
  *
  *  @param title           The title of the page to add
- *  @param discoveryMethod The method of discovery. MWKHistoryDiscoveryMethodUnknown is ignored if updating an existing entry.
- *
- *  @return The task. The result is the MWKHistoryEntry.
+ *  @param discoveryMethod The method of discovery. MWKHistoryDiscoveryMethodUnknown is ignored if updating an existing                 
+ *                         entry.
  */
 - (void)addPageToHistoryWithTitle:(MWKTitle*)title discoveryMethod:(MWKHistoryDiscoveryMethod)discoveryMethod;
-
 
 /**
  *  Add an entry to the the user history
  *  Use this method if you needed to create an entry directly.
  *
  *  @param entry The entry to add
- *
- *  @return The task. The result is the MWKHistoryEntry.
  */
 - (void)addEntry:(MWKHistoryEntry*)entry;
-
 
 /**
  *  Save the scroll position of a page
@@ -65,24 +61,18 @@ NS_ASSUME_NONNULL_BEGIN
  *  Remove a page from the user history
  *
  *  @param title The title of the page to remove
- *
- *  @return The task. The result is nil.
  */
 - (void)removePageFromHistoryWithTitle:(MWKTitle*)title;
 
 /**
- *  Remove the given hstory entries from the history
+ *  Remove the given history entries from the history
  *
  *  @param historyEntries An array of instances of MWKHistoryEntry
- *
- *  @return The task. The result is nil.
  */
 - (void)removeEntriesFromHistory:(NSArray*)historyEntries;
 
 /**
  *  Remove all history items.
- *
- *  @return The task. The result is nil.
  */
 - (void)removeAllEntriesFromHistory;
 

--- a/MediaWikiKit/MediaWikiKit/MWKHistoryList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryList.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Calling this on a page already in the history will simply update its @c date.
  *
  *  @param title           The title of the page to add
- *  @param discoveryMethod The method of discovery. MWKHistoryDiscoveryMethodUnknown is ignored if updating an existing                 
+ *  @param discoveryMethod The method of discovery. MWKHistoryDiscoveryMethodUnknown is ignored if updating an existing
  *                         entry.
  */
 - (void)addPageToHistoryWithTitle:(MWKTitle*)title

--- a/MediaWikiKit/MediaWikiKit/MWKHistoryList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryList.h
@@ -1,13 +1,13 @@
 
 #import "MWKList.h"
 #import "MWKHistoryEntry.h"
+#import "MWKTitle.h"
 
-@class MWKTitle;
 @class MWKDataStore;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MWKHistoryList : MWKList<MWKHistoryEntry*>
+@interface MWKHistoryList : MWKList<MWKHistoryEntry*, MWKTitle*>
 
 /**
  *  Create history list and connect with data store.
@@ -20,8 +20,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDataStore:(MWKDataStore*)dataStore;
 
 @property (nonatomic, weak, readonly) MWKDataStore* dataStore;
-
-- (MWKHistoryEntry* __nullable)entryForTitle:(MWKTitle*)title;
 
 - (MWKHistoryEntry*)mostRecentEntry;
 
@@ -48,23 +46,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)savePageScrollPosition:(CGFloat)scrollposition toPageInHistoryWithTitle:(MWKTitle*)title;
 
 /**
- *  Remove a page from the user history
- *
- *  @param title The title of the page to remove
- */
-- (void)removePageFromHistoryWithTitle:(MWKTitle*)title;
-
-/**
  *  Remove the given history entries from the history
  *
  *  @param historyEntries An array of instances of MWKHistoryEntry
  */
 - (void)removeEntriesFromHistory:(NSArray*)historyEntries;
-
-/**
- *  Remove all history items.
- */
-- (void)removeAllEntriesFromHistory;
 
 - (NSArray*)dataExport;
 

--- a/MediaWikiKit/MediaWikiKit/MWKHistoryList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryList.h
@@ -23,8 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (MWKHistoryEntry* __nullable)entryForTitle:(MWKTitle*)title;
 
-- (NSUInteger)indexForEntry:(MWKHistoryEntry*)entry;
-
 - (MWKHistoryEntry*)mostRecentEntry;
 
 /**

--- a/MediaWikiKit/MediaWikiKit/MWKHistoryList.m
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryList.m
@@ -43,6 +43,10 @@
 
 #pragma mark - Update Methods
 
+- (void)sortEntries {
+    [self sortEntriesWithDescriptors:[[self class] sortDescriptors]];
+}
+
 - (void)addPageToHistoryWithTitle:(MWKTitle*)title discoveryMethod:(MWKHistoryDiscoveryMethod)discoveryMethod {
     if (title == nil) {
         return;
@@ -59,7 +63,8 @@
     }
     if ([self containsEntryForListIndex:entry.title]) {
         [self updateEntryWithListIndex:entry.title update:^BOOL (MWKHistoryEntry* __nullable oldEntry) {
-            oldEntry.discoveryMethod = entry.discoveryMethod == MWKHistoryDiscoveryMethodUnknown ? oldEntry.discoveryMethod : entry.discoveryMethod;
+            oldEntry.discoveryMethod = entry.discoveryMethod == MWKHistoryDiscoveryMethodUnknown ?
+                                       oldEntry.discoveryMethod : entry.discoveryMethod;
             oldEntry.date = [NSDate date];
             return YES;
         }];
@@ -67,6 +72,7 @@
         entry.date = [NSDate date];
         [super addEntry:entry];
     }
+    [self sortEntries];
 }
 
 - (void)savePageScrollPosition:(CGFloat)scrollposition toPageInHistoryWithTitle:(MWKTitle*)title {
@@ -96,7 +102,27 @@
 }
 
 - (void)removeAllEntriesFromHistory {
+    [self removeAllEntries];
+}
+
+- (void)removeEntry:(id<MWKListObject>)entry {
+    [super removeEntry:entry];
+    [self sortEntries];
+}
+
+- (void)removeAllEntries {
     [super removeAllEntries];
+    [self sortEntries];
+}
+
++ (NSArray<NSSortDescriptor*>*)sortDescriptors {
+    static NSArray<NSSortDescriptor*>* sortDescriptors;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:WMF_SAFE_KEYPATH([MWKHistoryEntry new], date)
+                                                          ascending:NO]];
+    });
+    return sortDescriptors;
 }
 
 #pragma mark - Save

--- a/MediaWikiKit/MediaWikiKit/MWKHistoryList.m
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryList.m
@@ -31,7 +31,7 @@
 }
 
 - (MWKHistoryEntry*)mostRecentEntry {
-    return [self.entries lastObject];
+    return [self.entries firstObject];
 }
 
 #pragma mark - Update Methods

--- a/MediaWikiKit/MediaWikiKit/MWKHistoryList.m
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryList.m
@@ -26,10 +26,6 @@
 
 #pragma mark - Entry Access
 
-- (MWKHistoryEntry*)entryForTitle:(MWKTitle*)title {
-    return [super entryForListIndex:title];
-}
-
 - (MWKHistoryEntry*)mostRecentEntry {
     return [self.entries firstObject];
 }
@@ -85,11 +81,11 @@
     }];
 }
 
-- (void)removePageFromHistoryWithTitle:(MWKTitle*)title {
-    if ([title.text length] == 0) {
+- (void)removeEntryWithListIndex:(id)listIndex {
+    if ([[listIndex text] length] == 0) {
         return;
     }
-    [self removeEntryWithListIndex:title];
+    [super removeEntryWithListIndex:listIndex];
 }
 
 - (void)removeEntriesFromHistory:(NSArray*)historyEntries {
@@ -99,10 +95,6 @@
     [historyEntries enumerateObjectsUsingBlock:^(MWKHistoryEntry* entry, NSUInteger idx, BOOL* stop) {
         [self removeEntryWithListIndex:entry.title];
     }];
-}
-
-- (void)removeAllEntriesFromHistory {
-    [self removeAllEntries];
 }
 
 - (void)removeEntry:(id<MWKListObject>)entry {

--- a/MediaWikiKit/MediaWikiKit/MWKList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKList.h
@@ -11,15 +11,15 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface MWKList <EntryType : id<MWKListObject>,
-                    IndexType : id<NSCopying,NSObject>>
-           : MWKDataObject<NSFastEnumeration>
+                        IndexType : id<NSCopying, NSObject> >
+                                : MWKDataObject<NSFastEnumeration>
 
-- (instancetype)initWithEntries:(NSArray<EntryType>* __nullable)entries;
+                    - (instancetype)initWithEntries:(NSArray<EntryType>* __nullable)entries;
 
 /**
  *  Observable - observe to get KVO notifications
  */
-@property (nonatomic, strong, readonly) NSArray<EntryType>* entries;
+                    @property (nonatomic, strong, readonly) NSArray<EntryType>* entries;
 
 - (NSUInteger)countOfEntries;
 

--- a/MediaWikiKit/MediaWikiKit/MWKList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKList.h
@@ -41,6 +41,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)removeAllEntries;
 
+/**
+ *  Sort the receiver's entries in place with the given descriptors.
+ */
+- (void)sortEntriesWithDescriptors:(NSArray<NSSortDescriptor*>*)sortDesriptors;
+
 /*
  * Indicates if the list has unsaved changes
  */

--- a/MediaWikiKit/MediaWikiKit/MWKList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKList.h
@@ -10,7 +10,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MWKList <EntryType : id<MWKListObject>> : MWKDataObject<NSFastEnumeration>
+@interface MWKList <EntryType : id<MWKListObject>,
+                    IndexType : id<NSCopying,NSObject>>
+           : MWKDataObject<NSFastEnumeration>
 
 - (instancetype)initWithEntries:(NSArray<EntryType>* __nullable)entries;
 
@@ -29,15 +31,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (EntryType)entryAtIndex:(NSUInteger)index;
 
-- (EntryType __nullable)entryForListIndex:(id <NSCopying>)listIndex;
+- (EntryType __nullable)entryForListIndex:(IndexType)listIndex;
 
-- (BOOL)containsEntryForListIndex:(id <NSCopying>)listIndex;
+- (BOOL)containsEntryForListIndex:(IndexType)listIndex;
 
-- (void)updateEntryWithListIndex:(id <NSCopying>)listIndex update:(BOOL (^)(EntryType __nullable entry))update;
+- (void)updateEntryWithListIndex:(IndexType)listIndex update:(BOOL (^)(EntryType entry))update;
 
 - (void)removeEntry:(EntryType)entry;
 
-- (void)removeEntryWithListIndex:(id <NSCopying>)listIndex;
+- (void)removeEntryWithListIndex:(IndexType)listIndex;
 
 - (void)removeAllEntries;
 

--- a/MediaWikiKit/MediaWikiKit/MWKList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKList.h
@@ -10,32 +10,32 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MWKList : MWKDataObject<NSFastEnumeration>
+@interface MWKList <EntryType : id<MWKListObject>> : MWKDataObject<NSFastEnumeration>
 
-- (instancetype)initWithEntries:(NSArray* __nullable)entries;
+- (instancetype)initWithEntries:(NSArray<EntryType>* __nullable)entries;
 
 /**
  *  Observable - observe to get KVO notifications
  */
-@property (nonatomic, strong, readonly)  NSArray* entries;
+@property (nonatomic, strong, readonly) NSArray<EntryType>* entries;
 
 - (NSUInteger)countOfEntries;
 
-- (void)addEntry:(id<MWKListObject>)entry;
+- (void)addEntry:(EntryType)entry;
 
-- (void)insertEntry:(id<MWKListObject>)entry atIndex:(NSUInteger)index;
+- (void)insertEntry:(EntryType)entry atIndex:(NSUInteger)index;
 
-- (NSUInteger)indexForEntry:(id<MWKListObject>)entry;
+- (NSUInteger)indexForEntry:(EntryType)entry;
 
-- (id<MWKListObject>)entryAtIndex:(NSUInteger)index;
+- (EntryType)entryAtIndex:(NSUInteger)index;
 
-- (id<MWKListObject> __nullable)entryForListIndex:(id <NSCopying>)listIndex;
+- (EntryType __nullable)entryForListIndex:(id <NSCopying>)listIndex;
 
 - (BOOL)containsEntryForListIndex:(id <NSCopying>)listIndex;
 
-- (void)updateEntryWithListIndex:(id <NSCopying>)listIndex update:(BOOL (^)(id<MWKListObject> __nullable entry))update;
+- (void)updateEntryWithListIndex:(id <NSCopying>)listIndex update:(BOOL (^)(EntryType __nullable entry))update;
 
-- (void)removeEntry:(id<MWKListObject>)entry;
+- (void)removeEntry:(EntryType)entry;
 
 - (void)removeEntryWithListIndex:(id <NSCopying>)listIndex;
 

--- a/MediaWikiKit/MediaWikiKit/MWKList.m
+++ b/MediaWikiKit/MediaWikiKit/MWKList.m
@@ -5,7 +5,7 @@
 
 @interface MWKList ()
 
-@property (nonatomic, strong) NSMutableArray* mutableEntries;
+@property (nonatomic, strong) NSMutableArray<id<MWKListObject>>* mutableEntries;
 @property (nonatomic, readwrite, assign) BOOL dirty;
 
 @end

--- a/MediaWikiKit/MediaWikiKit/MWKList.m
+++ b/MediaWikiKit/MediaWikiKit/MWKList.m
@@ -37,7 +37,6 @@
     [entries enumerateObjectsUsingBlock:^(id < MWKListObject > obj, NSUInteger idx, BOOL* stop) {
         [self addEntry:obj];
     }];
-
     self.dirty = NO;
 }
 

--- a/MediaWikiKit/MediaWikiKit/MWKList.m
+++ b/MediaWikiKit/MediaWikiKit/MWKList.m
@@ -74,7 +74,7 @@
     return (id<MWKListObject>)[self objectInEntriesAtIndex : index];
 }
 
-- (id<MWKListObject> __nullable)entryForListIndex:(id <NSCopying>)listIndex {
+- (id<MWKListObject> __nullable)entryForListIndex:(id)listIndex {
     return [self.entries bk_match:^BOOL (id < MWKListObject > obj) {
         if ([[obj listIndex] isEqual:listIndex]) {
             return YES;
@@ -83,12 +83,12 @@
     }];
 }
 
-- (BOOL)containsEntryForListIndex:(id <NSCopying>)listIndex {
+- (BOOL)containsEntryForListIndex:(id)listIndex {
     id<MWKListObject> entry = [self entryForListIndex:listIndex];
     return (entry != nil);
 }
 
-- (void)updateEntryWithListIndex:(id <NSCopying>)listIndex update:(BOOL (^)(id<MWKListObject> entry))update {
+- (void)updateEntryWithListIndex:(id)listIndex update:(BOOL (^)(id<MWKListObject> entry))update {
     id<MWKListObject> obj = [self entryForListIndex:listIndex];
     if (update) {
         // prevent reseting "dirty" if block returns NO and dirty was already YES
@@ -101,7 +101,7 @@
     self.dirty = YES;
 }
 
-- (void)removeEntryWithListIndex:(id <NSCopying>)listIndex {
+- (void)removeEntryWithListIndex:(id)listIndex {
     id<MWKListObject> obj = [self entryForListIndex:listIndex];
     if (obj) {
         [self removeEntry:obj];

--- a/MediaWikiKit/MediaWikiKit/MWKList.m
+++ b/MediaWikiKit/MediaWikiKit/MWKList.m
@@ -5,7 +5,7 @@
 
 @interface MWKList ()
 
-@property (nonatomic, strong) NSMutableArray<id<MWKListObject>>* mutableEntries;
+@property (nonatomic, strong) NSMutableArray<id<MWKListObject> >* mutableEntries;
 @property (nonatomic, readwrite, assign) BOOL dirty;
 
 @end

--- a/MediaWikiKit/MediaWikiKit/MWKList.m
+++ b/MediaWikiKit/MediaWikiKit/MWKList.m
@@ -114,6 +114,10 @@
     self.dirty = YES;
 }
 
+- (void)sortEntriesWithDescriptors:(NSArray<NSSortDescriptor*>*)sortDesriptors {
+    [self.mutableEntries sortUsingDescriptors:sortDesriptors];
+}
+
 #pragma mark - Save
 
 - (AnyPromise*)save {

--- a/MediaWikiKit/MediaWikiKit/MWKRecentSearchList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKRecentSearchList.h
@@ -1,10 +1,11 @@
 
 #import "MWKList.h"
 #import "MWKRecentSearchEntry.h"
+#import "MWKTitle.h"
 
 @class MWKDataStore;
 
-@interface MWKRecentSearchList : MWKList<MWKRecentSearchEntry*>
+@interface MWKRecentSearchList : MWKList<MWKRecentSearchEntry*, NSString*>
 
 @property (readonly, weak, nonatomic) MWKDataStore* dataStore;
 
@@ -28,7 +29,6 @@
  *  @return The task. The result is the MWKSavedPageEntry.
  */
 - (void)addEntry:(MWKRecentSearchEntry*)entry;
-
 
 - (NSArray*)dataExport;
 

--- a/MediaWikiKit/MediaWikiKit/MWKRecentSearchList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKRecentSearchList.h
@@ -1,9 +1,10 @@
 
 #import "MWKList.h"
+#import "MWKRecentSearchEntry.h"
 
-@class MWKRecentSearchEntry, MWKDataStore;
+@class MWKDataStore;
 
-@interface MWKRecentSearchList : MWKList
+@interface MWKRecentSearchList : MWKList<MWKRecentSearchEntry*>
 
 @property (readonly, weak, nonatomic) MWKDataStore* dataStore;
 

--- a/MediaWikiKit/MediaWikiKit/MWKSavedPageList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKSavedPageList.h
@@ -1,13 +1,13 @@
 
 #import "MWKList.h"
 #import "MWKSavedPageEntry.h"
+#import "MWKTitle.h"
 
-@class MWKTitle;
 @class MWKDataStore;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MWKSavedPageList : MWKList<MWKSavedPageEntry*>
+@interface MWKSavedPageList : MWKList<MWKSavedPageEntry*, MWKTitle*>
 
 /**
  *  Create saved page list and connect with data store.
@@ -21,19 +21,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, weak, nonatomic) MWKDataStore* dataStore;
 
-- (MWKSavedPageEntry* __nullable)entryForTitle:(MWKTitle*)title;
+- (MWKSavedPageEntry* __nullable)entryForListIndex:(MWKTitle*)title;
 - (MWKSavedPageEntry*)           mostRecentEntry;
 
 - (BOOL)isSaved:(MWKTitle*)title;
-
-/**
- * Change properties on a specific entry without changing its order in the list
- * @param title     The title of the entry you want to change.
- * @param update    Block which mutates the entry matching that title, if one was found, then returns
- *                  `YES` if the entry was mutated (and the list should be changed the next time `save` is
- *                  called, or `NO` if no change occurred.
- */
-- (void)updateEntryWithTitle:(MWKTitle*)title update:(BOOL (^)(MWKSavedPageEntry*))update;
 
 /**
  * Toggle the save state for `title`.
@@ -48,18 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param title The title of the page to add
  */
 - (void)addSavedPageWithTitle:(MWKTitle*)title;
-
-/**
- *  Remove a saved page task
- *
- *  @param title The title of the page to remove
- */
-- (void)removeSavedPageWithTitle:(MWKTitle*)title;
-
-/**
- *  Remove all saved pages
- */
-- (void)removeAllSavedPages;
 
 - (NSArray*)dataExport;
 

--- a/MediaWikiKit/MediaWikiKit/MWKSavedPageList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKSavedPageList.h
@@ -1,13 +1,13 @@
 
 #import "MWKList.h"
+#import "MWKSavedPageEntry.h"
 
 @class MWKTitle;
-@class MWKSavedPageEntry;
 @class MWKDataStore;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MWKSavedPageList : MWKList
+@interface MWKSavedPageList : MWKList<MWKSavedPageEntry*>
 
 /**
  *  Create saved page list and connect with data store.
@@ -21,11 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, weak, nonatomic) MWKDataStore* dataStore;
 
-- (MWKSavedPageEntry*)entryAtIndex:(NSUInteger)index;
 - (MWKSavedPageEntry* __nullable)entryForTitle:(MWKTitle*)title;
 - (MWKSavedPageEntry*)           mostRecentEntry;
-
-- (NSUInteger)indexForEntry:(MWKSavedPageEntry*)entry;
 
 - (BOOL)isSaved:(MWKTitle*)title;
 
@@ -53,14 +50,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addSavedPageWithTitle:(MWKTitle*)title;
 
 /**
- *  Add an entry to the the user saved pages
- *  Use this method if you needed to create an entry directly.
- *
- *  @param entry The entry to add
- */
-- (void)addEntry:(MWKSavedPageEntry*)entry;
-
-/**
  *  Remove a saved page task
  *
  *  @param title The title of the page to remove
@@ -71,7 +60,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  Remove all saved pages
  */
 - (void)removeAllSavedPages;
-
 
 - (NSArray*)dataExport;
 

--- a/MediaWikiKit/MediaWikiKit/MWKSavedPageList.m
+++ b/MediaWikiKit/MediaWikiKit/MWKSavedPageList.m
@@ -59,10 +59,6 @@
     return [self containsEntryForListIndex:title];
 }
 
-- (NSUInteger)indexForEntry:(MWKHistoryEntry*)entry {
-    return [super indexForEntry:entry];
-}
-
 #pragma mark - Update Methods
 
 - (void)toggleSavedPageForTitle:(MWKTitle*)title {

--- a/MediaWikiKit/MediaWikiKit/MWKSavedPageList.m
+++ b/MediaWikiKit/MediaWikiKit/MWKSavedPageList.m
@@ -45,7 +45,7 @@
     return [self.entries lastObject];
 }
 
-- (MWKSavedPageEntry*)entryForTitle:(MWKTitle*)title {
+- (MWKSavedPageEntry*)entryForListIndex:(MWKTitle*)title {
     if ([title.text length] == 0) {
         return nil;
     }
@@ -63,7 +63,7 @@
 
 - (void)toggleSavedPageForTitle:(MWKTitle*)title {
     if ([self isSaved:title]) {
-        [self removeSavedPageWithTitle:title];
+        [self removeEntryWithListIndex:title];
     } else {
         [self addSavedPageWithTitle:title];
     }
@@ -84,19 +84,11 @@
     [super addEntry:entry];
 }
 
-- (void)updateEntryWithTitle:(MWKTitle*)title update:(BOOL (^)(MWKSavedPageEntry*))update {
-    [self updateEntryWithListIndex:title update:update];
-}
-
-- (void)removeSavedPageWithTitle:(MWKTitle*)title {
-    if (title == nil) {
+- (void)removeEntryWithListIndex:(id)listIndex {
+    if ([[listIndex text] length] == 0) {
         return;
     }
-    [self removeEntryWithListIndex:title];
-}
-
-- (void)removeAllSavedPages {
-    [super removeAllEntries];
+    [super removeEntryWithListIndex:listIndex];
 }
 
 #pragma mark - Save

--- a/MediaWikiKit/MediaWikiKitTests/MWKHistoryListTests.m
+++ b/MediaWikiKit/MediaWikiKitTests/MWKHistoryListTests.m
@@ -8,6 +8,10 @@
 
 #import "MWKTestCase.h"
 #import "MWKDataStore+TemporaryDataStore.h"
+#import "XCTestCase+PromiseKit.h"
+
+#define HC_SHORTHAND 1
+#import <OCHamcrest/OCHamcrest.h>
 
 @interface MWKHistoryListTests : MWKTestCase
 
@@ -43,53 +47,81 @@
     [super tearDown];
 }
 
-- (void)testEmptyCount {
+- (void)testInitialStateWithEmptyDataStore {
     XCTAssertEqual([historyList countOfEntries], 0, @"Should have length 0 initially");
+    XCTAssertFalse(self->historyList.dirty, @"Should not be dirty initially");
 }
 
-- (void)testAddCount {
+- (void)testAddingOneEntry {
+    MWKHistoryEntry* entry = [[MWKHistoryEntry alloc] initWithTitle:titleSFEn
+                                                    discoveryMethod:MWKHistoryDiscoveryMethodSearch];
+    [historyList addEntry:entry];
+    assertThat(historyList.entries, is(@[entry]));
+}
+
+- (void)testAddingTwoDifferentTitles {
+    MWKHistoryEntry* losAngeles = [[MWKHistoryEntry alloc] initWithTitle:titleLAEn
+                                                         discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+    MWKHistoryEntry* sanFrancisco = [[MWKHistoryEntry alloc] initWithTitle:titleSFFr
+                                                           discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+    [historyList addEntry:losAngeles];
+    [historyList addEntry:sanFrancisco];
+    assertThat(historyList.entries, is(@[sanFrancisco, losAngeles]));
+}
+
+- (void)testStatePersistsWhenSaved {
+    MWKHistoryEntry* losAngeles = [[MWKHistoryEntry alloc] initWithTitle:titleLAEn
+                                                        discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+    MWKHistoryEntry* sanFrancisco = [[MWKHistoryEntry alloc] initWithTitle:titleSFFr
+                                                          discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+
+    // HAX: need a difference on order of seconds for order to persist accurately due to date storage format
+    sanFrancisco.date = [NSDate dateWithTimeIntervalSinceNow:5];
+
+    [historyList addEntry:losAngeles];
+    [historyList addEntry:sanFrancisco];
+
+    [self expectAnyPromiseToResolve:^AnyPromise *{
+        return [self->historyList save];
+    } timeout:WMFDefaultExpectationTimeout WMFExpectFromHere];
+
+    XCTAssertFalse(historyList.dirty, @"Dirty flag should be reset after saving.");
+    MWKHistoryList* persistedList = [[MWKHistoryList alloc] initWithDataStore:dataStore];
+    // HAX: dates are not exactly the same so we need to compare manually
+    assertThat([persistedList.entries valueForKey:@"title"], is(equalTo([historyList.entries valueForKey:@"title"])));
+}
+
+- (void)testAddingIdenticalObjectUpdatesExistingEntryDate {
     MWKHistoryEntry* entry = [[MWKHistoryEntry alloc] initWithTitle:titleSFEn
                                                     discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+    NSDate* previousDate = entry.date;
     [historyList addEntry:entry];
-    XCTAssertEqual([historyList countOfEntries], 1, @"Should have length 1 after adding");
+    [historyList addEntry:entry];
+    assertThat(historyList.entries, is(@[entry]));
+    assertThat([entry.date laterDate:previousDate], is(entry.date));
 }
 
-- (void)testAddCount2 {
-    [historyList addEntry:[[MWKHistoryEntry alloc] initWithTitle:titleSFEn
-                                                 discoveryMethod :MWKHistoryDiscoveryMethodSearch]];
-    [historyList addEntry:[[MWKHistoryEntry alloc] initWithTitle:titleLAEn
-                                                 discoveryMethod :MWKHistoryDiscoveryMethodSearch]];
-    XCTAssertEqual([historyList countOfEntries], 2, @"Should have length 2 after adding");
+- (void)testAddingEquivalentObjectUpdatesExistingEntryDate {
+    MWKTitle* title1        = [titleSFEn.site titleWithString:@"This is a title"];
+    MWKHistoryEntry* entry1 = [[MWKHistoryEntry alloc] initWithTitle:title1
+                                                     discoveryMethod:MWKHistoryDiscoveryMethodSearch];
+    MWKTitle* copyOfTitle1        = [titleSFEn.site titleWithString:@"This is a title"];
+    MWKHistoryEntry* copyOfEntry1 = [[MWKHistoryEntry alloc] initWithTitle:copyOfTitle1
+                                                     discoveryMethod:MWKHistoryDiscoveryMethodSearch];
+    [historyList addEntry:entry1];
+    [historyList addEntry:copyOfEntry1];
+    assertThat(historyList.entries, is(@[entry1]));
+    assertThat(entry1.date, is(copyOfEntry1.date));
 }
 
-- (void)testAddCount2Same {
-    [historyList addEntry:[[MWKHistoryEntry alloc] initWithTitle:titleSFEn
-                                                 discoveryMethod :MWKHistoryDiscoveryMethodSearch]];
-    [historyList addEntry:[[MWKHistoryEntry alloc] initWithTitle:titleSFEn
-                                                 discoveryMethod :MWKHistoryDiscoveryMethodSearch]];
-    XCTAssertEqual([historyList countOfEntries], 1, @"Should have length 1 after adding a duplicate, not 2");
-}
-
-- (void)testAddCount2SameButDiffObjects {
-    MWKTitle* title1 = [titleSFEn.site titleWithString:@"This is a title"];
-    MWKTitle* title2 = [titleSFEn.site titleWithString:@"This is a title"];
-    [historyList addEntry:[[MWKHistoryEntry alloc] initWithTitle:title1
-                                                 discoveryMethod :MWKHistoryDiscoveryMethodSearch]];
-    [historyList addEntry:[[MWKHistoryEntry alloc] initWithTitle:title2
-                                                 discoveryMethod :MWKHistoryDiscoveryMethodSearch]];
-    XCTAssertEqual([historyList countOfEntries], 1, @"Should have length 1 after adding a duplicate, not 2");
-}
-
-- (void)testAddCount2DiffLanguages {
-    [historyList addEntry:[[MWKHistoryEntry alloc] initWithTitle:titleSFEn
-                                                 discoveryMethod :MWKHistoryDiscoveryMethodSearch]];
-    [historyList addEntry:[[MWKHistoryEntry alloc] initWithTitle:titleSFFr
-                                                 discoveryMethod :MWKHistoryDiscoveryMethodSearch]];
-    XCTAssertEqual([historyList countOfEntries], 2, @"Should have length 2 after adding a duplicate in another language, not 1");
-}
-
-- (void)testEmptyNotDirty {
-    XCTAssertFalse(self->historyList.dirty, @"Should not be dirty initially");
+- (void)testAddingTheSameTitleFromDifferentSites {
+    MWKHistoryEntry* en = [[MWKHistoryEntry alloc] initWithTitle:titleSFEn
+                                                 discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+    MWKHistoryEntry* fr = [[MWKHistoryEntry alloc] initWithTitle:titleSFFr
+                                                 discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+    [historyList addEntry:en];
+    [historyList addEntry:fr];
+    assertThat([historyList entries], is(@[fr, en]));
 }
 
 - (void)testEmptyDirtyAfterAdd {
@@ -106,7 +138,34 @@
     [historyList addEntry:entry1];
     [historyList addEntry:entry2];
     [historyList removePageFromHistoryWithTitle:entry1.title];
-    XCTAssertEqual([historyList countOfEntries], 1, @"Should have length 1 after adding two then removing one");
+    assertThat([historyList entries], is(@[entry2]));
+}
+
+- (void)testListOrdersByDateDescending {
+    MWKHistoryEntry* entry1 = [[MWKHistoryEntry alloc] initWithTitle:titleSFEn
+                                                    discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+    MWKHistoryEntry* entry2 = [[MWKHistoryEntry alloc] initWithTitle:titleLAEn
+                                                    discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+    [historyList addEntry:entry1];
+    [historyList addEntry:entry2];
+    NSAssert([[entry2.date laterDate:entry1.date] isEqualToDate:entry2.date],
+             @"Test assumes new entries are created w/ the current date.");
+    assertThat([historyList entries], is(@[entry2, entry1]));
+}
+
+- (void)testListOrderAfterAddingSameEntry {
+    MWKHistoryEntry* entry1 = [[MWKHistoryEntry alloc] initWithTitle:titleSFEn
+                                                     discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+    MWKHistoryEntry* entry2 = [[MWKHistoryEntry alloc] initWithTitle:titleLAEn
+                                                     discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+    [historyList addEntry:entry1];
+    NSDate* initialDate = entry1.date;
+    [historyList addEntry:entry2];
+    [historyList addEntry:entry1];
+    NSDate* updatedDate = entry1.date;
+    assertThat([initialDate laterDate:updatedDate], is(updatedDate));
+    assertThat([historyList entries], is(@[entry1, entry2]));
+    XCTAssertTrue(historyList.dirty);
 }
 
 @end

--- a/MediaWikiKit/MediaWikiKitTests/MWKHistoryListTests.m
+++ b/MediaWikiKit/MediaWikiKitTests/MWKHistoryListTests.m
@@ -146,7 +146,7 @@
                                                      discoveryMethod :MWKHistoryDiscoveryMethodSearch];
     [historyList addEntry:entry1];
     [historyList addEntry:entry2];
-    [historyList removePageFromHistoryWithTitle:entry1.title];
+    [historyList removeEntryWithListIndex:entry1.title];
     assertThat([historyList entries], is(@[entry2]));
 }
 

--- a/MediaWikiKit/MediaWikiKitTests/MWKHistoryListTests.m
+++ b/MediaWikiKit/MediaWikiKitTests/MWKHistoryListTests.m
@@ -54,7 +54,7 @@
 
 - (void)testAddingOneEntry {
     MWKHistoryEntry* entry = [[MWKHistoryEntry alloc] initWithTitle:titleSFEn
-                                                    discoveryMethod:MWKHistoryDiscoveryMethodSearch];
+                                                    discoveryMethod :MWKHistoryDiscoveryMethodSearch];
     [historyList addEntry:entry];
     assertThat(historyList.entries, is(@[entry]));
 }
@@ -71,20 +71,20 @@
 
 - (void)testStatePersistsWhenSaved {
     MWKHistoryEntry* losAngeles = [[MWKHistoryEntry alloc] initWithTitle:titleLAEn
-                                                        discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+                                                         discoveryMethod :MWKHistoryDiscoveryMethodSearch];
     MWKHistoryEntry* sanFrancisco = [[MWKHistoryEntry alloc] initWithTitle:titleSFFr
-                                                          discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+                                                           discoveryMethod :MWKHistoryDiscoveryMethodSearch];
 
     /*
-     HAX: dates are not precisely stored, so the difference must be >1s for the order to be persisted accurately. 
-     this shouldn't be a huge problem in practice because users (probably) won't save multiple pages in <1s
-    */
+       HAX: dates are not precisely stored, so the difference must be >1s for the order to be persisted accurately.
+       this shouldn't be a huge problem in practice because users (probably) won't save multiple pages in <1s
+     */
     sanFrancisco.date = [NSDate dateWithTimeIntervalSinceNow:5];
 
     [historyList addEntry:losAngeles];
     [historyList addEntry:sanFrancisco];
 
-    [self expectAnyPromiseToResolve:^AnyPromise *{
+    [self expectAnyPromiseToResolve:^AnyPromise*{
         return [self->historyList save];
     } timeout:WMFDefaultExpectationTimeout WMFExpectFromHere];
 
@@ -92,7 +92,7 @@
     MWKHistoryList* persistedList = [[MWKHistoryList alloc] initWithDataStore:dataStore];
 
     // HAX: dates aren't exactly persisted, so we need to compare manually
-    [persistedList.entries enumerateObjectsUsingBlock:^(MWKHistoryEntry *actualEntry, NSUInteger idx, BOOL *_) {
+    [persistedList.entries enumerateObjectsUsingBlock:^(MWKHistoryEntry* actualEntry, NSUInteger idx, BOOL* _) {
         MWKHistoryEntry* expectedEntry = self->historyList.entries[idx];
         assertThat(actualEntry.title, is(expectedEntry.title));
         assertThat(@(actualEntry.discoveryMethod), is(@(expectedEntry.discoveryMethod)));
@@ -113,10 +113,10 @@
 - (void)testAddingEquivalentObjectUpdatesExistingEntryDate {
     MWKTitle* title1        = [titleSFEn.site titleWithString:@"This is a title"];
     MWKHistoryEntry* entry1 = [[MWKHistoryEntry alloc] initWithTitle:title1
-                                                     discoveryMethod:MWKHistoryDiscoveryMethodSearch];
+                                                     discoveryMethod :MWKHistoryDiscoveryMethodSearch];
     MWKTitle* copyOfTitle1        = [titleSFEn.site titleWithString:@"This is a title"];
     MWKHistoryEntry* copyOfEntry1 = [[MWKHistoryEntry alloc] initWithTitle:copyOfTitle1
-                                                     discoveryMethod:MWKHistoryDiscoveryMethodSearch];
+                                                           discoveryMethod :MWKHistoryDiscoveryMethodSearch];
     [historyList addEntry:entry1];
     [historyList addEntry:copyOfEntry1];
     assertThat(historyList.entries, is(@[entry1]));
@@ -152,9 +152,9 @@
 
 - (void)testListOrdersByDateDescending {
     MWKHistoryEntry* entry1 = [[MWKHistoryEntry alloc] initWithTitle:titleSFEn
-                                                    discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+                                                     discoveryMethod :MWKHistoryDiscoveryMethodSearch];
     MWKHistoryEntry* entry2 = [[MWKHistoryEntry alloc] initWithTitle:titleLAEn
-                                                    discoveryMethod :MWKHistoryDiscoveryMethodSearch];
+                                                     discoveryMethod :MWKHistoryDiscoveryMethodSearch];
     [historyList addEntry:entry1];
     [historyList addEntry:entry2];
     NSAssert([[entry2.date laterDate:entry1.date] isEqualToDate:entry2.date],

--- a/MediaWikiKit/MediaWikiKitTests/MWKSavedPageListTests.m
+++ b/MediaWikiKit/MediaWikiKitTests/MWKSavedPageListTests.m
@@ -37,14 +37,14 @@
     [self.list addEntry:savedEntry];
     [self.list toggleSavedPageForTitle:savedEntry.title];
     XCTAssertFalse([self.list isSaved:savedEntry.title]);
-    XCTAssertNil([self.list entryForTitle:savedEntry.title]);
+    XCTAssertNil([self.list entryForListIndex:savedEntry.title]);
 }
 
 - (void)testToggleUnsavedPageReturnsYesAndAddsToList {
     MWKSavedPageEntry* unsavedEntry = [self entryWithTitleText:@"foo"];
     [self.list toggleSavedPageForTitle:unsavedEntry.title];
     XCTAssertTrue([self.list isSaved:unsavedEntry.title]);
-    XCTAssertEqualObjects([self.list entryForTitle:unsavedEntry.title], unsavedEntry);
+    XCTAssertEqualObjects([self.list entryForListIndex:unsavedEntry.title], unsavedEntry);
 }
 
 - (void)testTogglePageWithEmptyTitleReturnsNilWithError {

--- a/Wikipedia/Legacy Data Migration/WMFLegacyImageDataMigration.swift
+++ b/Wikipedia/Legacy Data Migration/WMFLegacyImageDataMigration.swift
@@ -80,7 +80,8 @@ public class WMFLegacyImageDataMigration : NSObject {
         let currentSavedPageList = legacyDataStore.userDataStore().savedPageList
         // grab the corresponding entry from the list on disk
         for migratedEntry: MWKSavedPageEntry in migratedEntries {
-            currentSavedPageList.updateEntryWithTitle(migratedEntry.title) { entry in
+            currentSavedPageList.updateEntryWithListIndex(migratedEntry.title) { entry in
+                let entry = entry as! MWKSavedPageEntry
                 if !entry.didMigrateImageData {
                     // mark as migrated if necessary, and mark the list as dirty
                     entry.didMigrateImageData = true
@@ -144,8 +145,8 @@ public class WMFLegacyImageDataMigration : NSObject {
 
     /// Mark the given entry as having its image data migrated.
     func markEntryAsMigrated(entry: MWKSavedPageEntry) {
-        savedPageList.updateEntryWithTitle(entry.title) { e in
-            e.didMigrateImageData = true
+        savedPageList.updateEntryWithListIndex(entry.title) { e in
+            (e as! MWKSavedPageEntry).didMigrateImageData = true
             return true
         }
     }

--- a/Wikipedia/Legacy Data Migration/WMFLegacyImageDataMigration.swift
+++ b/Wikipedia/Legacy Data Migration/WMFLegacyImageDataMigration.swift
@@ -74,7 +74,9 @@ public class WMFLegacyImageDataMigration : NSObject {
     /// Save the receiver's saved page list, making sure to preserve the current list on disk.
     func save() -> Promise<Void> {
         // for each entry that we migrated
-        let migratedEntries = savedPageList.entries.filter() { $0.didMigrateImageData == true } as! [MWKSavedPageEntry]
+        let migratedEntries = (savedPageList.entries as! [MWKSavedPageEntry]).filter() {
+            $0.didMigrateImageData == true
+        }
         let currentSavedPageList = legacyDataStore.userDataStore().savedPageList
         // grab the corresponding entry from the list on disk
         for migratedEntry: MWKSavedPageEntry in migratedEntries {

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.h
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.h
@@ -7,6 +7,7 @@
 @class MWKDataStore;
 @class MWKSavedPageList;
 @class MWKArticle;
+@class MWKHistoryList;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -14,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
     <WMFArticleContentController, WMFArticleListItemController, WMFAnalyticsLogging>
 
 + (instancetype)articleContainerViewControllerWithDataStore:(MWKDataStore*)dataStore
+                                                recentPages:(MWKHistoryList*)recentPages
                                                  savedPages:(MWKSavedPageList*)savedPages;
 
 @property (nonatomic, strong, readonly) WMFArticleViewController* articleViewController;

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -51,6 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Data
 @property (nonatomic, strong) MWKSavedPageList* savedPageList;
+@property (nonatomic, strong) MWKHistoryList* recentPages;
 @property (nonatomic, strong) MWKDataStore* dataStore;
 @property (nonatomic, strong) WMFSaveButtonController* saveButtonController;
 
@@ -85,14 +86,18 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Setup
 
 + (instancetype)articleContainerViewControllerWithDataStore:(MWKDataStore*)dataStore
-                                                 savedPages:(MWKSavedPageList*)savedPages {
-    return [[self alloc] initWithDataStore:dataStore savedPages:savedPages];
+                                                recentPages:(MWKHistoryList *)recentPages
+                                                 savedPages:(MWKSavedPageList *)savedPages {
+    return [[self alloc] initWithDataStore:dataStore recentPages:recentPages savedPages:savedPages];
 }
 
-- (instancetype)initWithDataStore:(MWKDataStore*)dataStore savedPages:(MWKSavedPageList*)savedPages {
+- (instancetype)initWithDataStore:(MWKDataStore*)dataStore
+                      recentPages:(MWKHistoryList*)recentPages
+                       savedPages:(MWKSavedPageList*)savedPages {
     self = [super init];
     if (self) {
         self.savedPageList = savedPages;
+        self.recentPages   = recentPages;
         self.dataStore     = dataStore;
         [self commonInit];
     }
@@ -317,6 +322,24 @@ NS_ASSUME_NONNULL_BEGIN
 //    }
 }
 
+#pragma mark - Article Navigation
+
+- (void)showArticleViewControllerForTitle:(MWKTitle*)title {
+    MWKArticle* article                          = [self.dataStore articleWithTitle:title];
+    WMFArticleContainerViewController* articleVC =
+        [[WMFArticleContainerViewController alloc] initWithDataStore:self.dataStore
+                                                         recentPages:self.recentPages
+                                                          savedPages:self.savedPageList];
+    articleVC.article = article;
+    [self showArticleViewController:articleVC];
+}
+
+- (void)showArticleViewController:(WMFArticleContainerViewController*)articleVC {
+    [self.recentPages addPageToHistoryWithTitle:articleVC.article.title
+                                discoveryMethod:MWKHistoryDiscoveryMethodLink];
+    [self.navigationController pushViewController:articleVC animated:YES];
+}
+
 #pragma mark - Article Fetching
 
 - (void)fetchArticle {
@@ -361,13 +384,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - WebView Transition
 
-- (void)showWebViewAnimated:(BOOL)animated {
-//    [self.contentNavigationController pushViewController:self.webViewController animated:YES];
-}
-
 - (void)showWebViewAtFragment:(NSString*)fragment animated:(BOOL)animated {
     [self.webViewController scrollToFragment:fragment];
-    [self showWebViewAnimated:animated];
 }
 
 #pragma mark - WMFArticleViewControllerDelegate
@@ -448,25 +466,17 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Popup
 
 - (void)presentPopupForTitle:(MWKTitle*)title {
-    MWKArticle* article = [self.dataStore articleWithTitle:title];
-
-    WMFArticleContainerViewController* vc =
-        [[WMFArticleContainerViewController alloc] initWithDataStore:self.dataStore
-                                                          savedPages:self.savedPageList];
-    vc.article = article;
-
     //TODO: Disabling pop ups until Popup VC is redesigned.
     //Renable preview when this true
-
-    [self.navigationController pushViewController:vc animated:YES];
+    [self showArticleViewControllerForTitle:title];
 
     return;
 
-    WMFPreviewController* previewController = [[WMFPreviewController alloc] initWithPreviewViewController:vc containingViewController:self tabBarController:self.navigationController.tabBarController];
-    previewController.delegate = self;
-    [previewController presentPreviewAnimated:YES];
-
-    self.previewController = previewController;
+//    WMFPreviewController* previewController = [[WMFPreviewController alloc] initWithPreviewViewController:vc containingViewController:self tabBarController:self.navigationController.tabBarController];
+//    previewController.delegate = self;
+//    [previewController presentPreviewAnimated:YES];
+//
+//    self.previewController = previewController;
 }
 
 #pragma mark - Analytics
@@ -486,12 +496,7 @@ NS_ASSUME_NONNULL_BEGIN
      * Work around, make another view controller and push it instead.
      */
     WMFArticleContainerViewController* previewed = (id)viewController;
-
-    WMFArticleContainerViewController* vc =
-        [[WMFArticleContainerViewController alloc] initWithDataStore:self.dataStore
-                                                          savedPages:self.savedPageList];
-    vc.article = previewed.article;
-    [self.navigationController pushViewController:vc animated:NO];
+    [self showArticleViewControllerForTitle:previewed.article.title];
 }
 
 - (void)   previewController:(WMFPreviewController*)previewController

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -86,8 +86,8 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Setup
 
 + (instancetype)articleContainerViewControllerWithDataStore:(MWKDataStore*)dataStore
-                                                recentPages:(MWKHistoryList *)recentPages
-                                                 savedPages:(MWKSavedPageList *)savedPages {
+                                                recentPages:(MWKHistoryList*)recentPages
+                                                 savedPages:(MWKSavedPageList*)savedPages {
     return [[self alloc] initWithDataStore:dataStore recentPages:recentPages savedPages:savedPages];
 }
 

--- a/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
@@ -203,7 +203,10 @@
 - (void)collectionView:(UICollectionView*)collectionView didSelectItemAtIndexPath:(NSIndexPath*)indexPath {
     self.selectedArticle = [self.dataSource articleForIndexPath:indexPath];
 
-    WMFArticleContainerViewController* container = [WMFArticleContainerViewController articleContainerViewControllerWithDataStore:self.dataStore savedPages:self.savedPages];
+    WMFArticleContainerViewController* container =
+        [WMFArticleContainerViewController articleContainerViewControllerWithDataStore:self.dataStore
+                                                                           recentPages:self.recentPages
+                                                                            savedPages:self.savedPages];
     container.article = self.selectedArticle;
 
     [self wmf_hideKeyboard];

--- a/Wikipedia/UI-V5/WMFHomeSectionController.h
+++ b/Wikipedia/UI-V5/WMFHomeSectionController.h
@@ -38,6 +38,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setSavedPageList:(MWKSavedPageList*)savedPageList;
 
+/**
+ *  The discovery method associated with where this section's data originated from.
+ *
+ *  Defaults to @c MWKHistoryDiscoveryMethodSearch if not implemented.
+ *
+ *  @return A discovery method.
+ */
+- (MWKHistoryDiscoveryMethod)discoveryMethod;
+
 @end
 
 typedef void (^ WMFHomeSectionCellEnumerator)(id cell, NSIndexPath* indexPath);

--- a/Wikipedia/UI-V5/WMFHomeViewController.m
+++ b/Wikipedia/UI-V5/WMFHomeViewController.m
@@ -407,16 +407,26 @@ NS_ASSUME_NONNULL_BEGIN
     id<WMFHomeSectionController> controller = [self sectionControllerForSectionAtIndex:indexPath.section];
     MWKTitle* title                         = [controller titleForItemAtIndex:indexPath.row];
     if (title) {
-        [self showArticleViewControllerForTitle:title animated:YES];
+        MWKHistoryDiscoveryMethod discoveryMethod = MWKHistoryDiscoveryMethodSearch;
+        if ([controller respondsToSelector:@selector(discoveryMethod)]) {
+            discoveryMethod = [controller discoveryMethod];
+        }
+        [self showArticleViewControllerForTitle:title animated:YES discoveryMethod:discoveryMethod];
     }
 }
 
 #pragma mark - Article Presentation
 
-- (void)showArticleViewControllerForTitle:(MWKTitle*)title animated:(BOOL)animated {
+- (void)showArticleViewControllerForTitle:(MWKTitle*)title
+                                 animated:(BOOL)animated
+                          discoveryMethod:(MWKHistoryDiscoveryMethod)discoveryMethod {
     MWKArticle* article                                   = [self.dataStore articleWithTitle:title];
-    WMFArticleContainerViewController* articleContainerVC = [WMFArticleContainerViewController articleContainerViewControllerWithDataStore:article.dataStore savedPages:self.savedPages];
+    WMFArticleContainerViewController* articleContainerVC =
+        [WMFArticleContainerViewController articleContainerViewControllerWithDataStore:article.dataStore
+                                                                           recentPages:self.recentPages
+                                                                            savedPages:self.savedPages];
     articleContainerVC.article = article;
+    [self.recentPages addPageToHistoryWithTitle:title discoveryMethod:discoveryMethod];
     [self.navigationController pushViewController:articleContainerVC animated:animated];
 }
 
@@ -477,7 +487,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)textView:(UITextView*)textView shouldInteractWithURL:(NSURL*)URL inRange:(NSRange)characterRange {
     MWKTitle* title = [[MWKTitle alloc] initWithURL:URL];
-    [self showArticleViewControllerForTitle:title animated:YES];
+    [self showArticleViewControllerForTitle:title animated:YES discoveryMethod:MWKHistoryDiscoveryMethodLink];
     return NO;
 }
 

--- a/Wikipedia/UI-V5/WMFRecentPagesDataSource.m
+++ b/Wikipedia/UI-V5/WMFRecentPagesDataSource.m
@@ -96,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)deleteArticleAtIndexPath:(NSIndexPath*)indexPath {
     MWKHistoryEntry* entry = [self recentPageForIndexPath:indexPath];
     if (entry) {
-        [self.recentPages removePageFromHistoryWithTitle:entry.title];
+        [self.recentPages removeEntryWithListIndex:entry.title];
         [self.recentPages save];
     }
 }

--- a/Wikipedia/UI-V5/WMFSavedPagesDataSource.m
+++ b/Wikipedia/UI-V5/WMFSavedPagesDataSource.m
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)deleteArticleAtIndexPath:(NSIndexPath*)indexPath {
     MWKSavedPageEntry* savedEntry = [self savedPageForIndexPath:indexPath];
     if (savedEntry) {
-        [self.savedPageList removeSavedPageWithTitle:savedEntry.title];
+        [self.savedPageList removeEntryWithListIndex:savedEntry.title];
         [self.savedPageList save];
     }
 }

--- a/Wikipedia/View Controllers/History/HistoryViewController.m
+++ b/Wikipedia/View Controllers/History/HistoryViewController.m
@@ -407,7 +407,7 @@
 - (void)deleteHistoryForIndexPath:(NSIndexPath*)indexPath {
     MWKHistoryEntry* historyEntry = self.historyDataArray[indexPath.section][@"data"][indexPath.row];
     if (historyEntry) {
-        [self.userDataStore.historyList removePageFromHistoryWithTitle:historyEntry.title];
+        [self.userDataStore.historyList removeEntryWithListIndex:historyEntry.title];
         [self.userDataStore.historyList save].then(^(){
             [self.tableView beginUpdates];
 
@@ -462,7 +462,7 @@
 }
 
 - (void)deleteAllHistoryItems {
-    [self.userDataStore.historyList removeAllEntriesFromHistory];
+    [self.userDataStore.historyList removeAllEntries];
     [self.userDataStore.historyList save].then(^(){
         // Remove any orphaned images.
         DataHousekeeping* dataHouseKeeping = [[DataHousekeeping alloc] init];

--- a/Wikipedia/View Controllers/WebView/WebViewController.m
+++ b/Wikipedia/View Controllers/WebView/WebViewController.m
@@ -1332,7 +1332,7 @@ typedef NS_ENUM (NSInteger, WMFWebViewAlertType) {
 }
 
 - (void)handleRedirectForTitle:(MWKTitle*)title {
-    MWKHistoryEntry* history                  = [self.session.userDataStore.historyList entryForTitle:title];
+    MWKHistoryEntry* history                  = [self.session.userDataStore.historyList entryForListIndex:title];
     MWKHistoryDiscoveryMethod discoveryMethod =
         (history) ? history.discoveryMethod : MWKHistoryDiscoveryMethodSearch;
 
@@ -1459,7 +1459,7 @@ typedef NS_ENUM (NSInteger, WMFWebViewAlertType) {
         self.session.currentArticleDiscoveryMethod == MWKHistoryDiscoveryMethodBackForward ||
         self.session.currentArticleDiscoveryMethod == MWKHistoryDiscoveryMethodReloadFromNetwork ||
         self.session.currentArticleDiscoveryMethod == MWKHistoryDiscoveryMethodReloadFromCache) {
-        MWKHistoryEntry* historyEntry = [self.session.userDataStore.historyList entryForTitle:article.title];
+        MWKHistoryEntry* historyEntry = [self.session.userDataStore.historyList entryForListIndex:article.title];
         CGPoint scrollOffset          = CGPointMake(0, historyEntry.scrollPosition);
         self.lastScrollOffset = scrollOffset;
     } else {

--- a/Wikipedia/WMFFaceDetectionCache.m
+++ b/Wikipedia/WMFFaceDetectionCache.m
@@ -91,9 +91,8 @@
     return [self.faceDetectionBoundsKeyedByURL objectForKey:url];
 }
 
-- (void)clearCache{
+- (void)clearCache {
     [self.faceDetectionBoundsKeyedByURL removeAllObjects];
 }
-
 
 @end

--- a/WikipediaUnitTests/UIImageView+MWKImageTests.m
+++ b/WikipediaUnitTests/UIImageView+MWKImageTests.m
@@ -82,12 +82,11 @@
     assertThat(self.imageView.image, is(successfulDownload.image));
 
     assertThat(@(testMetadata.didDetectFaces), isTrue());
-    
+
     XCTAssert([[UIImageView faceDetectionCache] imageRequiresFaceDetection:testMetadata] == NO,
               @"Face detection should have ran.");
-    
-    [MKTVerify(self.mockImageController) fetchImageWithURL:testURL];
 
+    [MKTVerify(self.mockImageController) fetchImageWithURL:testURL];
 }
 
 - (void)testSuccessfullySettingImageFromURLWithCenterFaces {
@@ -122,7 +121,7 @@
 
     XCTAssert([[UIImageView faceDetectionCache] imageAtURLRequiresFaceDetection:testURL] == NO,
               @"Face detection should have ran.");
-    
+
     [MKTVerify(self.mockImageController) fetchImageWithURL:testURL];
 }
 
@@ -201,7 +200,6 @@
               @"Face detection should NOT have ran.");
 
     [MKTVerify(self.mockImageController) fetchImageWithURL:testURL];
-
 }
 
 - (void)testSuccessfullySettingCachedImageWithoutCenterFaces {

--- a/WikipediaUnitTests/WMFLegacyImageDataMigrationTests.swift
+++ b/WikipediaUnitTests/WMFLegacyImageDataMigrationTests.swift
@@ -83,7 +83,7 @@ class WMFLegacyImageDataMigrationTests : XCTestCase {
                 result,
                 "Expected nil result after marking all entries as migrated, but got \(result). Current entries:\n"
                     + self.dataStore.userDataStore().savedPageList.entries.debugDescription)
-            let unmigratedEntries = self.dataStore.userDataStore().savedPageList.entries.filter() { $0.didMigrateImageData == false }
+            let unmigratedEntries = (self.dataStore.userDataStore().savedPageList.entries as! [MWKSavedPageEntry]).filter() { $0.didMigrateImageData == false }
             XCTAssertTrue(unmigratedEntries.isEmpty, "Expected data store to contain 0 unmigrated entries")
         },
         test: {

--- a/WikipediaUnitTests/WMFLegacyImageDataMigrationTests.swift
+++ b/WikipediaUnitTests/WMFLegacyImageDataMigrationTests.swift
@@ -62,7 +62,7 @@ class WMFLegacyImageDataMigrationTests : XCTestCase {
             .then() { _ -> Void in
                 XCTAssertNotNil(self.imageMigration.unmigratedEntry())
                 XCTAssertEqual(
-                    self.savedPageList.entryForTitle(unmigratedEntry.title)!,
+                    self.savedPageList.entryForListIndex(unmigratedEntry.title)!,
                     self.imageMigration.unmigratedEntry()!)
                 XCTAssertEqual(
                     self.imageMigration.unmigratedEntry()!,
@@ -118,13 +118,13 @@ class WMFLegacyImageDataMigrationTests : XCTestCase {
         let (article, legacyImageDataPaths) = prepareArticleFixtureWithTempImages("Barack_Obama")
 
         // mark Barack_Obama as an unmigrated entry
-        addUnmigratedEntryForTitle(article.title)
+        addUnmigratedentryForListIndex(article.title)
 
         expectPromise(toResolve(),
         timeout: 10,
         pipe: {
             XCTAssertNil(self.imageMigration.unmigratedEntry(), "Should be no remaining unmigrated entries")
-            let migratedEntry = self.dataStore.userDataStore().savedPageList.entryForTitle(article.title)!
+            let migratedEntry = self.dataStore.userDataStore().savedPageList.entryForListIndex(article.title)!
             XCTAssertTrue(migratedEntry.didMigrateImageData, "Expected article's saved page entry to be marked as migrated")
             self.verifySuccessfulMigration(ofArticle: article, legacyImageDataPaths: legacyImageDataPaths)
         },
@@ -145,8 +145,8 @@ class WMFLegacyImageDataMigrationTests : XCTestCase {
         let titleToAddWhileMigrating = MWKTitle(string: "addedWhileMigrating", site: MWKSite.siteWithCurrentLocale())
 
         // create saved page entries for 1 & 2, which will be migrated
-        addUnmigratedEntryForTitle(article1.title)
-        addUnmigratedEntryForTitle(article2.title)
+        addUnmigratedentryForListIndex(article1.title)
+        addUnmigratedentryForListIndex(article2.title)
 
         expectPromise(toResolve(),
         timeout: 10,
@@ -155,13 +155,13 @@ class WMFLegacyImageDataMigrationTests : XCTestCase {
 
             let currentSavedPageList = self.dataStore.userDataStore().savedPageList
 
-            XCTAssertNil(currentSavedPageList.entryForTitle(article1.title),
+            XCTAssertNil(currentSavedPageList.entryForListIndex(article1.title),
                          "Entry for article1 should have remained deleted.")
 
-            XCTAssertTrue(currentSavedPageList.entryForTitle(article2.title)!.didMigrateImageData,
+            XCTAssertTrue(currentSavedPageList.entryForListIndex(article2.title)!.didMigrateImageData,
                           "Expected article2 to still be in the list and marked as migrated (by imageMigration).")
 
-            XCTAssertTrue(currentSavedPageList.entryForTitle(titleToAddWhileMigrating)!.didMigrateImageData,
+            XCTAssertTrue(currentSavedPageList.entryForListIndex(titleToAddWhileMigrating)!.didMigrateImageData,
                           "Expected article3 to still be in the list and marked as migrated (by default).")
 
             // article 1 should still have been migrated, including deletion of legacy image data
@@ -182,7 +182,7 @@ class WMFLegacyImageDataMigrationTests : XCTestCase {
                 let mainSavedPageList = self.dataStore.userDataStore().savedPageList
 
                 // remove article 1
-                mainSavedPageList.removeSavedPageWithTitle(article1.title)
+                mainSavedPageList.removeEntryWithListIndex(article1.title)
 
                 // save article 3
                 mainSavedPageList.addSavedPageWithTitle(titleToAddWhileMigrating)
@@ -220,9 +220,10 @@ class WMFLegacyImageDataMigrationTests : XCTestCase {
         return (article, legacyImageDataPaths)
     }
 
-    func addUnmigratedEntryForTitle(title: MWKTitle) {
+    func addUnmigratedentryForListIndex(title: MWKTitle) {
         savedPageList.addSavedPageWithTitle(title)
-        savedPageList.updateEntryWithTitle(title, update: { entry in
+        savedPageList.updateEntryWithListIndex(title, update: { entry in
+            let entry = entry as! MWKSavedPageEntry
             entry.didMigrateImageData = false
             return true
         })


### PR DESCRIPTION
I think I have a problem. Once @montehurd pointed out history wasn't working I couldn't stop myself from fixing it. There were some surprising behaviors in the history list which are now fixed/tested, and all `MWKList` subclasses use ObjC lightweight generics for better type safety and less boilerplate.*

- [x] Pushing an article from a home section updates history
- [x] Pushing an article from another article updates history
- [x] Pushing the same article updates list order
- [x] History list is ordered by date in descending order

Next up, saved.

\* TIL: [Swift ignores non-Foundation ObjC generics](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/InteractingWithObjective-CAPIs.html#//apple_ref/doc/uid/TP40014216-CH4-ID173) :disappointed:

> Aside from these Foundation collection classes, Objective-C lightweight generics are ignored by Swift. Any other types using lightweight generics are imported into Swift as if they were unparameterized.