### PR TITLE
Invalid geometry crash fix

### DIFF
--- a/Wikipedia/Categories/UIScrollView+WMFContentOffsetUtils.h
+++ b/Wikipedia/Categories/UIScrollView+WMFContentOffsetUtils.h
@@ -34,4 +34,18 @@
  */
 - (CGRect)wmf_contentFrame;
 
+
+/**
+ *  Set offset if within bounds and valid (i.e. not NaN).
+ *
+ *  Use this when setting offsets that might have invalid values, e.g. those obtained from the
+ *  web view.
+ *
+ *  @param offset   The offset to apply.
+ *  @param animated Whether or not to animate scrolling to given offset.
+ *
+ *  @see setContentOffset:animated:
+ */
+- (void)wmf_safeSetContentOffset:(CGPoint)offset animated:(BOOL)animated;
+
 @end

--- a/Wikipedia/Categories/UIScrollView+WMFContentOffsetUtils.m
+++ b/Wikipedia/Categories/UIScrollView+WMFContentOffsetUtils.m
@@ -22,4 +22,16 @@
     return UIEdgeInsetsInsetRect(CGRectOffset(self.frame, 0, self.contentOffset.y), self.contentInset);
 }
 
+- (void)wmf_safeSetContentOffset:(CGPoint)offset animated:(BOOL)animated {
+    if (offset.x == offset.x && offset.y == offset.y) {
+        if (self.contentSize.width < offset.x || self.contentSize.height < offset.y) {
+            DDLogWarn(@"Attempting to scroll to offset %@ which exceeds contentSize scroll view %@",
+                      NSStringFromCGPoint(offset), self);
+        }
+        [self setContentOffset:offset animated:animated];
+    } else {
+        DDLogError(@"Ignoring invalid offset %@ for scroll view %@", NSStringFromCGPoint(offset), self);
+    }
+}
+
 @end

--- a/Wikipedia/Categories/UIScrollView+WMFContentOffsetUtils.m
+++ b/Wikipedia/Categories/UIScrollView+WMFContentOffsetUtils.m
@@ -23,11 +23,14 @@
 }
 
 - (void)wmf_safeSetContentOffset:(CGPoint)offset animated:(BOOL)animated {
-    if (offset.x == offset.x && offset.y == offset.y) {
+    if (isnan(offset.x) && isnan(offset.y)) {
+        #if DEBUG
+        // log warning, but still scroll, if we get an out-of-bounds offset
         if (self.contentSize.width < offset.x || self.contentSize.height < offset.y) {
-            DDLogWarn(@"Attempting to scroll to offset %@ which exceeds contentSize scroll view %@",
-                      NSStringFromCGPoint(offset), self);
+            DDLogDebug(@"Attempting to scroll to offset %@ which exceeds contentSize scroll view %@",
+                       NSStringFromCGPoint(offset), self);
         }
+        #endif
         [self setContentOffset:offset animated:animated];
     } else {
         DDLogError(@"Ignoring invalid offset %@ for scroll view %@", NSStringFromCGPoint(offset), self);

--- a/Wikipedia/UI-V5/WMFContinueReadingSectionController.m
+++ b/Wikipedia/UI-V5/WMFContinueReadingSectionController.m
@@ -26,7 +26,7 @@ static NSString* const WMFContinueReadingSectionIdentifier = @"WMFContinueReadin
 @synthesize delegate = _delegate;
 
 - (instancetype)initWithArticleTitle:(MWKTitle*)title
-                           dataStore:(MWKDataStore*)dataStore{
+                           dataStore:(MWKDataStore*)dataStore {
     NSParameterAssert(title);
     NSParameterAssert(dataStore);
     self = [super init];

--- a/Wikipedia/View Controllers/WebView/WebViewController.m
+++ b/Wikipedia/View Controllers/WebView/WebViewController.m
@@ -387,7 +387,7 @@ typedef NS_ENUM (NSInteger, WMFWebViewAlertType) {
             CGPoint elementOrigin =
                 CGPointMake(self.webView.scrollView.contentOffset.x,
                             self.webView.scrollView.contentOffset.y + r.origin.y + [self clientBoundingRectVerticalOffset]);
-            [self.webView.scrollView setContentOffset:elementOrigin animated:YES];
+            [self.webView.scrollView wmf_safeSetContentOffset:elementOrigin animated:YES];
         }
     }
 }
@@ -404,7 +404,7 @@ typedef NS_ENUM (NSInteger, WMFWebViewAlertType) {
 }
 
 - (void)scrollToVerticalOffset:(CGFloat)offset {
-    [self.webView.scrollView setContentOffset:CGPointMake(0, offset) animated:NO];
+    [self.webView.scrollView wmf_safeSetContentOffset:CGPointMake(0, offset) animated:NO];
 }
 
 - (CGFloat)currentVerticalOffset {
@@ -462,9 +462,7 @@ typedef NS_ENUM (NSInteger, WMFWebViewAlertType) {
                           delay:0.0f
                         options:UIViewAnimationOptionBeginFromCurrentState
                      animations:^{
-        // Not using "setContentOffset:animated:" so duration of animation
-        // can be controlled and action can be taken after animation completes.
-        self.webView.scrollView.contentOffset = point;
+        [self.webView.scrollView wmf_safeSetContentOffset:point animated:NO];
     } completion:^(BOOL done) {
     }];
 }


### PR DESCRIPTION
Phab: [T116468](https://phabricator.wikimedia.org/T116468)

---

During device rotation, we query the webview for element coordinates, which might not be available and result in `NaN`, which `UIScrollView` doesn't like :boom:.  So, we wrap potentially "unsafe" offsets in `wmf_safeSetContentOffset:animated:` to turn crashes into error logs:

> 2015-10-24 09:10:19:493 Wikipedia Debug[main] -[UIScrollView(WMFContentOffsetUtils) wmf_safeSetContentOffset:animated:]#L33 WARN:
Ignoring invalid offset {0, nan} for scroll view <_UIWebViewScrollView: 0x7fe0d315ca00; frame = (0 0; 375 667); clipsToBounds = YES; autoresize = H; gestureRecognizers = <NSArray: 0x7fe0d2c8c740>; animations = { bounds.origin=<CABasicAnimation: 0x7fe0d2f5cb30>; bounds.size=<CABasicAnimation: 0x7fe0d2f515e0>; position=<CABasicAnimation: 0x7fe0d51e7d50>; bounds.origin-2=<CABasicAnimation: 0x7fe0d51e6670>; bounds.size-2=<CABasicAnimation: 0x7fe0d2ed2b30>; position-2=<CABasicAnimation: 0x7fe0d51afa10>; bounds.origin-3=<CABasicAnimation: 0x7fe0d2ed2af0>; bounds.size-3=<CABasicAnimation: 0x7fe0d513ca50>; }; layer = <CALayer: 0x7fe0d5203220>; contentOffset: {0, -64}; contentSize: {375, 1825}>