### PR TITLE
Fix for random articles sometimes only showing title.

### DIFF
--- a/Wikipedia/UI-V5/WMFRandomArticleFetcher.m
+++ b/Wikipedia/UI-V5/WMFRandomArticleFetcher.m
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
                //random
                @"generator": @"random",
                @"grnnamespace": @0,
-               @"grnfilterredir": @"all",
+               @"grnfilterredir": @"nonredirects",
                @"grnlimit": @"1",
                // extracts
                @"exintro": @YES,


### PR DESCRIPTION
Problem was we weren't excluding redirect-from titles.
We can safely exclude these since the redirect-to titles
are still in the list of articles which may be returned.