### PR TITLE
Fix for appending to empty search results & full-text search regression

### DIFF
--- a/Wikipedia/Networking/Fetchers/WMFEnglishFeaturedTitleFetcher.m
+++ b/Wikipedia/Networking/Fetchers/WMFEnglishFeaturedTitleFetcher.m
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)isFetching {
-    return [[self.featuredTitleOperationManager operationQueue] operationCount] > 0 || [[self.titlePreviewOperationManager operationQueue] operationCount] > 0 ;
+    return [[self.featuredTitleOperationManager operationQueue] operationCount] > 0 || [[self.titlePreviewOperationManager operationQueue] operationCount] > 0;
 }
 
 - (AnyPromise*)fetchFeaturedArticlePreviewForDate:(NSDate*)date {

--- a/Wikipedia/UI-V5/WMFHomeSection.m
+++ b/Wikipedia/UI-V5/WMFHomeSection.m
@@ -26,7 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-
 - (NSComparisonResult)compare:(WMFHomeSection*)section {
     NSParameterAssert([section isKindOfClass:[WMFHomeSection class]]);
     switch (self.type) {

--- a/Wikipedia/UI-V5/WMFSearchDataSource.m
+++ b/Wikipedia/UI-V5/WMFSearchDataSource.m
@@ -20,7 +20,7 @@
 - (nonnull instancetype)initWithSearchSite:(MWKSite*)site searchResults:(WMFSearchResults*)searchResults {
     NSParameterAssert(site);
     NSParameterAssert(searchResults);
-    self = [super initWithItems:searchResults.results];
+    self = [super initWithTarget:searchResults keyPath:WMF_SAFE_KEYPATH(searchResults, results)];
     if (self) {
         self.searchSite    = site;
         self.searchResults = searchResults;

--- a/Wikipedia/UI-V5/WMFSearchResults.h
+++ b/Wikipedia/UI-V5/WMFSearchResults.h
@@ -8,8 +8,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface WMFSearchResults : MTLModel<MTLJSONSerializing>
 
 @property (nonatomic, copy, readonly) NSString* searchTerm;
-@property (nonatomic, strong, readonly) NSArray<MWKSearchResult*>* results;
-@property (nonatomic, strong, readonly) NSArray<MWKSearchRedirectMapping*>* redirectMappings;
+@property (nonatomic, strong, null_resettable, readonly) NSArray<MWKSearchResult*>* results;
+@property (nonatomic, strong, null_resettable, readonly) NSArray<MWKSearchRedirectMapping*>* redirectMappings;
 
 @property (nonatomic, copy, nullable, readonly) NSString* searchSuggestion;
 

--- a/Wikipedia/UI-V5/WMFSearchResults.m
+++ b/Wikipedia/UI-V5/WMFSearchResults.m
@@ -21,10 +21,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation WMFSearchResults
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _mutableResults = [NSMutableArray new];
+        _redirectMappings = @[];
+    }
+    return self;
+}
+
 - (instancetype)initWithSearchTerm:(NSString*)searchTerm
                            results:(nullable NSArray*)results
                   searchSuggestion:(nullable NSString*)suggestion {
-    self = [super init];
+    self = [self init];
     if (self) {
         self.searchTerm       = searchTerm;
         self.results          = results;
@@ -33,13 +42,26 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setResults:(NSArray<MWKSearchResult*>* _Nonnull)results {
-    [self willChangeValueForKey:WMF_SAFE_KEYPATH(self, results)];
-    if (_mutableResults == results) {
+- (void)setResults:(nullable NSArray<MWKSearchResult*>*)results {
+    if ([_mutableResults isEqualToArray:results]) {
         return;
     }
-    _mutableResults = [results mutableCopy];
+    [self willChangeValueForKey:WMF_SAFE_KEYPATH(self, results)];
+    if (results) {
+        [_mutableResults setArray:results];
+    } else {
+        [_mutableResults removeAllObjects];
+    }
     [self didChangeValueForKey:WMF_SAFE_KEYPATH(self, results)];
+}
+
+- (void)setRedirectMappings:(nullable NSArray<MWKSearchRedirectMapping *>*)redirectMappings {
+    if (WMF_EQUAL(self.redirectMappings, isEqualToArray:, redirectMappings)) {
+        return;
+    }
+    [self willChangeValueForKey:WMF_SAFE_KEYPATH(self, redirectMappings)];
+    _redirectMappings = [redirectMappings copy] ?: @[];
+    [self didChangeValueForKey:WMF_SAFE_KEYPATH(self, redirectMappings)];
 }
 
 - (NSArray*)results {

--- a/Wikipedia/UI-V5/WMFSearchResults.m
+++ b/Wikipedia/UI-V5/WMFSearchResults.m
@@ -43,25 +43,15 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setResults:(nullable NSArray<MWKSearchResult*>*)results {
-    if ([_mutableResults isEqualToArray:results]) {
-        return;
-    }
-    [self willChangeValueForKey:WMF_SAFE_KEYPATH(self, results)];
     if (results) {
         [_mutableResults setArray:results];
     } else {
         [_mutableResults removeAllObjects];
     }
-    [self didChangeValueForKey:WMF_SAFE_KEYPATH(self, results)];
 }
 
 - (void)setRedirectMappings:(nullable NSArray<MWKSearchRedirectMapping*>*)redirectMappings {
-    if (WMF_EQUAL(self.redirectMappings, isEqualToArray:, redirectMappings)) {
-        return;
-    }
-    [self willChangeValueForKey:WMF_SAFE_KEYPATH(self, redirectMappings)];
     _redirectMappings = [redirectMappings copy] ? : @[];
-    [self didChangeValueForKey:WMF_SAFE_KEYPATH(self, redirectMappings)];
 }
 
 - (NSArray*)results {
@@ -101,7 +91,6 @@ NS_ASSUME_NONNULL_BEGIN
     NSArray* newResults = [searchResults.results bk_reject:^BOOL (MWKSearchResult* obj) {
         return [self.results containsObject:obj];
     }];
-
     [self.mutableResults addObjectsFromArray:newResults];
 }
 

--- a/Wikipedia/UI-V5/WMFSearchResults.m
+++ b/Wikipedia/UI-V5/WMFSearchResults.m
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _mutableResults = [NSMutableArray new];
+        _mutableResults   = [NSMutableArray new];
         _redirectMappings = @[];
     }
     return self;
@@ -55,12 +55,12 @@ NS_ASSUME_NONNULL_BEGIN
     [self didChangeValueForKey:WMF_SAFE_KEYPATH(self, results)];
 }
 
-- (void)setRedirectMappings:(nullable NSArray<MWKSearchRedirectMapping *>*)redirectMappings {
+- (void)setRedirectMappings:(nullable NSArray<MWKSearchRedirectMapping*>*)redirectMappings {
     if (WMF_EQUAL(self.redirectMappings, isEqualToArray:, redirectMappings)) {
         return;
     }
     [self willChangeValueForKey:WMF_SAFE_KEYPATH(self, redirectMappings)];
-    _redirectMappings = [redirectMappings copy] ?: @[];
+    _redirectMappings = [redirectMappings copy] ? : @[];
     [self didChangeValueForKey:WMF_SAFE_KEYPATH(self, redirectMappings)];
 }
 

--- a/WikipediaUnitTests/WMFSearchFetcherTests.m
+++ b/WikipediaUnitTests/WMFSearchFetcherTests.m
@@ -65,7 +65,7 @@
 }
 
 - (void)testAppendingToPreviousEmptyResultsCausesKVOEvents {
-    id noResultsJSON = [[self wmf_bundle] wmf_jsonFromContentsOfFile:@"NoSearchResultsWithSuggestion"];
+    id noResultsJSON      = [[self wmf_bundle] wmf_jsonFromContentsOfFile:@"NoSearchResultsWithSuggestion"];
     id fullTextSearchJSON = [[self wmf_bundle] wmf_jsonFromContentsOfFile:@"MonetFullTextSearch"];
 
     stubRequest(@"GET", [NSRegularExpression regularExpressionWithPattern:@".*generator=prefixsearch.*" options:0 error:nil])
@@ -77,7 +77,7 @@
     .withJSON(fullTextSearchJSON);
 
     NSArray<NSString*>* fullTextTitles =
-    [[[fullTextSearchJSON valueForKeyPath:@"query.pages"] allValues] valueForKey:@"title"];
+        [[[fullTextSearchJSON valueForKeyPath:@"query.pages"] allValues] valueForKey:@"title"];
 
     WMFSearchResults* finalResults = [self verifyKVOEventWhenAppendingTitles:fullTextTitles toPrefixTitles:nil];
     assertThat(finalResults.searchSuggestion, is([noResultsJSON valueForKeyPath:@"query.searchinfo.suggestion"]));
@@ -108,7 +108,7 @@
 
 - (WMFSearchResults*)verifyKVOEventWhenAppendingTitles:(NSArray*)fullTextTitles
                                         toPrefixTitles:(nullable NSArray*)prefixTitles {
-    NSMutableSet* uniqueTitles = [NSMutableSet setWithArray:prefixTitles ?: @[]];
+    NSMutableSet* uniqueTitles = [NSMutableSet setWithArray:prefixTitles ? : @[]];
     [uniqueTitles addObjectsFromArray:fullTextTitles];
 
     MWKSite* searchSite = [MWKSite random];

--- a/WikipediaUnitTests/WMFSearchFetcherTests.m
+++ b/WikipediaUnitTests/WMFSearchFetcherTests.m
@@ -64,7 +64,26 @@
     });
 }
 
-- (void)testAppendingToPreviousResultsCausesKVOEvents {
+- (void)testAppendingToPreviousEmptyResultsCausesKVOEvents {
+    id noResultsJSON = [[self wmf_bundle] wmf_jsonFromContentsOfFile:@"NoSearchResultsWithSuggestion"];
+    id fullTextSearchJSON = [[self wmf_bundle] wmf_jsonFromContentsOfFile:@"MonetFullTextSearch"];
+
+    stubRequest(@"GET", [NSRegularExpression regularExpressionWithPattern:@".*generator=prefixsearch.*" options:0 error:nil])
+    .andReturn(200)
+    .withJSON(noResultsJSON);
+
+    stubRequest(@"GET", [NSRegularExpression regularExpressionWithPattern:@".*generator=search.*" options:0 error:nil])
+    .andReturn(200)
+    .withJSON(fullTextSearchJSON);
+
+    NSArray<NSString*>* fullTextTitles =
+    [[[fullTextSearchJSON valueForKeyPath:@"query.pages"] allValues] valueForKey:@"title"];
+
+    WMFSearchResults* finalResults = [self verifyKVOEventWhenAppendingTitles:fullTextTitles toPrefixTitles:nil];
+    assertThat(finalResults.searchSuggestion, is([noResultsJSON valueForKeyPath:@"query.searchinfo.suggestion"]));
+}
+
+- (void)testAppendingToPreviousNonEmptyResultsCausesKVOEvents {
     id prefixSearchJSON   = [[self wmf_bundle] wmf_jsonFromContentsOfFile:@"MonetPrefixSearch"];
     id fullTextSearchJSON = [[self wmf_bundle] wmf_jsonFromContentsOfFile:@"MonetFullTextSearch"];
 
@@ -82,7 +101,13 @@
     NSArray<NSString*>* fullTextTitles =
         [[[fullTextSearchJSON valueForKeyPath:@"query.pages"] allValues] valueForKey:@"title"];
 
-    NSMutableSet* uniqueTitles = [NSMutableSet setWithArray:prefixTitles];
+    [self verifyKVOEventWhenAppendingTitles:fullTextTitles toPrefixTitles:prefixTitles];
+}
+
+#pragma mark - Utils
+
+- (WMFSearchResults*)verifyKVOEventWhenAppendingTitles:(NSArray*)fullTextTitles toPrefixTitles:(nullable NSArray*)prefixTitles {
+    NSMutableSet* uniqueTitles = [NSMutableSet setWithArray:prefixTitles ?: @[]];
     [uniqueTitles addObjectsFromArray:fullTextTitles];
 
     MWKSite* searchSite = [MWKSite random];
@@ -111,9 +136,11 @@
                                          fullTextSearch:YES
                                 appendToPreviousResults:fetchedPrefixResult]
         .then(^(WMFSearchResults* appendedResults) {
+            XCTAssertEqual(fetchedPrefixResult, appendedResults, @"Expected resolved value to be identical to previous results object.");
             assertThat(appendedResults.results, hasCountOf(uniqueTitles.count));
         });
     });
+    return fetchedPrefixResult;
 }
 
 @end

--- a/WikipediaUnitTests/WMFSearchFetcherTests.m
+++ b/WikipediaUnitTests/WMFSearchFetcherTests.m
@@ -59,7 +59,7 @@
         return [self.fetcher fetchArticlesForSearchTerm:@"foo" site:[MWKSite random] resultLimit:15]
         .then(^(WMFSearchResults* result) {
             assertThat(result.searchSuggestion, is([json valueForKeyPath:@"query.searchinfo.suggestion"]));
-            assertThat(result.results, is(nilValue()));
+            assertThat(result.results, isEmpty());
         });
     });
 }
