### PR TITLE
Re-fix iOS 8 insta-crash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7
+osx_image: xcode7.1
 install:
   - make travis-get-deps
 script: bundle exec fastlane verify

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -398,6 +398,7 @@
 		BC905A111B447A8300523DFE /* NSURLRequest+WMFUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = BC905A101B447A8300523DFE /* NSURLRequest+WMFUtilities.m */; };
 		BC905A131B44815900523DFE /* SDImageCache+PromiseKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC905A121B44815900523DFE /* SDImageCache+PromiseKit.swift */; };
 		BC92A7731AFA88D3003C4212 /* MWKSection+WMFSharingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC92A7721AFA88D3003C4212 /* MWKSection+WMFSharingTests.m */; };
+		BC93553E1BE094CD00697CB0 /* UIViewController+SafePreviewing.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC93553D1BE094CD00697CB0 /* UIViewController+SafePreviewing.swift */; };
 		BC955BC71A82BEFD000EF9E4 /* MWKImageInfoFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BC955BC61A82BEFD000EF9E4 /* MWKImageInfoFetcher.m */; };
 		BC955BCF1A82C2FA000EF9E4 /* AFHTTPRequestOperationManager+WMFConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = BC955BCE1A82C2FA000EF9E4 /* AFHTTPRequestOperationManager+WMFConfig.m */; };
 		BC98781A1BCF307B003835EA /* MWKRecentSearchDataStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC9878191BCF307B003835EA /* MWKRecentSearchDataStoreTests.m */; };
@@ -1279,6 +1280,7 @@
 		BC905BCF1B60391F0010227E /* MWKLanguageLinkFetcherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MWKLanguageLinkFetcherTests.m; sourceTree = "<group>"; };
 		BC92A76E1AFA83D2003C4212 /* WMFSharing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFSharing.h; path = ShareCard/WMFSharing.h; sourceTree = "<group>"; };
 		BC92A7721AFA88D3003C4212 /* MWKSection+WMFSharingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MWKSection+WMFSharingTests.m"; sourceTree = "<group>"; };
+		BC93553D1BE094CD00697CB0 /* UIViewController+SafePreviewing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+SafePreviewing.swift"; sourceTree = "<group>"; };
 		BC955BC51A82BEFD000EF9E4 /* MWKImageInfoFetcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MWKImageInfoFetcher.h; sourceTree = "<group>"; };
 		BC955BC61A82BEFD000EF9E4 /* MWKImageInfoFetcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MWKImageInfoFetcher.m; sourceTree = "<group>"; };
 		BC955BCD1A82C2FA000EF9E4 /* AFHTTPRequestOperationManager+WMFConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "AFHTTPRequestOperationManager+WMFConfig.h"; path = "Queues/AFHTTPRequestOperationManager+WMFConfig.h"; sourceTree = "<group>"; };
@@ -2190,6 +2192,7 @@
 				BC305C341BA0E47F00E414B8 /* CLLocation+WMFApproximateEquality.m */,
 				BC305C361BA204EF00E414B8 /* NSString+WMFDistance.h */,
 				BC305C371BA204EF00E414B8 /* NSString+WMFDistance.m */,
+				BC93553D1BE094CD00697CB0 /* UIViewController+SafePreviewing.swift */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -4361,6 +4364,7 @@
 				0ED6897F1B82470900B30427 /* WMFLocationSearchFetcher.m in Sources */,
 				BCFB090D1B445A720077955B /* UIImage+WMFSerialization.m in Sources */,
 				BC8210D31B4EEA190010BF7B /* SDImageCache+WMFPersistentCache.m in Sources */,
+				BC93553E1BE094CD00697CB0 /* UIViewController+SafePreviewing.swift in Sources */,
 				BCE24FDD1B0CF0C7003F054B /* LegacyCoreDataMigrator.m in Sources */,
 				04478633185145090050563B /* HistoryViewController.m in Sources */,
 				BCB669B21A83F6C400C7B1FE /* MWKImageInfo.m in Sources */,

