### PR TITLE
Quick fix for false assertion failure when popping article VCs in RTL UI

### DIFF
--- a/Wikipedia/Custom Views/WMFPageCollectionViewController.m
+++ b/Wikipedia/Custom Views/WMFPageCollectionViewController.m
@@ -48,7 +48,7 @@
 }
 
 - (void)primitiveSetCurrentPage:(NSUInteger)page {
-    NSParameterAssert(page < [self.collectionView numberOfItemsInSection:0]);
+    NSParameterAssert(page < [self collectionView:self.collectionView numberOfItemsInSection:0]);
     _currentPage = page;
 }
 


### PR DESCRIPTION
collection view counts might not be up to date in the collection view, so query the delegate callback directly