### PR TITLE
Fix issue causing nearby to be empty after clean install or after feed reloads

### DIFF
--- a/Wikipedia/Code/WMFEmptyNearbyTableViewCell.xib
+++ b/Wikipedia/Code/WMFEmptyNearbyTableViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>

--- a/Wikipedia/Code/WMFLocationManager.m
+++ b/Wikipedia/Code/WMFLocationManager.m
@@ -1,6 +1,5 @@
 
 #import "WMFLocationManager.h"
-
 #import "WMFLocationSearchFetcher.h"
 
 static DDLogLevel WMFLocationManagerLogLevel = DDLogLevelDebug;
@@ -169,8 +168,29 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - CLLocationManagerDelegate
 
 - (void)locationManager:(CLLocationManager*)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
-    DDLogInfo(@"%@ changed auth status to %d, attempting to monitor location.", self, status);
-    [self startMonitoringLocation];
+    switch (status) {
+        case kCLAuthorizationStatusNotDetermined: {
+            DDLogVerbose(@"Ignoring not determined status call, should have already requested authorization.");
+            break;
+        }
+
+        case kCLAuthorizationStatusDenied: {
+            WMF_TECH_DEBT_TODO(inform delegate that access was denied)
+            break;
+        }
+
+        case kCLAuthorizationStatusAuthorizedWhenInUse: {
+            DDLogInfo(@"%@ was granted access to location when in use, attempting to monitor location.", self);
+            [self startMonitoringLocation];
+            break;
+        }
+
+        default: {
+            DDLogError(@"%@ was called with unexpected authorization status: %d", self, status);
+            NSAssert(NO, @"Unexpected location authorization status: %d", status);
+            break;
+        }
+    }
 }
 
 - (void)locationManager:(CLLocationManager*)manager didUpdateLocations:(NSArray*)locations {

--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -440,13 +440,12 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
     [[SessionSingleton sharedInstance] setSearchLanguage:self.searchSite.language];
 }
 
-- (NSArray*)allLanguagesFromController{
+- (NSArray*)allLanguagesFromController {
     NSMutableArray* lang = [NSMutableArray array];
     [lang addObjectsFromArray:[MWKLanguageLinkController sharedInstance].preferredLanguages];
     [lang addObjectsFromArray:[MWKLanguageLinkController sharedInstance].otherLanguages];
     return lang;
 }
-
 
 - (void)updateLanguages {
     NSArray* languages = [self allLanguagesFromController];
@@ -553,7 +552,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 
 #pragma mark - LanguageSelectionDelegate
 
-- (void)languagesController:(LanguagesViewController*)controller didSelectLanguage:(MWKLanguageLink*)language{
+- (void)languagesController:(LanguagesViewController*)controller didSelectLanguage:(MWKLanguageLink*)language {
     [[MWKLanguageLinkController sharedInstance] addPreferredLanguage:language];
     [self updateLanguageButtonsToPreferredLanguages];
     [self selectLanguageForSite:language.site];

--- a/Wikipedia/Code/WMFWelcomeLanguageTableViewCell.m
+++ b/Wikipedia/Code/WMFWelcomeLanguageTableViewCell.m
@@ -16,7 +16,7 @@
     _deleteButtonTapped = [deleteButtonTapped copy];
     if (_deleteButtonTapped == NULL) {
         self.rightButtons = nil;
-    }else{
+    } else {
         MGSwipeButton* delete = [MGSwipeButton buttonWithTitle:MWLocalizedString(@"menu-trash-accessibility-label", nil) backgroundColor:[UIColor redColor]];
         self.rightSwipeSettings.transition = MGSwipeTransitionBorder;
         self.rightButtons                  = @[delete];
@@ -29,7 +29,6 @@
             return YES;
         };
     }
-
 }
 
 - (void)layoutSubviews {

--- a/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
+++ b/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
@@ -86,7 +86,6 @@
     }], describedAs(@"All filtered languages have a name or localized name containing filter ignoring case",
                     isEmpty(), nil));
     [self verifyAllLanguageArrayProperties];
-
 }
 
 - (void)testEmptyAfterFiltering {


### PR DESCRIPTION
Phab: [T120505](https://phabricator.wikimedia.org/T120505)

---

- [x] Nearby section is populated with titles after clean install where user allows access
- [x] Nearby section is populated w/ same items after new sections are added on top of it (and feed reloads)

Turns out we had re-entrant code that was requesting access to the user's multiple times which, when removed, allowed the location manager to return valid locations.

This one's not easy to unit test, given all the various `WMFLocationManager` instances being used.  Open to ideas though.