### PR TITLE
Re-add login to settings screen

### DIFF
--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -464,11 +464,6 @@ static SecondaryMenuRowIndex const WMFDebugSections[WMFDebugSectionCount] = {
             [self deleteRowWithTag:WMFDebugSections[i]];
         }
     }
-
-    NSString* userName = [SessionSingleton sharedInstance].keychainCredentials.userName;
-    if (!userName) {
-        [self deleteRowWithTag:SECONDARY_MENU_ROW_INDEX_LOGIN];
-    }
 }
 
 - (void)updateLoginRow {
@@ -523,6 +518,8 @@ static SecondaryMenuRowIndex const WMFDebugSections[WMFDebugSectionCount] = {
                     for (NSHTTPCookie* cookie in[[NSHTTPCookieStorage sharedHTTPCookieStorage].cookies copy]) {
                         [[NSHTTPCookieStorage sharedHTTPCookieStorage] deleteCookie:cookie];
                     }
+                }else{
+                    [self presentViewController:[[UINavigationController alloc] initWithRootViewController:[LoginViewController wmf_initialViewControllerFromClassStoryboard]] animated:YES completion:nil];
                 }
             }
             break;

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -518,7 +518,7 @@ static SecondaryMenuRowIndex const WMFDebugSections[WMFDebugSectionCount] = {
                     for (NSHTTPCookie* cookie in[[NSHTTPCookieStorage sharedHTTPCookieStorage].cookies copy]) {
                         [[NSHTTPCookieStorage sharedHTTPCookieStorage] deleteCookie:cookie];
                     }
-                }else{
+                } else {
                     [self presentViewController:[[UINavigationController alloc] initWithRootViewController:[LoginViewController wmf_initialViewControllerFromClassStoryboard]] animated:YES completion:nil];
                 }
             }

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -116,7 +116,7 @@
 "main-menu-language-selection-saved" = "Language selection saved";
 "main-menu-account-title-logged-out" = "Account";
 "main-menu-account-title-logged-in" = "Logged in as: $1";
-"main-menu-account-login" = "Log in";
+"main-menu-account-login" = "Log in to Wikipedia";
 "main-menu-account-logout" = "Log out";
 "main-menu-show-title" = "Show me...";
 "main-menu-show-history" = "Recent";


### PR DESCRIPTION
https://phabricator.wikimedia.org/T115754

- [x] re-add "login" to settings menu when user not logged in (login-related item was formerly only shown in settings menu if user was logged in)
- [x] after login interface is dismissed (on successful login or if user cancels) the settings interface is re-shown
- [x] when logged in the settings menu item changes to "Log out *username*"
- [x] change "Log in" menu item text to "Log in to Wikipedia"
- [x] test logging in from settings
- [x] test account creation from settings (the login interface allows the user to tap "create account" if they don't already have one)

<img width="487" alt="screen shot 2015-12-07 at 12 28 21 pm" src="https://cloud.githubusercontent.com/assets/3143487/11638941/767281ce-9cde-11e5-8c1c-e9e5d253ac7e.png">
<img width="487" alt="screen shot 2015-12-07 at 12 29 33 pm" src="https://cloud.githubusercontent.com/assets/3143487/11638942/76744cfc-9cde-11e5-8345-6ad84dd29b17.png">