### PR TITLE
Language picker updates

### DIFF
--- a/Wikipedia/Code/LanguageCell.h
+++ b/Wikipedia/Code/LanguageCell.h
@@ -4,13 +4,11 @@
 /// Table cell designed for displaying a language autonym & a page title in that language.
 @interface LanguageCell : UITableViewCell
 
-/// Large, left-aligned label.
-@property (weak, nonatomic) IBOutlet UILabel* languageLabel;
+@property (strong, nonatomic) NSString* localizedLanguageName;
+@property (strong, nonatomic) NSString* articleTitle;
+@property (strong, nonatomic) NSString* languageName;
+@property (strong, nonatomic) NSString* languageCode;
 
-/// Smaller, left-aligned label beneath @c languageLabel.
-@property (weak, nonatomic) IBOutlet UILabel* titleLabel;
-
-@property (weak, nonatomic) IBOutlet UILabel* localizedLanguageLabel;
-@property (weak, nonatomic) IBOutlet UILabel* languageCodeLabel;
+@property (nonatomic) BOOL isPreferred;
 
 @end

--- a/Wikipedia/Code/LanguageCell.h
+++ b/Wikipedia/Code/LanguageCell.h
@@ -10,4 +10,7 @@
 /// Smaller, left-aligned label beneath @c languageLabel.
 @property (weak, nonatomic) IBOutlet UILabel* titleLabel;
 
+@property (weak, nonatomic) IBOutlet UILabel* localizedLanguageLabel;
+@property (weak, nonatomic) IBOutlet UILabel* languageCodeLabel;
+
 @end

--- a/Wikipedia/Code/LanguageCell.m
+++ b/Wikipedia/Code/LanguageCell.m
@@ -5,13 +5,13 @@
 #import "WikipediaAppUtils.h"
 #import "UILabel+WMFStyling.h"
 
-static CGFloat const WMFPreferredLanguageFontSize  = 22.f;
-static CGFloat const WMFPreferredTitleFontSize     = 17.f;
-static CGFloat const WMFOtherLanguageFontSize  = 17.f;
-static CGFloat const WMFOtherTitleFontSize     = 12.f;
-static CGFloat const WMFLanguageNameLabelHeight     = 18.f;
+static CGFloat const WMFPreferredLanguageFontSize = 22.f;
+static CGFloat const WMFPreferredTitleFontSize    = 17.f;
+static CGFloat const WMFOtherLanguageFontSize     = 17.f;
+static CGFloat const WMFOtherTitleFontSize        = 12.f;
+static CGFloat const WMFLanguageNameLabelHeight   = 18.f;
 
-@interface LanguageCell()
+@interface LanguageCell ()
 
 @property (strong, nonatomic) IBOutlet UILabel* localizedLanguageLabel;
 @property (strong, nonatomic) IBOutlet UILabel* articleTitleLabel;
@@ -24,45 +24,45 @@ static CGFloat const WMFLanguageNameLabelHeight     = 18.f;
 
 @implementation LanguageCell
 
