### PR TITLE
Request multiple random articles so we can show best one.

### DIFF
--- a/MediaWikiKit/MediaWikiKit/MWKSearchResult.h
+++ b/MediaWikiKit/MediaWikiKit/MWKSearchResult.h
@@ -15,11 +15,14 @@
 
 @property (nonatomic, copy, readonly) NSNumber* index;
 
+@property (nonatomic, assign, readonly) BOOL isDisambiguation;
+
 - (instancetype)initWithArticleID:(NSInteger)articleID
                      displayTitle:(NSString*)displayTitle
               wikidataDescription:(NSString*)wikidataDescription
                           extract:(NSString*)extract
                      thumbnailURL:(NSURL*)thumbnailURL
-                            index:(NSNumber*)index;
+                            index:(NSNumber*)index
+                 isDisambiguation:(BOOL)isDisambiguation;
 
 @end

--- a/MediaWikiKit/MediaWikiKit/MWKSearchResult.m
+++ b/MediaWikiKit/MediaWikiKit/MWKSearchResult.m
@@ -73,7 +73,8 @@
 
 + (NSValueTransformer*)isDisambiguationJSONTransformer {
     return [MTLValueTransformer transformerUsingForwardBlock:^id (NSArray* value, BOOL* success, NSError* __autoreleasing* error) {
-        return @1;
+        // In the event that the disambiguation field is present, its value is an empty string.
+        return @YES;
     }];
 }
 

--- a/MediaWikiKit/MediaWikiKit/MWKSearchResult.m
+++ b/MediaWikiKit/MediaWikiKit/MWKSearchResult.m
@@ -18,6 +18,8 @@
 
 @property (nonatomic, copy, readwrite) NSNumber* index;
 
+@property (nonatomic, assign, readwrite) BOOL isDisambiguation;
+
 @end
 
 @implementation MWKSearchResult
@@ -27,7 +29,8 @@
               wikidataDescription:(NSString*)wikidataDescription
                           extract:(NSString*)extract
                      thumbnailURL:(NSURL*)thumbnailURL
-                            index:(NSNumber*)index {
+                            index:(NSNumber*)index
+                 isDisambiguation:(BOOL)isDisambiguation {
     self = [super init];
     if (self) {
         self.articleID           = articleID;
@@ -36,6 +39,7 @@
         self.extract             = extract;
         self.thumbnailURL        = thumbnailURL;
         self.index               = index;
+        self.isDisambiguation    = isDisambiguation;
     }
     return self;
 }
@@ -67,6 +71,12 @@
     }];
 }
 
++ (NSValueTransformer*)isDisambiguationJSONTransformer {
+    return [MTLValueTransformer transformerUsingForwardBlock:^id (NSArray* value, BOOL* success, NSError* __autoreleasing* error) {
+        return @1;
+    }];
+}
+
 + (NSDictionary*)JSONKeyPathsByPropertyKey {
     return @{
                WMF_SAFE_KEYPATH(MWKSearchResult.new, displayTitle): @"title",
@@ -74,7 +84,8 @@
                WMF_SAFE_KEYPATH(MWKSearchResult.new, thumbnailURL): @"thumbnail.source",
                WMF_SAFE_KEYPATH(MWKSearchResult.new, wikidataDescription): @"terms.description",
                WMF_SAFE_KEYPATH(MWKSearchResult.new, extract): @"extract",
-               WMF_SAFE_KEYPATH(MWKSearchResult.new, index): @"index"
+               WMF_SAFE_KEYPATH(MWKSearchResult.new, index): @"index",
+               WMF_SAFE_KEYPATH(MWKSearchResult.new, isDisambiguation): @"pageprops.disambiguation"
     };
 }
 

--- a/Wikipedia/UI-V5/WMFArticleContainerViewController.m
+++ b/Wikipedia/UI-V5/WMFArticleContainerViewController.m
@@ -462,10 +462,10 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Significantly Viewed Timer
 
 - (void)startSignificantlyViewedTimer {
-    if(self.significantlyViewedTimer){
+    if (self.significantlyViewedTimer) {
         return;
     }
-    if(!self.article){
+    if (!self.article) {
         return;
     }
     MWKHistoryList* historyList = self.dataStore.userDataStore.historyList;
@@ -482,7 +482,7 @@ NS_ASSUME_NONNULL_BEGIN
     [historyList save];
 }
 
-- (void)stopSignificantlyViewedTimer{
+- (void)stopSignificantlyViewedTimer {
     [self.significantlyViewedTimer invalidate];
     self.significantlyViewedTimer = nil;
 }

--- a/WikipediaUnitTests/WMFSearchResultsMergeTests.m
+++ b/WikipediaUnitTests/WMFSearchResultsMergeTests.m
@@ -21,7 +21,8 @@ static MWKSearchResult* dummySearchResultWithIndex(NSUInteger index) {
                                   wikidataDescription:@"bar"
                                               extract:@"baz"
                                          thumbnailURL:[NSURL URLWithString:@"http://foo.bar/baz"]
-                                                index:@(index)];
+                                                index:@(index)
+                                     isDisambiguation:NO];
 }
 
 QuickSpecBegin(WMFSearchResultMergeTests)


### PR DESCRIPTION
Best one being non-disambig, with longest extract and hopefully
an image.

Needed to request multiple items because the api doesn't presently
let you request non-disambig random items. Filed ticket with
Discovery team for this.

Need similar fix for "read more like" items...