### PR TITLE
Preserve search results during a session

### DIFF
--- a/Wikipedia/UI-V5/UIViewController+WMFSearchButton.m
+++ b/Wikipedia/UI-V5/UIViewController+WMFSearchButton.m
@@ -25,11 +25,15 @@ static WMFSearchViewController * _sharedSearchViewController = nil;
 }
 
 + (void)wmfSearchButton_applicationDidEnterBackgroundWithNotification:(NSNotification*)note {
-    _sharedSearchViewController = nil;
+    if (!_sharedSearchViewController.view.window) {
+        _sharedSearchViewController = nil;
+    }
 }
 
 + (void)wmfSearchButton_applicationDidReceiveMemoryWarningWithNotification:(NSNotification*)note {
-    _sharedSearchViewController = nil;
+    if (!_sharedSearchViewController.view.window) {
+        _sharedSearchViewController = nil;
+    }
 }
 
 - (UIBarButtonItem*)wmf_searchBarButtonItemWithDelegate:(UIViewController<WMFSearchPresentationDelegate>*)delegate {

--- a/Wikipedia/UI-V5/UIViewController+WMFSearchButton.m
+++ b/Wikipedia/UI-V5/UIViewController+WMFSearchButton.m
@@ -11,10 +11,26 @@
 #import <BlocksKit/UIBarButtonItem+BlocksKit.h>
 #import "SessionSingleton.h"
 #import "UIViewController+WMFArticlePresentation.h"
+#import "MWKSite.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation UIViewController (WMFSearchButton)
+
+static WMFSearchViewController * _sharedSearchViewController = nil;
+
++ (void)load {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(wmfSearchButton_applicationDidEnterBackgroundWithNotification:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(wmfSearchButton_applicationDidReceiveMemoryWarningWithNotification:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+}
+
++ (void)wmfSearchButton_applicationDidEnterBackgroundWithNotification:(NSNotification*)note {
+    _sharedSearchViewController = nil;
+}
+
++ (void)wmfSearchButton_applicationDidReceiveMemoryWarningWithNotification:(NSNotification*)note {
+    _sharedSearchViewController = nil;
+}
 
 - (UIBarButtonItem*)wmf_searchBarButtonItemWithDelegate:(UIViewController<WMFSearchPresentationDelegate>*)delegate {
     @weakify(self);
@@ -36,11 +52,14 @@ NS_ASSUME_NONNULL_BEGIN
             searchSite = [[SessionSingleton sharedInstance] searchSite];
         }
 
-        WMFSearchViewController* searchVC =
-            [WMFSearchViewController searchViewControllerWithSite:searchSite
-                                                        dataStore:[delegate searchDataStore]];
-        searchVC.searchResultDelegate = delegate;
-        [self presentViewController:searchVC animated:YES completion:nil];
+        if (![searchSite isEqual:_sharedSearchViewController.searchSite]) {
+            WMFSearchViewController* searchVC =
+                [WMFSearchViewController searchViewControllerWithSite:searchSite
+                                                            dataStore:[delegate searchDataStore]];
+            searchVC.searchResultDelegate = delegate;
+            _sharedSearchViewController = searchVC;
+        }
+        [self presentViewController:_sharedSearchViewController animated:YES completion:nil];
     }];
 }
 


### PR DESCRIPTION
- Keep search VC as a static ivar
- Remove it when the app backgrounds
- Remove it if we get a memory warning
- Don't restore if the search site has changed