--(void)setIsPreferred:(BOOL)isPreferred {
+- (void)setIsPreferred:(BOOL)isPreferred {
     _isPreferred = isPreferred;
     if (isPreferred) {
-        self.localizedLanguageLabel.font    = [UIFont systemFontOfSize:WMFPreferredLanguageFontSize];
-        self.articleTitleLabel.font    = [UIFont systemFontOfSize:WMFPreferredTitleFontSize];
-        self.languageNameLabel.font = [UIFont systemFontOfSize:WMFPreferredTitleFontSize];
-        self.languageCodeLabel.font    = [UIFont systemFontOfSize:WMFPreferredTitleFontSize];
-    }else{
-        self.localizedLanguageLabel.font    = [UIFont systemFontOfSize:WMFOtherLanguageFontSize];
-        self.articleTitleLabel.font    = [UIFont systemFontOfSize:WMFOtherTitleFontSize];
-        self.languageNameLabel.font = [UIFont systemFontOfSize:WMFOtherTitleFontSize];
-        self.languageCodeLabel.font    = [UIFont systemFontOfSize:WMFOtherTitleFontSize];
+        self.localizedLanguageLabel.font = [UIFont systemFontOfSize:WMFPreferredLanguageFontSize];
+        self.articleTitleLabel.font      = [UIFont systemFontOfSize:WMFPreferredTitleFontSize];
+        self.languageNameLabel.font      = [UIFont systemFontOfSize:WMFPreferredTitleFontSize];
+        self.languageCodeLabel.font      = [UIFont systemFontOfSize:WMFPreferredTitleFontSize];
+    } else {
+        self.localizedLanguageLabel.font = [UIFont systemFontOfSize:WMFOtherLanguageFontSize];
+        self.articleTitleLabel.font      = [UIFont systemFontOfSize:WMFOtherTitleFontSize];
+        self.languageNameLabel.font      = [UIFont systemFontOfSize:WMFOtherTitleFontSize];
+        self.languageCodeLabel.font      = [UIFont systemFontOfSize:WMFOtherTitleFontSize];
     }
 }
 
--(void)setLocalizedLanguageName:(NSString *)localizedLanguageName {
-    _localizedLanguageName = localizedLanguageName;
+- (void)setLocalizedLanguageName:(NSString*)localizedLanguageName {
+    _localizedLanguageName           = localizedLanguageName;
     self.localizedLanguageLabel.text = localizedLanguageName;
 }
 
--(void)setArticleTitle:(NSString *)articleTitle {
-    _articleTitle = articleTitle;
+- (void)setArticleTitle:(NSString*)articleTitle {
+    _articleTitle               = articleTitle;
     self.articleTitleLabel.text = articleTitle;
 }
 
--(void)setLanguageName:(NSString *)languageName {
+- (void)setLanguageName:(NSString*)languageName {
     if ([self shouldShowLanguageName:languageName]) {
         self.languageNameLabelHeight.constant = WMFLanguageNameLabelHeight;
     }
-    _languageName = languageName;
+    _languageName               = languageName;
     self.languageNameLabel.text = languageName;
 }
 
--(BOOL)shouldShowLanguageName:(NSString*)languageName {
+- (BOOL)shouldShowLanguageName:(NSString*)languageName {
     return ![languageName isEqualToString:self.localizedLanguageName];
 }
 
--(void)setLanguageCode:(NSString *)languageCode {
-    _languageCode = languageCode;
+- (void)setLanguageCode:(NSString*)languageCode {
+    _languageCode               = languageCode;
     self.languageCodeLabel.text = languageCode;
 }
 
@@ -71,12 +71,12 @@ static CGFloat const WMFLanguageNameLabelHeight     = 18.f;
     [self prepareForReuse];
 }
 
--(void)prepareForReuse {
+- (void)prepareForReuse {
     [super prepareForReuse];
-    self.languageNameLabel.text = @"";
-    self.articleTitleLabel.text = @"";
-    self.localizedLanguageLabel.text = @"";
-    self.languageCodeLabel.text = @"";
+    self.languageNameLabel.text           = @"";
+    self.articleTitleLabel.text           = @"";
+    self.localizedLanguageLabel.text      = @"";
+    self.languageCodeLabel.text           = @"";
     self.languageNameLabelHeight.constant = 0.f;
 }
 

--- a/Wikipedia/Code/LanguageCell.m
+++ b/Wikipedia/Code/LanguageCell.m
@@ -18,6 +18,8 @@
     self.titleLabel.textAlignment    = NSTextAlignmentNatural;
     [self.languageLabel wmf_applyMenuScaleMultiplier];
     [self.titleLabel wmf_applyMenuScaleMultiplier];
+    [self.localizedLanguageLabel wmf_applyMenuScaleMultiplier];
+    [self.languageCodeLabel wmf_applyMenuScaleMultiplier];
 }
 
 @end

--- a/Wikipedia/Code/LanguageCell.m
+++ b/Wikipedia/Code/LanguageCell.m
@@ -3,23 +3,81 @@
 
 #import "LanguageCell.h"
 #import "WikipediaAppUtils.h"
-#import "UIView+ConstraintsScale.h"
-#import "Defines.h"
 #import "UILabel+WMFStyling.h"
+
+static CGFloat const WMFPreferredLanguageFontSize  = 22.f;
+static CGFloat const WMFPreferredTitleFontSize     = 17.f;
+static CGFloat const WMFOtherLanguageFontSize  = 17.f;
+static CGFloat const WMFOtherTitleFontSize     = 12.f;
+static CGFloat const WMFLanguageNameLabelHeight     = 18.f;
+
+@interface LanguageCell()
+
+@property (strong, nonatomic) IBOutlet UILabel* localizedLanguageLabel;
+@property (strong, nonatomic) IBOutlet UILabel* articleTitleLabel;
+@property (strong, nonatomic) IBOutlet UILabel* languageNameLabel;
+@property (strong, nonatomic) IBOutlet UILabel* languageCodeLabel;
+
+@property (strong, nonatomic) IBOutlet NSLayoutConstraint* languageNameLabelHeight;
+
+@end
 
 @implementation LanguageCell
 
-@synthesize languageLabel;
-@synthesize titleLabel;
+-(void)setIsPreferred:(BOOL)isPreferred {
+    _isPreferred = isPreferred;
+    if (isPreferred) {
+        self.localizedLanguageLabel.font    = [UIFont systemFontOfSize:WMFPreferredLanguageFontSize];
+        self.articleTitleLabel.font    = [UIFont systemFontOfSize:WMFPreferredTitleFontSize];
+        self.languageNameLabel.font = [UIFont systemFontOfSize:WMFPreferredTitleFontSize];
+        self.languageCodeLabel.font    = [UIFont systemFontOfSize:WMFPreferredTitleFontSize];
+    }else{
+        self.localizedLanguageLabel.font    = [UIFont systemFontOfSize:WMFOtherLanguageFontSize];
+        self.articleTitleLabel.font    = [UIFont systemFontOfSize:WMFOtherTitleFontSize];
+        self.languageNameLabel.font = [UIFont systemFontOfSize:WMFOtherTitleFontSize];
+        self.languageCodeLabel.font    = [UIFont systemFontOfSize:WMFOtherTitleFontSize];
+    }
+}
+
+-(void)setLocalizedLanguageName:(NSString *)localizedLanguageName {
+    _localizedLanguageName = localizedLanguageName;
+    self.localizedLanguageLabel.text = localizedLanguageName;
+}
+
+-(void)setArticleTitle:(NSString *)articleTitle {
+    _articleTitle = articleTitle;
+    self.articleTitleLabel.text = articleTitle;
+}
+
+-(void)setLanguageName:(NSString *)languageName {
+    if ([self shouldShowLanguageName:languageName]) {
+        self.languageNameLabelHeight.constant = WMFLanguageNameLabelHeight;
+    }
+    _languageName = languageName;
+    self.languageNameLabel.text = languageName;
+}
+
+-(BOOL)shouldShowLanguageName:(NSString*)languageName {
+    return ![languageName isEqualToString:self.localizedLanguageName];
+}
+
+-(void)setLanguageCode:(NSString *)languageCode {
+    _languageCode = languageCode;
+    self.languageCodeLabel.text = languageCode;
+}
 
 - (void)awakeFromNib {
     [super awakeFromNib];
-    self.languageLabel.textAlignment = NSTextAlignmentNatural;
-    self.titleLabel.textAlignment    = NSTextAlignmentNatural;
-    [self.languageLabel wmf_applyMenuScaleMultiplier];
-    [self.titleLabel wmf_applyMenuScaleMultiplier];
-    [self.localizedLanguageLabel wmf_applyMenuScaleMultiplier];
-    [self.languageCodeLabel wmf_applyMenuScaleMultiplier];
+    [self prepareForReuse];
+}
+
+-(void)prepareForReuse {
+    [super prepareForReuse];
+    self.languageNameLabel.text = @"";
+    self.articleTitleLabel.text = @"";
+    self.localizedLanguageLabel.text = @"";
+    self.languageCodeLabel.text = @"";
+    self.languageNameLabelHeight.constant = 0.f;
 }
 
 @end

--- a/Wikipedia/Code/LanguagesViewController.m
+++ b/Wikipedia/Code/LanguagesViewController.m
@@ -204,17 +204,16 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
 #pragma mark - Cell Specialization
 
 - (void)configurePreferredLanguageCell:(LanguageCell*)cell atRow:(NSUInteger)row {
-    MWKLanguageLink* langLink = self.languageFilter.filteredPreferredLanguages[row];
     cell.isPreferred           = YES;
-    cell.localizedLanguageName = langLink.localizedName;
-    cell.languageName          = langLink.name;
-    cell.articleTitle          = langLink.pageTitleText;
-    cell.languageCode          = [self stringForLanguageCode:langLink.languageCode];
+    [self configureCell:cell forLangLink:self.languageFilter.filteredPreferredLanguages[row]];
 }
 
 - (void)configureOtherLanguageCell:(LanguageCell*)cell atRow:(NSUInteger)row {
-    MWKLanguageLink* langLink = self.languageFilter.filteredOtherLanguages[row];
     cell.isPreferred           = NO;
+    [self configureCell:cell forLangLink:self.languageFilter.filteredOtherLanguages[row]];
+}
+
+- (void)configureCell:(LanguageCell*)cell forLangLink:(MWKLanguageLink*)langLink {
     cell.localizedLanguageName = langLink.localizedName;
     cell.languageName          = langLink.name;
     cell.articleTitle          = langLink.pageTitleText;
@@ -222,7 +221,7 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
 }
 
 - (NSString*)stringForLanguageCode:(NSString*)code {
-    return [NSString stringWithFormat:@"%@.wikipedia.org", code];
+    return [NSString stringWithFormat:@"%@.%@", code, WMFDefaultSiteDomain];
 }
 
 #pragma mark - UITableViewDataSource

--- a/Wikipedia/Code/LanguagesViewController.m
+++ b/Wikipedia/Code/LanguagesViewController.m
@@ -7,7 +7,6 @@
 #import "WikipediaAppUtils.h"
 #import "Defines.h"
 #import "UIViewController+Alert.h"
-#import "UIView+ConstraintsScale.h"
 #import "MWKLanguageLink.h"
 #import "UIView+WMFDefaultNib.h"
 #import "UIBarButtonItem+WMFButtonConvenience.h"
@@ -16,14 +15,8 @@
 #import "UIView+WMFRTLMirroring.h"
 #import "MediaWikiKit.h"
 
-static CGFloat const LanguagesSectionFooterHeight = 10.f;
-
-static CGFloat const PreferredLanguageFontSize  = 22.f;
-static CGFloat const PreferredTitleFontSize     = 17.f;
-
-static CGFloat const OtherLanguageRowHeight = 138.f;
-static CGFloat const OtherLanguageFontSize  = 17.f;
-static CGFloat const OtherTitleFontSize     = 12.f;
+static CGFloat const WMFLanguagesSectionFooterHeight = 10.f;
+static CGFloat const WMFOtherLanguageRowHeight = 138.f;
 
 // This assumes the language cell is configured in IB by LanguagesViewController
 static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectionSeparator";
@@ -81,7 +74,7 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
     [self.tableView registerClass:[UITableViewHeaderFooterView class]
      forHeaderFooterViewReuseIdentifier:LangaugesSectionFooterReuseIdentifier];
 
-    self.tableView.estimatedRowHeight = OtherLanguageRowHeight * MENUS_SCALE_MULTIPLIER;
+    self.tableView.estimatedRowHeight = WMFOtherLanguageRowHeight * MENUS_SCALE_MULTIPLIER;
     self.tableView.rowHeight          = UITableViewAutomaticDimension;
 
     // remove a 1px black border around the search field
@@ -210,28 +203,26 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
 
 #pragma mark - Cell Specialization
 
-- (void)configurePreferredLanguageCell:(LanguageCell*)languageCell atRow:(NSUInteger)row {
+- (void)configurePreferredLanguageCell:(LanguageCell*)cell atRow:(NSUInteger)row {
     MWKLanguageLink* langLink = self.languageFilter.filteredPreferredLanguages[row];
-    languageCell.languageLabel.font = [UIFont systemFontOfSize:PreferredTitleFontSize * MENUS_SCALE_MULTIPLIER];
-    languageCell.titleLabel.font    = [UIFont systemFontOfSize:PreferredTitleFontSize * MENUS_SCALE_MULTIPLIER];
-    languageCell.localizedLanguageLabel.font    = [UIFont systemFontOfSize:PreferredLanguageFontSize * MENUS_SCALE_MULTIPLIER];
-    languageCell.languageCodeLabel.font    = [UIFont systemFontOfSize:PreferredTitleFontSize * MENUS_SCALE_MULTIPLIER];
-    languageCell.languageLabel.text = langLink.name;
-    languageCell.titleLabel.text    = langLink.pageTitleText;
-    languageCell.localizedLanguageLabel.text = langLink.localizedName;
-    languageCell.languageCodeLabel.text = [NSString stringWithFormat:@"%@.wikipedia.org", langLink.languageCode];
+    cell.isPreferred = YES;
+    cell.localizedLanguageName = langLink.localizedName;
+    cell.languageName = langLink.name;
+    cell.articleTitle = langLink.pageTitleText;
+    cell.languageCode = [self stringForLanguageCode:langLink.languageCode];
 }
 
-- (void)configureOtherLanguageCell:(LanguageCell*)languageCell atRow:(NSUInteger)row {
+- (void)configureOtherLanguageCell:(LanguageCell*)cell atRow:(NSUInteger)row {
     MWKLanguageLink* langLink = self.languageFilter.filteredOtherLanguages[row];
-    languageCell.languageLabel.font = [UIFont systemFontOfSize:OtherTitleFontSize * MENUS_SCALE_MULTIPLIER];
-    languageCell.titleLabel.font    = [UIFont systemFontOfSize:OtherTitleFontSize * MENUS_SCALE_MULTIPLIER];
-    languageCell.localizedLanguageLabel.font    = [UIFont systemFontOfSize:OtherLanguageFontSize * MENUS_SCALE_MULTIPLIER];
-    languageCell.languageCodeLabel.font    = [UIFont systemFontOfSize:OtherTitleFontSize * MENUS_SCALE_MULTIPLIER];
-    languageCell.languageLabel.text = langLink.name;
-    languageCell.titleLabel.text    = langLink.pageTitleText;
-    languageCell.localizedLanguageLabel.text = langLink.localizedName;
-    languageCell.languageCodeLabel.text = [NSString stringWithFormat:@"%@.wikipedia.org", langLink.languageCode];
+    cell.isPreferred = NO;
+    cell.localizedLanguageName = langLink.localizedName;
+    cell.languageName = langLink.name;
+    cell.articleTitle = langLink.pageTitleText;
+    cell.languageCode = [self stringForLanguageCode:langLink.languageCode];
+}
+
+-(NSString*)stringForLanguageCode:(NSString*)code {
+    return [NSString stringWithFormat:@"%@.wikipedia.org", code];
 }
 
 #pragma mark - UITableViewDataSource
@@ -281,7 +272,7 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
 - (CGFloat)tableView:(UITableView*)tableView heightForFooterInSection:(NSInteger)section {
     if ([self isPreferredSection:section] && self.languageFilter.filteredPreferredLanguages.count > 0) {
         // collapse footer when empty, removing needless padding of "other" section from top of table
-        return LanguagesSectionFooterHeight;
+        return WMFLanguagesSectionFooterHeight;
     } else {
         return 0.f;
     }

--- a/Wikipedia/Code/LanguagesViewController.m
+++ b/Wikipedia/Code/LanguagesViewController.m
@@ -212,9 +212,9 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
 
 - (void)configurePreferredLanguageCell:(LanguageCell*)languageCell atRow:(NSUInteger)row {
     MWKLanguageLink* langLink = self.languageFilter.filteredPreferredLanguages[row];
-    languageCell.languageLabel.font = [UIFont systemFontOfSize:PreferredLanguageFontSize * MENUS_SCALE_MULTIPLIER];
+    languageCell.languageLabel.font = [UIFont systemFontOfSize:PreferredTitleFontSize * MENUS_SCALE_MULTIPLIER];
     languageCell.titleLabel.font    = [UIFont systemFontOfSize:PreferredTitleFontSize * MENUS_SCALE_MULTIPLIER];
-    languageCell.localizedLanguageLabel.font    = [UIFont systemFontOfSize:PreferredTitleFontSize * MENUS_SCALE_MULTIPLIER];
+    languageCell.localizedLanguageLabel.font    = [UIFont systemFontOfSize:PreferredLanguageFontSize * MENUS_SCALE_MULTIPLIER];
     languageCell.languageCodeLabel.font    = [UIFont systemFontOfSize:PreferredTitleFontSize * MENUS_SCALE_MULTIPLIER];
     languageCell.languageLabel.text = langLink.name;
     languageCell.titleLabel.text    = langLink.pageTitleText;
@@ -224,9 +224,9 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
 
 - (void)configureOtherLanguageCell:(LanguageCell*)languageCell atRow:(NSUInteger)row {
     MWKLanguageLink* langLink = self.languageFilter.filteredOtherLanguages[row];
-    languageCell.languageLabel.font = [UIFont systemFontOfSize:OtherLanguageFontSize * MENUS_SCALE_MULTIPLIER];
+    languageCell.languageLabel.font = [UIFont systemFontOfSize:OtherTitleFontSize * MENUS_SCALE_MULTIPLIER];
     languageCell.titleLabel.font    = [UIFont systemFontOfSize:OtherTitleFontSize * MENUS_SCALE_MULTIPLIER];
-    languageCell.localizedLanguageLabel.font    = [UIFont systemFontOfSize:OtherTitleFontSize * MENUS_SCALE_MULTIPLIER];
+    languageCell.localizedLanguageLabel.font    = [UIFont systemFontOfSize:OtherLanguageFontSize * MENUS_SCALE_MULTIPLIER];
     languageCell.languageCodeLabel.font    = [UIFont systemFontOfSize:OtherTitleFontSize * MENUS_SCALE_MULTIPLIER];
     languageCell.languageLabel.text = langLink.name;
     languageCell.titleLabel.text    = langLink.pageTitleText;

--- a/Wikipedia/Code/LanguagesViewController.m
+++ b/Wikipedia/Code/LanguagesViewController.m
@@ -16,7 +16,7 @@
 #import "MediaWikiKit.h"
 
 static CGFloat const WMFLanguagesSectionFooterHeight = 10.f;
-static CGFloat const WMFOtherLanguageRowHeight = 138.f;
+static CGFloat const WMFOtherLanguageRowHeight       = 138.f;
 
 // This assumes the language cell is configured in IB by LanguagesViewController
 static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectionSeparator";
@@ -205,23 +205,23 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
 
 - (void)configurePreferredLanguageCell:(LanguageCell*)cell atRow:(NSUInteger)row {
     MWKLanguageLink* langLink = self.languageFilter.filteredPreferredLanguages[row];
-    cell.isPreferred = YES;
+    cell.isPreferred           = YES;
     cell.localizedLanguageName = langLink.localizedName;
-    cell.languageName = langLink.name;
-    cell.articleTitle = langLink.pageTitleText;
-    cell.languageCode = [self stringForLanguageCode:langLink.languageCode];
+    cell.languageName          = langLink.name;
+    cell.articleTitle          = langLink.pageTitleText;
+    cell.languageCode          = [self stringForLanguageCode:langLink.languageCode];
 }
 
 - (void)configureOtherLanguageCell:(LanguageCell*)cell atRow:(NSUInteger)row {
     MWKLanguageLink* langLink = self.languageFilter.filteredOtherLanguages[row];
-    cell.isPreferred = NO;
+    cell.isPreferred           = NO;
     cell.localizedLanguageName = langLink.localizedName;
-    cell.languageName = langLink.name;
-    cell.articleTitle = langLink.pageTitleText;
-    cell.languageCode = [self stringForLanguageCode:langLink.languageCode];
+    cell.languageName          = langLink.name;
+    cell.articleTitle          = langLink.pageTitleText;
+    cell.languageCode          = [self stringForLanguageCode:langLink.languageCode];
 }
 
--(NSString*)stringForLanguageCode:(NSString*)code {
+- (NSString*)stringForLanguageCode:(NSString*)code {
     return [NSString stringWithFormat:@"%@.wikipedia.org", code];
 }
 

--- a/Wikipedia/Code/LanguagesViewController.m
+++ b/Wikipedia/Code/LanguagesViewController.m
@@ -204,12 +204,12 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
 #pragma mark - Cell Specialization
 
 - (void)configurePreferredLanguageCell:(LanguageCell*)cell atRow:(NSUInteger)row {
-    cell.isPreferred           = YES;
+    cell.isPreferred = YES;
     [self configureCell:cell forLangLink:self.languageFilter.filteredPreferredLanguages[row]];
 }
 
 - (void)configureOtherLanguageCell:(LanguageCell*)cell atRow:(NSUInteger)row {
-    cell.isPreferred           = NO;
+    cell.isPreferred = NO;
     [self configureCell:cell forLangLink:self.languageFilter.filteredOtherLanguages[row]];
 }
 

--- a/Wikipedia/Code/LanguagesViewController.m
+++ b/Wikipedia/Code/LanguagesViewController.m
@@ -18,11 +18,10 @@
 
 static CGFloat const LanguagesSectionFooterHeight = 10.f;
 
-static CGFloat const PreferredLanguageRowHeight = 75.f;
 static CGFloat const PreferredLanguageFontSize  = 22.f;
 static CGFloat const PreferredTitleFontSize     = 17.f;
 
-static CGFloat const OtherLanguageRowHeight = 60.f;
+static CGFloat const OtherLanguageRowHeight = 138.f;
 static CGFloat const OtherLanguageFontSize  = 17.f;
 static CGFloat const OtherTitleFontSize     = 12.f;
 
@@ -215,16 +214,24 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
     MWKLanguageLink* langLink = self.languageFilter.filteredPreferredLanguages[row];
     languageCell.languageLabel.font = [UIFont systemFontOfSize:PreferredLanguageFontSize * MENUS_SCALE_MULTIPLIER];
     languageCell.titleLabel.font    = [UIFont systemFontOfSize:PreferredTitleFontSize * MENUS_SCALE_MULTIPLIER];
+    languageCell.localizedLanguageLabel.font    = [UIFont systemFontOfSize:PreferredTitleFontSize * MENUS_SCALE_MULTIPLIER];
+    languageCell.languageCodeLabel.font    = [UIFont systemFontOfSize:PreferredTitleFontSize * MENUS_SCALE_MULTIPLIER];
     languageCell.languageLabel.text = langLink.name;
     languageCell.titleLabel.text    = langLink.pageTitleText;
+    languageCell.localizedLanguageLabel.text = langLink.localizedName;
+    languageCell.languageCodeLabel.text = [NSString stringWithFormat:@"%@.wikipedia.org", langLink.languageCode];
 }
 
 - (void)configureOtherLanguageCell:(LanguageCell*)languageCell atRow:(NSUInteger)row {
     MWKLanguageLink* langLink = self.languageFilter.filteredOtherLanguages[row];
     languageCell.languageLabel.font = [UIFont systemFontOfSize:OtherLanguageFontSize * MENUS_SCALE_MULTIPLIER];
     languageCell.titleLabel.font    = [UIFont systemFontOfSize:OtherTitleFontSize * MENUS_SCALE_MULTIPLIER];
+    languageCell.localizedLanguageLabel.font    = [UIFont systemFontOfSize:OtherTitleFontSize * MENUS_SCALE_MULTIPLIER];
+    languageCell.languageCodeLabel.font    = [UIFont systemFontOfSize:OtherTitleFontSize * MENUS_SCALE_MULTIPLIER];
     languageCell.languageLabel.text = langLink.name;
     languageCell.titleLabel.text    = langLink.pageTitleText;
+    languageCell.localizedLanguageLabel.text = langLink.localizedName;
+    languageCell.languageCodeLabel.text = [NSString stringWithFormat:@"%@.wikipedia.org", langLink.languageCode];
 }
 
 #pragma mark - UITableViewDataSource
@@ -252,7 +259,6 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
     UITableViewCell* cell =
         [tableView dequeueReusableCellWithIdentifier:[LanguageCell wmf_nibName]
                                         forIndexPath:indexPath];
-
     if ([self isPreferredSection:indexPath.section]) {
         [self configurePreferredLanguageCell:(LanguageCell*)cell atRow:indexPath.row];
     } else {
@@ -271,17 +277,6 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
 }
 
 #pragma mark - UITableViewDelegate
-
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
-#warning heightForRowAtIndexPath: is not necessary in iOS 8, since it will rely on the cell's intrinsic content size
-#endif
-- (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {
-    if ([self isPreferredSection:indexPath.section]) {
-        return PreferredLanguageRowHeight * MENUS_SCALE_MULTIPLIER;
-    } else {
-        return OtherLanguageRowHeight * MENUS_SCALE_MULTIPLIER;
-    }
-}
 
 - (CGFloat)tableView:(UITableView*)tableView heightForFooterInSection:(NSInteger)section {
     if ([self isPreferredSection:section] && self.languageFilter.filteredPreferredLanguages.count > 0) {

--- a/Wikipedia/Code/LanguagesViewController.m
+++ b/Wikipedia/Code/LanguagesViewController.m
@@ -5,7 +5,7 @@
 #import "MWKTitleLanguageController.h"
 #import "LanguageCell.h"
 #import "WikipediaAppUtils.h"
-#import "Defines.h"
+#import "UIColor+WMFStyle.h"
 #import "UIViewController+Alert.h"
 #import "MWKLanguageLink.h"
 #import "UIView+WMFDefaultNib.h"
@@ -69,23 +69,23 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
     }];
     self.navigationItem.leftBarButtonItems = @[xButton];
 
-    self.tableView.backgroundColor = CHROME_COLOR;
+    self.tableView.backgroundColor = [UIColor wmf_settingsBackgroundColor];
 
     [self.tableView registerClass:[UITableViewHeaderFooterView class]
      forHeaderFooterViewReuseIdentifier:LangaugesSectionFooterReuseIdentifier];
 
-    self.tableView.estimatedRowHeight = WMFOtherLanguageRowHeight * MENUS_SCALE_MULTIPLIER;
+    self.tableView.estimatedRowHeight = WMFOtherLanguageRowHeight;
     self.tableView.rowHeight          = UITableViewAutomaticDimension;
 
     // remove a 1px black border around the search field
-    self.languageFilterField.layer.borderColor = [CHROME_COLOR CGColor];
+    self.languageFilterField.layer.borderColor = [[UIColor wmf_settingsBackgroundColor] CGColor];
     self.languageFilterField.layer.borderWidth = 1.f;
 
     // stylize
     if ([self.languageFilterField respondsToSelector:@selector(setReturnKeyType:)]) {
         [self.languageFilterField setReturnKeyType:UIReturnKeyDone];
     }
-    self.languageFilterField.barTintColor = CHROME_COLOR;
+    self.languageFilterField.barTintColor = [UIColor wmf_settingsBackgroundColor];;
     self.languageFilterField.placeholder  = MWLocalizedString(@"article-languages-filter-placeholder", nil);
 }
 
@@ -282,7 +282,7 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
 - (UIView*)tableView:(UITableView*)tableView viewForFooterInSection:(NSInteger)section {
     UITableViewHeaderFooterView* footerView =
         [tableView dequeueReusableHeaderFooterViewWithIdentifier:LangaugesSectionFooterReuseIdentifier];
-    footerView.contentView.backgroundColor = CHROME_COLOR;
+    footerView.contentView.backgroundColor = [UIColor wmf_settingsBackgroundColor];;
     return footerView;
 }
 

--- a/Wikipedia/Code/LanguagesViewController.storyboard
+++ b/Wikipedia/Code/LanguagesViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vqp-1K-wjM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vqp-1K-wjM">
     <dependencies>
         <deployment identifier="iOS"/>
         <development version="5100" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -21,7 +21,6 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="iFX-H4-bkt">
                                 <rect key="frame" x="0.0" y="64" width="320" height="504"/>
-                                <animations/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="gray" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="LanguageCell" rowHeight="138" id="aOG-CK-VHw" customClass="LanguageCell">
@@ -34,16 +33,17 @@
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QuT-sm-MtF">
                                                     <rect key="frame" x="28" y="13" width="264" height="112"/>
                                                     <subviews>
-                                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wVn-n7-pdy" userLabel="Language">
-                                                            <rect key="frame" x="0.0" y="0.0" width="264" height="58"/>
-                                                            <animations/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wVn-n7-pdy" userLabel="Language">
+                                                            <rect key="frame" x="0.0" y="76" width="264" height="18"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="18" id="jOO-T3-pcc"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="748" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ib6-Zk-jUw" userLabel="Article title">
+                                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="748" text="Article title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ib6-Zk-jUw" userLabel="Article title">
                                                             <rect key="frame" x="0.0" y="58" width="264" height="18"/>
-                                                            <animations/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="18" placeholder="YES" id="Vuo-LR-40O"/>
                                                             </constraints>
@@ -51,19 +51,13 @@
                                                             <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rLN-Zb-UJl" userLabel="Localized language name">
-                                                            <rect key="frame" x="0.0" y="76" width="264" height="18"/>
-                                                            <animations/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="18" id="s7W-fq-KrJ"/>
-                                                            </constraints>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Localized language name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rLN-Zb-UJl" userLabel="Localized language name">
+                                                            <rect key="frame" x="0.0" y="0.0" width="264" height="58"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lQo-0f-Md2" userLabel="Language code">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lQo-0f-Md2" userLabel="Language code">
                                                             <rect key="frame" x="0.0" y="94" width="264" height="18"/>
-                                                            <animations/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="18" id="QuJ-cG-Rpw"/>
                                                             </constraints>
@@ -72,26 +66,24 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
-                                                    <animations/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstItem="lQo-0f-Md2" firstAttribute="leading" secondItem="QuT-sm-MtF" secondAttribute="leading" id="4Px-zA-KUu"/>
                                                         <constraint firstAttribute="bottom" secondItem="lQo-0f-Md2" secondAttribute="bottom" id="67w-Rm-QSf"/>
                                                         <constraint firstAttribute="trailing" secondItem="ib6-Zk-jUw" secondAttribute="trailing" id="8mj-lY-xSI"/>
-                                                        <constraint firstItem="ib6-Zk-jUw" firstAttribute="top" secondItem="wVn-n7-pdy" secondAttribute="bottom" id="Buz-nf-ha8"/>
-                                                        <constraint firstItem="rLN-Zb-UJl" firstAttribute="top" secondItem="ib6-Zk-jUw" secondAttribute="bottom" id="Qww-N0-Afs"/>
+                                                        <constraint firstItem="lQo-0f-Md2" firstAttribute="top" secondItem="wVn-n7-pdy" secondAttribute="bottom" id="HAa-1K-ifJ"/>
                                                         <constraint firstItem="wVn-n7-pdy" firstAttribute="leading" secondItem="QuT-sm-MtF" secondAttribute="leading" id="Rfw-zW-rvG"/>
+                                                        <constraint firstItem="ib6-Zk-jUw" firstAttribute="top" secondItem="rLN-Zb-UJl" secondAttribute="bottom" id="T7p-eZ-dn7"/>
                                                         <constraint firstItem="rLN-Zb-UJl" firstAttribute="leading" secondItem="QuT-sm-MtF" secondAttribute="leading" id="VGe-jJ-L93"/>
-                                                        <constraint firstItem="wVn-n7-pdy" firstAttribute="top" secondItem="QuT-sm-MtF" secondAttribute="top" id="VYa-6o-e5K"/>
+                                                        <constraint firstItem="rLN-Zb-UJl" firstAttribute="top" secondItem="QuT-sm-MtF" secondAttribute="top" id="Yot-KT-N8j"/>
                                                         <constraint firstAttribute="trailing" secondItem="wVn-n7-pdy" secondAttribute="trailing" id="cIv-p3-MTs"/>
                                                         <constraint firstAttribute="trailing" secondItem="lQo-0f-Md2" secondAttribute="trailing" id="g8u-Hv-dzN"/>
-                                                        <constraint firstItem="lQo-0f-Md2" firstAttribute="top" secondItem="rLN-Zb-UJl" secondAttribute="bottom" id="ig5-Uu-qBn"/>
+                                                        <constraint firstItem="wVn-n7-pdy" firstAttribute="top" secondItem="ib6-Zk-jUw" secondAttribute="bottom" id="gzX-hV-pFk"/>
                                                         <constraint firstAttribute="trailing" secondItem="rLN-Zb-UJl" secondAttribute="trailing" id="tJd-8k-rsv"/>
                                                         <constraint firstItem="ib6-Zk-jUw" firstAttribute="leading" secondItem="QuT-sm-MtF" secondAttribute="leading" id="yq6-IZ-DYQ"/>
                                                     </constraints>
                                                 </view>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstAttribute="trailingMargin" secondItem="QuT-sm-MtF" secondAttribute="trailing" constant="20" id="XM2-T9-UEr"/>
                                                 <constraint firstAttribute="bottomMargin" secondItem="QuT-sm-MtF" secondAttribute="bottom" constant="5" id="kqP-vV-Kec"/>
@@ -99,7 +91,6 @@
                                                 <constraint firstItem="QuT-sm-MtF" firstAttribute="leading" secondItem="u7F-wb-Bsy" secondAttribute="leadingMargin" constant="20" id="q95-c0-ppO"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                         <connections>
                                             <outlet property="languageCodeLabel" destination="lQo-0f-Md2" id="LAk-bL-qcq"/>
                                             <outlet property="languageLabel" destination="wVn-n7-pdy" id="YNC-p2-GST"/>
@@ -115,7 +106,6 @@
                             </tableView>
                             <searchBar contentMode="redraw" searchBarStyle="prominent" translatesAutoresizingMaskIntoConstraints="NO" id="HRn-z3-mks">
                                 <rect key="frame" x="0.0" y="20" width="320" height="44"/>
-                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="6qh-TC-frw"/>
                                 </constraints>
@@ -125,7 +115,6 @@
                                 </connections>
                             </searchBar>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="HRn-z3-mks" secondAttribute="trailing" id="56v-Xv-cFF"/>

--- a/Wikipedia/Code/LanguagesViewController.storyboard
+++ b/Wikipedia/Code/LanguagesViewController.storyboard
@@ -33,13 +33,9 @@
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QuT-sm-MtF">
                                                     <rect key="frame" x="28" y="13" width="264" height="112"/>
                                                     <subviews>
-                                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wVn-n7-pdy" userLabel="Language">
-                                                            <rect key="frame" x="0.0" y="76" width="264" height="18"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="18" id="jOO-T3-pcc"/>
-                                                            </constraints>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Localized language name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rLN-Zb-UJl" userLabel="Localized language name">
+                                                            <rect key="frame" x="0.0" y="0.0" width="264" height="58"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="748" text="Article title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ib6-Zk-jUw" userLabel="Article title">
@@ -51,9 +47,13 @@
                                                             <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Localized language name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rLN-Zb-UJl" userLabel="Localized language name">
-                                                            <rect key="frame" x="0.0" y="0.0" width="264" height="58"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Language name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wVn-n7-pdy" userLabel="Language name">
+                                                            <rect key="frame" x="0.0" y="76" width="264" height="18"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="18" id="jOO-T3-pcc"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lQo-0f-Md2" userLabel="Language code">
@@ -92,10 +92,11 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
+                                            <outlet property="articleTitleLabel" destination="ib6-Zk-jUw" id="yrT-6L-wLN"/>
                                             <outlet property="languageCodeLabel" destination="lQo-0f-Md2" id="LAk-bL-qcq"/>
-                                            <outlet property="languageLabel" destination="wVn-n7-pdy" id="YNC-p2-GST"/>
+                                            <outlet property="languageNameLabel" destination="wVn-n7-pdy" id="uca-Ov-HGk"/>
+                                            <outlet property="languageNameLabelHeight" destination="jOO-T3-pcc" id="l7k-8K-VGq"/>
                                             <outlet property="localizedLanguageLabel" destination="rLN-Zb-UJl" id="SAQ-ks-taJ"/>
-                                            <outlet property="titleLabel" destination="ib6-Zk-jUw" id="iMX-wj-fc1"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>

--- a/Wikipedia/Code/LanguagesViewController.storyboard
+++ b/Wikipedia/Code/LanguagesViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vqp-1K-wjM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vqp-1K-wjM">
     <dependencies>
         <deployment identifier="iOS"/>
         <development version="5100" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -21,26 +21,29 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="iFX-H4-bkt">
                                 <rect key="frame" x="0.0" y="64" width="320" height="504"/>
+                                <animations/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="gray" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="LanguageCell" rowHeight="75" id="aOG-CK-VHw" customClass="LanguageCell">
-                                        <rect key="frame" x="0.0" y="22" width="320" height="60"/>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="gray" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="LanguageCell" rowHeight="138" id="aOG-CK-VHw" customClass="LanguageCell">
+                                        <rect key="frame" x="0.0" y="22" width="320" height="138"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" tableViewCell="aOG-CK-VHw" id="u7F-wb-Bsy">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="138"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QuT-sm-MtF">
-                                                    <rect key="frame" x="28" y="13" width="264" height="49"/>
+                                                    <rect key="frame" x="28" y="13" width="264" height="112"/>
                                                     <subviews>
-                                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wVn-n7-pdy" userLabel="Language">
-                                                            <rect key="frame" x="0.0" y="0.0" width="264" height="31"/>
+                                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wVn-n7-pdy" userLabel="Language">
+                                                            <rect key="frame" x="0.0" y="0.0" width="264" height="58"/>
+                                                            <animations/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="748" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ib6-Zk-jUw" userLabel="Canonical Language">
-                                                            <rect key="frame" x="0.0" y="31" width="264" height="18"/>
+                                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="748" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ib6-Zk-jUw" userLabel="Article title">
+                                                            <rect key="frame" x="0.0" y="58" width="264" height="18"/>
+                                                            <animations/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="18" placeholder="YES" id="Vuo-LR-40O"/>
                                                             </constraints>
@@ -48,19 +51,47 @@
                                                             <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rLN-Zb-UJl" userLabel="Localized language name">
+                                                            <rect key="frame" x="0.0" y="76" width="264" height="18"/>
+                                                            <animations/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="18" id="s7W-fq-KrJ"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lQo-0f-Md2" userLabel="Language code">
+                                                            <rect key="frame" x="0.0" y="94" width="264" height="18"/>
+                                                            <animations/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="18" id="QuJ-cG-Rpw"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
                                                     </subviews>
+                                                    <animations/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="bottom" secondItem="ib6-Zk-jUw" secondAttribute="bottom" id="6Jw-FK-Js5"/>
+                                                        <constraint firstItem="lQo-0f-Md2" firstAttribute="leading" secondItem="QuT-sm-MtF" secondAttribute="leading" id="4Px-zA-KUu"/>
+                                                        <constraint firstAttribute="bottom" secondItem="lQo-0f-Md2" secondAttribute="bottom" id="67w-Rm-QSf"/>
                                                         <constraint firstAttribute="trailing" secondItem="ib6-Zk-jUw" secondAttribute="trailing" id="8mj-lY-xSI"/>
                                                         <constraint firstItem="ib6-Zk-jUw" firstAttribute="top" secondItem="wVn-n7-pdy" secondAttribute="bottom" id="Buz-nf-ha8"/>
+                                                        <constraint firstItem="rLN-Zb-UJl" firstAttribute="top" secondItem="ib6-Zk-jUw" secondAttribute="bottom" id="Qww-N0-Afs"/>
                                                         <constraint firstItem="wVn-n7-pdy" firstAttribute="leading" secondItem="QuT-sm-MtF" secondAttribute="leading" id="Rfw-zW-rvG"/>
+                                                        <constraint firstItem="rLN-Zb-UJl" firstAttribute="leading" secondItem="QuT-sm-MtF" secondAttribute="leading" id="VGe-jJ-L93"/>
                                                         <constraint firstItem="wVn-n7-pdy" firstAttribute="top" secondItem="QuT-sm-MtF" secondAttribute="top" id="VYa-6o-e5K"/>
                                                         <constraint firstAttribute="trailing" secondItem="wVn-n7-pdy" secondAttribute="trailing" id="cIv-p3-MTs"/>
+                                                        <constraint firstAttribute="trailing" secondItem="lQo-0f-Md2" secondAttribute="trailing" id="g8u-Hv-dzN"/>
+                                                        <constraint firstItem="lQo-0f-Md2" firstAttribute="top" secondItem="rLN-Zb-UJl" secondAttribute="bottom" id="ig5-Uu-qBn"/>
+                                                        <constraint firstAttribute="trailing" secondItem="rLN-Zb-UJl" secondAttribute="trailing" id="tJd-8k-rsv"/>
                                                         <constraint firstItem="ib6-Zk-jUw" firstAttribute="leading" secondItem="QuT-sm-MtF" secondAttribute="leading" id="yq6-IZ-DYQ"/>
                                                     </constraints>
                                                 </view>
                                             </subviews>
+                                            <animations/>
                                             <constraints>
                                                 <constraint firstAttribute="trailingMargin" secondItem="QuT-sm-MtF" secondAttribute="trailing" constant="20" id="XM2-T9-UEr"/>
                                                 <constraint firstAttribute="bottomMargin" secondItem="QuT-sm-MtF" secondAttribute="bottom" constant="5" id="kqP-vV-Kec"/>
@@ -68,8 +99,11 @@
                                                 <constraint firstItem="QuT-sm-MtF" firstAttribute="leading" secondItem="u7F-wb-Bsy" secondAttribute="leadingMargin" constant="20" id="q95-c0-ppO"/>
                                             </constraints>
                                         </tableViewCellContentView>
+                                        <animations/>
                                         <connections>
+                                            <outlet property="languageCodeLabel" destination="lQo-0f-Md2" id="LAk-bL-qcq"/>
                                             <outlet property="languageLabel" destination="wVn-n7-pdy" id="YNC-p2-GST"/>
+                                            <outlet property="localizedLanguageLabel" destination="rLN-Zb-UJl" id="SAQ-ks-taJ"/>
                                             <outlet property="titleLabel" destination="ib6-Zk-jUw" id="iMX-wj-fc1"/>
                                         </connections>
                                     </tableViewCell>
@@ -81,6 +115,7 @@
                             </tableView>
                             <searchBar contentMode="redraw" searchBarStyle="prominent" translatesAutoresizingMaskIntoConstraints="NO" id="HRn-z3-mks">
                                 <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="6qh-TC-frw"/>
                                 </constraints>
@@ -90,6 +125,7 @@
                                 </connections>
                             </searchBar>
                         </subviews>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="HRn-z3-mks" secondAttribute="trailing" id="56v-Xv-cFF"/>
@@ -113,9 +149,4 @@
             <point key="canvasLocation" x="111" y="-3528"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>

--- a/Wikipedia/Code/MWKLanguageFilter.m
+++ b/Wikipedia/Code/MWKLanguageFilter.m
@@ -44,15 +44,18 @@
     } else {
         self.filteredLanguages = [self.dataSource.allLanguages bk_select:^BOOL (MWKLanguageLink* langLink) {
             return [langLink.name wmf_caseInsensitiveContainsString:self.languageFilter]
-            || [langLink.localizedName wmf_caseInsensitiveContainsString:self.languageFilter];
+            || [langLink.localizedName wmf_caseInsensitiveContainsString:self.languageFilter]
+            || [langLink.languageCode wmf_caseInsensitiveContainsString:self.languageFilter];
         }];
         self.filteredPreferredLanguages = [self.dataSource.preferredLanguages bk_select:^BOOL (MWKLanguageLink* langLink) {
             return [langLink.name wmf_caseInsensitiveContainsString:self.languageFilter]
-            || [langLink.localizedName wmf_caseInsensitiveContainsString:self.languageFilter];
+            || [langLink.localizedName wmf_caseInsensitiveContainsString:self.languageFilter]
+            || [langLink.languageCode wmf_caseInsensitiveContainsString:self.languageFilter];
         }];
         self.filteredOtherLanguages = [self.dataSource.otherLanguages bk_select:^BOOL (MWKLanguageLink* langLink) {
             return [langLink.name wmf_caseInsensitiveContainsString:self.languageFilter]
-            || [langLink.localizedName wmf_caseInsensitiveContainsString:self.languageFilter];
+            || [langLink.localizedName wmf_caseInsensitiveContainsString:self.languageFilter]
+            || [langLink.languageCode wmf_caseInsensitiveContainsString:self.languageFilter];
         }];
     }
 }

--- a/Wikipedia/Code/MWKLanguageLink.m
+++ b/Wikipedia/Code/MWKLanguageLink.m
@@ -35,8 +35,7 @@ WMF_SYNTHESIZE_IS_EQUAL(MWKLanguageLink, isEqualToLanguageLink :)
         self.languageCode  = languageCode;
         self.pageTitleText = pageTitleText;
         self.name          = name;
-        NSString *osLocalizedName = [WikipediaAppUtils localizedLanguageNameForCode:languageCode];
-        self.localizedName = osLocalizedName ? osLocalizedName : localizedName;
+        self.localizedName = localizedName;
     }
     return self;
 }

--- a/Wikipedia/Code/MWKLanguageLink.m
+++ b/Wikipedia/Code/MWKLanguageLink.m
@@ -9,6 +9,7 @@
 #import "MWKLanguageLink.h"
 #import "NSObjectUtilities.h"
 #import "MWKTitle.h"
+#import "WikipediaAppUtils.h"
 
 @interface MWKLanguageLink ()
 
@@ -34,7 +35,7 @@ WMF_SYNTHESIZE_IS_EQUAL(MWKLanguageLink, isEqualToLanguageLink :)
         self.languageCode  = languageCode;
         self.pageTitleText = pageTitleText;
         self.name          = name;
-        NSString *osLocalizedName = [[NSLocale currentLocale] displayNameForKey:NSLocaleLanguageCode value:languageCode];
+        NSString *osLocalizedName = [WikipediaAppUtils localizedLanguageNameForCode:languageCode];
         self.localizedName = osLocalizedName ? osLocalizedName : localizedName;
     }
     return self;

--- a/Wikipedia/Code/MWKLanguageLink.m
+++ b/Wikipedia/Code/MWKLanguageLink.m
@@ -48,7 +48,7 @@ WMF_SYNTHESIZE_IS_EQUAL(MWKLanguageLink, isEqualToLanguageLink :)
 }
 
 - (NSComparisonResult)compare:(MWKLanguageLink*)other {
-    return [self.localizedName compare:other.localizedName];
+    return [self.languageCode compare:other.languageCode];
 }
 
 - (NSUInteger)hash {

--- a/Wikipedia/Code/MWKLanguageLink.m
+++ b/Wikipedia/Code/MWKLanguageLink.m
@@ -34,7 +34,8 @@ WMF_SYNTHESIZE_IS_EQUAL(MWKLanguageLink, isEqualToLanguageLink :)
         self.languageCode  = languageCode;
         self.pageTitleText = pageTitleText;
         self.name          = name;
-        self.localizedName = localizedName;
+        NSString *osLocalizedName = [[NSLocale currentLocale] displayNameForKey:NSLocaleLanguageCode value:languageCode];
+        self.localizedName = osLocalizedName ? osLocalizedName : localizedName;
     }
     return self;
 }

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -76,7 +76,7 @@ static id _sharedInstance;
         if (![self isCompoundLanguageCode:code]) {
             // iOS will return less descriptive name for compound codes - ie "Chinese" for zh-yue which
             // should be "Cantonese". It looks like iOS ignores anything after the "-".
-            NSString *iOSLocalizedName = [WikipediaAppUtils localizedLanguageNameForCode:code];
+            NSString* iOSLocalizedName = [WikipediaAppUtils localizedLanguageNameForCode:code];
             if (iOSLocalizedName) {
                 localizedName = iOSLocalizedName;
             }
@@ -88,7 +88,7 @@ static id _sharedInstance;
     }];
 }
 
--(BOOL)isCompoundLanguageCode:(NSString*)code {
+- (BOOL)isCompoundLanguageCode:(NSString*)code {
     return [code containsString:@"-"];
 }
 

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -14,7 +14,7 @@
 #import "MediaWikiKit.h"
 #import "Defines.h"
 #import "WMFAssetsFile.h"
-
+#import "WikipediaAppUtils.h"
 #import <BlocksKit/BlocksKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -71,11 +71,25 @@ static id _sharedInstance;
 - (void)loadLanguagesFromFile {
     WMFAssetsFile* assetsFile = [[WMFAssetsFile alloc] initWithFileType:WMFAssetsFileTypeLanguages];
     self.allLanguages = [assetsFile.array bk_map:^id (NSDictionary* langAsset) {
-        return [[MWKLanguageLink alloc] initWithLanguageCode:langAsset[@"code"]
+        NSString* code = langAsset[@"code"];
+        NSString* localizedName = langAsset[@"canonical_name"];
+        if (![self isCompoundLanguageCode:code]) {
+            // iOS will return less descriptive name for compound codes - ie "Chinese" for zh-yue which
+            // should be "Cantonese". It looks like iOS ignores anything after the "-".
+            NSString *iOSLocalizedName = [WikipediaAppUtils localizedLanguageNameForCode:code];
+            if (iOSLocalizedName) {
+                localizedName = iOSLocalizedName;
+            }
+        }
+        return [[MWKLanguageLink alloc] initWithLanguageCode:code
                                                pageTitleText:@""
                                                         name:langAsset[@"name"]
-                                               localizedName:langAsset[@"canonical_name"]];
+                                               localizedName:localizedName];
     }];
+}
+
+-(BOOL)isCompoundLanguageCode:(NSString*)code {
+    return [code containsString:@"-"];
 }
 
 #pragma mark - Getters & Setters

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -16,6 +16,7 @@
 #import "WMFAssetsFile.h"
 #import "WikipediaAppUtils.h"
 #import <BlocksKit/BlocksKit.h>
+#import "Wikipedia-Swift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -76,7 +77,7 @@ static id _sharedInstance;
         if (![self isCompoundLanguageCode:code]) {
             // iOS will return less descriptive name for compound codes - ie "Chinese" for zh-yue which
             // should be "Cantonese". It looks like iOS ignores anything after the "-".
-            NSString* iOSLocalizedName = [WikipediaAppUtils localizedLanguageNameForCode:code];
+            NSString* iOSLocalizedName = [[NSLocale currentLocale] wmf_localizedLanguageNameForCode:code];
             if (iOSLocalizedName) {
                 localizedName = iOSLocalizedName;
             }

--- a/Wikipedia/Code/NSLocale+WMFExtras.swift
+++ b/Wikipedia/Code/NSLocale+WMFExtras.swift
@@ -10,4 +10,7 @@ extension NSLocale {
         }
         return (langCode == "en" || langCode.hasPrefix("en-")) ? true : false;
     }
+    func wmf_localizedLanguageNameForCode(code: String) -> String? {
+        return self.displayNameForKey(NSLocaleLanguageCode, value: code)
+    }
 }

--- a/Wikipedia/Code/SecondaryMenuRowView.m
+++ b/Wikipedia/Code/SecondaryMenuRowView.m
@@ -70,7 +70,7 @@
     _rowType = rowType;
     switch (rowType) {
         case ROW_TYPE_HEADING:
-            self.backgroundColor     = CHROME_COLOR;
+            self.backgroundColor     = [UIColor wmf_settingsBackgroundColor];
             self.textLabel.padding   = UIEdgeInsetsMake(31, 0, 5, 0);
             self.textLabel.textColor = MENU_SUB_TITLE_TEXT_COLOR;
             self.textLabel.font      = [UIFont systemFontOfSize:MENU_HEADING_FONT_SIZE];

--- a/Wikipedia/Code/UIColor+WMFStyle.h
+++ b/Wikipedia/Code/UIColor+WMFStyle.h
@@ -60,4 +60,6 @@
 
 + (instancetype)wmf_nearbyDistanceTextColor;
 
++ (instancetype)wmf_settingsBackgroundColor;
+
 @end

--- a/Wikipedia/Code/UIColor+WMFStyle.m
+++ b/Wikipedia/Code/UIColor+WMFStyle.m
@@ -219,4 +219,14 @@
     return c;
 }
 
++ (instancetype)wmf_settingsBackgroundColor {
+    static UIColor* c = nil;
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        c = [UIColor colorWithRed:0.94 green:0.94 blue:0.96 alpha:1.0];
+    });
+    return c;
+}
+
 @end

