### PR TITLE
Fix crashes related to unnecessary preview registration

### DIFF
--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -331,9 +331,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.article = [self.dataStore existingArticleWithTitle:self.articleTitle];
     [self fetchArticle];
 
-    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 0, 0}]) {
-        [self configureLinkPreviewingDelegation];
-    }
+    [self configureLinkPreviewingDelegationIfNeeded];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -539,7 +537,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - UIViewControllerPreviewingDelegate
 
-- (void)configureLinkPreviewingDelegation {
+- (void)configureLinkPreviewingDelegationIfNeeded {
+    if (self.traitCollection.forceTouchCapability != UIForceTouchCapabilityAvailable) {
+        return;
+    }
     id <UIViewControllerPreviewing>pc = [self registerForPreviewingWithDelegate:self sourceView:[self.webViewController.webView wmf_browserView]];
     for (UIGestureRecognizer* r in [self.webViewController.webView wmf_browserView].gestureRecognizers) {
         [r requireGestureRecognizerToFail:pc.previewingGestureRecognizerForFailureRelationship];

--- a/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
@@ -227,7 +227,7 @@
 
     [self observeArticleUpdates];
 
-    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 0, 0}]) {
+    if (self.traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable) {
         [self registerForPreviewingWithDelegate:self sourceView:self.collectionView];
         ((WMFEditingCollectionViewLayout*)self.collectionView.collectionViewLayout).previewingEnabled = YES;
     }

--- a/Wikipedia/UI-V5/WMFContinueReadingSectionController.m
+++ b/Wikipedia/UI-V5/WMFContinueReadingSectionController.m
@@ -26,7 +26,7 @@ static NSString* const WMFContinueReadingSectionIdentifier = @"WMFContinueReadin
 @synthesize delegate = _delegate;
 
 - (instancetype)initWithArticleTitle:(MWKTitle*)title
-                           dataStore:(MWKDataStore*)dataStore{
+                           dataStore:(MWKDataStore*)dataStore {
     NSParameterAssert(title);
     NSParameterAssert(dataStore);
     self = [super init];

--- a/Wikipedia/UI-V5/WMFHomeViewController.m
+++ b/Wikipedia/UI-V5/WMFHomeViewController.m
@@ -198,7 +198,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidEnterForegroundWithNotification:) name:UIApplicationWillEnterForegroundNotification object:nil];
 
-    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 0, 0}]) {
+    if (self.traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable) {
         [self registerForPreviewingWithDelegate:self sourceView:self.collectionView];
     }
 

--- a/Wikipedia/UI-V5/WMFSearchViewController.storyboard
+++ b/Wikipedia/UI-V5/WMFSearchViewController.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="15A284" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tkf-8P-b2O">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tkf-8P-b2O">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
     </dependencies>
     <scenes>
         <!--Search View Controller-->


### PR DESCRIPTION
Phab: [T116648](https://phabricator.wikimedia.org/T116648)

---

Somehow, registering for previews (and then setting up failure relationships w/ their gesture recognizers) was causing the app to crash when an article VC was popped and UIKit tried to clean up the gesture recognizers.