--- a/Wikipedia/Categories/UIViewController+SafePreviewing.swift
+++ b/Wikipedia/Categories/UIViewController+SafePreviewing.swift
@@ -9,13 +9,14 @@
 import Foundation
 
 extension UIViewController {
-    public var wmf_isForceTouchAvailable: Bool {
-        get {
-            if #available(iOS 9, *) {
-                return self.traitCollection.forceTouchCapability == UIForceTouchCapability.Available
-            } else {
-                return false
-            }
+    public func wmf_ifForceTouchAvailable(then: Void->Void, unavailable: Void->Void) {
+        guard #available(iOS 9, *) else {
+            return
+        }
+        if self.traitCollection.forceTouchCapability == UIForceTouchCapability.Available {
+            then()
+        } else {
+            unavailable()
         }
     }
 }

--- a/Wikipedia/Categories/UIViewController+SafePreviewing.swift
+++ b/Wikipedia/Categories/UIViewController+SafePreviewing.swift
@@ -1,0 +1,21 @@
+//
+//  UIViewController+SafePreviewing.swift
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 10/27/15.
+//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
+//
+
+import Foundation
+
+extension UIViewController {
+    public var wmf_isForceTouchAvailable: Bool {
+        get {
+            if #available(iOS 9, *) {
+                return self.traitCollection.forceTouchCapability == UIForceTouchCapability.Available
+            } else {
+                return false
+            }
+        }
+    }
+}

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -284,7 +284,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)updateToolbarItemsIfNeeded {
-    
     if (!self.saveButtonController) {
         self.saveButtonController = [[WMFSaveButtonController alloc] initWithBarButtonItem:self.saveToolbarItem savedPageList:self.savedPages title:self.articleTitle];
     }

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -600,7 +600,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - UIViewControllerPreviewingDelegate
 
 - (void)configureLinkPreviewingDelegationIfNeeded {
-    if (self.traitCollection.forceTouchCapability != UIForceTouchCapabilityAvailable) {
+    if (![self wmf_isForceTouchAvailable]) {
         return;
     }
     id <UIViewControllerPreviewing>pc = [self registerForPreviewingWithDelegate:self sourceView:[self.webViewController.webView wmf_browserView]];

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -401,7 +401,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self registerForPreviewingIfAvailable];
 }
 
-- (void)traitCollectionDidChange:(nullable UITraitCollection *)previousTraitCollection {
+- (void)traitCollectionDidChange:(nullable UITraitCollection*)previousTraitCollection {
     [super traitCollectionDidChange:previousTraitCollection];
     [self registerForPreviewingIfAvailable];
 }

--- a/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
@@ -26,6 +26,7 @@
 
 #import "UIColor+WMFHexColor.h"
 #import <BlocksKit/BlocksKit.h>
+#import "Wikipedia-Swift.h"
 
 @interface WMFArticleListCollectionViewController ()
 <UICollectionViewDelegate,
@@ -227,8 +228,9 @@
 
     [self observeArticleUpdates];
 
-    if (self.traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable) {
-        [self registerForPreviewingWithDelegate:self sourceView:self.collectionView];
+    if ([self wmf_isForceTouchAvailable]) {
+        [self registerForPreviewingWithDelegate:self
+                                     sourceView:self.collectionView];
         ((WMFEditingCollectionViewLayout*)self.collectionView.collectionViewLayout).previewingEnabled = YES;
     }
 }

--- a/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleListCollectionViewController.m
@@ -259,7 +259,7 @@
     [self registerForPreviewingIfAvailable];
 }
 
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+- (void)traitCollectionDidChange:(UITraitCollection*)previousTraitCollection {
     [super traitCollectionDidChange:previousTraitCollection];
     [self registerForPreviewingIfAvailable];
 }

--- a/Wikipedia/UI-V5/WMFHomeViewController.m
+++ b/Wikipedia/UI-V5/WMFHomeViewController.m
@@ -232,7 +232,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self registerForPreviewingIfAvailable];
 }
 
