### PR TITLE
Make search language and sendUsageReports settings idempotent

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -556,6 +556,8 @@
 		BC22F9961C176F9D003232CD /* WMFBaseImageGalleryViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC22F9951C176F9D003232CD /* WMFBaseImageGalleryViewControllerTests.m */; };
 		BC22F99A1C17BCED003232CD /* SSArrayDataSource+WMFReverseIfRTL.m in Sources */ = {isa = PBXBuildFile; fileRef = BC22F9991C17BCED003232CD /* SSArrayDataSource+WMFReverseIfRTL.m */; };
 		BC22F99C1C17BFB3003232CD /* WMFGalleryDataSourceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC22F99B1C17BFB3003232CD /* WMFGalleryDataSourceTests.m */; };
+		BC318E131C1A34A500DACD9D /* SessionSingletonTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC318E121C1A34A500DACD9D /* SessionSingletonTests.m */; };
+		BC318E151C1A39B300DACD9D /* PostNotificationMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC318E141C1A38D900DACD9D /* PostNotificationMatcher.swift */; };
 		BC5620931B6970EE0013FFB0 /* 640px-President_Barack_Obama.jpg in Resources */ = {isa = PBXBuildFile; fileRef = BC5620921B6970EE0013FFB0 /* 640px-President_Barack_Obama.jpg */; };
 		BC56209D1B6BAB910013FFB0 /* Exoplanet.mobileview.json in Resources */ = {isa = PBXBuildFile; fileRef = BC56209C1B6BAB910013FFB0 /* Exoplanet.mobileview.json */; };
 		BC5FE5701B1DF02900273BC0 /* ENWikiSiteInfo.json in Resources */ = {isa = PBXBuildFile; fileRef = BC5FE56F1B1DF02900273BC0 /* ENWikiSiteInfo.json */; };
@@ -1617,6 +1619,9 @@
 		BC22F9991C17BCED003232CD /* SSArrayDataSource+WMFReverseIfRTL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "SSArrayDataSource+WMFReverseIfRTL.m"; path = "Wikipedia/Code/SSArrayDataSource+WMFReverseIfRTL.m"; sourceTree = SOURCE_ROOT; };
 		BC22F99B1C17BFB3003232CD /* WMFGalleryDataSourceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFGalleryDataSourceTests.m; path = Code/WMFGalleryDataSourceTests.m; sourceTree = "<group>"; };
 		BC2F420B1BE9385C0033E185 /* Wikipedia.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Wikipedia.entitlements; sourceTree = "<group>"; };
+		BC318E121C1A34A500DACD9D /* SessionSingletonTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SessionSingletonTests.m; path = Code/SessionSingletonTests.m; sourceTree = "<group>"; };
+		BC318E141C1A38D900DACD9D /* PostNotificationMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostNotificationMatcher.swift; path = WikipediaUnitTests/Code/PostNotificationMatcher.swift; sourceTree = SOURCE_ROOT; };
+		BC318E161C1A5C2900DACD9D /* PostNotificationMatcherShorthand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PostNotificationMatcherShorthand.h; path = WikipediaUnitTests/Code/PostNotificationMatcherShorthand.h; sourceTree = SOURCE_ROOT; };
 		BC4273521A7C736800068882 /* WikipediaUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WikipediaUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC5620921B6970EE0013FFB0 /* 640px-President_Barack_Obama.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "640px-President_Barack_Obama.jpg"; sourceTree = "<group>"; };
 		BC56209C1B6BAB910013FFB0 /* Exoplanet.mobileview.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Exoplanet.mobileview.json; sourceTree = "<group>"; };
@@ -3440,6 +3445,7 @@
 				BCC4D3541C11F39700F00D58 /* NSDate+WMFPOTDTitleTests.m */,
 				BC22F9951C176F9D003232CD /* WMFBaseImageGalleryViewControllerTests.m */,
 				BC22F99B1C17BFB3003232CD /* WMFGalleryDataSourceTests.m */,
+				BC318E121C1A34A500DACD9D /* SessionSingletonTests.m */,
 			);
 			name = Code;
 			sourceTree = "<group>";
@@ -3882,6 +3888,8 @@
 			children = (
 				B0E8088A1C0D15D90065EBC0 /* HCIsCollectionContainingInAnyOrder+WMFCollectionMatcherUtils.h */,
 				B0E8088B1C0D15D90065EBC0 /* HCIsCollectionContainingInAnyOrder+WMFCollectionMatcherUtils.m */,
+				BC318E141C1A38D900DACD9D /* PostNotificationMatcher.swift */,
+				BC318E161C1A5C2900DACD9D /* PostNotificationMatcherShorthand.h */,
 			);
 			name = "Custom Matchers";
 			path = "WikipediaUnitTests/Code/Custom Matchers";
@@ -4575,6 +4583,7 @@
 				BCCB814F1C11E1B2008BC602 /* NSDate+WMFRangesTests.m in Sources */,
 				B0E8087A1C0D15660065EBC0 /* XCTestCase+DataStoreFixtureTesting.m in Sources */,
 				B0E809151C0D19150065EBC0 /* WMFArticleImageInjectionTests.m in Sources */,
