### PR TITLE
Fix crash when interacting with toolbar while article loads

### DIFF
--- a/Wikipedia/UI-V5/WMFArticleContainerViewController+TOC.swift
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController+TOC.swift
@@ -51,18 +51,6 @@ extension WMFArticleContainerViewController {
         }
     }
 
-    public var tableOfContentsToolbarItem: UIBarButtonItem  {
-        get {
-            // unfortunately BlocksKit "handler" API doesn't port to Swift well due to "bk_" prefix
-            let tocToolbarItem = UIBarButtonItem(image: UIImage(named:"toc"),
-                                                 style: UIBarButtonItemStyle.Plain,
-                                                 target: self,
-                                                 action: Selector("didTapTableOfContentsButton:"))
-            tocToolbarItem.tintColor = UIColor.blackColor()
-            return tocToolbarItem
-        }
-    }
-
     public func didTapTableOfContentsButton(sender: AnyObject?) {
         if let item: TableOfContentsItem = webViewController.currentVisibleSection() {
             tableOfContentsViewController!.selectAndScrollToItem(item, animated: false)

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -324,7 +324,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (UIBarButtonItem*)saveToolbarItem {
     if (!_saveToolbarItem) {
-        return [[UIBarButtonItem alloc] initWithCustomView:self.saveButtonController.button];
+        _saveToolbarItem = [[UIBarButtonItem alloc] initWithCustomView:self.saveButtonController.button];
     }
     return _saveToolbarItem;
 }

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -91,6 +91,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Views
 @property (nonatomic, strong) MASConstraint* headerHeightConstraint;
+@property (nonatomic, strong) UIBarButtonItem* refreshToolbarItem;
+@property (nonatomic, strong) UIBarButtonItem* saveToolbarItem;
+@property (nonatomic, strong) UIBarButtonItem* shareToolbarItem;
+@property (nonatomic, strong) UIBarButtonItem* tableOfContentsToolbarItem;
 
 @end
 
@@ -139,7 +143,6 @@ NS_ASSUME_NONNULL_BEGIN
     self.webViewController.article = _article;
     [self.headerGallery setImagesFromArticle:_article];
 
-    // need to remove TOC button if article is main
     [self setupToolbar];
 }
 
@@ -258,24 +261,32 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)observeArticleUpdates {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:MWKArticleSavedNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(articleUpdatedWithNotification:) name:MWKArticleSavedNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(articleUpdatedWithNotification:)
+                                                 name:MWKArticleSavedNotification
+                                               object:nil];
 }
 
 - (void)unobserveArticleUpdates {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:MWKArticleSavedNotification object:nil];
 }
 
