### PR TITLE
Fix POTD error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: objective-c
 osx_image: xcode7.1
+env:
+  matrix:
+    - FL_ARGS="verify"
+    - FL_ARGS="verify scheme:WikipediaArabic"
 
 install:
   - make travis-get-deps
@@ -11,10 +15,13 @@ script:
   - echo $SIMULATOR_ID
   - open -b com.apple.iphonesimulator --args -CurrentDeviceUDID $SIMULATOR_ID
   - set -o pipefail
-  - bundle exec fastlane verify
+  - bundle exec fastlane $FL_ARGS
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+after_failure:
+  - tail -n 500 ./build/xcodebuild.og
 
 branches:
   only:

--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/WikipediaArabic.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/WikipediaArabic.xcscheme
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D4991434181D51DE00E6073C"
+               BuildableName = "Wikipedia.app"
+               BlueprintName = "Wikipedia"
+               ReferencedContainer = "container:Wikipedia.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BC4273511A7C736800068882"
+               BuildableName = "WikipediaUnitTests.xctest"
+               BlueprintName = "WikipediaUnitTests"
+               ReferencedContainer = "container:Wikipedia.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "ArticleFetcherTests">
+               </Test>
+               <Test
+                  Identifier = "ArticleLoadingTests">
+               </Test>
+               <Test
+                  Identifier = "CLLocation_WMFBearingTests">
+               </Test>
+               <Test
+                  Identifier = "CircularBitwiseRotationTests">
+               </Test>
+               <Test
+                  Identifier = "LegacyCoreDataMigratorTests">
+               </Test>
+               <Test
+                  Identifier = "MWKArticleEqualityCheckTests">
+               </Test>
+               <Test
+                  Identifier = "MWKArticleExtractionTests">
+               </Test>
+               <Test
+                  Identifier = "MWKArticlePreviewSerializationTests">
+               </Test>
+               <Test
+                  Identifier = "MWKArticleStoreTestCase">
+               </Test>
+               <Test
+                  Identifier = "MWKDataStoreListTests">
+               </Test>
+               <Test
+                  Identifier = "MWKDataStorePathTests">
+               </Test>
+               <Test
+                  Identifier = "MWKDataStoreStorageTests">
+               </Test>
+               <Test
+                  Identifier = "MWKHistoryListCorruptDataTests">
+               </Test>
+               <Test
+                  Identifier = "MWKHistoryListDataStoreTests">
+               </Test>
+               <Test
+                  Identifier = "MWKHistoryListPerformanceTests">
+               </Test>
+               <Test
+                  Identifier = "MWKHistoryListSharedTests">
+               </Test>
+               <Test
+                  Identifier = "MWKHistoryListUniquenessTests">
+               </Test>
+               <Test
+                  Identifier = "MWKImageFaceDetectionTests">
+               </Test>
+               <Test
+                  Identifier = "MWKImageInfoSerializationTest">
+               </Test>
+               <Test
+                  Identifier = "MWKImageInfo_MWKImageComparisonTests">
+               </Test>
+               <Test
+                  Identifier = "MWKImageListTests">
+               </Test>
+               <Test
+                  Identifier = "MWKImageStorageTests">
+               </Test>
+               <Test
+                  Identifier = "MWKLanguageLinkControllerTests">
+               </Test>
+               <Test
+                  Identifier = "MWKLanguageLinkFetcherTests">
+               </Test>
+               <Test
+                  Identifier = "MWKLanguageLinkResponseSerializerTests">
+               </Test>
+               <Test
+                  Identifier = "MWKListInsertionTests">
+               </Test>
+               <Test
+                  Identifier = "MWKListLegacyTests">
+               </Test>
+               <Test
+                  Identifier = "MWKListSharedTests">
+               </Test>
+               <Test
+                  Identifier = "MWKListTestBase">
+               </Test>
+               <Test
+                  Identifier = "MWKProtectionStatusTests">
+               </Test>
+               <Test
+                  Identifier = "MWKRecentSearchDataStoreTests">
+               </Test>
+               <Test
+                  Identifier = "MWKRecentSearchesSharedTests">
+               </Test>
+               <Test
+                  Identifier = "MWKSavedPageListCorruptDataTests">
+               </Test>
+               <Test
+                  Identifier = "MWKSavedPageListDataStoreTests">
+               </Test>
+               <Test
+                  Identifier = "MWKSavedPageListSharedTests">
+               </Test>
+               <Test
+                  Identifier = "MWKSavedPageListTogglingTests">
+               </Test>
+               <Test
+                  Identifier = "MWKSectionHasTextDataTests">
+               </Test>
+               <Test
+                  Identifier = "MWKSectionListHierarchyTests">
+               </Test>
+               <Test
+                  Identifier = "MWKSectionListTests">
+               </Test>
+               <Test
+                  Identifier = "MWKSection_HTMLImageParsingTests">
+               </Test>
+               <Test
+                  Identifier = "MWKSection_WMFSharingTests">
+               </Test>
+               <Test
+                  Identifier = "MWKSiteInfoFetcherTests">
+               </Test>
+               <Test
+                  Identifier = "MWKSiteTests">
+               </Test>
+               <Test
+                  Identifier = "MWKTestCase">
+               </Test>
+               <Test
+                  Identifier = "MWKTitleTests">
+               </Test>
+               <Test
+                  Identifier = "MWKUserTests">
+               </Test>
+               <Test
+                  Identifier = "NSArray_BKIndexTests">
+               </Test>
+               <Test
+                  Identifier = "NSArray_PredicateTests">
+               </Test>
+               <Test
+                  Identifier = "NSArray_WMFExtensionsTests">
+               </Test>
+               <Test
+                  Identifier = "NSAttributedString_WMFModifyTests">
+               </Test>
+               <Test
+                  Identifier = "NSAttributedString_WMFTrimTests">
+               </Test>
+               <Test
+                  Identifier = "NSDate_WMFRangesTests">
+               </Test>
+               <Test
+                  Identifier = "NSIndexSet_BKReduceTests">
+               </Test>
+               <Test
+                  Identifier = "NSMutableDictionary_WMFMaybeSetTests">
+               </Test>
+               <Test
+                  Identifier = "NSString_FormattedAttributedStringTests">
+               </Test>
+               <Test
+                  Identifier = "NSString_WMFHTMLParsingTests">
+               </Test>
+               <Test
+                  Identifier = "NSURLExtrasTests">
+               </Test>
+               <Test
+                  Identifier = "NSURL_WMFLinkParsingTests">
+               </Test>
+               <Test
+                  Identifier = "SavedArticlesFetcherTests">
+               </Test>
+               <Test
+                  Identifier = "UIImageViewWMFImageFetchingVisualTests">
+               </Test>
+               <Test
+                  Identifier = "UIImageView_MWKImageTests">
+               </Test>
+               <Test
+                  Identifier = "WMFArticleImageInjectionTests">
+               </Test>
+               <Test
+                  Identifier = "WMFArticleListCellVisualTests">
+               </Test>
+               <Test
+                  Identifier = "WMFAsyncTestCase">
+               </Test>
+               <Test
+                  Identifier = "WMFBackgroundTaskManagerTests">
+               </Test>
+               <Test
+                  Identifier = "WMFCollectionViewExtensionTests">
+               </Test>
+               <Test
+                  Identifier = "WMFDateFormatterTests">
+               </Test>
+               <Test
+                  Identifier = "WMFENFeaturedTitleFetcherTests">
+               </Test>
+               <Test
+                  Identifier = "WMFErrorForApiErrorObjectTests">
+               </Test>
+               <Test
+                  Identifier = "WMFGeometryTests">
+               </Test>
+               <Test
+                  Identifier = "WMFImageControllerTests">
+               </Test>
+               <Test
+                  Identifier = "WMFImageInfoControllerTests">
+               </Test>
+               <Test
+                  Identifier = "WMFImageURLParsingTests">
+               </Test>
+               <Test
+                  Identifier = "WMFJoinedPropertyParametersTests">
+               </Test>
+               <Test
+                  Identifier = "WMFLegacyImageDataMigrationTests">
+               </Test>
+               <Test
+                  Identifier = "WMFMathTests">
+               </Test>
+               <Test
+                  Identifier = "WMFPicOfTheDayTableViewCellVisualTests">
+               </Test>
+               <Test
+                  Identifier = "WMFRecentPagesDataSourceTests">
+               </Test>
+               <Test
+                  Identifier = "WMFSafeAssignTests">
+               </Test>
+               <Test
+                  Identifier = "WMFSaveButtonControllerTests">
+               </Test>
+               <Test
+                  Identifier = "WMFSearchFetcherTests">
+               </Test>
+               <Test
+                  Identifier = "WMFSearchResultMergeTests">
+               </Test>
+               <Test
+                  Identifier = "WMFSearchResultsSerializationTests">
+               </Test>
+               <Test
+                  Identifier = "WMFSubstringUtilsTests">
+               </Test>
+               <Test
+                  Identifier = "XCTestCase_PromiseKitSwiftTests">
+               </Test>
+               <Test
+                  Identifier = "XCTestCase_PromiseKitTests">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D4991434181D51DE00E6073C"
+            BuildableName = "Wikipedia.app"
+            BlueprintName = "Wikipedia"
+            ReferencedContainer = "container:Wikipedia.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      language = "ar"
+      region = "EG">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D4991434181D51DE00E6073C"
+            BuildableName = "Wikipedia.app"
+            BlueprintName = "Wikipedia"
+            ReferencedContainer = "container:Wikipedia.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D4991434181D51DE00E6073C"
+            BuildableName = "Wikipedia.app"
+            BlueprintName = "Wikipedia"
+            ReferencedContainer = "container:Wikipedia.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Wikipedia/Code/NSDate+WMFPOTDTitle.m
+++ b/Wikipedia/Code/NSDate+WMFPOTDTitle.m
@@ -16,7 +16,7 @@ NSString* const WMFPOTDTitlePrefix = @"Template:Potd";
 @implementation NSDate (WMFPOTDTitle)
 
 - (NSString*)wmf_picOfTheDayPageTitle {
-    NSString* potdTitleDateComponent = [[NSDateFormatter wmf_hyphenatedYearMonthDayFormatter] stringFromDate:self];
+    NSString* potdTitleDateComponent = [[NSDateFormatter wmf_englishHyphenatedYearMonthDayFormatter] stringFromDate:self];
     NSParameterAssert(potdTitleDateComponent);
     return [WMFPOTDTitlePrefix stringByAppendingFormat:@"/%@", potdTitleDateComponent];
 }

