### PR TITLE
Move first good paragraph *and* non-p elements up to next p.

### DIFF
--- a/Wikipedia/assets/bundle.js
+++ b/Wikipedia/assets/bundle.js
@@ -908,58 +908,58 @@ transformer.register( "moveFirstGoodParagraphUp", function( content ) {
     var edit_section_button_0 = content.getElementById( "edit_section_button_0" );
     if(!edit_section_button_0) return;
 
-    function moveAfter(newNode, referenceNode) {
-        // Based on: http://stackoverflow.com/a/4793630/135557
-        referenceNode.parentNode.insertBefore(newNode.parentNode.removeChild(newNode), referenceNode.nextSibling);
-    }
-
-    for ( var i = 0; i < allPs.length; i++ ) {
-        var p = allPs[i];
-
-        // Narrow down to first P which is direct child of content_block_0 DIV.
-        // (Don't want to yank P from somewhere in the middle of a table!)
-        if  (p.parentNode != block_0) continue;
-
-
-        // Ensure the P being pulled up has at least a couple lines of text.
-        // Otherwise silly things like a empty P or P which only contains a
-        // BR tag will get pulled up (see articles on "Chemical Reaction" and
-        // "Hawaii").
-        // Trick for quickly determining element height:
-        //      https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement.offsetHeight
-        //      http://stackoverflow.com/a/1343350/135557
-        var minHeight = 40;
-        var pIsTooSmall = (p.offsetHeight < minHeight);
-        if(pIsTooSmall) continue;
-
-
-        /*
-        // Note: this works - just not sure if needed?
-        // Sometimes P will be mostly image and not much text. Don't
-        // want to move these!
-        var pIsMostlyImage = false;
-        var imgs = p.getElementsByTagName('img');
-        for (var j = 0; j < imgs.length; j++) {
-            var thisImg = imgs[j];
-            // Get image height from img tag's height attribute - otherwise
-            // you'd have to wait for the image to render (if you used offsetHeight).
-            var thisImgHeight = thisImg.getAttribute("height");
-            if(thisImgHeight == 0) continue;
-            var imgHeightPercentOfParagraphTagHeight = thisImgHeight / p.offsetHeight;
-            if (imgHeightPercentOfParagraphTagHeight > 0.5){
-                pIsMostlyImage = true;
-                break;
-            }
+    var firstGoodParagraph = function(){
+        for ( var i = 0; i < allPs.length; i++ ) {
+            var p = allPs[i];
+             // Narrow down to first P which is direct child of content_block_0 DIV.
+             // (Don't want to yank P from somewhere in the middle of a table!)
+             if  (p.parentNode != block_0) continue;
+                     
+             // Ensure the P being pulled up has at least a couple lines of text.
+             // Otherwise silly things like a empty P or P which only contains a
+             // BR tag will get pulled up (see articles on "Chemical Reaction" and
+             // "Hawaii").
+             // Trick for quickly determining element height:
+             //      https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement.offsetHeight
+             //      http://stackoverflow.com/a/1343350/135557
+             var minHeight = 40;
+             var pIsTooSmall = (p.offsetHeight < minHeight);
+             if(pIsTooSmall) continue;
+             return p;
         }
-        if(pIsMostlyImage) continue;
-        */
+        return null;
+    }();
 
-        // Move the P! Place it just after the lead section edit button.
-        moveAfter(p, edit_section_button_0);
+    if(!firstGoodParagraph) return;
 
-        // But only move one P!
-        break;
-    }
+    // Move everything between the firstGoodParagraph and the next paragraph to a light-weight fragment.
+    var fragmentOfItemsToRelocate = function(){
+        var didHitGoodP = false;
+        var didHitNextP = false;
+
+        var shouldElementMoveUp = function(element) {
+            if(didHitGoodP && element.tagName === 'P'){
+                didHitNextP = true;
+            }else if(element.isEqualNode(firstGoodParagraph)){
+                didHitGoodP = true;
+            }
+            return (didHitGoodP && !didHitNextP);
+        };
+
+        var fragment = document.createDocumentFragment();
+        Array.prototype.slice.call(firstGoodParagraph.parentNode.childNodes).forEach(function(element) {
+            if(shouldElementMoveUp(element)){
+                // appendChild() attaches the element to the fragment *and* removes it from DOM.
+                fragment.appendChild(element);
+            }
+        });
+        return fragment;
+    }();
+
+    // Attach the fragment just after the lead section edit button.
+    // insertBefore() on a fragment inserts "the children of the fragment, not the fragment itself."
+    // https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment
+    block_0.insertBefore(fragmentOfItemsToRelocate, edit_section_button_0.nextSibling);
 });
 
 },{"../transformer":8}],16:[function(require,module,exports){

--- a/www/js/transforms/relocateFirstParagraph.js
+++ b/www/js/transforms/relocateFirstParagraph.js
@@ -19,56 +19,56 @@ transformer.register( "moveFirstGoodParagraphUp", function( content ) {
     var edit_section_button_0 = content.getElementById( "edit_section_button_0" );
     if(!edit_section_button_0) return;
 
-    function moveAfter(newNode, referenceNode) {
-        // Based on: http://stackoverflow.com/a/4793630/135557
-        referenceNode.parentNode.insertBefore(newNode.parentNode.removeChild(newNode), referenceNode.nextSibling);
-    }
-
-    for ( var i = 0; i < allPs.length; i++ ) {
-        var p = allPs[i];
-
-        // Narrow down to first P which is direct child of content_block_0 DIV.
-        // (Don't want to yank P from somewhere in the middle of a table!)
-        if  (p.parentNode != block_0) continue;
-
-
-        // Ensure the P being pulled up has at least a couple lines of text.
-        // Otherwise silly things like a empty P or P which only contains a
-        // BR tag will get pulled up (see articles on "Chemical Reaction" and
-        // "Hawaii").
-        // Trick for quickly determining element height:
-        //      https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement.offsetHeight
-        //      http://stackoverflow.com/a/1343350/135557
-        var minHeight = 40;
-        var pIsTooSmall = (p.offsetHeight < minHeight);
-        if(pIsTooSmall) continue;
-
-
-        /*
-        // Note: this works - just not sure if needed?
-        // Sometimes P will be mostly image and not much text. Don't
-        // want to move these!
-        var pIsMostlyImage = false;
-        var imgs = p.getElementsByTagName('img');
-        for (var j = 0; j < imgs.length; j++) {
-            var thisImg = imgs[j];
-            // Get image height from img tag's height attribute - otherwise
-            // you'd have to wait for the image to render (if you used offsetHeight).
-            var thisImgHeight = thisImg.getAttribute("height");
-            if(thisImgHeight == 0) continue;
-            var imgHeightPercentOfParagraphTagHeight = thisImgHeight / p.offsetHeight;
-            if (imgHeightPercentOfParagraphTagHeight > 0.5){
-                pIsMostlyImage = true;
-                break;
-            }
+    var firstGoodParagraph = function(){
+        for ( var i = 0; i < allPs.length; i++ ) {
+            var p = allPs[i];
+             // Narrow down to first P which is direct child of content_block_0 DIV.
+             // (Don't want to yank P from somewhere in the middle of a table!)
+             if  (p.parentNode != block_0) continue;
+                     
+             // Ensure the P being pulled up has at least a couple lines of text.
+             // Otherwise silly things like a empty P or P which only contains a
+             // BR tag will get pulled up (see articles on "Chemical Reaction" and
+             // "Hawaii").
+             // Trick for quickly determining element height:
+             //      https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement.offsetHeight
+             //      http://stackoverflow.com/a/1343350/135557
+             var minHeight = 40;
+             var pIsTooSmall = (p.offsetHeight < minHeight);
+             if(pIsTooSmall) continue;
+             return p;
         }
-        if(pIsMostlyImage) continue;
-        */
+        return null;
+    }();
 
-        // Move the P! Place it just after the lead section edit button.
-        moveAfter(p, edit_section_button_0);
+    if(!firstGoodParagraph) return;
 
-        // But only move one P!
-        break;
-    }
+    // Move everything between the firstGoodParagraph and the next paragraph to a light-weight fragment.
+    var fragmentOfItemsToRelocate = function(){
+        var didHitGoodP = false;
+        var didHitNextP = false;
+
+        var shouldElementMoveUp = function(element) {
+            if(didHitGoodP && element.tagName === 'P'){
+                didHitNextP = true;
+            }else if(element.isEqualNode(firstGoodParagraph)){
+                didHitGoodP = true;
+            }
+            return (didHitGoodP && !didHitNextP);
+        };
+
+        var fragment = document.createDocumentFragment();
+        Array.prototype.slice.call(firstGoodParagraph.parentNode.childNodes).forEach(function(element) {
+            if(shouldElementMoveUp(element)){
+                // appendChild() attaches the element to the fragment *and* removes it from DOM.
+                fragment.appendChild(element);
+            }
+        });
+        return fragment;
+    }();
+
+    // Attach the fragment just after the lead section edit button.
+    // insertBefore() on a fragment inserts "the children of the fragment, not the fragment itself."
+    // https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment
+    block_0.insertBefore(fragmentOfItemsToRelocate, edit_section_button_0.nextSibling);
 });


### PR DESCRIPTION
Description of the issue from Michael's pr:

Moving the first P element up, as we did before, can result
in elements appearing between the first paragraph as
designated by P tags and other elements (such as an
unnumbered list) that may be intended as part of the
first display paragraph (see, e.g., "Planet" on enwiki)