-#pragma mark - Toolbar
+#pragma mark - Toolbar Setup
 
 - (void)setupToolbar {
+    [self updateToolbarItemsIfNeeded];
+    [self updateToolbarItemEnabledState];
+}
+
+- (void)updateToolbarItemsIfNeeded {
     NSMutableArray<UIBarButtonItem*>* toolbarItems =
-        [NSMutableArray arrayWithObjects:
-         [self refreshToolbarItem], [self flexibleSpaceToolbarItem],
-         [self shareToolbarItem], [self flexibleSpaceToolbarItem],
-         [self saveToolbarItem], nil];
+    [NSMutableArray arrayWithObjects:
+     self.refreshToolbarItem, [self flexibleSpaceToolbarItem],
+     self.shareToolbarItem, [self flexibleSpaceToolbarItem],
+     self.saveToolbarItem, nil];
 
     if (!self.article.isMain) {
-        [toolbarItems addObjectsFromArray:@[[self flexibleSpaceToolbarItem], [self tableOfContentsToolbarItem]]];
+        [toolbarItems addObjectsFromArray:@[[self flexibleSpaceToolbarItem], self.tableOfContentsToolbarItem]];
     }
 
     if (self.toolbarItems.count != toolbarItems.count) {
@@ -284,6 +295,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+- (void)updateToolbarItemEnabledState {
+    self.refreshToolbarItem.enabled = self.article != nil;
+    self.tableOfContentsToolbarItem.enabled = self.article != nil;
+    self.shareToolbarItem.enabled = self.article != nil;
+}
+
+#pragma mark - Toolbar Items
+
 - (UIBarButtonItem*)paddingToolbarItem {
     UIBarButtonItem* item =
         [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
@@ -291,17 +310,35 @@ NS_ASSUME_NONNULL_BEGIN
     return item;
 }
 
+- (UIBarButtonItem*)tableOfContentsToolbarItem {
+    if (!_tableOfContentsToolbarItem) {
+        _tableOfContentsToolbarItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"toc"]
+                                                                       style:UIBarButtonItemStylePlain
+                                                                      target:self
+                                                                      action:@selector(didTapTableOfContentsButton:)];
+        _tableOfContentsToolbarItem.tintColor = [UIColor blackColor];
+        return _tableOfContentsToolbarItem;
+    }
+    return _tableOfContentsToolbarItem;
+}
+
 - (UIBarButtonItem*)saveToolbarItem {
-    return [[UIBarButtonItem alloc] initWithCustomView:self.saveButtonController.button];;
+    if (!_saveToolbarItem) {
+        return [[UIBarButtonItem alloc] initWithCustomView:self.saveButtonController.button];
+    }
+    return _saveToolbarItem;
 }
 
 - (UIBarButtonItem*)refreshToolbarItem {
-    @weakify(self);
-    return [[UIBarButtonItem alloc] bk_initWithBarButtonSystemItem:UIBarButtonSystemItemRefresh
-                                                           handler:^(id _Nonnull sender) {
-        @strongify(self);
-        [self fetchArticle];
-    }];
+    if (!_refreshToolbarItem) {
+        @weakify(self);
+        _refreshToolbarItem = [[UIBarButtonItem alloc] bk_initWithBarButtonSystemItem:UIBarButtonSystemItemRefresh
+                                                                              handler:^(id _Nonnull sender) {
+            @strongify(self);
+            [self fetchArticle];
+        }];
+    }
+    return _refreshToolbarItem;
 }
 
 - (UIBarButtonItem*)flexibleSpaceToolbarItem {
@@ -311,12 +348,15 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (UIBarButtonItem*)shareToolbarItem {
-    @weakify(self);
-    return [[UIBarButtonItem alloc] bk_initWithBarButtonSystemItem:UIBarButtonSystemItemAction
+    if (!_shareToolbarItem) {
+        @weakify(self);
+        _shareToolbarItem = [[UIBarButtonItem alloc] bk_initWithBarButtonSystemItem:UIBarButtonSystemItemAction
                                                            handler:^(id sender){
-        @strongify(self);
-        [self shareArticleWithTextSnippet:[self.webViewController selectedText] fromButton:sender];
-    }];
+            @strongify(self);
+            [self shareArticleWithTextSnippet:[self.webViewController selectedText] fromButton:sender];
+        }];
+    }
+    return _shareToolbarItem;
 }
 
 #pragma mark - ViewController

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -280,10 +280,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateToolbarItemsIfNeeded {
     NSMutableArray<UIBarButtonItem*>* toolbarItems =
-    [NSMutableArray arrayWithObjects:
-     self.refreshToolbarItem, [self flexibleSpaceToolbarItem],
-     self.shareToolbarItem, [self flexibleSpaceToolbarItem],
-     self.saveToolbarItem, nil];
+        [NSMutableArray arrayWithObjects:
+         self.refreshToolbarItem, [self flexibleSpaceToolbarItem],
+         self.shareToolbarItem, [self flexibleSpaceToolbarItem],
+         self.saveToolbarItem, nil];
 
     if (!self.article.isMain) {
         [toolbarItems addObjectsFromArray:@[[self flexibleSpaceToolbarItem], self.tableOfContentsToolbarItem]];
@@ -296,9 +296,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)updateToolbarItemEnabledState {
-    self.refreshToolbarItem.enabled = self.article != nil;
+    self.refreshToolbarItem.enabled         = self.article != nil;
     self.tableOfContentsToolbarItem.enabled = self.article != nil;
-    self.shareToolbarItem.enabled = self.article != nil;
+    self.shareToolbarItem.enabled           = self.article != nil;
 }
 
 #pragma mark - Toolbar Items
@@ -351,7 +351,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (!_shareToolbarItem) {
         @weakify(self);
         _shareToolbarItem = [[UIBarButtonItem alloc] bk_initWithBarButtonSystemItem:UIBarButtonSystemItemAction
-                                                           handler:^(id sender){
+                                                                            handler:^(id sender){
             @strongify(self);
             [self shareArticleWithTextSnippet:[self.webViewController selectedText] fromButton:sender];
         }];

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController_Private.h
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController_Private.h
@@ -14,6 +14,8 @@ typedef NS_ENUM (NSInteger, WMFArticleFooterViewIndex) {
     WMFArticleFooterViewIndexReadMore = 0
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface WMFArticleContainerViewController ()
 
 // Data
@@ -21,6 +23,8 @@ typedef NS_ENUM (NSInteger, WMFArticleFooterViewIndex) {
 
 // Children
 @property (nonatomic, strong, null_resettable) WMFTableOfContentsViewController* tableOfContentsViewController;
-@property (nonatomic, strong, nonnull) WebViewController* webViewController;
+@property (nonatomic, strong) WebViewController* webViewController;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wikipedia/UI-V5/WMFContinueReadingSectionController.m
+++ b/Wikipedia/UI-V5/WMFContinueReadingSectionController.m
@@ -26,7 +26,7 @@ static NSString* const WMFContinueReadingSectionIdentifier = @"WMFContinueReadin
 @synthesize delegate = _delegate;
 
 - (instancetype)initWithArticleTitle:(MWKTitle*)title
-                           dataStore:(MWKDataStore*)dataStore{
+                           dataStore:(MWKDataStore*)dataStore {
     NSParameterAssert(title);
     NSParameterAssert(dataStore);
     self = [super init];


### PR DESCRIPTION
Phab: [T116469](https://phabricator.wikimedia.org/T116469)

---

This disables interaction w/ article-sensitive toolbar itms until data is available (see screenshot below).  Doing so required we keep refs to toolbar items for easy access.  Similar logic can be employed when we implement [T112876](https://phabricator.wikimedia.org/T112876).

> Caveat: _technically_ there's race condition between when the DOM finishes being loaded and transformed and when we try to query it for user location.  The window of time should be relatively small on most newer devices, but ideally we'd find a way to make interactions requiring data from the DOM optimistically asynchronous.  That said, the app should currently throw an assertion if we couldn't get DOM information in debug, and do nothing in production.

<img src="https://cloud.githubusercontent.com/assets/444217/10730641/93cd6140-7bc7-11e5-83b6-8b9f9b000d3e.png" width=200>