### PR TITLE
Only show read more for recent items that have been significantly read.

### DIFF
--- a/MediaWikiKit/MediaWikiKit/MWKHistoryEntry.h
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryEntry.h
@@ -66,6 +66,7 @@ typedef NS_ENUM (NSUInteger, MWKHistoryDiscoveryMethod) {
 @property (readwrite, strong, nonatomic) NSDate* date;
 @property (readwrite, assign, nonatomic) MWKHistoryDiscoveryMethod discoveryMethod;
 @property (readwrite, assign, nonatomic) CGFloat scrollPosition;
+@property (readwrite, assign, nonatomic) BOOL titleWasSignificantlyViewed;
 
 - (instancetype)initWithTitle:(MWKTitle*)title discoveryMethod:(MWKHistoryDiscoveryMethod)discoveryMethod;
 - (instancetype)initWithDict:(NSDictionary*)dict;

--- a/MediaWikiKit/MediaWikiKit/MWKHistoryEntry.m
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryEntry.m
@@ -36,10 +36,11 @@
 
     self = [self initWithSite:[MWKSite siteWithDomain:domain language:language]];
     if (self) {
-        self.title           = [self requiredTitle:@"title" dict:dict allowEmpty:NO];
-        self.date            = [self requiredDate:@"date" dict:dict];
-        self.discoveryMethod = [MWKHistoryEntry discoveryMethodForString:[self requiredString:@"discoveryMethod" dict:dict]];
-        self.scrollPosition  = [[self requiredNumber:@"scrollPosition" dict:dict] floatValue];
+        self.title                       = [self requiredTitle:@"title" dict:dict allowEmpty:NO];
+        self.date                        = [self requiredDate:@"date" dict:dict];
+        self.discoveryMethod             = [MWKHistoryEntry discoveryMethodForString:[self requiredString:@"discoveryMethod" dict:dict]];
+        self.scrollPosition              = [[self requiredNumber:@"scrollPosition" dict:dict] floatValue];
+        self.titleWasSignificantlyViewed = [[self optionalNumber:@"titleWasSignificantlyViewed" dict:dict] boolValue];
     }
     return self;
 }
@@ -137,6 +138,7 @@
     [dict wmf_maybeSetObject:[self iso8601DateString:self.date] forKey:@"date"];
     [dict wmf_maybeSetObject:[MWKHistoryEntry stringForDiscoveryMethod:self.discoveryMethod] forKey:@"discoveryMethod"];
     [dict wmf_maybeSetObject:@(self.scrollPosition) forKey:@"scrollPosition"];
+    [dict wmf_maybeSetObject:@(self.titleWasSignificantlyViewed) forKey:@"titleWasSignificantlyViewed"];
 
     return [NSDictionary dictionaryWithDictionary:dict];
 }