+				BC318E131C1A34A500DACD9D /* SessionSingletonTests.m in Sources */,
 				B0E808CA1C0D178E0065EBC0 /* MWKRecentSearchDataStoreTests.m in Sources */,
 				B0E8088C1C0D15D90065EBC0 /* HCIsCollectionContainingInAnyOrder+WMFCollectionMatcherUtils.m in Sources */,
 				B0E8093B1C0D1A590065EBC0 /* WMFSafeAssignTests.m in Sources */,
@@ -4678,6 +4687,7 @@
 				B0E8091F1C0D19700065EBC0 /* NSIndexSet+BKReduceTests.m in Sources */,
 				B0E809621C0D1BAD0065EBC0 /* WMFSearchResultsMergeTests.m in Sources */,
 				B0E808F71C0D18410065EBC0 /* MWKTestCase.m in Sources */,
+				BC318E151C1A39B300DACD9D /* PostNotificationMatcher.swift in Sources */,
 				B0E808E31C0D17C20065EBC0 /* MWKSavedPageListTogglingTests.m in Sources */,
 				B0E809091C0D18BC0065EBC0 /* NSString+WMFHTMLParsingTests.m in Sources */,
 			);

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -558,6 +558,9 @@
 		BC22F99C1C17BFB3003232CD /* WMFGalleryDataSourceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC22F99B1C17BFB3003232CD /* WMFGalleryDataSourceTests.m */; };
 		BC318E131C1A34A500DACD9D /* SessionSingletonTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC318E121C1A34A500DACD9D /* SessionSingletonTests.m */; };
 		BC318E151C1A39B300DACD9D /* PostNotificationMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC318E141C1A38D900DACD9D /* PostNotificationMatcher.swift */; };
+		BC45FF481C1B1F9F00BAE501 /* NSUserDefaults+WMFReset.m in Sources */ = {isa = PBXBuildFile; fileRef = BC45FF471C1B1F9F00BAE501 /* NSUserDefaults+WMFReset.m */; };
+		BC45FF4B1C1B22C200BAE501 /* NSObject+WMFReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = BC45FF4A1C1B22C200BAE501 /* NSObject+WMFReflection.m */; };
+		BC45FF4E1C1B2DDB00BAE501 /* QueuesSingleton+AllManagers.m in Sources */ = {isa = PBXBuildFile; fileRef = BC45FF4D1C1B2DDB00BAE501 /* QueuesSingleton+AllManagers.m */; };
 		BC5620931B6970EE0013FFB0 /* 640px-President_Barack_Obama.jpg in Resources */ = {isa = PBXBuildFile; fileRef = BC5620921B6970EE0013FFB0 /* 640px-President_Barack_Obama.jpg */; };
 		BC56209D1B6BAB910013FFB0 /* Exoplanet.mobileview.json in Resources */ = {isa = PBXBuildFile; fileRef = BC56209C1B6BAB910013FFB0 /* Exoplanet.mobileview.json */; };
 		BC5FE5701B1DF02900273BC0 /* ENWikiSiteInfo.json in Resources */ = {isa = PBXBuildFile; fileRef = BC5FE56F1B1DF02900273BC0 /* ENWikiSiteInfo.json */; };
@@ -1623,6 +1626,12 @@
 		BC318E141C1A38D900DACD9D /* PostNotificationMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostNotificationMatcher.swift; path = WikipediaUnitTests/Code/PostNotificationMatcher.swift; sourceTree = SOURCE_ROOT; };
 		BC318E161C1A5C2900DACD9D /* PostNotificationMatcherShorthand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PostNotificationMatcherShorthand.h; path = WikipediaUnitTests/Code/PostNotificationMatcherShorthand.h; sourceTree = SOURCE_ROOT; };
 		BC4273521A7C736800068882 /* WikipediaUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WikipediaUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BC45FF461C1B1F9F00BAE501 /* NSUserDefaults+WMFReset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSUserDefaults+WMFReset.h"; path = "WikipediaUnitTests/Code/NSUserDefaults+WMFReset.h"; sourceTree = SOURCE_ROOT; };
+		BC45FF471C1B1F9F00BAE501 /* NSUserDefaults+WMFReset.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSUserDefaults+WMFReset.m"; path = "WikipediaUnitTests/Code/NSUserDefaults+WMFReset.m"; sourceTree = SOURCE_ROOT; };
+		BC45FF491C1B22C200BAE501 /* NSObject+WMFReflection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSObject+WMFReflection.h"; path = "WikipediaUnitTests/Code/NSObject+WMFReflection.h"; sourceTree = SOURCE_ROOT; };
+		BC45FF4A1C1B22C200BAE501 /* NSObject+WMFReflection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+WMFReflection.m"; path = "WikipediaUnitTests/Code/NSObject+WMFReflection.m"; sourceTree = SOURCE_ROOT; };
+		BC45FF4C1C1B2DDB00BAE501 /* QueuesSingleton+AllManagers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "QueuesSingleton+AllManagers.h"; path = "WikipediaUnitTests/Code/QueuesSingleton+AllManagers.h"; sourceTree = SOURCE_ROOT; };
+		BC45FF4D1C1B2DDB00BAE501 /* QueuesSingleton+AllManagers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "QueuesSingleton+AllManagers.m"; path = "WikipediaUnitTests/Code/QueuesSingleton+AllManagers.m"; sourceTree = SOURCE_ROOT; };
 		BC5620921B6970EE0013FFB0 /* 640px-President_Barack_Obama.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "640px-President_Barack_Obama.jpg"; sourceTree = "<group>"; };
 		BC56209C1B6BAB910013FFB0 /* Exoplanet.mobileview.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Exoplanet.mobileview.json; sourceTree = "<group>"; };
 		BC5FE56F1B1DF02900273BC0 /* ENWikiSiteInfo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ENWikiSiteInfo.json; sourceTree = "<group>"; };
@@ -3631,6 +3640,12 @@
 				B0E808B81C0D17160065EBC0 /* WMFHTTPHangingProtocol.m */,
 				BC97FF081C18897500FA40E3 /* NSUserDefaults+WMFBatchRecordMode.h */,
 				BC97FF091C18897500FA40E3 /* NSUserDefaults+WMFBatchRecordMode.m */,
