### PR TITLE
Fix WebViewController article display flow

### DIFF
--- a/Wikipedia/View Controllers/WebView/WebViewController.m
+++ b/Wikipedia/View Controllers/WebView/WebViewController.m
@@ -634,9 +634,7 @@ typedef NS_ENUM (NSInteger, WMFWebViewAlertType) {
 #warning TODO: remove dependency on session current article
     self.session.currentArticle = article;
 
-    // HAX: Need to check the window to see if we are on screen, isViewLoaded is not enough.
-    // see http://stackoverflow.com/a/2777460/48311
-    if ([self isViewLoaded] && self.view.window) {
+    if ([self isViewLoaded]) {
         [self displayArticle];
     }
 }


### PR DESCRIPTION
Turns out `WebViewController` was only calling `displayArticle` when we got the article fetch back, since `setArticle:` within `viewDidLoad` wasn't triggering display due to the `self.view.window` check.  By removing it, the article display logic is simplified to:

1. Display article when set **and** view is loaded
2. Display article when view is loaded 

1 handles the case when the article is set _after_ `viewDidLoad` (e.g. due to an update elsewhere) and 2 handles the case where the article is set _before_ `viewDidLoad` by deferring the display until the view is available to render the content.

Other options are to keep track of the last article we displayed, and display it when we get calls to `viewWillAppear:`.  We'd need to keep track of the last article we displayed in order to prevent redundant (and user-hindering) content renderings.