### PR TITLE
Fix lead image placeholder

### DIFF
--- a/Wikipedia/Custom Views/WMFImageCollectionViewCell.m
+++ b/Wikipedia/Custom Views/WMFImageCollectionViewCell.m
@@ -32,7 +32,7 @@
 
 - (void)configureImageViewWithPlaceholder {
     [self.imageView wmf_reset];
-    self.imageView.contentMode = UIViewContentModeCenter;
+    self.imageView.contentMode     = UIViewContentModeCenter;
     self.imageView.backgroundColor = [UIColor wmf_placeholderImageBackgroundColor];
     self.imageView.tintColor       = [UIColor wmf_placeholderImageTintColor];
     self.imageView.image           = [UIImage wmf_placeholderImage];

--- a/Wikipedia/Custom Views/WMFImageCollectionViewCell.m
+++ b/Wikipedia/Custom Views/WMFImageCollectionViewCell.m
@@ -25,8 +25,22 @@
             make.edges.equalTo(self.contentView);
         }];
         self.imageView.clipsToBounds = YES;
+        [self configureImageViewWithPlaceholder];
     }
     return self;
+}
+
+- (void)configureImageViewWithPlaceholder {
+    [self.imageView wmf_reset];
+    self.imageView.contentMode = UIViewContentModeCenter;
+    self.imageView.backgroundColor = [UIColor wmf_placeholderImageBackgroundColor];
+    self.imageView.tintColor       = [UIColor wmf_placeholderImageTintColor];
+    self.imageView.image           = [UIImage wmf_placeholderImage];
+}
+
+- (void)prepareForReuse {
+    [super prepareForReuse];
+    [self configureImageViewWithPlaceholder];
 }
 
 @end

--- a/Wikipedia/UI-V5/WMFArticleListTableViewCell.m
+++ b/Wikipedia/UI-V5/WMFArticleListTableViewCell.m
@@ -9,8 +9,8 @@
 - (void)configureImageViewWithPlaceholder {
 //    self.articleImageView.contentMode     = UIViewContentModeCenter;
 //    self.articleImageView.backgroundColor = [UIColor wmf_placeholderImageBackgroundColor];
-    self.articleImageView.tintColor       = [UIColor wmf_placeholderImageTintColor];
-    self.articleImageView.image           = [UIImage wmf_placeholderImage];
+    self.articleImageView.tintColor = [UIColor wmf_placeholderImageTintColor];
+    self.articleImageView.image     = [UIImage wmf_placeholderImage];
 }
 
 - (void)configureCell {


### PR DESCRIPTION
Somehow forgot to use the same placeholder stuff in header image gallery.  I don't think there's much more DRY-ing that can be done for this sort of thing.

![image](https://cloud.githubusercontent.com/assets/444217/10979645/92e8dca8-83cb-11e5-8793-5dfcb5139347.png)