+				BC45FF461C1B1F9F00BAE501 /* NSUserDefaults+WMFReset.h */,
+				BC45FF471C1B1F9F00BAE501 /* NSUserDefaults+WMFReset.m */,
+				BC45FF491C1B22C200BAE501 /* NSObject+WMFReflection.h */,
+				BC45FF4A1C1B22C200BAE501 /* NSObject+WMFReflection.m */,
+				BC45FF4C1C1B2DDB00BAE501 /* QueuesSingleton+AllManagers.h */,
+				BC45FF4D1C1B2DDB00BAE501 /* QueuesSingleton+AllManagers.m */,
 			);
 			name = Utilities;
 			path = WikipediaUnitTests/Code/Utilities;
@@ -4577,6 +4592,7 @@
 				B0E809411C0D1A820065EBC0 /* NSURL+WMFLinkParsingTests.m in Sources */,
 				B0E808981C0D16430065EBC0 /* XCTestCase+WMFLocaleTesting.m in Sources */,
 				B0E809011C0D188B0065EBC0 /* NSArray+PredicateTests.m in Sources */,
+				BC45FF4B1C1B22C200BAE501 /* NSObject+WMFReflection.m in Sources */,
 				B0E808E11C0D17C20065EBC0 /* MWKSavedPageListDataStoreTests.m in Sources */,
 				B0E808FF1C0D18800065EBC0 /* WMFErrorForApiErrorObjectTests.m in Sources */,
 				B0E808741C0D154C0065EBC0 /* NSBundle+TestAssets.m in Sources */,
@@ -4607,6 +4623,7 @@
 				B0E808C11C0D17520065EBC0 /* MWKListLegacyTests.m in Sources */,
 				B0E808F91C0D184B0065EBC0 /* MWKTitleTests.m in Sources */,
 				B0E809231C0D199E0065EBC0 /* ArticleLoadingTests.m in Sources */,
+				BC45FF4E1C1B2DDB00BAE501 /* QueuesSingleton+AllManagers.m in Sources */,
 				B0E809031C0D18950065EBC0 /* NSMutableDictionary+MaybeSetTests.m in Sources */,
 				B0E808921C0D16240065EBC0 /* MWKImage+AssociationTestUtils.m in Sources */,
 				B0E808D31C0D17A60065EBC0 /* MWKHistoryEntry+MWKRandom.m in Sources */,
@@ -4655,6 +4672,7 @@
 				B0E808C41C0D175D0065EBC0 /* MWKListSharedTests.m in Sources */,
 				B0E808AC1C0D16B30065EBC0 /* FBSnapshotTestCase+WMFConvenience.m in Sources */,
 				B0E808A91C0D16A00065EBC0 /* UIView+VisualTestSizingUtils.m in Sources */,
+				BC45FF481C1B1F9F00BAE501 /* NSUserDefaults+WMFReset.m in Sources */,
 				B0E809291C0D19D00065EBC0 /* MWKArticleExtractionTests.m in Sources */,
 				BC22F9961C176F9D003232CD /* WMFBaseImageGalleryViewControllerTests.m in Sources */,
 				B0E808C71C0D176A0065EBC0 /* MWKListTestBase.m in Sources */,

--- a/Wikipedia/Code/SessionSingleton.m
+++ b/Wikipedia/Code/SessionSingleton.m
@@ -188,6 +188,9 @@ NSString* const WMFSearchLanguageDidChangeNotification = @"WMFSearchLanguageDidC
 }
 
 - (void)setShouldSendUsageReports:(BOOL)sendUsageReports {
+    if (sendUsageReports == [self shouldSendUsageReports]) {
+        return;
+    }
     [[NSUserDefaults standardUserDefaults] wmf_setSendUsageReports:sendUsageReports];
     [[QueuesSingleton sharedInstance] reset];
 }