@@ -106,7 +106,8 @@
 
 #pragma mark - Utils
 
-- (WMFSearchResults*)verifyKVOEventWhenAppendingTitles:(NSArray*)fullTextTitles toPrefixTitles:(nullable NSArray*)prefixTitles {
+- (WMFSearchResults*)verifyKVOEventWhenAppendingTitles:(NSArray*)fullTextTitles
+                                        toPrefixTitles:(nullable NSArray*)prefixTitles {
     NSMutableSet* uniqueTitles = [NSMutableSet setWithArray:prefixTitles ?: @[]];
     [uniqueTitles addObjectsFromArray:fullTextTitles];
 

--- a/WikipediaUnitTests/WMFSearchResultsSerializationTests.m
+++ b/WikipediaUnitTests/WMFSearchResultsSerializationTests.m
@@ -20,6 +20,20 @@
 
 @implementation WMFSearchResultsSerializationTests
 
+- (void)testResultsAndRedirectsAreNonnullForZeroResultResponse {
+    NSData* noResultJSONData =
+        [[self wmf_bundle] wmf_dataFromContentsOfFile:@"NoSearchResultsWithSuggestion" ofType:@"json"];
+    id noResultJSON = [[self wmf_bundle] wmf_jsonFromContentsOfFile:@"NoSearchResultsWithSuggestion"];
+    NSError* error;
+    WMFSearchResults* searchResults = [[WMFSearchResults responseSerializer] responseObjectForResponse:nil
+                                                                                                  data:noResultJSONData
+                                                                                                 error:&error];
+    XCTAssertNil(error);
+    assertThat(searchResults.results, isEmpty());
+    assertThat(searchResults.redirectMappings, isEmpty());
+    assertThat(searchResults.searchSuggestion, is([noResultJSON valueForKeyPath:@"query.searchinfo.suggestion"]));
+}
+
 - (void)testSerializesPrefixResultsInOrderOfIndex {
     NSString* fixtureName = @"BarackSearch";
     NSData* resultData    = [[self wmf_bundle] wmf_dataFromContentsOfFile:fixtureName ofType:@"json"];
@@ -31,8 +45,8 @@
     NSError* error;
     WMFSearchResults* searchResults = [[WMFSearchResults responseSerializer] responseObjectForResponse:nil
                                                                                                   data:resultData
-                                                                                                 error:nil];
-
+                                                                                                 error:&error];
+    XCTAssertNil(error);
     assertThat(searchResults.results, hasCountOf(resultJSONObjects.count));
 
     XCTAssertNotNil(searchResults, @"Failed to serialize search results from 'BarackSearch' fixture; %@", error);


### PR DESCRIPTION
Phab: [T118921](https://phabricator.wikimedia.org/T118921)

---

Caused a crash due to `nil` throwing a wrench in KVO connections.  Also re-fixed full-text appending which wasn't hooked up properly.  Will add an integration test for all of this soon...