-- (void)traitCollectionDidChange:(nullable UITraitCollection *)previousTraitCollection {
+- (void)traitCollectionDidChange:(nullable UITraitCollection*)previousTraitCollection {
     [super traitCollectionDidChange:previousTraitCollection];
     [self registerForPreviewingIfAvailable];
 }

--- a/Wikipedia/UI-V5/WMFHomeViewController.m
+++ b/Wikipedia/UI-V5/WMFHomeViewController.m
@@ -1,4 +1,5 @@
 #import "WMFHomeViewController.h"
+#import "Wikipedia-Swift.h"
 
 // Frameworks
 @import SelfSizingWaterfallCollectionViewLayout;
@@ -198,8 +199,9 @@ NS_ASSUME_NONNULL_BEGIN
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidEnterForegroundWithNotification:) name:UIApplicationWillEnterForegroundNotification object:nil];
 
-    if (self.traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable) {
-        [self registerForPreviewingWithDelegate:self sourceView:self.collectionView];
+    if ([self wmf_isForceTouchAvailable]) {
+        [self registerForPreviewingWithDelegate:self
+                                     sourceView:self.collectionView];
     }
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tweaksDidChangeWithNotification:) name:FBTweakShakeViewControllerDidDismissNotification object:nil];

--- a/Wikipedia/UI-V5/WMFSaveableTitleCollectionViewCell.m
+++ b/Wikipedia/UI-V5/WMFSaveableTitleCollectionViewCell.m
@@ -31,7 +31,7 @@
     [self configureContentView];
     [self configureImageViewWithPlaceholder];
     [self.saveButton wmf_setButtonType:WMFButtonTypeBookmarkMini];
-    self.saveButton.tintColor            = [UIColor wmf_blueTintColor];
+    self.saveButton.tintColor = [UIColor wmf_blueTintColor];
     [self.saveButton setTitleColor:[UIColor wmf_blueTintColor] forState:UIControlStateNormal];
 }
 

--- a/Wikipedia/UI-V5/WMFSearchFetcher.m
+++ b/Wikipedia/UI-V5/WMFSearchFetcher.m
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
         self.operation = nil;
         self.resolver  = nil;
     } else {
-        DDLogWarn(@"No resolver set for results %@ from operation %@", error ?: fetchedData, self.operation);
+        DDLogWarn(@"No resolver set for results %@ from operation %@", error ? : fetchedData, self.operation);
     }
 }
 

--- a/Wikipedia/UI-V5/WMFSearchFetcher.m
+++ b/Wikipedia/UI-V5/WMFSearchFetcher.m
@@ -49,7 +49,13 @@ NS_ASSUME_NONNULL_BEGIN
         self.resolver = resolve;
 
         self.fetcher = [[SearchResultFetcher alloc] init];
-        self.operation = [self.fetcher searchForTerm:searchTerm searchType:type searchReason:SEARCH_REASON_UNKNOWN language:self.searchSite.language maxResults:self.maxSearchResults withManager:self.operationManager thenNotifyDelegate:self];
+        self.operation = [self.fetcher searchForTerm:searchTerm
+                                          searchType:type
+                                        searchReason:SEARCH_REASON_UNKNOWN
+                                            language:self.searchSite.language
+                                          maxResults:self.maxSearchResults
+                                         withManager:self.operationManager
+                                  thenNotifyDelegate:self];
     }];
 }
 
@@ -67,13 +73,18 @@ NS_ASSUME_NONNULL_BEGIN
                status:(FetchFinalStatus)status
                 error:(NSError*)error {
     if (self.resolver) {
-        if (!error) {
-            self.resolver([self searchResultsFromFetcher:sender]);
-        } else {
+        if (error) {
+            DDLogDebug(@"Resolving operation %@ with error %@", self.operation, fetchedData);
             self.resolver(error);
+        } else {
+            WMFSearchResults* results = [self searchResultsFromFetcher:sender];
+            DDLogDebug(@"Resolving operation %@ with results %@", self.operation, results);
+            self.resolver(results);
         }
         self.operation = nil;
         self.resolver  = nil;
+    } else {
+        DDLogWarn(@"No resolver set for results %@ from operation %@", error ?: fetchedData, self.operation);
     }
 }
 


### PR DESCRIPTION
Re-wrap previewing API calls in iOS 9 checks.  This also fixes previewing on Search, which was broken due to unavailable force touch at `viewDidLoad` time.