--- a/Wikipedia/Code/SessionSingleton.m
+++ b/Wikipedia/Code/SessionSingleton.m
@@ -73,29 +73,34 @@ NSString* const WMFSearchLanguageDidChangeNotification = @"WMFSearchLanguageDidC
 #pragma mark - Site
 
 - (void)setCurrentArticleSite:(MWKSite*)site {
-    if (site) {
-        _currentArticleSite = site;
-        [[NSUserDefaults standardUserDefaults] setObject:site.language forKey:@"CurrentArticleDomain"];
-        [[NSUserDefaults standardUserDefaults] synchronize];
+    NSParameterAssert(site);
+    if (!site || [_currentArticleSite isEqual:site]) {
+        return;
     }
+    _currentArticleSite = site;
+    [[NSUserDefaults standardUserDefaults] setObject:site.language forKey:@"CurrentArticleDomain"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 #pragma mark - Article
 
 - (void)setCurrentArticleTitle:(MWKTitle*)currentArticle {
-    if (currentArticle) {
-        _currentArticleTitle = currentArticle;
-        [[NSUserDefaults standardUserDefaults] setObject:currentArticle.dataBaseKey forKey:@"CurrentArticleTitle"];
-        [[NSUserDefaults standardUserDefaults] synchronize];
+    NSParameterAssert(currentArticle);
+    if (!_currentArticle || [_currentArticle isEqual:currentArticle]) {
+        return;
     }
+    _currentArticleTitle = currentArticle;
+    [[NSUserDefaults standardUserDefaults] setObject:currentArticle.dataBaseKey forKey:@"CurrentArticleTitle"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 - (void)setCurrentArticle:(MWKArticle*)currentArticle {
-    if (currentArticle) {
-        _currentArticle          = currentArticle;
-        self.currentArticleTitle = currentArticle.title;
-        self.currentArticleSite  = currentArticle.site;
+    if (!currentArticle || [_currentArticle isEqual:currentArticle]) {
+        return;
     }
+    _currentArticle          = currentArticle;
+    self.currentArticleTitle = currentArticle.title;
+    self.currentArticleSite  = currentArticle.site;
 }
 
 - (MWKArticle*)currentArticle {
@@ -114,7 +119,7 @@ NSString* const WMFSearchLanguageDidChangeNotification = @"WMFSearchLanguageDidC
 - (MWKTitle*)lastLoadedTitle {
     MWKSite* lastKnownSite = [self lastKnownSite];
     NSString* titleText    = [[NSUserDefaults standardUserDefaults] objectForKey:@"CurrentArticleTitle"];
-    if (!titleText) {
+    if (!titleText.length) {
         return nil;
     }
     MWKTitle* title = [lastKnownSite titleWithString:titleText];
@@ -138,10 +143,16 @@ NSString* const WMFSearchLanguageDidChangeNotification = @"WMFSearchLanguageDidC
 
 - (NSString*)searchApiUrlForLanguage:(NSString*)language {
     NSString* endpoint = self.fallback ? @"" : @".m";
+    if (!self.currentArticleSite) {
+        return nil;
+    }
     return [NSString stringWithFormat:@"https://%@%@.%@/w/api.php", language, endpoint, self.currentArticleSite.domain];
 }
 
 - (void)setSearchLanguage:(NSString*)searchLanguage {
+    if (!searchLanguage || [self.searchSite.language isEqualToString:searchLanguage]) {
+        return;
+    }
     [[NSUserDefaults standardUserDefaults] setObject:searchLanguage forKey:@"Domain"];
     [[NSUserDefaults standardUserDefaults] synchronize];
     self.searchSite = nil;
@@ -163,7 +174,11 @@ NSString* const WMFSearchLanguageDidChangeNotification = @"WMFSearchLanguageDidC
 
 - (NSURL*)urlForLanguage:(NSString*)language {
     NSString* endpoint = self.fallback ? @"" : @".m";
-    return [NSURL URLWithString:[NSString stringWithFormat:@"https://%@%@.%@/w/api.php", language, endpoint, self.currentArticleSite.domain]];
+    if (!self.currentArticleSite) {
+        return nil;
+    }
+    return [NSURL URLWithString:
+            [NSString stringWithFormat:@"https://%@%@.%@/w/api.php", language, endpoint, self.currentArticleSite.domain]];
 }
 
 #pragma mark - Usage Reports

--- a/WikipediaUnitTests/Code/NSObject+WMFReflection.h
+++ b/WikipediaUnitTests/Code/NSObject+WMFReflection.h
@@ -1,0 +1,22 @@
+//
+//  NSObject+WMFReflection.h
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 12/11/15.
+//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import <objc/runtime.h>
+
+typedef void(^WMFObjCPropertyEnumerator)(objc_property_t, BOOL* stop);
+
+/**
+ *  Reflection utilities inspired by Mantle's runtime methods.
+ */
+@interface NSObject (WMFReflection)
+
++ (void)wmf_enumeratePropertiesUntilSuperclass:(Class)superClass usingBlock:(WMFObjCPropertyEnumerator)block;
+
+@end

--- a/WikipediaUnitTests/Code/NSObject+WMFReflection.h
+++ b/WikipediaUnitTests/Code/NSObject+WMFReflection.h
@@ -10,7 +10,7 @@
 
 #import <objc/runtime.h>
 
-typedef void(^WMFObjCPropertyEnumerator)(objc_property_t, BOOL* stop);
+typedef void (^ WMFObjCPropertyEnumerator)(objc_property_t, BOOL* stop);
 
 /**
  *  Reflection utilities inspired by Mantle's runtime methods.

--- a/WikipediaUnitTests/Code/NSObject+WMFReflection.m
+++ b/WikipediaUnitTests/Code/NSObject+WMFReflection.m
@@ -24,15 +24,19 @@ static inline void objc_propertyListRelease(objc_property_t** objectRef) __attri
     BOOL stop = NO;
 
     while (!stop && ![cls isEqual:superClass]) {
-        unsigned count = 0;
-        freePropertyListOnExit objc_property_t*  properties = class_copyPropertyList(cls, &count);
+        unsigned count                                     = 0;
+        freePropertyListOnExit objc_property_t* properties = class_copyPropertyList(cls, &count);
 
         cls = cls.superclass;
-        if (properties == NULL) continue;
+        if (properties == NULL) {
+            continue;
+        }
 
         for (unsigned i = 0; i < count; i++) {
             block(properties[i], &stop);
-            if (stop) break;
+            if (stop) {
+                break;
+            }
         }
     }
 }

--- a/WikipediaUnitTests/Code/NSObject+WMFReflection.m
+++ b/WikipediaUnitTests/Code/NSObject+WMFReflection.m
@@ -1,0 +1,40 @@
+//
+//  NSObject+WMFReflection.m
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 12/11/15.
+//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import "NSObject+WMFReflection.h"
+
+static inline void objc_propertyListRelease(objc_property_t** objectRef) __attribute__((overloadable));
+static inline void objc_propertyListRelease(objc_property_t** objectRef) __attribute__((overloadable)) {
+    if (*objectRef != NULL) {
+        free((*objectRef));
+    }
+}
+
+#define freePropertyListOnExit __attribute__((cleanup(objc_propertyListRelease)))
+
+@implementation NSObject (WMFReflection)
+
++ (void)wmf_enumeratePropertiesUntilSuperclass:(Class)superClass usingBlock:(WMFObjCPropertyEnumerator)block {
+    Class cls = self;
+    BOOL stop = NO;
+
+    while (!stop && ![cls isEqual:superClass]) {
+        unsigned count = 0;
+        freePropertyListOnExit objc_property_t*  properties = class_copyPropertyList(cls, &count);
+
+        cls = cls.superclass;
+        if (properties == NULL) continue;
+
+        for (unsigned i = 0; i < count; i++) {
+            block(properties[i], &stop);
+            if (stop) break;
+        }
+    }
+}
+
+@end

--- a/WikipediaUnitTests/Code/NSUserDefaults+WMFReset.h
+++ b/WikipediaUnitTests/Code/NSUserDefaults+WMFReset.h
@@ -1,0 +1,25 @@
+//
+//  NSUserDefaults+WMFReset.h
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 12/11/15.
+//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSUserDefaults (WMFReset)
+
+/**
+ *  Resets the receiver to its default values.
+ *
+ *  Removes all values in the persistent application domain (based on the main bundle). Once performed, the values will
+ *  equal the defaults registered in the application domain.
+ *
+ *  @note <code>+[NSUserDefaults resetStandardDefaults]</code> (despite the name) is not the same as this method.
+ *
+ *  @see -[NSUserDefaults registerDefaults]
+ */
+- (void)wmf_resetToDefaultValues;
+
+@end

--- a/WikipediaUnitTests/Code/NSUserDefaults+WMFReset.m
+++ b/WikipediaUnitTests/Code/NSUserDefaults+WMFReset.m
@@ -1,0 +1,17 @@
+//
+//  NSUserDefaults+WMFReset.m
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 12/11/15.
+//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import "NSUserDefaults+WMFReset.h"
+
+@implementation NSUserDefaults (WMFReset)
+
+- (void)wmf_resetToDefaultValues {
+    [self removePersistentDomainForName:[[NSBundle mainBundle] bundleIdentifier]];
+}
+
+@end

--- a/WikipediaUnitTests/Code/PostNotificationMatcher.swift
+++ b/WikipediaUnitTests/Code/PostNotificationMatcher.swift
@@ -1,0 +1,64 @@
+//
+//  PostNotificationMatcher.swift
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 12/10/15.
+//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
+//
+
+import Nimble
+
+public func postNotification<T where T: Equatable, T: AnyObject>(
+                name: String,
+                object: T? = nil,
+                fromCenter center: NSNotificationCenter = NSNotificationCenter.defaultCenter()) -> MatcherFunc<T> {
+    return MatcherFunc { actual, failureMessage in
+        var postedNotification: NSNotification? = nil
+        let token = center.addObserverForName(name, object: object, queue: nil) { notification in
+            postedNotification = notification
+        }
+        defer {
+            center.removeObserver(token)
+        }
+
+        try actual.evaluate()
+
+        failureMessage.postfixMessage = "observe a notification"
+
+        let centerDesc = center === NSNotificationCenter.defaultCenter() ? "defaultCenter" : center.description
+
+        failureMessage.postfixMessage += " from \(centerDesc)"
+        failureMessage.postfixMessage += " with name \(name)"
+        if object != nil {
+            failureMessage.postfixMessage += " and object \(object)"
+        }
+
+        failureMessage.actualValue = "\(postedNotification?.description ?? "no notification")"
+
+        guard let notification = postedNotification else {
+            return false
+        }
+
+        if let postedObject = notification.object as? T where
+               postedObject != object {
+            return false
+        }
+
+        return notification.name == name
+    }
+}
+
+extension NMBObjCMatcher {
+    public class func postNotificationMatcher(
+                        forName name: String,
+                        object: NSObject?,
+                        fromCenter center: NSNotificationCenter) -> NMBObjCMatcher {
+       // must be able to match nil since expectAction blocks always return nil
+       return NMBObjCMatcher(canMatchNil: true) { (actualExpression: Expression<NSObject>,
+                                                   failureMessage: FailureMessage) -> Bool in
+            return try! postNotification(name,
+                                         object: object,
+                                         fromCenter: center).matches(actualExpression, failureMessage: failureMessage)
+        }
+    }
+}

--- a/WikipediaUnitTests/Code/PostNotificationMatcherShorthand.h
+++ b/WikipediaUnitTests/Code/PostNotificationMatcherShorthand.h
@@ -1,0 +1,24 @@
+//
+//  PostNotificationMatcherShorthand.h
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 12/10/15.
+//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import "WikipediaUnitTests-Swift.h"
+@import Nimble;
+
+NS_ASSUME_NONNULL_BEGIN
+
+static inline NMBObjCMatcher* postNotificationFromCenter(NSString* named,
+                                                         id _Nullable object,
+                                                         NSNotificationCenter* center) {
+    return [NMBObjCMatcher postNotificationMatcherForName:named object:object fromCenter:center];
+}
+
+static inline NMBObjCMatcher* postNotification(NSString* named, id _Nullable object) {
+    return postNotificationFromCenter(named, object, [NSNotificationCenter defaultCenter]);
+}
+
+NS_ASSUME_NONNULL_END

--- a/WikipediaUnitTests/Code/QueuesSingleton+AllManagers.h
+++ b/WikipediaUnitTests/Code/QueuesSingleton+AllManagers.h
@@ -1,0 +1,15 @@
+//
+//  QueuesSingleton+AllManagers.h
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 12/11/15.
+//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import "QueuesSingleton.h"
+
+@interface QueuesSingleton (AllManagers)
+
+- (NSArray<AFHTTPRequestOperationManager*>*)allManagers;
+
+@end

--- a/WikipediaUnitTests/Code/QueuesSingleton+AllManagers.m
+++ b/WikipediaUnitTests/Code/QueuesSingleton+AllManagers.m
@@ -1,0 +1,27 @@
+//
+//  QueuesSingleton+AllManagers.m
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 12/11/15.
+//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import "QueuesSingleton+AllManagers.h"
+#import "NSObject+WMFReflection.h"
+
+@implementation QueuesSingleton (AllManagers)
+
+- (NSArray<AFHTTPRequestOperationManager*>*)allManagers {
+    NSMutableArray<NSString*>* managerKeys = [NSMutableArray new];
+    [QueuesSingleton wmf_enumeratePropertiesUntilSuperclass:[NSObject class] usingBlock:^(objc_property_t prop, BOOL *stop) {
+        NSString* name = [NSString stringWithCString:property_getName(prop) encoding:NSUTF8StringEncoding];
+        if ([name hasSuffix:@"Manager"]) {
+            [managerKeys addObject:name];
+        }
+    }];
+    return [managerKeys bk_map:^id(NSString* key) {
+        return [[QueuesSingleton sharedInstance] valueForKey:key];
+    }];
+}
+
+@end

--- a/WikipediaUnitTests/Code/QueuesSingleton+AllManagers.m
+++ b/WikipediaUnitTests/Code/QueuesSingleton+AllManagers.m
@@ -13,13 +13,13 @@
 
 - (NSArray<AFHTTPRequestOperationManager*>*)allManagers {
     NSMutableArray<NSString*>* managerKeys = [NSMutableArray new];
-    [QueuesSingleton wmf_enumeratePropertiesUntilSuperclass:[NSObject class] usingBlock:^(objc_property_t prop, BOOL *stop) {
+    [QueuesSingleton wmf_enumeratePropertiesUntilSuperclass:[NSObject class] usingBlock:^(objc_property_t prop, BOOL* stop) {
         NSString* name = [NSString stringWithCString:property_getName(prop) encoding:NSUTF8StringEncoding];
         if ([name hasSuffix:@"Manager"]) {
             [managerKeys addObject:name];
         }
     }];
-    return [managerKeys bk_map:^id(NSString* key) {
+    return [managerKeys bk_map:^id (NSString* key) {
         return [[QueuesSingleton sharedInstance] valueForKey:key];
     }];
 }

--- a/WikipediaUnitTests/Code/SessionSingletonTests.m
+++ b/WikipediaUnitTests/Code/SessionSingletonTests.m
@@ -1,0 +1,51 @@
+//
+//  SessionSingletonTests.m
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 12/10/15.
+//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
+//
+
+@import Quick;
+@import Nimble;
+
+#import "MWKDataStore+TempDataStoreForEach.h"
+#import "MWKDataStore+TemporaryDataStore.h"
+#import "PostNotificationMatcherShorthand.h"
+
+#import "SessionSingleton.h"
+
+QuickSpecBegin(SessionSingletonTests)
+
+__block SessionSingleton* testSession;
+
+configureTempDataStoreForEach(tempDataStore, ^{
+    NSString *appDomain = [[NSBundle bundleForClass:[SessionSingleton class]] bundleIdentifier];
+    [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:appDomain];
+    testSession = [[SessionSingleton alloc] initWithDataStore:tempDataStore];
+});
+
+describe(@"searchSite", ^{
+    it(@"should default to the current device language", ^{
+        expect(testSession.searchSite.language)
+        .to(equal([[NSLocale currentLocale] objectForKey:NSLocaleLanguageCode]));
+    });
+
+    it(@"should be persistent", ^{
+        expectAction(^{
+            [testSession setSearchLanguage:@"fr"];
+        }).to(postNotification(WMFSearchLanguageDidChangeNotification, nil));
+        MWKSite* expectedSite = testSession.searchSite;
+        SessionSingleton* newSession = [[SessionSingleton alloc] initWithDataStore:[MWKDataStore temporaryDataStore]];
+        expect(newSession.searchSite).to(equal(expectedSite));
+        [newSession.dataStore removeFolderAtBasePath];
+    });
+
+    it(@"should be idempotent", ^{
+        expectAction(^{
+            [testSession setSearchLanguage:testSession.searchSite.language];
+        }).notTo(postNotification(WMFSearchLanguageDidChangeNotification, nil));
+    });
+});
+
+QuickSpecEnd

--- a/WikipediaUnitTests/Code/SessionSingletonTests.m
+++ b/WikipediaUnitTests/Code/SessionSingletonTests.m
@@ -25,6 +25,13 @@ __block SessionSingleton* testSession;
 configureTempDataStoreForEach(tempDataStore, ^{
     [[NSUserDefaults standardUserDefaults] wmf_resetToDefaultValues];
     testSession = [[SessionSingleton alloc] initWithDataStore:tempDataStore];
+    WMF_TECH_DEBT_TODO(refactor sendUsageReports to use a notification to make it easier to test)
+    /*
+     ^ this only works now because the queues singleton grabs its values directly from the shared instance
+     AND the shared instance doesn't "cache" the sendUsageReports value in memory, so setting it from a different
+     "SessionSingleton" is fine
+     */
+    [[QueuesSingleton sharedInstance] reset];
 });
 
 describe(@"searchLanguage", ^{

--- a/WikipediaUnitTests/Code/SessionSingletonTests.m
+++ b/WikipediaUnitTests/Code/SessionSingletonTests.m
@@ -20,16 +20,16 @@
 
 QuickSpecBegin(SessionSingletonTests)
 
-__block SessionSingleton* testSession;
+__block SessionSingleton * testSession;
 
 configureTempDataStoreForEach(tempDataStore, ^{
     [[NSUserDefaults standardUserDefaults] wmf_resetToDefaultValues];
     testSession = [[SessionSingleton alloc] initWithDataStore:tempDataStore];
     WMF_TECH_DEBT_TODO(refactor sendUsageReports to use a notification to make it easier to test)
     /*
-     ^ this only works now because the queues singleton grabs its values directly from the shared instance
-     AND the shared instance doesn't "cache" the sendUsageReports value in memory, so setting it from a different
-     "SessionSingleton" is fine
+       ^ this only works now because the queues singleton grabs its values directly from the shared instance
+       AND the shared instance doesn't "cache" the sendUsageReports value in memory, so setting it from a different
+       "SessionSingleton" is fine
      */
     [[QueuesSingleton sharedInstance] reset];
 });
@@ -72,12 +72,12 @@ describe(@"send usage reports", ^{
     itBehavesLike(@"a persistent property", ^{
         return @{ @"session": testSession,
                   @"key": WMF_SAFE_KEYPATH(testSession, shouldSendUsageReports),
-                  // set to different value by 
+                  // set to different value by
                   @"value": @(!testSession.shouldSendUsageReports) };
     });
 
-    void(^expectAllManagersToHaveExpectedAnalyticsHeaderForCurrentUsageReportsValue)(NSArray* managers) =
-    ^ (NSArray* managers) {
+    void (^ expectAllManagersToHaveExpectedAnalyticsHeaderForCurrentUsageReportsValue)(NSArray* managers) =
+        ^(NSArray* managers) {
         NSString* expectedHeaderValue = [[ReadingActionFunnel new] appInstallID];
         NSArray* headerValues =
             [managers valueForKeyPath:@"requestSerializer.HTTPRequestHeaders.X-WMF-UUID"];
@@ -87,7 +87,7 @@ describe(@"send usage reports", ^{
         expect(headerValues).to(allEqualExpectedValueOrNull);
     };
 
-    WMF_TECH_DEBT_TODO(shared example for all non-global fetchers to ensure they honor current & future values of this prop)
+    WMF_TECH_DEBT_TODO(shared example for all non - global fetchers to ensure they honor current & future values of this prop)
     it(@"should reset the global request managers", ^{
         NSArray* oldManagers = [[QueuesSingleton sharedInstance] allManagers];
         expect(oldManagers).toNot(beEmpty());
@@ -124,7 +124,7 @@ QuickSpecEnd
 
 QuickConfigurationBegin(SessionSingletonSharedExamples)
 
-+ (void)configure:(Configuration *)configuration {
++ (void)configure : (Configuration*)configuration {
     sharedExamples(@"a persistent property", ^(QCKDSLSharedExampleContext getContext) {
         __block SessionSingleton* session;
         __block id value;

--- a/WikipediaUnitTests/Code/SessionSingletonTests.m
+++ b/WikipediaUnitTests/Code/SessionSingletonTests.m
@@ -41,6 +41,12 @@ describe(@"searchSite", ^{
         [newSession.dataStore removeFolderAtBasePath];
     });
 
+    it(@"should ignore nil values", ^{
+        NSString* langBeforeNil = [testSession searchLanguage];
+        [testSession setSearchLanguage:nil];
+        expect(testSession.searchLanguage).to(equal(langBeforeNil));
+    });
+
     it(@"should be idempotent", ^{
         expectAction(^{
             [testSession setSearchLanguage:testSession.searchSite.language];

--- a/WikipediaUnitTests/Code/SessionSingletonTests.m
+++ b/WikipediaUnitTests/Code/SessionSingletonTests.m
@@ -100,7 +100,16 @@ describe(@"send usage reports", ^{
     });
 
     it(@"should be idempotent", ^{
+        NSArray* oldManagers = [[QueuesSingleton sharedInstance] allManagers];
+        expect(oldManagers).toNot(beEmpty());
+        expect(oldManagers).to(allPass(beAKindOf([AFHTTPRequestOperationManager class])));
+        expectAllManagersToHaveExpectedAnalyticsHeaderForCurrentUsageReportsValue(oldManagers);
 
+        [testSession setShouldSendUsageReports:testSession.shouldSendUsageReports];
+
+        NSArray* managersAfterRedundantSet = [[QueuesSingleton sharedInstance] allManagers];
+        expect(managersAfterRedundantSet).to(equal(oldManagers));
+        expectAllManagersToHaveExpectedAnalyticsHeaderForCurrentUsageReportsValue(managersAfterRedundantSet);
     });
 });
 

--- a/WikipediaUnitTests/Code/WMFPicOfTheDayTableViewCellVisualTests.m
+++ b/WikipediaUnitTests/Code/WMFPicOfTheDayTableViewCellVisualTests.m
@@ -74,7 +74,6 @@
 
     [self wmf_verifyViewAtScreenWidth:self.cell];
     [[LSNocilla sharedInstance] stop];
-
 }
 
 @end

--- a/WikipediaUnitTests/Code/WMFPicOfTheDayTableViewCellVisualTests.m
+++ b/WikipediaUnitTests/Code/WMFPicOfTheDayTableViewCellVisualTests.m
@@ -36,7 +36,6 @@
 
 - (void)tearDown {
     [super tearDown];
-    [[LSNocilla sharedInstance] stop];
 }
 
 - (void)testInitialStateOnlyShowsPlaceholderWithoutCaption {
@@ -74,6 +73,8 @@
     [self waitForExpectationsWithTimeout:5 handler:nil];
 
     [self wmf_verifyViewAtScreenWidth:self.cell];
+    [[LSNocilla sharedInstance] stop];
+
 }
 
 @end


### PR DESCRIPTION
Phab: [T120434](https://phabricator.wikimedia.org/T120434)

---

Fixes were relatively simple, but went ahead and added some tests to make sure this sort of thing doesn't happen again.

- [x] Feed no longer reloads needlessly when search is dismissed
- [x] Feed reloads when search site is changed via search language picker
- [x] Feed & search are affected by search site changes from settings