### PR TITLE
Fix initial search results not having thumbnails

### DIFF
--- a/MediaWikiKit/MediaWikiKit/UIImageView+WMFImageFetchingInternal.m
+++ b/MediaWikiKit/MediaWikiKit/UIImageView+WMFImageFetchingInternal.m
@@ -184,6 +184,8 @@ static const char* const WMFImageControllerAssociationKey = "WMFImageController"
 
 - (void)wmf_cancelImageDownload {
     [self.wmf_imageController cancelFetchForURL:[self wmf_imageURLToFetch]];
+    self.wmf_imageURL      = nil;
+    self.wmf_imageMetadata = nil;
 }
 
 @end

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 		BC23759E1AB8928600B0BAA8 /* WMFDateFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC23759D1AB8928600B0BAA8 /* WMFDateFormatterTests.m */; };
 		BC2375C11ABB14CC00B0BAA8 /* WMFArticleImageInjectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC2375C01ABB14CC00B0BAA8 /* WMFArticleImageInjectionTests.m */; };
 		BC2CBB8E1AA10F400079A313 /* UIView+WMFFrameUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = BC2CBB8D1AA10F400079A313 /* UIView+WMFFrameUtils.m */; };
+		BC2F420E1BEB9BBC0033E185 /* WMFImageControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC12F2451B7A8EEB0042DB3C /* WMFImageControllerTests.swift */; };
 		BC3047C21B45E65400D7DF1A /* SDWebImageManager+WMFCacheRemoval.m in Sources */ = {isa = PBXBuildFile; fileRef = BC3047C11B45E65400D7DF1A /* SDWebImageManager+WMFCacheRemoval.m */; };
 		BC3059B41B69416E00AA5703 /* MWKImageFaceDetectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC3059B31B69416E00AA5703 /* MWKImageFaceDetectionTests.m */; };
 		BC3059B91B6948C800AA5703 /* XCTestCase+PromiseKit.m in Sources */ = {isa = PBXBuildFile; fileRef = BC3059B81B6948C800AA5703 /* XCTestCase+PromiseKit.m */; };
@@ -4028,6 +4029,7 @@
 				BCA6765A1AC0600500A16160 /* MWKDataStore+TemporaryDataStore.m in Sources */,
 				04F122671ACB818F002FC3B5 /* NSString+FormattedAttributedString.m in Sources */,
 				BC0FED711AAA026C002488D7 /* WMFJoinedPropertyParametersTests.m in Sources */,
+				BC2F420E1BEB9BBC0033E185 /* WMFImageControllerTests.swift in Sources */,
 				BC0FED6A1AAA0268002488D7 /* MWKDataStorePathTests.m in Sources */,
 				BC725ECA1B617E1A00E0A64C /* WMFSafeAssignTests.m in Sources */,
 				BC0FED761AAA026C002488D7 /* NSString+WMFHTMLParsingTests.m in Sources */,

--- a/Wikipedia/Images/UIImageView+WMFImageFetching.m
+++ b/Wikipedia/Images/UIImageView+WMFImageFetching.m
@@ -10,21 +10,17 @@ NS_ASSUME_NONNULL_BEGIN
     self.image = nil;
     [self wmf_resetContentsRect];
     [self wmf_cancelImageDownload];
-    self.wmf_imageURL      = nil;
-    self.wmf_imageMetadata = nil;
 }
 
 - (AnyPromise*)wmf_setImageWithURL:(NSURL*)imageURL detectFaces:(BOOL)detectFaces {
     [self wmf_cancelImageDownload];
-    self.wmf_imageURL      = imageURL;
-    self.wmf_imageMetadata = nil;
+    self.wmf_imageURL = imageURL;
     return [self wmf_fetchImageDetectFaces:detectFaces];
 }
 
 - (AnyPromise*)wmf_setImageWithMetadata:(MWKImage*)imageMetadata detectFaces:(BOOL)detectFaces {
     [self wmf_cancelImageDownload];
     self.wmf_imageMetadata = imageMetadata;
-    self.wmf_imageURL      = nil;
     return [self wmf_fetchImageDetectFaces:detectFaces];
 }
 

