### PR TITLE
only search using the searchSite user preference

### DIFF
--- a/Wikipedia/Code/UIViewController+WMFSearchButton.h
+++ b/Wikipedia/Code/UIViewController+WMFSearchButton.h
@@ -17,10 +17,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (MWKDataStore*)searchDataStore;
 
-@optional
-
-- (MWKSite*)searchSite;
-
 @end
 
 @interface UIViewController (WMFSearchButton)

--- a/Wikipedia/Code/UIViewController+WMFSearchButton.m
+++ b/Wikipedia/Code/UIViewController+WMFSearchButton.m
@@ -48,13 +48,7 @@ static WMFSearchViewController * _sharedSearchViewController = nil;
             return;
         }
 
-        MWKSite* searchSite;
-        if ([delegate respondsToSelector:@selector(searchSite)]) {
-            searchSite = [delegate searchSite];
-        } else {
-            // if the delegate doesn't have a specific site we should search from, default to the user's setting
-            searchSite = [[SessionSingleton sharedInstance] searchSite];
-        }
+        MWKSite* searchSite = [[SessionSingleton sharedInstance] searchSite];
 
         if (![searchSite isEqual:_sharedSearchViewController.searchSite]) {
             WMFSearchViewController* searchVC =

--- a/Wikipedia/Code/WMFArticleContainerViewController.m
+++ b/Wikipedia/Code/WMFArticleContainerViewController.m
@@ -730,10 +730,6 @@ NS_ASSUME_NONNULL_BEGIN
     return self.dataStore;
 }
 
-- (MWKSite*)searchSite {
-    return self.articleTitle.site;
-}
-
 - (void)didSelectTitle:(MWKTitle*)title sender:(id)sender discoveryMethod:(MWKHistoryDiscoveryMethod)discoveryMethod {
     [self dismissViewControllerAnimated:YES completion:^{
         [self wmf_pushArticleViewControllerWithTitle:title

--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -223,6 +223,10 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
     [super viewWillDisappear:animated];
 
     if (!self.presentedViewController) {
+        /*
+         Only perform animations & search site sync if search is being modally dismissed (as opposed to having another
+         view presented on top of it.
+         */
         [self saveLastSearch];
         [self saveSearchlanguage];
 


### PR DESCRIPTION
Phab: [T121184](https://phabricator.wikimedia.org/T121184)

---

- [x] changing site from settings works
  - [x] reloads feed
  - [x] sets selected site when search is presented
- [x] reading an article from a site other than the current search site does not change search site (e.g. EN featured article while search site is ES)

removes the searchSite delegate method & any implementations (it was optional anyway).