--- a/Wikipedia/Code/NSDateFormatter+WMFExtensions.h
+++ b/Wikipedia/Code/NSDateFormatter+WMFExtensions.h
@@ -39,6 +39,6 @@
 
 + (instancetype)wmf_mediumDateFormatterWithoutTime;
 
-+ (instancetype)wmf_hyphenatedYearMonthDayFormatter;
++ (instancetype)wmf_englishHyphenatedYearMonthDayFormatter;
 
 @end

--- a/Wikipedia/Code/NSDateFormatter+WMFExtensions.m
+++ b/Wikipedia/Code/NSDateFormatter+WMFExtensions.m
@@ -63,12 +63,13 @@ static NSString* const WMF_ISO8601_FORMAT = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'";
     return _dateFormatter;
 }
 
-+ (instancetype)wmf_hyphenatedYearMonthDayFormatter {
++ (instancetype)wmf_englishHyphenatedYearMonthDayFormatter {
     static NSDateFormatter* _dateFormatter;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         _dateFormatter = [[NSDateFormatter alloc] init];
         _dateFormatter.dateFormat = @"yyyy'-'MM'-'dd'";
+        _dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en"];
     });
     return _dateFormatter;
 }

--- a/Wikipedia/Code/WMFPictureOfTheDaySectionController.m
+++ b/Wikipedia/Code/WMFPictureOfTheDaySectionController.m
@@ -35,7 +35,7 @@ static NSString* WMFPlaceholderImageInfoTitle = @"WMFPlaceholderImageInfoTitle";
 
 @property (nonatomic, strong) MWKImageInfo* imageInfo;
 