--- a/MediaWikiKit/MediaWikiKit/MWKHistoryList.h
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryList.h
@@ -39,6 +39,14 @@ extern NSString* const MWKHistoryListDidUpdateNotification;
 - (void)setPageScrollPosition:(CGFloat)scrollposition onPageInHistoryWithTitle:(MWKTitle*)title;
 
 /**
+ *  Sets the history entry to be "significantly viewed"
+ *  This denotes that a user looked at this title for a period of time to indicate interest
+ *
+ *  @param title The title to set to significantly viewed
+ */
+- (void)setSignificantlyViewedOnPageInHistoryWithTitle:(MWKTitle*)title;
+
+/**
  *  Remove the given history entries from the history.
  *
  *  @param historyEntries An array of instances of MWKHistoryEntry

--- a/MediaWikiKit/MediaWikiKit/MWKHistoryList.m
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryList.m
@@ -70,6 +70,16 @@ NSString* const MWKHistoryListDidUpdateNotification = @"MWKHistoryListDidUpdateN
     }];
 }
 
+- (void)setSignificantlyViewedOnPageInHistoryWithTitle:(MWKTitle*)title {
+    if ([title.text length] == 0) {
+        return;
+    }
+    [self updateEntryWithListIndex:title update:^BOOL (MWKHistoryEntry* __nullable entry) {
+        entry.titleWasSignificantlyViewed = YES;
+        return YES;
+    }];
+}
+
 - (void)removeEntry:(MWKListEntry)entry {
     [super removeEntry:entry];
     [[NSNotificationCenter defaultCenter] postNotificationName:MWKHistoryListDidUpdateNotification object:self];

--- a/MediaWikiKit/MediaWikiKit/MWKHistoryList.m
+++ b/MediaWikiKit/MediaWikiKit/MWKHistoryList.m
@@ -75,6 +75,9 @@ NSString* const MWKHistoryListDidUpdateNotification = @"MWKHistoryListDidUpdateN
         return;
     }
     [self updateEntryWithListIndex:title update:^BOOL (MWKHistoryEntry* __nullable entry) {
+        if (entry.titleWasSignificantlyViewed) {
+            return NO;
+        }
         entry.titleWasSignificantlyViewed = YES;
         return YES;
     }];

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -465,6 +465,9 @@ NS_ASSUME_NONNULL_BEGIN
     if(self.significantlyViewedTimer){
         return;
     }
+    if(!self.article){
+        return;
+    }
     MWKHistoryList* historyList = self.dataStore.userDataStore.historyList;
     MWKHistoryEntry* entry      = [historyList entryForTitle:self.articleTitle];
     if (!entry.titleWasSignificantlyViewed) {
@@ -473,11 +476,15 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)significantlyViewedTimerFired:(NSTimer*)timer {
-    [self.significantlyViewedTimer invalidate];
-    self.significantlyViewedTimer = nil;
+    [self stopSignificantlyViewedTimer];
     MWKHistoryList* historyList = self.dataStore.userDataStore.historyList;
     [historyList setSignificantlyViewedOnPageInHistoryWithTitle:self.articleTitle];
     [historyList save];
+}
+
+- (void)stopSignificantlyViewedTimer{
+    [self.significantlyViewedTimer invalidate];
+    self.significantlyViewedTimer = nil;
 }
 
 #pragma mark - ViewController
@@ -498,11 +505,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [self registerForPreviewingIfAvailable];
-}
-
-- (void)traitCollectionDidChange:(nullable UITraitCollection*)previousTraitCollection {
-    [super traitCollectionDidChange:previousTraitCollection];
-    [self registerForPreviewingIfAvailable];
+    [self startSignificantlyViewedTimer];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -512,10 +515,16 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
+    [self stopSignificantlyViewedTimer];
     [self saveWebViewScrollOffset];
     [self removeProgressView];
     [super viewWillDisappear:animated];
     [[NSUserDefaults standardUserDefaults] wmf_setOpenArticleTitle:nil];
+}
+
+- (void)traitCollectionDidChange:(nullable UITraitCollection*)previousTraitCollection {
+    [super traitCollectionDidChange:previousTraitCollection];
+    [self registerForPreviewingIfAvailable];
 }
 
 #pragma mark - Web View Setup

--- a/Wikipedia/UI-V5/WMFHomeSectionSchema.m
+++ b/Wikipedia/UI-V5/WMFHomeSectionSchema.m
@@ -316,7 +316,10 @@ static NSString* const WMFHomeSectionsFileExtension = @"plist";
 - (NSArray<WMFHomeSection*>*)sectionsFromHistoryEntriesExcludingExistingTitlesInSections:(nullable NSArray<WMFHomeSection*>*)existingSections maxLength:(NSUInteger)maxLength {
     NSArray<MWKTitle*>* existingTitles = [existingSections valueForKeyPath:WMF_SAFE_KEYPATH([WMFHomeSection new], title)];
 
-    NSArray<MWKHistoryEntry*>* entries = [self.historyPages.entries wmf_arrayByTrimmingToLength:maxLength + [existingSections count]];
+    NSArray<MWKHistoryEntry*>* entries = [self.historyPages.entries bk_select:^BOOL (MWKHistoryEntry* obj) {
+        return obj.titleWasSignificantlyViewed;
+    }];
+    entries = [entries wmf_arrayByTrimmingToLength:maxLength + [existingSections count]];
 
     entries = [entries bk_reject:^BOOL (MWKHistoryEntry* obj) {
         return [existingTitles containsObject:obj.title];


### PR DESCRIPTION
Adding "significantly viewed" property to MWKHistory to signify when a user as read an article.

- Significant viewed property is toggled by the article VC after 30 seconds (tweakable)
- Home Schema ignores history items that are not significantly viewed