--- a/Wikipedia/Images/WMFImageController.swift
+++ b/Wikipedia/Images/WMFImageController.swift
@@ -300,7 +300,7 @@ public class WMFImageController : NSObject {
         guard let url = url else {
             return
         }
-        dispatch_async(self.cancellingQueue) { [weak self] in
+        dispatch_sync(self.cancellingQueue) { [weak self] in
             if let strongSelf = self,
                    cancellable = strongSelf.cancellables.objectForKey(url.absoluteString) as? Cancellable {
                 strongSelf.cancellables.removeObjectForKey(url.absoluteString)
@@ -318,7 +318,7 @@ public class WMFImageController : NSObject {
     }
 
     private func addCancellableForURL(cancellable: Cancellable, url: NSURL) {
-        dispatch_async(self.cancellingQueue) { [weak self] in
+        dispatch_sync(self.cancellingQueue) { [weak self] in
             guard let cancellables = self?.cancellables else {
                 return
             }
@@ -326,6 +326,7 @@ public class WMFImageController : NSObject {
                 DDLogWarn("Ignoring duplicate cancellable for \(url)")
                 return
             }
+            DDLogVerbose("Adding cancellable for \(url)")
             cancellables.setObject(cancellable, forKey: url.absoluteString)
         }
     }

--- a/Wikipedia/Images/WMFImageController.swift
+++ b/Wikipedia/Images/WMFImageController.swift
@@ -73,7 +73,7 @@ public class WMFImageController : NSObject {
 
     let imageManager: SDWebImageManager
 
-    private let cancellingQueue: dispatch_queue_t
+    let cancellingQueue: dispatch_queue_t
 
     private lazy var cancellables: NSMapTable = {
         NSMapTable.strongToWeakObjectsMapTable()
@@ -155,6 +155,7 @@ public class WMFImageController : NSObject {
         return checkForValidURL(url) { url in
             let (cancellable, promise) =
             imageManager.promisedImageWithURL(url.wmf_urlByPrependingSchemeIfSchemeless(), options: options)
+            DDLogVerbose("Fetching image \(url)")
             addCancellableForURL(cancellable, url: url)
             return applyDebugTransformIfEnabled(promise)
         }
@@ -181,7 +182,10 @@ public class WMFImageController : NSObject {
     }
 
     public func hasDataOnDiskForImageWithURL(url: NSURL?) -> Bool {
-        return url == nil ? false : imageManager.diskImageExistsForURL(url)
+        guard let url = url else {
+            return false
+        }
+        return imageManager.diskImageExistsForURL(url)
     }
 
     func diskDataForImageWithURL(url: NSURL?) -> NSData? {
@@ -199,8 +203,8 @@ public class WMFImageController : NSObject {
 
     public func cachedImageWithURL(url: NSURL) -> Promise<WMFImageDownload> {
         let (cancellable, promise) = imageManager.imageCache.queryDiskCacheForKey(cacheKeyForURL(url))
-        if let cancellable = cancellable {
-            addCancellableForURL(cancellable, url: url)
+        if let c = cancellable {
+            addCancellableForURL(c, url: url)
         }
         return applyDebugTransformIfEnabled(promise.then() { image, origin in
             return WMFImageDownload(url: url, image: image, origin: origin.rawValue)
@@ -273,7 +277,7 @@ public class WMFImageController : NSObject {
         }
     }
 
-    private func cacheKeyForURL(url: NSURL) -> String {
+    func cacheKeyForURL(url: NSURL) -> String {
         return imageManager.cacheKeyForURL(url)
     }
 
@@ -286,44 +290,43 @@ public class WMFImageController : NSObject {
     - returns: A rejected promise with `InvalidOrEmptyURL` error if `url` is `nil`, otherwise the promise from `then`.
     */
     private func checkForValidURL(url: NSURL?, @noescape then: (NSURL) -> Promise<WMFImageDownload>) -> Promise<WMFImageDownload> {
-        if url == nil { return Promise(error: WMFImageControllerErrorCode.InvalidOrEmptyURL.error) }
-        else { return then(url!) }
+        return url.map(then) ?? Promise(error: WMFImageControllerErrorCode.InvalidOrEmptyURL.error)
     }
 
     // MARK: - Cancellation
 
     /// Cancel a pending fetch for an image at `url`.
     public func cancelFetchForURL(url: NSURL?) {
-        if let url = url {
-            weak var wself = self;
-            dispatch_async(self.cancellingQueue) {
-                let sself = wself
-                if let cancellable = sself?.cancellables.objectForKey(url.absoluteString) as? Cancellable {
-                    sself?.cancellables.removeObjectForKey(url.absoluteString)
-                    DDLogDebug("Cancelling request for image \(url)")
-                    cancellable.cancel()
-                }
-            }
+        guard let url = url else {
+            return
         }
-    }
-
-    public func cancelAllFetches() {
-        var currentCancellables: [Cancellable]!
-        dispatch_sync(self.cancellingQueue) {
-            currentCancellables = self.cancellables.objectEnumerator()!.allObjects as! [Cancellable]
-        }
-        dispatch_async(dispatch_get_global_queue(0, 0)) {
-            for cancellable in currentCancellables {
+        dispatch_async(self.cancellingQueue) { [weak self] in
+            if let strongSelf = self,
+                   cancellable = strongSelf.cancellables.objectForKey(url.absoluteString) as? Cancellable {
+                strongSelf.cancellables.removeObjectForKey(url.absoluteString)
+                DDLogDebug("Cancelling request for image \(url)")
                 cancellable.cancel()
             }
         }
     }
 
+    public func cancelAllFetches() {
+        dispatch_sync(self.cancellingQueue) {
+            let currentCancellables = self.cancellables.objectEnumerator()!.allObjects as! [Cancellable]
+            currentCancellables.forEach({ $0.cancel() })
+        }
+    }
+
     private func addCancellableForURL(cancellable: Cancellable, url: NSURL) {
-        weak var wself = self;
-        dispatch_async(self.cancellingQueue) {
-            let sself = wself
-            sself?.cancellables.setObject(cancellable, forKey: url.absoluteString)
+        dispatch_async(self.cancellingQueue) { [weak self] in
+            guard let cancellables = self?.cancellables else {
+                return
+            }
+            if cancellables.objectForKey(url.absoluteString) != nil {
+                DDLogWarn("Ignoring duplicate cancellable for \(url)")
+                return
+            }
+            cancellables.setObject(cancellable, forKey: url.absoluteString)
         }
     }
 

--- a/Wikipedia/Images/WMFImageController.swift
+++ b/Wikipedia/Images/WMFImageController.swift
@@ -300,6 +300,7 @@ public class WMFImageController : NSObject {
                 let sself = wself
                 if let cancellable = sself?.cancellables.objectForKey(url.absoluteString) as? Cancellable {
                     sself?.cancellables.removeObjectForKey(url.absoluteString)
+                    DDLogDebug("Cancelling request for image \(url)")
                     cancellable.cancel()
                 }
             }

--- a/Wikipedia/SDImageCache+PromiseKit.swift
+++ b/Wikipedia/SDImageCache+PromiseKit.swift
@@ -10,8 +10,10 @@ import Foundation
 import PromiseKit
 import SDWebImage
 
+public typealias DiskQueryResult = (cancellable: Cancellable?, promise: Promise<(UIImage, ImageOrigin)>)
+
 extension SDImageCache {
-    public func queryDiskCacheForKey(key: String) -> (Cancellable?, Promise<(UIImage, ImageOrigin)>) {
+    public func queryDiskCacheForKey(key: String) -> DiskQueryResult {
         let (promise, fulfill, reject) = Promise<(UIImage, ImageOrigin)>.pendingPromise()
 
         // queryDiskCache will return nil if the image is in memory

--- a/Wikipedia/UI-V5/WMFSaveableTitleCollectionViewCell.m
+++ b/Wikipedia/UI-V5/WMFSaveableTitleCollectionViewCell.m
@@ -20,6 +20,7 @@
 @implementation WMFSaveableTitleCollectionViewCell
 
 - (void)configureImageViewWithPlaceholder {
+    [self.imageView wmf_reset];
     self.imageView.contentMode     = UIViewContentModeCenter;
     self.imageView.backgroundColor = [UIColor wmf_placeholderImageBackgroundColor];
     self.imageView.tintColor       = [UIColor wmf_placeholderImageTintColor];

--- a/Wikipedia/UI-V5/WMFSearchDataSource.m
+++ b/Wikipedia/UI-V5/WMFSearchDataSource.m
@@ -30,7 +30,7 @@
     NSParameterAssert(site);
     NSParameterAssert(searchResults);
     NSParameterAssert(savedPages);
-    self = [super initWithItems:searchResults.results];
+    self = [super initWithTarget:searchResults keyPath:WMF_SAFE_KEYPATH(searchResults, results)];
     if (self) {
         self.searchSite    = site;
         self.searchResults = searchResults;
@@ -54,9 +54,9 @@
     return self;
 }
 
-- (NSString*)descriptionForSearchResult:(MWKSearchResult*)result{
+- (NSString*)descriptionForSearchResult:(MWKSearchResult*)result {
     MWKSearchRedirectMapping* mapping = [self redirectMappingForResult:result];
-    if(!mapping){
+    if (!mapping) {
         return result.wikidataDescription;
     }
     NSString* description = result.wikidataDescription ? [@"\n" stringByAppendingString : [result.wikidataDescription wmf_stringByCapitalizingFirstCharacter]] : @"";

--- a/Wikipedia/UI-V5/WMFSearchFetcher.m
+++ b/Wikipedia/UI-V5/WMFSearchFetcher.m
@@ -91,17 +91,14 @@ NSUInteger const WMFMaxSearchResultLimit = 24;
         WMFSearchResults* searchResults = response;
         searchResults.searchTerm = searchTerm;
 
-        if (previousResults) {
-            NSArray* results = [searchResults.results bk_reject:^BOOL (MWKSearchResult* obj) {
-                return ([previousResults.results containsObject:obj]);
-            }];
-
-            results = [previousResults.results arrayByAddingObjectsFromArray:results];
-            //Grab the previous search suggestion if none is returned
-            NSString* searchSuggestion = searchResults.searchSuggestion.length > 0 ? searchResults.searchSuggestion : previousResults.searchSuggestion;
-            searchResults = [[WMFSearchResults alloc] initWithSearchTerm:searchResults.searchTerm results:results searchSuggestion:searchSuggestion];
+        if (!previousResults) {
+            resolve(searchResults);
+            return;
         }
-        resolve(searchResults);
+
+        [previousResults mergeValuesForKeysFromModel:searchResults];
+
+        resolve(previousResults);
     }
                        failure:^(AFHTTPRequestOperation* operation, NSError* error) {
         if ([url isEqual:[site mobileApiEndpoint]] && [error wmf_shouldFallbackToDesktopURLError]) {

--- a/Wikipedia/UI-V5/WMFSearchResults.h
+++ b/Wikipedia/UI-V5/WMFSearchResults.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithSearchTerm:(NSString*)searchTerm
                            results:(nullable NSArray*)results
                   searchSuggestion:(nullable NSString*)suggestion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/UI-V5/WMFSearchViewController.m
+++ b/Wikipedia/UI-V5/WMFSearchViewController.m
@@ -314,7 +314,10 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
            collection view, meaning there's a chance the collectionView accesses deallocated memory during an animation
          */
 
-        WMFSearchDataSource* dataSource = [[WMFSearchDataSource alloc] initWithSearchSite:self.searchSite searchResults:results savedPages:self.dataStore.userDataStore.savedPageList];
+        WMFSearchDataSource* dataSource =
+            [[WMFSearchDataSource alloc] initWithSearchSite:self.searchSite
+                                              searchResults:results
+                                                 savedPages:self.dataStore.userDataStore.savedPageList];
 
         self.resultsListController.dataSource = dataSource;
 
@@ -323,7 +326,11 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
         }];
 
         if ([results.results count] < kWMFMinResultsBeforeAutoFullTextSearch) {
-            return [self.fetcher fetchArticlesForSearchTerm:searchTerm site:self.searchSite resultLimit:WMFMaxSearchResultLimit fullTextSearch:YES appendToPreviousResults:results];
+            return [self.fetcher fetchArticlesForSearchTerm:searchTerm
+                                                       site:self.searchSite
+                                                resultLimit:WMFMaxSearchResultLimit
+                                             fullTextSearch:YES
+                                    appendToPreviousResults:results];
         }
         return [AnyPromise promiseWithValue:results];
     }).then(^(WMFSearchResults* results){
@@ -331,18 +338,18 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
             if (results.results.count == 0) {
                 [self showAlert:MWLocalizedString(@"search-no-matches", nil) type:ALERT_TYPE_TOP duration:2.0];
             }
-
-            WMFSearchDataSource* dataSource = [[WMFSearchDataSource alloc] initWithSearchSite:self.searchSite searchResults:results savedPages:self.dataStore.userDataStore.savedPageList];
-
-            self.resultsListController.dataSource = dataSource;
         }
-        if (results.results.count == 0) {
-            [self showAlert:MWLocalizedString(@"search-no-matches", nil) type:ALERT_TYPE_TOP duration:2.0];
-        }
+
+        // change recent search visibility if no prefix results returned, and update suggestion if needed
+        [UIView animateWithDuration:0.25 animations:^{
+            [self updateUIWithResults:results];
+        }];
     }).catch(^(NSError* error){
         @strongify(self);
-        [self showAlert:error.userInfo[NSLocalizedDescriptionKey] type:ALERT_TYPE_TOP duration:2.0];
-        DDLogError(@"Encountered search error: %@", error);
+        if ([searchTerm isEqualToString:self.searchField.text]) {
+            [self showAlert:error.userInfo[NSLocalizedDescriptionKey] type:ALERT_TYPE_TOP duration:2.0];
+            DDLogError(@"Encountered search error: %@", error);
+        }
     });
 }
 

--- a/Wikipedia/UI-V5/WMFSearchViewController.storyboard
+++ b/Wikipedia/UI-V5/WMFSearchViewController.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tkf-8P-b2O">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tkf-8P-b2O">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>


### PR DESCRIPTION
Phab: [T117012](https://phabricator.wikimedia.org/T117012)

---

## Diagnosis
The issue was caused by a couple of things.  On our end, we were setting the search results list data source twice, _even if we didn't fetch more full-text search results_.  This caused the collection view to render the same cells twice, implicitly cancelling and re-fetching the cells' images.

I think SDWebImage is also partially to blame, as cancelling & refetching _should_ be fine.  You can see logs for the second fetch get emitted, but no callback ever occurs for the second fetch.  I think this is caused by the internal callback queueing mechanism in `SDWebImageManager` which is supposed to prevent redundant requests, but seems to also accidentally cancel fetches that are executed too closely together.

## Cure
Anyway, I solved the issue by only using one `WMFSearchResults` object for each query.  In case we fetch more full-text results, we append them to the first set of results.  I'm not crazy about the implications for mutability, but it's either this or calculating collection view updates from a diff of two immutable objects.  

As an aside, this "merge" API exists on _all `MTLModel`subclasses_, which we'll need to be careful with... Great power and great responsibility and all that... 