### PR TITLE
Disable upsidedown support for now. Search has weird bug in upsidedown mode.

### DIFF
--- a/Wikipedia/UI-V5/WMFAppViewController.m
+++ b/Wikipedia/UI-V5/WMFAppViewController.m
@@ -300,10 +300,6 @@ static dispatch_once_t launchToken;
     return YES;
 }
 
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    return UIInterfaceOrientationMaskAll;
-}
-
 #pragma mark - Onboarding
 
 - (BOOL)shouldShowOnboarding {

--- a/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
@@ -209,10 +209,6 @@
     [[self dynamicDataSource] stopUpdating];
 }
 
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    return UIInterfaceOrientationMaskAll;
-}
-
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id <UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 

--- a/Wikipedia/View Controllers/Onboarding/OnboardingViewController.m
+++ b/Wikipedia/View Controllers/Onboarding/OnboardingViewController.m
@@ -49,10 +49,9 @@ typedef NS_ENUM (NSUInteger, DisplayMode) {
     return YES;
 }
 
-- (NSUInteger)supportedInterfaceOrientations {
-    //return UIInterfaceOrientationMaskAll;
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) ?
-           UIInterfaceOrientationMaskPortrait : UIInterfaceOrientationMaskAll;
+           UIInterfaceOrientationMaskPortrait : [super supportedInterfaceOrientations];
 }
 
 - (BOOL)prefersAlertsHidden {

--- a/Wikipedia/Wikipedia-Info.plist
+++ b/Wikipedia/Wikipedia-Info.plist
@@ -52,7 +52,6 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>


### PR DESCRIPTION
Search icon tap inverts entire interface for an instant when upside-down.

Added phab ticket for fixing the upside-down flicker issue: https://phabricator.wikimedia.org/T115520