### PR TITLE
Toc scroll fix

### DIFF
--- a/Wikipedia/Categories/UIWebView+ElementLocation.m
+++ b/Wikipedia/Categories/UIWebView+ElementLocation.m
@@ -88,7 +88,7 @@
     // by count index (if prefix is "things_" and count is 3 it will check "thing_0", "thing_1"
     // and "thing_2") to see if they are onscreen. Returns index of first one found to be so.
     NSString* strToEval =
-        [NSString stringWithFormat:@"window.elementLocation.getIndexOfFirstOnScreenElementWithTopGreaterThanY('%@', %lu, %f);", prefix, (unsigned long)count, self.scrollView.contentOffset.y];
+        [NSString stringWithFormat:@"window.elementLocation.getIndexOfFirstOnScreenElement('%@', %lu);", prefix, (unsigned long)count];
     NSString* result = [self stringByEvaluatingJavaScriptFromString:strToEval];
     return (result) ? result.integerValue : -1;
 }

--- a/Wikipedia/assets/bundle.js
+++ b/Wikipedia/assets/bundle.js
@@ -84,7 +84,7 @@ exports.getElementRectAsJson = function(element) {
     return JSON.stringify(this.getElementRect(element));
 };
 
-exports.getIndexOfFirstOnScreenElementWithTopGreaterThanY = function(elementPrefix, elementCount){
+exports.getIndexOfFirstOnScreenElement = function(elementPrefix, elementCount){
     for (var i = 0; i < elementCount; ++i) {
         var div = document.getElementById(elementPrefix + i);
         if (div === null) {

--- a/Wikipedia/assets/bundle.js
+++ b/Wikipedia/assets/bundle.js
@@ -91,7 +91,7 @@ exports.getIndexOfFirstOnScreenElement = function(elementPrefix, elementCount){
             continue;
         }
         var rect = this.getElementRect(div);
-        if ( (rect.top >= 0) || ((rect.top + rect.height) >= 0)) {
+        if ( (rect.top >= -1) || ((rect.top + rect.height) >= 50)) {
             return i;
         }
     }

--- a/www/js/elementLocation.js
+++ b/www/js/elementLocation.js
@@ -39,7 +39,7 @@ exports.getElementRectAsJson = function(element) {
     return JSON.stringify(this.getElementRect(element));
 };
 
-exports.getIndexOfFirstOnScreenElementWithTopGreaterThanY = function(elementPrefix, elementCount){
+exports.getIndexOfFirstOnScreenElement = function(elementPrefix, elementCount){
     for (var i = 0; i < elementCount; ++i) {
         var div = document.getElementById(elementPrefix + i);
         if (div === null) {

--- a/www/js/elementLocation.js
+++ b/www/js/elementLocation.js
@@ -46,7 +46,7 @@ exports.getIndexOfFirstOnScreenElement = function(elementPrefix, elementCount){
             continue;
         }
         var rect = this.getElementRect(div);
-        if ( (rect.top >= 0) || ((rect.top + rect.height) >= 0)) {
+        if ( (rect.top >= -1) || ((rect.top + rect.height) >= 50)) {
             return i;
         }
     }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T114956

- Fix for TOC not always showing what you had just selected as the current section if you make selection from TOC then immediately re-open TOC.

- Made bottom of the section above the "current" section able to be scrolled a max of 50 pixels onscreen before that section is considered "current".