### PR TITLE
Made ArticleListCollection VC refresh cells if cell article is saved.

### DIFF
--- a/Wikipedia/UI-V5/WMFArticleListCollectionViewController.h
+++ b/Wikipedia/UI-V5/WMFArticleListCollectionViewController.h
@@ -32,8 +32,6 @@ typedef NS_ENUM (NSUInteger, WMFArticleListMode) {
 
 - (SelfSizingWaterfallCollectionViewLayout*)flowLayout;
 
-- (void)refreshVisibleCells;
-
 - (void)scrollToArticle:(MWKArticle*)article animated:(BOOL)animated;
 
 - (void)scrollToArticleIfOffscreen:(MWKArticle*)article animated:(BOOL)animated;

--- a/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
@@ -144,13 +144,11 @@
 }
 
 - (void)refreshAnyVisibleCellsWhichAreShowingTitle:(MWKTitle*)title {
-    NSArray* indexPathsToRefresh = [[self.collectionView indexPathsForVisibleItems] bk_select:^BOOL (NSIndexPath* path) {
-        WMFArticlePreviewCell* cell = (WMFArticlePreviewCell*)[self.collectionView cellForItemAtIndexPath:path];
-        return (cell.title == title);
+    NSArray* indexPathsToRefresh = [[self.collectionView indexPathsForVisibleItems] bk_select:^BOOL (NSIndexPath* indexPath) {
+        MWKArticle* article = [self.dataSource articleForIndexPath:indexPath];
+        return [article.title isEqualToTitle:title];
     }];
-    if (indexPathsToRefresh.count > 0) {
-        [self.collectionView reloadItemsAtIndexPaths:indexPathsToRefresh];
-    }
+    [self.collectionView reloadItemsAtIndexPaths:indexPathsToRefresh];
 }
 
 - (void)dealloc {

--- a/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
@@ -55,7 +55,6 @@
 }
 
 - (void)commonInit {
-    [self observeArticleUpdates];
     self.navigationItem.rightBarButtonItem = [self wmf_searchBarButtonItemWithDelegate:self];
 }
 
@@ -131,7 +130,7 @@
 #pragma mark - Stay Fresh... yo
 
 - (void)observeArticleUpdates {
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:MWKArticleSavedNotification object:nil];
+    [self unobserveArticleUpdates];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(articleUpdatedWithNotification:) name:MWKArticleSavedNotification object:nil];
 }
 
@@ -224,6 +223,8 @@
     [self flowLayout].numberOfColumns    = 1;
     [self flowLayout].sectionInset       = UIEdgeInsetsMake(10.0, 0.0, 10.0, 0.0);
     [self flowLayout].minimumLineSpacing = 1.0;
+
+    [self observeArticleUpdates];
 }
 
 - (void)viewWillAppear:(BOOL)animated {


### PR DESCRIPTION
Fixes this:
https://phabricator.wikimedia.org/T113738

**Also fixes following bug:**
-Go to recent.
-Tap first article card.
-Tap on a link in that article.
-Go back to recent.
-The card for the link-tap article will only be showing its title - not summary or image.

**Before:**
![before](https://cloud.githubusercontent.com/assets/3143487/10530882/7e74ebde-7360-11e5-971e-af9afccbb5b1.gif)

**After:**
![after](https://cloud.githubusercontent.com/assets/3143487/10530885/8280a38a-7360-11e5-8442-074cf99fd57f.gif)