-@property (nonatomic, strong, nullable) NSDate* fetchedDate;
+@property (nonatomic, strong) NSDate* fetchedDate;
 
 @end
 
@@ -73,7 +73,7 @@ static NSString* WMFPlaceholderImageInfoTitle = @"WMFPlaceholderImageInfoTitle";
     .catch(^(NSError* error) {
         @strongify(self);
         [self.delegate controller:self didFailToUpdateWithError:error];
-        self.fetchedDate = nil;
+        DDLogError(@"POTD error: %@", error);
     });
 }
 

--- a/WikipediaUnitTests/Code/NSDate+WMFPOTDTitleTests.m
+++ b/WikipediaUnitTests/Code/NSDate+WMFPOTDTitleTests.m
@@ -12,63 +12,31 @@
 #import "NSDate+WMFPOTDTitle.h"
 #import "NSDate+Utilities.h"
 
-static inline NSString* expectedPOTDTitleStringForYearMonthDay(int year, int month, int day) {
-    return [NSString stringWithFormat:@"%@/%d-%02d-%02d", WMFPOTDTitlePrefix, year, month, day];
+static inline NSString* expectedPOTDTitleStringForYearMonthDay(NSInteger year, NSInteger month, NSInteger day) {
+    return [NSString stringWithFormat:@"%@/%ld-%02ld-%02ld", WMFPOTDTitlePrefix, year, month, day];
 }
 
 QuickSpecBegin(NSDate_WMFPOTDTitleTests)
 
-WMF_TECH_DEBT_TODO(test this to ensure it is not affected by system calendar)
+describe(@"potd date formatting", ^{
+    it(@"should always have two digits for the month & day", ^{
+        NSDateComponents* testDateComponents = [[NSDateComponents alloc] init];
+        testDateComponents.calendar = [NSCalendar currentCalendar];
+        testDateComponents.day = 1;
+        testDateComponents.month = 1;
+        testDateComponents.year = 2015;
+        expect([testDateComponents.date wmf_picOfTheDayPageTitle])
+        .to(equal(expectedPOTDTitleStringForYearMonthDay(testDateComponents.year,
+                                                         testDateComponents.month,
+                                                         testDateComponents.day)));
 
-static NSDate * testDate;
-static int const year  = 2015;
-static int const month = 2;
-static int const day   = 2;
-
-beforeSuite(^{
-    NSDateComponents* testDateComponents = [[NSDateComponents alloc] init];
-    testDateComponents.calendar = [NSCalendar currentCalendar];
-    testDateComponents.day = day;
-    testDateComponents.month = month;
-    testDateComponents.year = year;
-
-    testDate = testDateComponents.date;
-});
-
-describe(@"example dates", ^{
-    it(@"should return the expected title for the test date", ^{
-        expect([testDate wmf_picOfTheDayPageTitle])
-        .to(equal(expectedPOTDTitleStringForYearMonthDay(year, month, day)));
-    });
-
-    it(@"should return the expected title for the day before the test date", ^{
-        expect([[testDate dateBySubtractingDays:1] wmf_picOfTheDayPageTitle])
-        .to(equal(expectedPOTDTitleStringForYearMonthDay(year, month, day - 1)));
-    });
-
-    it(@"should return the expected title for the day after the test date", ^{
-        expect([[testDate dateByAddingDays:1] wmf_picOfTheDayPageTitle])
-        .to(equal(expectedPOTDTitleStringForYearMonthDay(year, month, day + 1)));
-    });
-
-    it(@"should return the expected title for the month before the test date", ^{
-        expect([[testDate dateBySubtractingMonths:1] wmf_picOfTheDayPageTitle])
-        .to(equal(expectedPOTDTitleStringForYearMonthDay(year, month - 1, day)));
-    });
-
-    it(@"should return the expected title for the month after the test date", ^{
-        expect([[testDate dateByAddingMonths:1] wmf_picOfTheDayPageTitle])
-        .to(equal(expectedPOTDTitleStringForYearMonthDay(year, month + 1, day)));
-    });
-
-    it(@"should return the expected title for the year before the test date", ^{
-        expect([[testDate dateBySubtractingYears:1] wmf_picOfTheDayPageTitle])
-        .to(equal(expectedPOTDTitleStringForYearMonthDay(year - 1, month, day)));
-    });
-
-    it(@"should return the expected title for the year after the test date", ^{
-        expect([[testDate dateByAddingYears:1] wmf_picOfTheDayPageTitle])
-        .to(equal(expectedPOTDTitleStringForYearMonthDay(year + 1, month, day)));
+        testDateComponents.day = 10;
+        testDateComponents.month = 10;
+        testDateComponents.year = 2015;
+        expect([testDateComponents.date wmf_picOfTheDayPageTitle])
+        .to(equal(expectedPOTDTitleStringForYearMonthDay(testDateComponents.year,
+                                                         testDateComponents.month,
+                                                         testDateComponents.day)));
     });
 });
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,7 @@ platform :ios do
   desc "Runs unit tests, optionally generating a JUnit report."
   lane :verify do |options|
     opts = {
-      :scheme => 'Wikipedia',
+      :scheme =>  options[:scheme] || 'Wikipedia',
       :workspace => 'Wikipedia.xcworkspace',
       :configuration => 'Debug',
       :destination => 'platform=iOS Simulator,name=iPhone 6,OS=9.1',


### PR DESCRIPTION
Phab: [T120687](https://phabricator.wikimedia.org/T120687)

Oversight, meant to force date formatter used w/ POTD to be EN-only.  Added tests, including a scheme just for running the app & tests in Arabic.  New `.travis.yml` should test all our usual tests in English, and the selected tests again in Arabic, in parallel.