### PR TITLE
comment out nullability annotation on MWKImage.allNormalizedFaceBounds

### DIFF
--- a/MediaWikiKit/MediaWikiKit/MWKImage.h
+++ b/MediaWikiKit/MediaWikiKit/MWKImage.h
@@ -90,7 +90,7 @@
  *
  * @see CIDetector+WMFFaceDetection
  */
-@property (copy, nonatomic, nullable) NSArray<NSValue*>* allNormalizedFaceBounds;
+@property (copy, nonatomic/*, nullable*/) NSArray<NSValue*>* allNormalizedFaceBounds;
 
 /**
  * Convenience accessor for the bounds of the first face in `allNormalizedFaceBounds`.


### PR DESCRIPTION
was causing a bunch of "nullability unspecified" warnings for a lot of classes due to global MediaWikiKit import