### PR TITLE
enforce code coverage via fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,7 +29,8 @@ platform :ios do
       :destination => 'platform=iOS Simulator,name=iPhone 6,OS=9.1',
       :destination_timeout => 240, # Increase timeout for Travis builds
       :xcpretty_output => 'simple',
-      :buildlog_path => './build'
+      :buildlog_path => './build',
+      :enable_code_coverage => true
     }
     opts[:reports] = [{ 'report' => 'junit', 'output' => 'build/reports/unit-tests.xml' }] if options[:junit]
     xctest(opts)


### PR DESCRIPTION
(don't depend on Xcode)