### PR TITLE
Specify code signing identity in Gymfile

### DIFF
--- a/WikipediaUnitTests/WMFImageControllerTests.swift
+++ b/WikipediaUnitTests/WMFImageControllerTests.swift
@@ -179,7 +179,7 @@ class WMFImageControllerTests: XCTestCase {
                                     evaluatedWithObject: operation,
                                     handler: nil)
 
-            wmf_waitForExpectations()
+            wmf_waitForExpectations(5)
 
             operation.cancel()
 
@@ -198,7 +198,7 @@ class WMFImageControllerTests: XCTestCase {
             }
 
 
-            wmf_waitForExpectations(2)
+            wmf_waitForExpectations(5)
 
             LSNocilla.sharedInstance().stop()
         }

--- a/fastlane/Gymfile
+++ b/fastlane/Gymfile
@@ -2,3 +2,4 @@ workspace 'Wikipedia.xcworkspace'
 include_bitcode false
 clean true
 output_directory './build'
+codesigning_identity 'iPhone Distribution: Wikimedia Foundation'


### PR DESCRIPTION
Phab: [T118986](https://phabricator.wikimedia.org/T118986)

---

- Need to specify code signing identity, otherwise developer profiles will be used :confounded: 
  - See [build 511 on HockeyApp](https://rink.hockeyapp.net/manage/apps/205667/app_versions/77) for proof, has all 78 devices in the embedded profile