### PR TITLE
Hide lead image if no article image or if mainpage.

### DIFF
--- a/Wikipedia/View Controllers/WebView/WebViewController.m
+++ b/Wikipedia/View Controllers/WebView/WebViewController.m
@@ -314,6 +314,9 @@ typedef NS_ENUM (NSInteger, WMFWebViewAlertType) {
 }
 
 - (CGFloat)headerHeightForTraitCollection:(UITraitCollection*)traitCollection {
+    if (self.article.isMain || !self.article.imageURL) {
+        return 0;
+    }
     switch (traitCollection.verticalSizeClass) {
         case UIUserInterfaceSizeClassRegular:
             return 210;


### PR DESCRIPTION
The lead image (above web view article) was not collapsed when no image exists for article.

https://phabricator.wikimedia.org/T115417
https://phabricator.wikimedia.org/T115540

Before
![soltan after](https://cloud.githubusercontent.com/assets/3143487/10528823/909a6068-734d-11e5-8f3e-fbeb68380f3c.png)
After
![soltan before](https://cloud.githubusercontent.com/assets/3143487/10528816/8aee18e4-734d-11e5-8ed6-9bc6b415f86d.png)

Before
![viral after](https://cloud.githubusercontent.com/assets/3143487/10528831/99a6973a-734d-11e5-94bb-7feada50ad4a.png)
After
![viral before](https://cloud.githubusercontent.com/assets/3143487/10528829/95e8cec4-734d-11e5-9604-5c8adabd1701.png)

Before
![theorem after](https://cloud.githubusercontent.com/assets/3143487/10528840/a3ff5aaa-734d-11e5-81fd-6b03f8896e65.png)
After
![theorem before](https://cloud.githubusercontent.com/assets/3143487/10528836/a1508e46-734d-11e5-83d2-ad31c2dc95e7.png)

Before
![main after](https://cloud.githubusercontent.com/assets/3143487/10528847/aef98a84-734d-11e5-9cb3-11fb8c999ea5.png)After
![main before](https://cloud.githubusercontent.com/assets/3143487/10528844/ac0f5ee8-734d-11e5-908d-d0bcb8f37323.png)