### PR TITLE
bump timeout of flaky test

### DIFF
--- a/WikipediaUnitTests/WMFImageControllerTests.swift
+++ b/WikipediaUnitTests/WMFImageControllerTests.swift
@@ -198,7 +198,7 @@ class WMFImageControllerTests: XCTestCase {
             }
 
 
-            wmf_waitForExpectations()
+            wmf_waitForExpectations(2)
 
             LSNocilla.sharedInstance().stop()
         }


### PR DESCRIPTION
Saw this test fail on Jenkins, so figured we should bump the timeout up to 2s:

> [14:06:24]: [SHELL]: ✗ -[WMFImageControllerTests testSDWebImageSanity] (1074 ms) (0)
