### PR TITLE
clip header images to bounds

### DIFF
--- a/Wikipedia/Custom Views/WMFImageCollectionViewCell.m
+++ b/Wikipedia/Custom Views/WMFImageCollectionViewCell.m
@@ -21,6 +21,7 @@
         [self.imageView mas_makeConstraints:^(MASConstraintMaker* make) {
             make.edges.equalTo(self.contentView);
         }];
+        self.imageView.clipsToBounds = YES;
     }
     return self;
 }


### PR DESCRIPTION
prevents them from overlapping while scrolling:

### Before
![image](https://cloud.githubusercontent.com/assets/444217/10469537/0125d914-71d4-11e5-84cb-2a6dd77558bc.png)

### After
![image](https://cloud.githubusercontent.com/assets/444217/10469448/450042e2-71d3-11e5-961c-f86426b6f7ec.png)
