### PR TITLE
Improve tap area of save button in article toolbar

### DIFF
--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -117,8 +117,6 @@ NS_ASSUME_NONNULL_BEGIN
         self.discoveryMethod = discoveryMethod;
         [self observeArticleUpdates];
         self.hidesBottomBarWhenPushed = YES;
-        [self setupToolbar];
-        self.navigationItem.rightBarButtonItem = [self wmf_searchBarButtonItemWithDelegate:self];
     }
     return self;
 }
@@ -234,18 +232,6 @@ NS_ASSUME_NONNULL_BEGIN
     return _shareOptionsController;
 }
 
-- (WMFSaveButtonController*)saveButtonController {
-    if (!_saveButtonController) {
-        _saveButtonController = [[WMFSaveButtonController alloc] init];
-        UIButton* saveButton = [UIButton wmf_buttonType:WMFButtonTypeBookmark handler:nil];
-        [saveButton sizeToFit];
-        _saveButtonController.button        = saveButton;
-        _saveButtonController.savedPageList = self.savedPages;
-        _saveButtonController.title         = self.articleTitle;
-    }
-    return _saveButtonController;
-}
-
 #pragma mark - Notifications and Observations
 
 - (void)applicationWillResignActiveWithNotification:(NSNotification*)note {
@@ -279,6 +265,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)updateToolbarItemsIfNeeded {
+    
+    if (!self.saveButtonController) {
+        self.saveButtonController = [[WMFSaveButtonController alloc] initWithBarButtonItem:self.saveToolbarItem savedPageList:self.savedPages title:self.articleTitle];
+    }
+
     NSMutableArray<UIBarButtonItem*>* toolbarItems =
         [NSMutableArray arrayWithObjects:
          self.refreshToolbarItem, [self flexibleSpaceToolbarItem],
@@ -324,7 +315,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (UIBarButtonItem*)saveToolbarItem {
     if (!_saveToolbarItem) {
-        _saveToolbarItem = [[UIBarButtonItem alloc] initWithCustomView:self.saveButtonController.button];
+        _saveToolbarItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"save"] style:UIBarButtonItemStylePlain target:nil action:nil];
     }
     return _saveToolbarItem;
 }
@@ -363,6 +354,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+
+    [self setupToolbar];
+    self.navigationItem.rightBarButtonItem = [self wmf_searchBarButtonItemWithDelegate:self];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillResignActiveWithNotification:) name:UIApplicationWillResignActiveNotification object:nil];
 

--- a/Wikipedia/UI-V5/WMFSaveButtonController.h
+++ b/Wikipedia/UI-V5/WMFSaveButtonController.h
@@ -9,10 +9,15 @@
 
 @property (copy, nonatomic) MWKTitle* title;
 @property (strong, nonatomic) UIButton* button;
+@property (strong, nonatomic) UIBarButtonItem* barButtonItem;
 @property (strong, nonatomic) MWKSavedPageList* savedPageList;
 
 - (instancetype)initWithButton:(UIButton*)button
                  savedPageList:(MWKSavedPageList*)savedPageList
                          title:(MWKTitle*)title;
+
+- (instancetype)initWithBarButtonItem:(UIBarButtonItem*)barButtonItem
+                        savedPageList:(MWKSavedPageList*)savedPageList
+                                title:(MWKTitle*)title;
 
 @end

--- a/Wikipedia/UI-V5/WMFSaveButtonController.m
+++ b/Wikipedia/UI-V5/WMFSaveButtonController.m
@@ -27,6 +27,19 @@
     return self;
 }
 
+- (instancetype)initWithBarButtonItem:(UIBarButtonItem*)barButtonItem
+                        savedPageList:(MWKSavedPageList*)savedPageList
+                                title:(MWKTitle*)title {
+    NSParameterAssert(savedPageList);
+    self = [super init];
+    if (self) {
+        self.barButtonItem = barButtonItem;
+        self.title         = title;
+        self.savedPageList = savedPageList;
+    }
+    return self;
+}
+
 - (void)dealloc {
     [self unobserveSavedPages];
 }
@@ -62,6 +75,15 @@
     [self updateSavedButtonState];
 }
 
+- (void)setBarButtonItem:(UIBarButtonItem*)barButtonItem {
+    [_barButtonItem setTarget:nil];
+    [_barButtonItem setAction:nil];
+    _barButtonItem = barButtonItem;
+    [_barButtonItem setTarget:self];
+    [_barButtonItem setAction:@selector(toggleSave:)];
+    [self updateSavedButtonState];
+}
+
 - (SavedPagesFunnel*)savedPagesFunnel {
     if (!_savedPagesFunnel) {
         _savedPagesFunnel = [[SavedPagesFunnel alloc] init];
@@ -93,7 +115,13 @@
 #pragma mark - Save State
 
 - (void)updateSavedButtonState {
-    self.button.selected = [self isSaved];
+    BOOL isSaved = [self isSaved];
+    self.button.selected = isSaved;
+    if (isSaved) {
+        self.barButtonItem.image = [UIImage imageNamed:@"save-filled"];
+    } else {
+        self.barButtonItem.image = [UIImage imageNamed:@"save"];
+    }
 }
 
 - (BOOL)isSaved {


### PR DESCRIPTION
Being a custom button was interfering with Apple's touch logic. Converted to a normal bar button item. Also updated the button controller to handle bar button items.

Additional pull request is coming for the save button on home screen feed items.