### PR TITLE
Fix for card image aspect ratio across devices.

### DIFF
--- a/Wikipedia/UI-V5/WMFArticlePreviewCell.m
+++ b/Wikipedia/UI-V5/WMFArticlePreviewCell.m
@@ -12,7 +12,6 @@
 
 @property (nonatomic) CGFloat paddingAboveDescriptionFromIB;
 @property (nonatomic) CGFloat paddingBelowDescriptionFromIB;
-@property (nonatomic) CGFloat heightOfImageFromIB;
 
 @property (strong, nonatomic) IBOutlet NSLayoutConstraint* paddingConstraintAboveDescription;
 @property (strong, nonatomic) IBOutlet NSLayoutConstraint* paddingConstraintBelowDescription;
@@ -37,7 +36,6 @@
 - (void)rememberSettingsFromIB {
     self.paddingAboveDescriptionFromIB = self.paddingConstraintAboveDescription.constant;
     self.paddingBelowDescriptionFromIB = self.paddingConstraintBelowDescription.constant;
-    self.heightOfImageFromIB           = self.imageHeightConstraint.constant;
 }
 
 - (UICollectionViewLayoutAttributes*)preferredLayoutAttributesFittingAttributes:(UICollectionViewLayoutAttributes*)layoutAttributes {
@@ -119,7 +117,14 @@
 }
 
 - (void)restoreImageToFullHeight {
-    self.imageHeightConstraint.constant = self.heightOfImageFromIB;
+    self.imageHeightConstraint.constant = [self sixteenByNineHeightForImageWithSameHeightForLandscape];
+}
+
+- (CGFloat)sixteenByNineHeightForImageWithSameHeightForLandscape {
+    // Design said landscape should use same height used for portrait.
+    CGFloat horizontalPadding = self.paddingConstraintLeading.constant + self.paddingConstraintTrailing.constant;
+    CGFloat ratio             = (9.0 / 16.0);
+    return floor((MIN(CGRectGetWidth([UIScreen mainScreen].bounds), CGRectGetHeight([UIScreen mainScreen].bounds)) - horizontalPadding) * ratio);
 }
 
 @end


### PR DESCRIPTION
Bug noted by Katie:
https://phabricator.wikimedia.org/T113001#1737188

Josh said give it a peek but timebox to before lunch.

Problem was the image height from IB was 16 by 9 ratio when shown only on the simulator device I used when testing, but not other devices - i.e. screens with different resolutions. 

Katie said use same height for landscape as we use for portrait.