--- a/Wikipedia/Code/UIColor+WMFStyle.m
+++ b/Wikipedia/Code/UIColor+WMFStyle.m
@@ -221,7 +221,7 @@
 
 + (instancetype)wmf_settingsBackgroundColor {
     static UIColor* c = nil;
-    
+
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         c = [UIColor colorWithRed:0.94 green:0.94 blue:0.96 alpha:1.0];

--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -455,7 +455,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 - (void)updateLanguageButtonsToPreferredLanguages {
     [self updateLanguages];
     [self.languageButtons enumerateObjectsUsingBlock:^(UIButton* _Nonnull obj, NSUInteger idx, BOOL* _Nonnull stop) {
-        [obj setTitle:[(MWKLanguageLink*)self.searchLanguages[idx] name]  forState:UIControlStateNormal];
+        [obj setTitle:[(MWKLanguageLink*)self.searchLanguages[idx] localizedName]  forState:UIControlStateNormal];
     }];
     [self resizeLanguageButtonsIfNeeded];
 }

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -45,6 +45,7 @@
 
 // Other
 #import "UIViewController+WMFOpenExternalUrl.h"
+#import "Wikipedia-Swift.h"
 
 #pragma mark - Defines
 
@@ -303,7 +304,7 @@ static SecondaryMenuRowIndex const WMFDebugSections[WMFDebugSectionCount] = {
     //NSString *currentArticleTitle = [SessionSingleton sharedInstance].currentArticleTitle;
 
     NSString* languageCode = [SessionSingleton sharedInstance].searchSite.language;
-    NSString* languageName = [WikipediaAppUtils localizedLanguageNameForCode:languageCode];
+    NSString* languageName = [[NSLocale currentLocale] wmf_localizedLanguageNameForCode:languageCode];
     if (!languageName) {
         languageName = [WikipediaAppUtils languageNameForCode:languageCode];
     }

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -302,8 +302,8 @@ static SecondaryMenuRowIndex const WMFDebugSections[WMFDebugSectionCount] = {
 
     //NSString *currentArticleTitle = [SessionSingleton sharedInstance].currentArticleTitle;
 
-    NSString* languageCode              = [SessionSingleton sharedInstance].searchSite.language;
-    NSString* languageName              = [WikipediaAppUtils localizedLanguageNameForCode:languageCode];
+    NSString* languageCode = [SessionSingleton sharedInstance].searchSite.language;
+    NSString* languageName = [WikipediaAppUtils localizedLanguageNameForCode:languageCode];
     if (!languageName) {
         languageName = [WikipediaAppUtils languageNameForCode:languageCode];
     }

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -303,7 +303,10 @@ static SecondaryMenuRowIndex const WMFDebugSections[WMFDebugSectionCount] = {
     //NSString *currentArticleTitle = [SessionSingleton sharedInstance].currentArticleTitle;
 
     NSString* languageCode              = [SessionSingleton sharedInstance].searchSite.language;
-    NSString* languageName              = [WikipediaAppUtils languageNameForCode:languageCode];
+    NSString* languageName              = [WikipediaAppUtils localizedLanguageNameForCode:languageCode];
+    if (!languageName) {
+        languageName = [WikipediaAppUtils languageNameForCode:languageCode];
+    }
     NSAttributedString* searchWikiTitle =
         [MWLocalizedString(@"main-menu-language-title", nil) attributedStringWithAttributes:nil
                                                                         substitutionStrings:@[languageName]

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -123,7 +123,7 @@ static SecondaryMenuRowIndex const WMFDebugSections[WMFDebugSectionCount] = {
 
     self.highlightedTextAttributes = @{ NSFontAttributeName: [UIFont italicSystemFontOfSize:MENU_TITLE_FONT_SIZE] };
 
-    self.view.backgroundColor = CHROME_COLOR;
+    self.view.backgroundColor = [UIColor wmf_settingsBackgroundColor];
 
     self.scrollView.clipsToBounds    = NO;
     self.scrollView.minSubviewHeight = 45;

--- a/Wikipedia/Code/WikipediaAppUtils.h
+++ b/Wikipedia/Code/WikipediaAppUtils.h
@@ -6,6 +6,8 @@
 #import "NSObjectUtilities.h"
 #import "NSString+WMFPageUtilities.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// @return Number of bytes equivalent to `m` megabytes.
 extern NSUInteger MegabytesToBytes(NSUInteger m);
 
@@ -16,8 +18,11 @@ extern NSUInteger MegabytesToBytes(NSUInteger m);
 + (NSString*)versionedUserAgent;
 + (NSString*)relativeTimestamp:(NSDate*)date;
 + (NSString*)languageNameForCode:(NSString*)code;
++ (nullable NSString*)localizedLanguageNameForCode:(NSString*)code;
 + (BOOL)     isDeviceLanguageRTL;
 
 + (void)copyAssetsFolderToAppDataDocuments;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WikipediaAppUtils.h
+++ b/Wikipedia/Code/WikipediaAppUtils.h
@@ -18,8 +18,7 @@ extern NSUInteger MegabytesToBytes(NSUInteger m);
 + (NSString*)versionedUserAgent;
 + (NSString*)relativeTimestamp:(NSDate*)date;
 + (NSString*)languageNameForCode:(NSString*)code;
-+ (nullable NSString*)localizedLanguageNameForCode:(NSString*)code;
-+ (BOOL)              isDeviceLanguageRTL;
++ (BOOL)     isDeviceLanguageRTL;
 
 + (void)copyAssetsFolderToAppDataDocuments;
 

--- a/Wikipedia/Code/WikipediaAppUtils.h
+++ b/Wikipedia/Code/WikipediaAppUtils.h
@@ -19,7 +19,7 @@ extern NSUInteger MegabytesToBytes(NSUInteger m);
 + (NSString*)relativeTimestamp:(NSDate*)date;
 + (NSString*)languageNameForCode:(NSString*)code;
 + (nullable NSString*)localizedLanguageNameForCode:(NSString*)code;
-+ (BOOL)     isDeviceLanguageRTL;
++ (BOOL)              isDeviceLanguageRTL;
 
 + (void)copyAssetsFolderToAppDataDocuments;
 

--- a/Wikipedia/Code/WikipediaAppUtils.m
+++ b/Wikipedia/Code/WikipediaAppUtils.m
@@ -96,10 +96,6 @@ static WMFAssetsFile* languageFile = nil;
     }][@"name"];
 }
 
-+ (nullable NSString*)localizedLanguageNameForCode:(NSString*)code {
-    return [[NSLocale currentLocale] displayNameForKey:NSLocaleLanguageCode value:code];
-}
-
 #pragma mark Copy bundled assets folder and contents to app "AppData/Documents/assets/"
 
 + (void)copyAssetsFolderToAppDataDocuments {

--- a/Wikipedia/Code/WikipediaAppUtils.m
+++ b/Wikipedia/Code/WikipediaAppUtils.m
@@ -8,6 +8,8 @@
 #import <BlocksKit/BlocksKit.h>
 #import "MediaWikiKit.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 NSUInteger MegabytesToBytes(NSUInteger m) {
     static NSUInteger const MEGABYTE = 1 << 20;
     return m * MEGABYTE;
@@ -92,6 +94,10 @@ static WMFAssetsFile* languageFile = nil;
     return [languageFile.array bk_match:^BOOL (NSDictionary* obj) {
         return [obj[@"code"] isEqualToString:code];
     }][@"name"];
+}
+
++ (nullable NSString*)localizedLanguageNameForCode:(NSString*)code {
+    return [[NSLocale currentLocale] displayNameForKey:NSLocaleLanguageCode value:code];
 }
 
 #pragma mark Copy bundled assets folder and contents to app "AppData/Documents/assets/"
@@ -185,3 +191,6 @@ static WMFAssetsFile* languageFile = nil;
 }
 
 @end
+
+NS_ASSUME_NONNULL_END
+

--- a/Wikipedia/assets/languages.json
+++ b/Wikipedia/assets/languages.json
@@ -715,7 +715,7 @@
         "name": "\u0440\u0443\u0441\u0438\u043d\u044c\u0441\u043a\u044b\u0439 \u044f\u0437\u044b\u043a"
     }, 
     {
-        "canonical_name": "Central_Bicolano", 
+        "canonical_name": "Central Bicolano", 
         "code": "bcl", 
         "name": "Bikol"
     }, 

--- a/WikipediaUnitTests/Code/ArticleFetcherTests.m
+++ b/WikipediaUnitTests/Code/ArticleFetcherTests.m
@@ -71,8 +71,8 @@
     __block MWKArticle* savedArticleAfterFirstFetch;
 
     WMFArticleFetcher* fetcher = self.articleFetcher;
-    expectResolutionWithTimeout(5, ^AnyPromise *{
-        return [fetcher fetchArticleForPageTitle:dummyTitle progress:NULL].then(^id(MWKArticle* article){
+    expectResolutionWithTimeout(5, ^AnyPromise*{
+        return [fetcher fetchArticleForPageTitle:dummyTitle progress:NULL].then(^id (MWKArticle* article){
             savedArticleAfterFirstFetch = [self.tempDataStore articleWithTitle:dummyTitle];
             firstFetchResult = article;
             return [fetcher fetchArticleForPageTitle:dummyTitle progress:NULL]

--- a/www/languages.json
+++ b/www/languages.json
@@ -715,7 +715,7 @@
         "name": "\u0440\u0443\u0441\u0438\u043d\u044c\u0441\u043a\u044b\u0439 \u044f\u0437\u044b\u043a"
     }, 
     {
-        "canonical_name": "Central_Bicolano", 
+        "canonical_name": "Central Bicolano", 
         "code": "bcl", 
         "name": "Bikol"
     }, 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T119150
https://phabricator.wikimedia.org/T111555

- [x] Add localized language name to language picker cell.
Note the following: 

At the moment, when we get a list of *article* languages (i.e. when you want to see all the languages the Obama article is available in) we are also returned the localized name for each language, with some having English fallbacks. 

When we're showing the full language list but *not* for a given article (i.e. when you're picking the search language) we don't presently get this list from the server, but we may want to in the future. In the mean time, for this use case, the localized language names are retrieved from iOS, which can provide *most* of them for given language codes - i.e. "en" -> "English". We fallback to English when iOS can't provide a localized language name. We also don't ask iOS for language names if the language code is compound - i.e. if the code has a "-" in it. This is because iOS will, for example, report back "Chinese" for every language code starting with "zh-" regardless of what comes after the "-". This is a further reason to either refactor later to ping the server for these, or bundle a full matrix mapping all localized lang names to all wiki lang codes.

- [x] Add language code to language picker cell.
- [x] Make localized language name be first thing in lang cell. (Per Moriel and Josh)
- [x] If the localized language code turns out to be the *exact* same thing as the non-localized lang name, don't show the non-localized lang name. Looks silly to have same string twice.
- [x] Make language filter work on lang codes too.
- [x] Sort by lang codes - same as desktop wikipedia. (Per Moriel and Josh)

**English Screenshots**

Before 1:
![before 1](https://cloud.githubusercontent.com/assets/3143487/11705071/123608aa-9ea2-11e5-9cd8-11e7d481f097.png)

After 1:
![after 1](https://cloud.githubusercontent.com/assets/3143487/11705073/1495770c-9ea2-11e5-89f4-b229471f1563.png)

Before 2:
![before 2](https://cloud.githubusercontent.com/assets/3143487/11705076/168eb456-9ea2-11e5-943b-38dd346a39ac.png)

After 2:
![after 2](https://cloud.githubusercontent.com/assets/3143487/11705082/1b1063b2-9ea2-11e5-93e4-436b47472b86.png)

**Hebrew Screenshots**

Before 1:
![before 1](https://cloud.githubusercontent.com/assets/3143487/11705047/f0f4d23e-9ea1-11e5-94c1-2b1c6fe35c30.png)

After 1:
![after 1](https://cloud.githubusercontent.com/assets/3143487/11705055/fc0642fc-9ea1-11e5-8373-37084ae8a529.png)

Before 2:
![before 2](https://cloud.githubusercontent.com/assets/3143487/11705048/f3c4f868-9ea1-11e5-94a5-c596b747203f.png)

After 2:
![after 2](https://cloud.githubusercontent.com/assets/3143487/11705060/03784f3a-9ea2-11e5-9c01-c6b572a934ad.png)

Before 3:
![before 3](https://cloud.githubusercontent.com/assets/3143487/11705049/f5d5ce7a-9ea1-11e5-8a20-ca8c84f062ef.png)

After 3:
![after 3](https://cloud.githubusercontent.com/assets/3143487/11705063/06a2afde-9ea2-11e5-8ccf-de26acbe5e5e.png)

Before 4:
![before 4](https://cloud.githubusercontent.com/assets/3143487/11705052/f838034a-9ea1-11e5-87c9-b54a9e1feca7.png)

After 4:
![after 4](https://cloud.githubusercontent.com/assets/3143487/11705064/092beb62-9ea2-11e5-835a-9aaac0a113e3.png)