### PR TITLE
Add event logging for home view

### DIFF
--- a/PiwikTracker+WMFExtensions.h
+++ b/PiwikTracker+WMFExtensions.h
@@ -23,6 +23,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)wmf_logActionSaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
 - (void)wmf_logActionUnsaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
+
+- (void)wmf_logActionScrollToHomeSection:(id<WMFAnalyticsLogging>)section;
+- (void)wmf_logActionOpenMoreForHomeSection:(id<WMFAnalyticsLogging>)section;
+
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/PiwikTracker+WMFExtensions.h
+++ b/PiwikTracker+WMFExtensions.h
@@ -26,7 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)wmf_logActionSaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
 - (void)wmf_logActionUnsaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
 
-- (void)wmf_logActionScrollToHomeSection:(id<WMFAnalyticsLogging>)section;
+- (void)wmf_logActionScrollToTitle:(MWKTitle*)title inHomeSection:(id<WMFAnalyticsLogging>)section;
+- (void)wmf_logActionOpenTitle:(MWKTitle*)title inHomeSection:(id<WMFAnalyticsLogging>)section;
 - (void)wmf_logActionOpenMoreForHomeSection:(id<WMFAnalyticsLogging>)section;
 
 

--- a/PiwikTracker+WMFExtensions.h
+++ b/PiwikTracker+WMFExtensions.h
@@ -1,0 +1,20 @@
+
+@import PiwikTracker;
+#import "WMFAnalyticsLogging.h"
+
+@class MWKTitle;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PiwikTracker (WMFExtensions)
+
++ (void)wmf_start;
+
+- (void)wmf_logView:(id<WMFAnalyticsLogging>)view;
+
+- (void)wmf_logPreviewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
+- (void)wmf_logViewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PiwikTracker+WMFExtensions.h
+++ b/PiwikTracker+WMFExtensions.h
@@ -17,9 +17,11 @@ NS_ASSUME_NONNULL_BEGIN
  *  If you do, every article will be count as a unique source. We don't want to track that.
  *  We just want to know if a someone performed an action on a particular screen.
  */
-
-- (void)wmf_logPreviewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
 - (void)wmf_logViewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
+
+- (void)wmf_logActionPreviewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
+- (void)wmf_logActionPreviewDismissedForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
+- (void)wmf_logActionPreviewCommittedForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
 
 - (void)wmf_logActionSaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
 - (void)wmf_logActionUnsaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;

--- a/PiwikTracker+WMFExtensions.h
+++ b/PiwikTracker+WMFExtensions.h
@@ -12,9 +12,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)wmf_logView:(id<WMFAnalyticsLogging>)view;
 
+/**
+ *  For events that take a "source". Do not ever send an article VC.
+ *  If you do, every article will be count as a unique source. We don't want to track that.
+ *  We just want to know if a someone performed an action on a particular screen.
+ */
+
 - (void)wmf_logPreviewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
 - (void)wmf_logViewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
 
+- (void)wmf_logActionSaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
+- (void)wmf_logActionUnsaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/PiwikTracker+WMFExtensions.m
+++ b/PiwikTracker+WMFExtensions.m
@@ -4,7 +4,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSString* const WMFPiwikServerURL = @"http://piwik.wmflabs.org/";
+static NSString* const WMFPiwikServerURL = @"http://piwik.wmflabs.org/piwik/";
 static NSString* const WMFPiwikSiteID    = @"4";
 
 @implementation PiwikTracker (WMFExtensions)
@@ -12,6 +12,7 @@ static NSString* const WMFPiwikSiteID    = @"4";
 + (void)wmf_start {
 #ifdef PIWIK_ENABLED
     [PiwikTracker sharedInstanceWithSiteID:WMFPiwikSiteID baseURL:[NSURL URLWithString:WMFPiwikServerURL]];
+    [[PiwikTracker sharedInstance] setDispatchInterval:60];
 #endif
 }
 

--- a/PiwikTracker+WMFExtensions.m
+++ b/PiwikTracker+WMFExtensions.m
@@ -1,0 +1,40 @@
+
+#import "PiwikTracker+WMFExtensions.h"
+#import "MWKTitle+WMFAnalyticsLogging.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString* const WMFPiwikServerURL = @"http://piwik.wmflabs.org/";
+static NSString* const WMFPiwikSiteID    = @"4";
+
+@implementation PiwikTracker (WMFExtensions)
+
++ (void)wmf_start {
+#if PIWIK_ENABLED
+    [PiwikTracker sharedInstanceWithSiteID:WMFPiwikSiteID baseURL:[NSURL URLWithString:WMFPiwikServerURL]];
+#endif
+}
+
+- (void)wmf_logView:(id<WMFAnalyticsLogging>)view {
+    [self sendView:[view analyticsName]];
+}
+
+- (void)wmf_logPreviewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source {
+    if (source) {
+        [self sendViewsFromArray:@[[source analyticsName], @"Article-Preview", [title analyticsName]]];
+    } else {
+        [self sendViewsFromArray:@[@"Article-Preview", [title analyticsName]]];
+    }
+}
+
+- (void)wmf_logViewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source {
+    if (source) {
+        [self sendViewsFromArray:@[[source analyticsName], @"Article", [title analyticsName]]];
+    } else {
+        [self sendViewsFromArray:@[@"Article", [title analyticsName]]];
+    }
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PiwikTracker+WMFExtensions.m
+++ b/PiwikTracker+WMFExtensions.m
@@ -10,45 +10,62 @@ static NSString* const WMFPiwikSiteID    = @"4";
 @implementation PiwikTracker (WMFExtensions)
 
 + (void)wmf_start {
-#if PIWIK_ENABLED
+#ifdef PIWIK_ENABLED
     [PiwikTracker sharedInstanceWithSiteID:WMFPiwikSiteID baseURL:[NSURL URLWithString:WMFPiwikServerURL]];
 #endif
 }
 
 - (void)wmf_logView:(id<WMFAnalyticsLogging>)view {
+    NSParameterAssert([view analyticsName]);
+#ifdef PIWIK_ENABLED
     [self sendView:[view analyticsName]];
+#endif
 }
 
 - (void)wmf_logViewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source {
+    NSParameterAssert([title analyticsName]);
+#ifdef PIWIK_ENABLED
     if (source) {
         [self sendViewsFromArray:@[[source analyticsName], @"Article", [title analyticsName]]];
     } else {
         [self sendViewsFromArray:@[@"Article", [title analyticsName]]];
     }
+#endif
+}
+
+
+- (void)wmf_sendEventWithCategory:(NSString*)category action:(NSString*)action name:(nullable NSString*)name value:(nullable NSNumber*)value {
+#ifdef PIWIK_ENABLED
+    [self sendEventWithCategory:category action:action name:name value:value];
+#endif
 }
 
 - (void)wmf_logActionPreviewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source {
-    [self sendEventWithCategory:@"Preview" action:@"Shown" name:[source analyticsName] value:nil];
+    [self wmf_sendEventWithCategory:@"Preview" action:@"Shown" name:[source analyticsName] value:nil];
 }
 
 - (void)wmf_logActionPreviewDismissedForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source{
-    [self sendEventWithCategory:@"Preview" action:@"Dismissed" name:[source analyticsName] value:nil];
+    [self wmf_sendEventWithCategory:@"Preview" action:@"Dismissed" name:[source analyticsName] value:nil];
 }
 
 - (void)wmf_logActionPreviewCommittedForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source{
-    [self sendEventWithCategory:@"Preview" action:@"Converted" name:[source analyticsName] value:nil];
+    [self wmf_sendEventWithCategory:@"Preview" action:@"Converted" name:[source analyticsName] value:nil];
 }
 
 - (void)wmf_logActionSaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source {
-    [self sendEventWithCategory:@"Save" action:@"Save" name:[source analyticsName] value:nil];
+    [self wmf_sendEventWithCategory:@"Save" action:@"Save" name:[source analyticsName] value:nil];
 }
 
 - (void)wmf_logActionUnsaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source {
-    [self sendEventWithCategory:@"Save" action:@"Unsave" name:[source analyticsName] value:nil];
+    [self wmf_sendEventWithCategory:@"Save" action:@"Unsave" name:[source analyticsName] value:nil];
 }
 
-- (void)wmf_logActionScrollToHomeSection:(id<WMFAnalyticsLogging>)section {
-    [self sendEventWithCategory:@"Home" action:@"Scroll To Section" name:[section analyticsName] value:nil];
+- (void)wmf_logActionScrollToTitle:(MWKTitle*)title inHomeSection:(id<WMFAnalyticsLogging>)section{
+    [self wmf_sendEventWithCategory:@"Home" action:@"View Article" name:[section analyticsName] value:nil];
+}
+
+- (void)wmf_logActionOpenTitle:(MWKTitle*)title inHomeSection:(id<WMFAnalyticsLogging>)section{
+    [self wmf_sendEventWithCategory:@"Home" action:@"Open Article" name:[section analyticsName] value:nil];
 }
 
 - (void)wmf_logActionOpenMoreForHomeSection:(id<WMFAnalyticsLogging>)section {

--- a/PiwikTracker+WMFExtensions.m
+++ b/PiwikTracker+WMFExtensions.m
@@ -35,6 +35,13 @@ static NSString* const WMFPiwikSiteID    = @"4";
     }
 }
 
+- (void)wmf_logActionSaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source {
+    [self sendEventWithCategory:@"Save" action:@"Save" name:[source analyticsName] value:nil];
+}
+
+- (void)wmf_logActionUnsaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source {
+    [self sendEventWithCategory:@"Save" action:@"Unsave" name:[source analyticsName] value:nil];
+}
 @end
 
 NS_ASSUME_NONNULL_END

--- a/PiwikTracker+WMFExtensions.m
+++ b/PiwikTracker+WMFExtensions.m
@@ -42,6 +42,15 @@ static NSString* const WMFPiwikSiteID    = @"4";
 - (void)wmf_logActionUnsaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source {
     [self sendEventWithCategory:@"Save" action:@"Unsave" name:[source analyticsName] value:nil];
 }
+
+- (void)wmf_logActionScrollToHomeSection:(id<WMFAnalyticsLogging>)section {
+    [self sendEventWithCategory:@"Home" action:@"Scroll To Section" name:[section analyticsName] value:nil];
+}
+
+- (void)wmf_logActionOpenMoreForHomeSection:(id<WMFAnalyticsLogging>)section {
+    [self sendEventWithCategory:@"Home" action:@"Open More Like" name:[section analyticsName] value:nil];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/PiwikTracker+WMFExtensions.m
+++ b/PiwikTracker+WMFExtensions.m
@@ -19,20 +19,24 @@ static NSString* const WMFPiwikSiteID    = @"4";
     [self sendView:[view analyticsName]];
 }
 
-- (void)wmf_logPreviewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source {
-    if (source) {
-        [self sendViewsFromArray:@[[source analyticsName], @"Article-Preview", [title analyticsName]]];
-    } else {
-        [self sendViewsFromArray:@[@"Article-Preview", [title analyticsName]]];
-    }
-}
-
 - (void)wmf_logViewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source {
     if (source) {
         [self sendViewsFromArray:@[[source analyticsName], @"Article", [title analyticsName]]];
     } else {
         [self sendViewsFromArray:@[@"Article", [title analyticsName]]];
     }
+}
+
+- (void)wmf_logActionPreviewForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source {
+    [self sendEventWithCategory:@"Preview" action:@"Shown" name:[source analyticsName] value:nil];
+}
+
+- (void)wmf_logActionPreviewDismissedForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source{
+    [self sendEventWithCategory:@"Preview" action:@"Dismissed" name:[source analyticsName] value:nil];
+}
+
+- (void)wmf_logActionPreviewCommittedForTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source{
+    [self sendEventWithCategory:@"Preview" action:@"Converted" name:[source analyticsName] value:nil];
 }
 
 - (void)wmf_logActionSaveTitle:(MWKTitle*)title fromSource:(nullable id<WMFAnalyticsLogging>)source {

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		0E26B0841C0F4F720004D687 /* WMFWelcomeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E26B07E1C0F4F720004D687 /* WMFWelcomeViewController.m */; };
 		0E26B0871C0FD5170004D687 /* WMFBoringNavigationTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E26B0861C0FD5170004D687 /* WMFBoringNavigationTransition.m */; };
 		0E36C2271AE0B59D00C58CFF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D4991453181D51DE00E6073C /* Images.xcassets */; };
+		0E7AAEED1C21F4410046B5B6 /* PiwikTracker+WMFExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E7AAEEC1C21F4410046B5B6 /* PiwikTracker+WMFExtensions.m */; };
 		0EBCA7431C162ECF004F1FD9 /* MWKTitleLanguageController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EBCA7411C162ECF004F1FD9 /* MWKTitleLanguageController.m */; };
 		0EBCA7461C162EE9004F1FD9 /* MWKLanguageFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EBCA7451C162EE9004F1FD9 /* MWKLanguageFilter.m */; };
 		0EBCA7481C176389004F1FD9 /* WMFAlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBCA7471C176389004F1FD9 /* WMFAlertManager.swift */; };
@@ -658,6 +659,8 @@
 		0E26B0851C0FD5170004D687 /* WMFBoringNavigationTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFBoringNavigationTransition.h; path = Wikipedia/Code/WMFBoringNavigationTransition.h; sourceTree = SOURCE_ROOT; };
 		0E26B0861C0FD5170004D687 /* WMFBoringNavigationTransition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFBoringNavigationTransition.m; path = Wikipedia/Code/WMFBoringNavigationTransition.m; sourceTree = SOURCE_ROOT; };
 		0E36C2281AE0B5BD00C58CFF /* SourceIcons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = SourceIcons.xcassets; path = Wikipedia/SourceIcons.xcassets; sourceTree = "<group>"; };
+		0E7AAEEB1C21F4410046B5B6 /* PiwikTracker+WMFExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PiwikTracker+WMFExtensions.h"; sourceTree = SOURCE_ROOT; };
+		0E7AAEEC1C21F4410046B5B6 /* PiwikTracker+WMFExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PiwikTracker+WMFExtensions.m"; sourceTree = SOURCE_ROOT; };
 		0EBCA7411C162ECF004F1FD9 /* MWKTitleLanguageController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MWKTitleLanguageController.m; path = Wikipedia/Code/MWKTitleLanguageController.m; sourceTree = SOURCE_ROOT; };
 		0EBCA7421C162ECF004F1FD9 /* MWKTitleLanguageController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MWKTitleLanguageController.h; path = Wikipedia/Code/MWKTitleLanguageController.h; sourceTree = SOURCE_ROOT; };
 		0EBCA7441C162EE9004F1FD9 /* MWKLanguageFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MWKLanguageFilter.h; path = Wikipedia/Code/MWKLanguageFilter.h; sourceTree = SOURCE_ROOT; };
@@ -2833,6 +2836,37 @@
 			path = Wikipedia/Code/Footer;
 			sourceTree = SOURCE_ROOT;
 		};
+		0E7AAEEA1C21F4160046B5B6 /* WIkimedia EL */ = {
+			isa = PBXGroup;
+			children = (
+				B0E805771C0CE2C60065EBC0 /* CreateAccountFunnel.h */,
+				B0E805781C0CE2C60065EBC0 /* CreateAccountFunnel.m */,
+				B0E805791C0CE2C60065EBC0 /* EditFunnel.h */,
+				B0E8057A1C0CE2C60065EBC0 /* EditFunnel.m */,
+				B0E8057B1C0CE2C60065EBC0 /* EventLogger.h */,
+				B0E8057C1C0CE2C60065EBC0 /* EventLogger.m */,
+				B0E8057D1C0CE2C60065EBC0 /* EventLoggingFunnel.h */,
+				B0E8057E1C0CE2C60065EBC0 /* EventLoggingFunnel.m */,
+				B0E8057F1C0CE2C60065EBC0 /* LoginFunnel.h */,
+				B0E805801C0CE2C60065EBC0 /* LoginFunnel.m */,
+				B0E805811C0CE2C60065EBC0 /* ProtectedEditAttemptFunnel.h */,
+				B0E805821C0CE2C60065EBC0 /* ProtectedEditAttemptFunnel.m */,
+				B0E805831C0CE2C60065EBC0 /* ReadingActionFunnel.h */,
+				B0E805841C0CE2C60065EBC0 /* ReadingActionFunnel.m */,
+				B0E805871C0CE2C60065EBC0 /* ToCInteractionFunnel.h */,
+				B0E805881C0CE2C60065EBC0 /* ToCInteractionFunnel.m */,
+				B0E805891C0CE2C60065EBC0 /* WMFHamburgerMenuFunnel.h */,
+				B0E8058A1C0CE2C60065EBC0 /* WMFHamburgerMenuFunnel.m */,
+				B0E8058B1C0CE2C60065EBC0 /* WMFSuggestedPagesFunnel.h */,
+				B0E8058C1C0CE2C60065EBC0 /* WMFSuggestedPagesFunnel.m */,
+				B0E805981C0CE2E40065EBC0 /* WMFSearchFunnel.h */,
+				B0E805991C0CE2E40065EBC0 /* WMFSearchFunnel.m */,
+				B0E8059B1C0CE2F50065EBC0 /* WMFShareFunnel.h */,
+				B0E8059C1C0CE2F50065EBC0 /* WMFShareFunnel.m */,
+			);
+			name = "WIkimedia EL";
+			sourceTree = "<group>";
+		};
 		0E7E602E1B7CFA9B00ED1C69 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
@@ -4265,30 +4299,9 @@
 		D4B0ADFF19365F4600F0AC90 /* EventLogging */ = {
 			isa = PBXGroup;
 			children = (
-				B0E805771C0CE2C60065EBC0 /* CreateAccountFunnel.h */,
-				B0E805781C0CE2C60065EBC0 /* CreateAccountFunnel.m */,
-				B0E805791C0CE2C60065EBC0 /* EditFunnel.h */,
-				B0E8057A1C0CE2C60065EBC0 /* EditFunnel.m */,
-				B0E8057B1C0CE2C60065EBC0 /* EventLogger.h */,
-				B0E8057C1C0CE2C60065EBC0 /* EventLogger.m */,
-				B0E8057D1C0CE2C60065EBC0 /* EventLoggingFunnel.h */,
-				B0E8057E1C0CE2C60065EBC0 /* EventLoggingFunnel.m */,
-				B0E8057F1C0CE2C60065EBC0 /* LoginFunnel.h */,
-				B0E805801C0CE2C60065EBC0 /* LoginFunnel.m */,
-				B0E805811C0CE2C60065EBC0 /* ProtectedEditAttemptFunnel.h */,
-				B0E805821C0CE2C60065EBC0 /* ProtectedEditAttemptFunnel.m */,
-				B0E805831C0CE2C60065EBC0 /* ReadingActionFunnel.h */,
-				B0E805841C0CE2C60065EBC0 /* ReadingActionFunnel.m */,
-				B0E805871C0CE2C60065EBC0 /* ToCInteractionFunnel.h */,
-				B0E805881C0CE2C60065EBC0 /* ToCInteractionFunnel.m */,
-				B0E805891C0CE2C60065EBC0 /* WMFHamburgerMenuFunnel.h */,
-				B0E8058A1C0CE2C60065EBC0 /* WMFHamburgerMenuFunnel.m */,
-				B0E8058B1C0CE2C60065EBC0 /* WMFSuggestedPagesFunnel.h */,
-				B0E8058C1C0CE2C60065EBC0 /* WMFSuggestedPagesFunnel.m */,
-				B0E805981C0CE2E40065EBC0 /* WMFSearchFunnel.h */,
-				B0E805991C0CE2E40065EBC0 /* WMFSearchFunnel.m */,
-				B0E8059B1C0CE2F50065EBC0 /* WMFShareFunnel.h */,
-				B0E8059C1C0CE2F50065EBC0 /* WMFShareFunnel.m */,
+				0E7AAEEA1C21F4160046B5B6 /* WIkimedia EL */,
+				0E7AAEEB1C21F4410046B5B6 /* PiwikTracker+WMFExtensions.h */,
+				0E7AAEEC1C21F4410046B5B6 /* PiwikTracker+WMFExtensions.m */,
 			);
 			name = EventLogging;
 			path = Wikipedia/Code/EventLogging;
@@ -4922,6 +4935,7 @@
 				B0E806741C0CE9850065EBC0 /* QueuesSingleton.m in Sources */,
 				B0E8055E1C0CE0DC0065EBC0 /* UIViewController+WMFChildViewController.m in Sources */,
 				B0E806D21C0CEB6E0065EBC0 /* PageHistoryViewController.m in Sources */,
+				0E7AAEED1C21F4410046B5B6 /* PiwikTracker+WMFExtensions.m in Sources */,
 				B0E803CC1C0CDC9B0065EBC0 /* WMFTitleInsetRespectingButton.m in Sources */,
 				B0E807681C0CEE3A0065EBC0 /* GalleryImage.m in Sources */,
 				B0E803FA1C0CDDBA0065EBC0 /* WMFUnderlineButton.m in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -5458,6 +5458,11 @@
 				GCC_OPTIMIZATION_LEVEL = 3;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "wikipedia/Wikipedia-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"COCOAPODS=1",
+					"PIWIK_ENABLED=1",
+				);
 				INFOPLIST_FILE = "Wikipedia/Wikipedia-Info.plist";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DDEBUG";
@@ -5565,6 +5570,11 @@
 				GCC_OPTIMIZATION_LEVEL = 3;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "wikipedia/Wikipedia-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"COCOAPODS=1",
+					"PIWIK_ENABLED=1",
+				);
 				INFOPLIST_FILE = "Wikipedia/Wikipedia-Info.plist";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DDEBUG";
@@ -5675,6 +5685,11 @@
 				ENABLE_TESTABILITY = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "wikipedia/Wikipedia-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"COCOAPODS=1",
+					"PIWIK_ENABLED=1",
+				);
 				INFOPLIST_FILE = "Wikipedia/Wikipedia-Info.plist";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DDEBUG";
@@ -5897,6 +5912,11 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "wikipedia/Wikipedia-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"COCOAPODS=1",
+					"PIWIK_ENABLED=1",
+				);
 				INFOPLIST_FILE = "Wikipedia/Wikipedia-Info.plist";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DDEBUG";

--- a/Wikipedia/Code/AppDelegate.m
+++ b/Wikipedia/Code/AppDelegate.m
@@ -4,11 +4,9 @@
 #import "Wikipedia-Swift.h"
 
 #import "BITHockeyManager+WMFExtensions.h"
+#import "PiwikTracker+WMFExtensions.h"
 #import "WMFAppViewController.h"
 
-@import PiwikTracker;
-static NSString* const WMFPiwikServerURL = @"http://piwik.wmflabs.org/";
-static NSString* const WMFPiwikSiteID    = @"4";
 
 @import Tweaks;
 
@@ -48,10 +46,7 @@ static NSString* const WMFPiwikSiteID    = @"4";
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
     [[NSUserDefaults standardUserDefaults] wmf_setAppLaunchDate:[NSDate date]];
     [[BITHockeyManager sharedHockeyManager] wmf_setupAndStart];
-
-#if PIWIK_ENABLED
-    [PiwikTracker sharedInstanceWithSiteID:WMFPiwikSiteID baseURL:[NSURL URLWithString:WMFPiwikServerURL]];
-#endif
+    [PiwikTracker wmf_start];
 
     WMFAppViewController* vc = [WMFAppViewController initialAppViewControllerFromDefaultStoryBoard];
     [vc launchAppInWindow:self.window];

--- a/Wikipedia/Code/Global.h
+++ b/Wikipedia/Code/Global.h
@@ -28,12 +28,4 @@
 
 #define URL_PRIVACY_POLICY @"https://m.wikimediafoundation.org/wiki/Privacy_Policy"
 
-#ifndef PIWIK_ENABLED
-    #if NDEBUG
-        #define PIWIK_ENABLED 0
-    #else
-        #define PIWIK_ENABLED 1
-    #endif
-#endif
-
 #endif

--- a/Wikipedia/Code/UIViewController+WMFArticlePresentation.m
+++ b/Wikipedia/Code/UIViewController+WMFArticlePresentation.m
@@ -15,6 +15,7 @@
 #import "MWKSavedPageList.h"
 #import "MWKUserDataStore.h"
 #import "WMFArticleContainerViewController.h"
+#import "PiwikTracker+WMFExtensions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -36,6 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
     NSAssert(self.navigationController, @"Illegal attempt to push article %@ from %@ without a navigation controller.",
              articleViewController,
              self);
+    id<WMFAnalyticsLogging> source = [self conformsToProtocol:@protocol(WMFAnalyticsLogging)] ? (id<WMFAnalyticsLogging>)self : nil;
+
+    [[PiwikTracker sharedInstance] wmf_logViewForTitle:[articleViewController articleTitle] fromSource:source];
     [self.navigationController pushViewController:articleViewController animated:YES];
 
     //Delay this so any visual updates to lists are postponed until the article after the article is displayed

--- a/Wikipedia/Code/UIViewController+WMFSearchButton.h
+++ b/Wikipedia/Code/UIViewController+WMFSearchButton.h
@@ -1,10 +1,3 @@
-//
-//  UIViewController+WMFSearchButton.h
-//  Wikipedia
-//
-//  Created by Brian Gerstle on 9/30/15.
-//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
-//
 
 #import <UIKit/UIKit.h>
 #import "WMFArticleSelectionDelegate.h"

--- a/Wikipedia/Code/UIViewController+WMFSearchButton.m
+++ b/Wikipedia/Code/UIViewController+WMFSearchButton.m
@@ -1,10 +1,3 @@
-//
-//  UIViewController+WMFSearchButton.m
-//  Wikipedia
-//
-//  Created by Brian Gerstle on 9/30/15.
-//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
-//
 
 #import "UIViewController+WMFSearchButton_Testing.h"
 #import "WMFSearchViewController.h"
@@ -12,6 +5,8 @@
 #import "SessionSingleton.h"
 #import "UIViewController+WMFArticlePresentation.h"
 #import "MWKSite.h"
+#import "PiwikTracker+WMFExtensions.h"
+
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -63,6 +58,7 @@ static BOOL isSearchPresentationAnimated = YES;
             _sharedSearchViewController = searchVC;
         }
         _sharedSearchViewController.searchResultDelegate = delegate;
+        [[PiwikTracker sharedInstance] wmf_logView:_sharedSearchViewController];
         [self presentViewController:_sharedSearchViewController animated:isSearchPresentationAnimated completion:nil];
     }];
 }

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -3,11 +3,9 @@
 #import "Wikipedia-Swift.h"
 
 // Frameworks
-#if PIWIK_ENABLED
-@import PiwikTracker;
-#endif
 @import Masonry;
 #import <Tweaks/FBTweakInline.h>
+#import "PiwikTracker+WMFExtensions.h"
 
 //Utility
 #import "NSDate+Utilities.h"
@@ -107,9 +105,7 @@ static dispatch_once_t launchToken;
     [self configureHomeViewController];
     [self configureSavedViewController];
     [self configureRecentViewController];
-#if PIWIK_ENABLED
-    [[PiwikTracker sharedInstance] sendView:@"Home"];
-#endif
+    [[PiwikTracker sharedInstance] logViewHome];
 }
 
 - (void)configureTabController {
@@ -266,7 +262,7 @@ static dispatch_once_t launchToken;
     return (UINavigationController*)[self.rootTabBarController viewControllers][tab];
 }
 
-- (UIViewController*)rootViewControllerForTab:(WMFAppTabType)tab {
+- (UIViewController<WMFAnalyticsLogging>*)rootViewControllerForTab:(WMFAppTabType)tab {
     return [[[self navigationControllerForTab:tab] viewControllers] firstObject];
 }
 
@@ -447,17 +443,18 @@ static NSString* const WMFDidShowOnboarding = @"DidShowOnboarding5.0";
     [self wmf_hideKeyboard];
 #if PIWIK_ENABLED
     WMFAppTabType tab = [[tabBarController viewControllers] indexOfObject:viewController];
+    [[PiwikTracker sharedInstance] wmf_logView:[self rootViewControllerForTab:tab]];
     switch (tab) {
         case WMFAppTabTypeHome: {
-            [[PiwikTracker sharedInstance] sendView:@"Home"];
+            [[PiwikTracker sharedInstance] logViewHome];
         }
         break;
         case WMFAppTabTypeSaved: {
-            [[PiwikTracker sharedInstance] sendView:@"Saved"];
+            [[PiwikTracker sharedInstance] logViewSaved];
         }
         break;
         case WMFAppTabTypeRecent: {
-            [[PiwikTracker sharedInstance] sendView:@"Recent"];
+            [[PiwikTracker sharedInstance] logViewRecent];
         }
         break;
     }

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -105,7 +105,6 @@ static dispatch_once_t launchToken;
     [self configureHomeViewController];
     [self configureSavedViewController];
     [self configureRecentViewController];
-    [[PiwikTracker sharedInstance] logViewHome];
 }
 
 - (void)configureTabController {
@@ -218,6 +217,7 @@ static dispatch_once_t launchToken;
             [self loadMainUI];
             [self hideSplashViewAnimated:!didShowOnboarding];
             [self resumeApp];
+            [[PiwikTracker sharedInstance] wmf_logView:[self rootViewControllerForTab:WMFAppTabTypeHome]];
         }];
     }];
 }
@@ -441,24 +441,8 @@ static NSString* const WMFDidShowOnboarding = @"DidShowOnboarding5.0";
 
 - (void)tabBarController:(UITabBarController*)tabBarController didSelectViewController:(UIViewController*)viewController {
     [self wmf_hideKeyboard];
-#if PIWIK_ENABLED
     WMFAppTabType tab = [[tabBarController viewControllers] indexOfObject:viewController];
     [[PiwikTracker sharedInstance] wmf_logView:[self rootViewControllerForTab:tab]];
-    switch (tab) {
-        case WMFAppTabTypeHome: {
-            [[PiwikTracker sharedInstance] logViewHome];
-        }
-        break;
-        case WMFAppTabTypeSaved: {
-            [[PiwikTracker sharedInstance] logViewSaved];
-        }
-        break;
-        case WMFAppTabTypeRecent: {
-            [[PiwikTracker sharedInstance] logViewRecent];
-        }
-        break;
-    }
-#endif
 }
 
 #pragma mark - Notifications

--- a/Wikipedia/Code/WMFArticleContainerViewController.h
+++ b/Wikipedia/Code/WMFArticleContainerViewController.h
@@ -1,5 +1,4 @@
 @import UIKit;
-#import "WMFAnalyticsLogging.h"
 #import "MWKHistoryEntry.h"
 
 @class MWKDataStore;
@@ -11,7 +10,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  View controller responsible for displaying article content.
  */
 @interface WMFArticleContainerViewController : UIViewController
-    <WMFAnalyticsLogging>
 
 - (instancetype)initWithArticleTitle:(MWKTitle*)title
                            dataStore:(MWKDataStore*)dataStore

--- a/Wikipedia/Code/WMFArticleContainerViewController.m
+++ b/Wikipedia/Code/WMFArticleContainerViewController.m
@@ -709,12 +709,6 @@ NS_ASSUME_NONNULL_BEGIN
     return nil;
 }
 
-#pragma mark - Analytics
-
-- (NSString*)analyticsName {
-    return [self.article analyticsName];
-}
-
 #pragma mark - WMFArticleHeadermageGalleryViewControllerDelegate
 
 - (void)headerImageGallery:(WMFArticleHeaderImageGalleryViewController* __nonnull)gallery

--- a/Wikipedia/Code/WMFArticleContainerViewController.m
+++ b/Wikipedia/Code/WMFArticleContainerViewController.m
@@ -25,7 +25,7 @@
 //Funnel
 #import "WMFShareFunnel.h"
 #import "ProtectedEditAttemptFunnel.h"
-
+#import "PiwikTracker+WMFExtensions.h"
 
 // Model
 #import "MWKDataStore.h"
@@ -836,6 +836,9 @@ NS_ASSUME_NONNULL_BEGIN
 
     UIViewController* peekVC = [self viewControllerForPreviewURL:peekURL];
     if (peekVC) {
+        if ([peekVC isKindOfClass:[WMFArticleContainerViewController class]]) {
+            [[PiwikTracker sharedInstance] wmf_logPreviewForTitle:[(WMFArticleContainerViewController*)peekVC articleTitle] fromSource:nil];
+        }
         self.webViewController.isPeeking = YES;
         previewingContext.sourceRect     = [self.webViewController rectForHTMLElement:peekElement];
         return peekVC;
@@ -860,6 +863,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)previewingContext:(id<UIViewControllerPreviewing>)previewingContext
      commitViewController:(UIViewController*)viewControllerToCommit {
     if ([viewControllerToCommit isKindOfClass:[WMFArticleContainerViewController class]]) {
+        [[PiwikTracker sharedInstance] wmf_logViewForTitle:[(WMFArticleContainerViewController*)viewControllerToCommit articleTitle] fromSource:nil];
         [self wmf_pushArticleViewController:(WMFArticleContainerViewController*)viewControllerToCommit];
     } else {
         [self presentViewController:viewControllerToCommit animated:YES completion:nil];

--- a/Wikipedia/Code/WMFArticleListTableViewController.h
+++ b/Wikipedia/Code/WMFArticleListTableViewController.h
@@ -2,12 +2,13 @@
 #import <UIKit/UIKit.h>
 #import "WMFTitleListDataSource.h"
 #import "WMFArticleSelectionDelegate.h"
+#import "WMFAnalyticsLogging.h"
 
 @class SSBaseDataSource, MWKDataStore;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface WMFArticleListTableViewController : UITableViewController
+@interface WMFArticleListTableViewController : UITableViewController<WMFAnalyticsLogging>
 
 @property (nonatomic, strong) MWKDataStore* dataStore;
 @property (nonatomic, strong, nullable) SSBaseDataSource<WMFTitleListDataSource>* dataSource;

--- a/Wikipedia/Code/WMFArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFArticleListTableViewController.m
@@ -24,10 +24,12 @@
 #import "UIBarButtonItem+WMFButtonConvenience.h"
 #import "PiwikTracker+WMFExtensions.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface WMFArticleListTableViewController ()<WMFSearchPresentationDelegate, UIViewControllerPreviewingDelegate>
 
 @property (nonatomic, weak) id<UIViewControllerPreviewing> previewingContext;
-@property (nonatomic, strong) MWKTitle* previewingTitle;
+@property (nonatomic, strong, null_resettable) MWKTitle* previewingTitle;
 
 @end
 
@@ -212,7 +214,7 @@
     [[self dynamicDataSource] stopUpdating];
 }
 
-- (void)traitCollectionDidChange:(UITraitCollection*)previousTraitCollection {
+- (void)traitCollectionDidChange:(nullable UITraitCollection*)previousTraitCollection {
     [super traitCollectionDidChange:previousTraitCollection];
     [self registerForPreviewingIfAvailable];
 }
@@ -318,3 +320,4 @@
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFArticleListTableViewController.m
@@ -22,6 +22,7 @@
 #import <BlocksKit/BlocksKit+UIKit.h>
 #import "Wikipedia-Swift.h"
 #import "UIBarButtonItem+WMFButtonConvenience.h"
+#import "PiwikTracker+WMFExtensions.h"
 
 @interface WMFArticleListTableViewController ()<WMFSearchPresentationDelegate, UIViewControllerPreviewingDelegate>
 
@@ -272,6 +273,7 @@
     previewingContext.sourceRect = [self.tableView cellForRowAtIndexPath:previewIndexPath].frame;
 
     MWKTitle* title = [self.dataSource titleForIndexPath:previewIndexPath];
+    [[PiwikTracker sharedInstance] wmf_logPreviewForTitle:title fromSource:self];
     return [[WMFArticleContainerViewController alloc] initWithArticleTitle:title
                                                                  dataStore:[self dataStore]
                                                            discoveryMethod:self.dataSource.discoveryMethod];
@@ -280,10 +282,15 @@
 - (void)previewingContext:(id<UIViewControllerPreviewing>)previewingContext
      commitViewController:(WMFArticleContainerViewController*)viewControllerToCommit {
     if (self.delegate) {
+        [[PiwikTracker sharedInstance] wmf_logViewForTitle:[(WMFArticleContainerViewController*)viewControllerToCommit articleTitle] fromSource:self];
         [self.delegate didCommitToPreviewedArticleViewController:viewControllerToCommit sender:self];
     } else {
         [self wmf_pushArticleViewController:viewControllerToCommit];
     }
+}
+
+- (NSString*)analyticsName {
+    return [self.dataSource analyticsName];
 }
 
 @end

--- a/Wikipedia/Code/WMFArticlePreviewTableViewCell.h
+++ b/Wikipedia/Code/WMFArticlePreviewTableViewCell.h
@@ -3,6 +3,7 @@
 @class MWKTitle;
 @class MWKSavedPageList;
 @class MWKImage;
+@class WMFSaveButtonController;
 
 @interface WMFArticlePreviewTableViewCell : WMFArticleListTableViewCell
 
@@ -42,5 +43,11 @@
  *  @param loading    Shows/hides blur and loading indicator
  */
 - (void)setLoading:(BOOL)loading;
+
+
+/**
+ *  Exposed so the analytics source can be set.
+ */
+@property (strong, nonatomic, readonly) WMFSaveButtonController* saveButtonController;
 
 @end

--- a/Wikipedia/Code/WMFArticlePreviewTableViewCell.m
+++ b/Wikipedia/Code/WMFArticlePreviewTableViewCell.m
@@ -12,7 +12,7 @@
 @property (strong, nonatomic) IBOutlet UILabel* snippetLabel;
 @property (strong, nonatomic) IBOutlet UIButton* saveButton;
 
-@property (strong, nonatomic) WMFSaveButtonController* saveButtonController;
+@property (strong, nonatomic, readwrite) WMFSaveButtonController* saveButtonController;
 
 @property (strong, nonatomic) IBOutlet NSLayoutConstraint* paddingConstraintLeading;
 @property (strong, nonatomic) IBOutlet NSLayoutConstraint* paddingConstraintTrailing;

--- a/Wikipedia/Code/WMFContinueReadingSectionController.m
+++ b/Wikipedia/Code/WMFContinueReadingSectionController.m
@@ -94,4 +94,8 @@ static NSString* const WMFContinueReadingSectionIdentifier = @"WMFContinueReadin
     return description;
 }
 
+- (NSString*)analyticsName {
+    return @"Continue Reading";
+}
+
 @end

--- a/Wikipedia/Code/WMFFeaturedArticleSectionController.m
+++ b/Wikipedia/Code/WMFFeaturedArticleSectionController.m
@@ -11,6 +11,7 @@
 #import "WMFArticlePlaceholderTableViewCell.h"
 #import "UIView+WMFDefaultNib.h"
 #import "UITableViewCell+WMFLayout.h"
+#import "WMFSaveButtonController.h"
 
 #import "NSString+FormattedAttributedString.h"
 
@@ -118,6 +119,7 @@ static NSString* const WMFFeaturedArticleSectionIdentifierPrefix = @"WMFFeatured
         [previewCell setImageURL:self.featuredArticlePreview.thumbnailURL];
         [previewCell setSaveableTitle:[self titleForItemAtIndex:indexPath.row] savedPageList:self.savedPageList];
         [previewCell wmf_layoutIfNeededIfOperatingSystemVersionLessThan9_0_0];
+        previewCell.saveButtonController.analyticsSource = self;
     }
 }
 
@@ -142,6 +144,10 @@ static NSString* const WMFFeaturedArticleSectionIdentifierPrefix = @"WMFFeatured
         @strongify(self);
         [self.delegate controller:self didFailToUpdateWithError:error];
     });
+}
+
+- (NSString*)analyticsName {
+    return @"Featured Article";
 }
 
 @end

--- a/Wikipedia/Code/WMFHomeSectionController.h
+++ b/Wikipedia/Code/WMFHomeSectionController.h
@@ -1,6 +1,7 @@
 
 #import <Foundation/Foundation.h>
 #import "MWKHistoryEntry.h"
+#import "WMFAnalyticsLogging.h"
 
 @class SSSectionedDataSource, SSArrayDataSource;
 
@@ -8,7 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol WMFHomeSectionController <NSObject>
+@protocol WMFHomeSectionController <WMFAnalyticsLogging>
 
 @property (nonatomic, weak) id<WMFHomeSectionControllerDelegate> delegate;
 

--- a/Wikipedia/Code/WMFHomeViewController.m
+++ b/Wikipedia/Code/WMFHomeViewController.m
@@ -673,7 +673,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     self.sectionLoadErrors[@(section)] = error;
-    if ([self.sectionLoadErrors count] > ([self.sectionControllers count] / 2)) {
+    if ([self.sectionLoadErrors count] > ([self.sectionControllers count] / 2) && self.view.superview) {
         [self wmf_showEmptyViewOfType:WMFEmptyViewTypeNoFeed];
     }
     [[WMFAlertManager sharedInstance] showErrorAlert:error sticky:NO dismissPreviousAlerts:NO tapCallBack:NULL];

--- a/Wikipedia/Code/WMFHomeViewController.m
+++ b/Wikipedia/Code/WMFHomeViewController.m
@@ -5,6 +5,7 @@
 #import <BlocksKit/BlocksKit+UIKit.h>
 @import Tweaks;
 @import SSDataSources;
+#import "PiwikTracker+WMFExtensions.h"
 
 // Sections
 #import "WMFMainPageSectionController.h"
@@ -58,7 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
 <WMFHomeSectionSchemaDelegate,
  WMFHomeSectionControllerDelegate,
  WMFSearchPresentationDelegate,
- UIViewControllerPreviewingDelegate>
+ UIViewControllerPreviewingDelegate,
+ WMFAnalyticsLogging>
 
 @property (nonatomic, strong, null_resettable) WMFHomeSectionSchema* schemaManager;
 
@@ -689,6 +691,7 @@ NS_ASSUME_NONNULL_BEGIN
         MWKTitle* title =
             [(id < WMFArticleHomeSectionController >)sectionController titleForItemAtIndex:previewIndexPath.item];
         if (title) {
+            [[PiwikTracker sharedInstance] wmf_logPreviewForTitle:title fromSource:self];
             return [[WMFArticleContainerViewController alloc]
                     initWithArticleTitle:title
                                dataStore:[self dataStore]
@@ -704,10 +707,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)previewingContext:(id<UIViewControllerPreviewing>)previewingContext
      commitViewController:(UIViewController*)viewControllerToCommit {
     if ([viewControllerToCommit isKindOfClass:[WMFArticleContainerViewController class]]) {
+        [[PiwikTracker sharedInstance] wmf_logViewForTitle:[(WMFArticleContainerViewController*)viewControllerToCommit articleTitle] fromSource:self];
         [self wmf_pushArticleViewController:(WMFArticleContainerViewController*)viewControllerToCommit];
     } else {
         [self presentViewController:viewControllerToCommit animated:YES completion:nil];
     }
+}
+
+- (NSString*)analyticsName {
+    return @"Home";
 }
 
 @end

--- a/Wikipedia/Code/WMFHomeViewController.m
+++ b/Wikipedia/Code/WMFHomeViewController.m
@@ -76,6 +76,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSMutableDictionary* sectionLoadErrors;
 
+@property (nonatomic, strong) MWKTitle* previewingTitle;
+
 @end
 
 @implementation WMFHomeViewController
@@ -200,6 +202,10 @@ NS_ASSUME_NONNULL_BEGIN
     [super viewDidAppear:animated];
     [self configureDataSource];
     [self.locationManager startMonitoringLocation];
+    if (self.previewingTitle) {
+        [[PiwikTracker sharedInstance] wmf_logActionPreviewDismissedForTitle:self.previewingTitle fromSource:self];
+        self.previewingTitle = nil;
+    }
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
@@ -702,7 +708,8 @@ NS_ASSUME_NONNULL_BEGIN
         MWKTitle* title =
             [(id < WMFArticleHomeSectionController >)sectionController titleForItemAtIndex:previewIndexPath.item];
         if (title) {
-            [[PiwikTracker sharedInstance] wmf_logPreviewForTitle:title fromSource:self];
+            self.previewingTitle = title;
+            [[PiwikTracker sharedInstance] wmf_logActionPreviewForTitle:title fromSource:self];
             return [[WMFArticleContainerViewController alloc]
                     initWithArticleTitle:title
                                dataStore:[self dataStore]
@@ -718,7 +725,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)previewingContext:(id<UIViewControllerPreviewing>)previewingContext
      commitViewController:(UIViewController*)viewControllerToCommit {
     if ([viewControllerToCommit isKindOfClass:[WMFArticleContainerViewController class]]) {
-        [[PiwikTracker sharedInstance] wmf_logViewForTitle:[(WMFArticleContainerViewController*)viewControllerToCommit articleTitle] fromSource:self];
+        [[PiwikTracker sharedInstance] wmf_logActionPreviewCommittedForTitle:self.previewingTitle fromSource:self];
+        self.previewingTitle = nil;
         [self wmf_pushArticleViewController:(WMFArticleContainerViewController*)viewControllerToCommit];
     } else {
         [self presentViewController:viewControllerToCommit animated:YES completion:nil];

--- a/Wikipedia/Code/WMFHomeViewController.m
+++ b/Wikipedia/Code/WMFHomeViewController.m
@@ -480,6 +480,7 @@ NS_ASSUME_NONNULL_BEGIN
     WMFArticleListTableViewController* extendedList              = [[WMFArticleListTableViewController alloc] init];
     extendedList.dataStore  = self.dataStore;
     extendedList.dataSource = [articleSectionController extendedListDataSource];
+    [[PiwikTracker sharedInstance] wmf_logActionOpenMoreForHomeSection:articleSectionController];
     [self.navigationController pushViewController:extendedList animated:YES];
 }
 
@@ -566,6 +567,16 @@ NS_ASSUME_NONNULL_BEGIN
         footer.whenTapped                  = NULL;
     }
     return footer;
+}
+
+- (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
+    //only log a section as visible for the first index path
+    if (indexPath.row == 0) {
+        id<WMFHomeSectionController> controller = [self sectionControllerForSectionAtIndex:indexPath.section];
+        if (controller) {
+            [[PiwikTracker sharedInstance] wmf_logActionScrollToHomeSection:controller];
+        }
+    }
 }
 
 - (BOOL)tableView:(UITableView*)tableView shouldHighlightRowAtIndexPath:(NSIndexPath*)indexPath {

--- a/Wikipedia/Code/WMFMainPageSectionController.m
+++ b/Wikipedia/Code/WMFMainPageSectionController.m
@@ -134,6 +134,10 @@ static NSString* const WMFMainPageSectionIdentifier = @"WMFMainPageSectionIdenti
     });
 }
 
+- (NSString*)analyticsName {
+    return @"Main Page";
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFNearbySectionController.m
+++ b/Wikipedia/Code/WMFNearbySectionController.m
@@ -178,6 +178,10 @@ static NSString* const WMFNearbySectionIdentifier = @"WMFNearbySectionIdentifier
     [self.delegate controller:self didSetItems:self.items];
 }
 
+- (NSString*)analyticsName {
+    return @"Nearby";
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFNearbyTitleListDataSource.m
+++ b/Wikipedia/Code/WMFNearbyTitleListDataSource.m
@@ -137,6 +137,10 @@ NS_ASSUME_NONNULL_BEGIN
     return [self numberOfItems] == 0;
 }
 
+- (NSString*)analyticsName {
+    return @"Nearby";
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFPictureOfTheDaySectionController.m
+++ b/Wikipedia/Code/WMFPictureOfTheDaySectionController.m
@@ -133,6 +133,10 @@ static NSString* WMFPlaceholderImageInfoTitle = @"WMFPlaceholderImageInfoTitle";
     return [[WMFModalImageGalleryViewController alloc] initWithInfo:self.imageInfo forDate:self.fetchedDate];
 }
 
+- (NSString*)analyticsName {
+    return @"Picture of the Day";
+}
+
 @end
 
 @implementation MWKImageInfo (Feed)

--- a/Wikipedia/Code/WMFRandomSectionController.m
+++ b/Wikipedia/Code/WMFRandomSectionController.m
@@ -10,6 +10,8 @@
 #import "WMFArticlePlaceholderTableViewCell.h"
 #import "UIView+WMFDefaultNib.h"
 #import "UITableViewCell+WMFLayout.h"
+#import "WMFSaveButtonController.h"
+
 
 static NSString* const WMFRandomSectionIdentifier = @"WMFRandomSectionIdentifier";
 
@@ -102,6 +104,7 @@ static NSString* const WMFRandomSectionIdentifier = @"WMFRandomSectionIdentifier
         [previewCell setSaveableTitle:[self titleForItemAtIndex:indexPath.row] savedPageList:self.savedPageList];
         previewCell.loading = self.fetcher.isFetching;
         [previewCell wmf_layoutIfNeededIfOperatingSystemVersionLessThan9_0_0];
+        previewCell.saveButtonController.analyticsSource = self;
     }
 }
 
@@ -127,6 +130,10 @@ static NSString* const WMFRandomSectionIdentifier = @"WMFRandomSectionIdentifier
         @strongify(self);
         [self.delegate controller:self didFailToUpdateWithError:error];
     });
+}
+
+- (NSString*)analyticsName {
+    return @"Random";
 }
 
 @end

--- a/Wikipedia/Code/WMFRecentPagesDataSource.m
+++ b/Wikipedia/Code/WMFRecentPagesDataSource.m
@@ -198,6 +198,10 @@ NS_ASSUME_NONNULL_BEGIN
     return MWKHistoryDiscoveryMethodUnknown;
 }
 
+- (NSString*)analyticsName {
+    return @"Recent";
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFRelatedSectionController.m
+++ b/Wikipedia/Code/WMFRelatedSectionController.m
@@ -18,6 +18,7 @@
 #import "WMFArticlePlaceholderTableViewCell.h"
 #import "UIView+WMFDefaultNib.h"
 #import "UITableViewCell+WMFLayout.h"
+#import "WMFSaveButtonController.h"
 
 // Style
 #import "UIFont+WMFStyle.h"
@@ -127,6 +128,7 @@ static NSUInteger const WMFRelatedSectionMaxResults      = 3;
         [previewCell setImageURL:result.thumbnailURL];
         [previewCell setSaveableTitle:[self titleForItemAtIndex:indexPath.row] savedPageList:self.savedPageList];
         [previewCell wmf_layoutIfNeededIfOperatingSystemVersionLessThan9_0_0];
+        previewCell.saveButtonController.analyticsSource = self;
     }
 }
 
@@ -178,6 +180,10 @@ static NSUInteger const WMFRelatedSectionMaxResults      = 3;
         @strongify(self);
         [self.delegate controller:self didFailToUpdateWithError:error];
     });
+}
+
+- (NSString*)analyticsName {
+    return @"Related";
 }
 
 @end

--- a/Wikipedia/Code/WMFRelatedTitleListDataSource.m
+++ b/Wikipedia/Code/WMFRelatedTitleListDataSource.m
@@ -27,6 +27,8 @@
 #import "MWKHistoryEntry.h"
 #import "MWKDataStore.h"
 #import "WMFRelatedSearchResults.h"
+#import "WMFSaveButtonController.h"
+
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -87,6 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
             cell.snippetText     = searchResult.extract;
             [cell setImageURL:searchResult.thumbnailURL];
             [cell wmf_layoutIfNeededIfOperatingSystemVersionLessThan9_0_0];
+            cell.saveButtonController.analyticsSource = self;
         };
     }
     return self;

--- a/Wikipedia/Code/WMFRelatedTitleListDataSource.m
+++ b/Wikipedia/Code/WMFRelatedTitleListDataSource.m
@@ -148,6 +148,10 @@ NS_ASSUME_NONNULL_BEGIN
     return NO;
 }
 
+- (NSString*)analyticsName {
+    return @"Related";
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFSaveButtonController.h
+++ b/Wikipedia/Code/WMFSaveButtonController.h
@@ -2,6 +2,7 @@
 //  Copyright (c) 2015 Wikimedia Foundation. Provided under MIT-style license; please copy and modify!
 
 #import <Foundation/Foundation.h>
+#import "WMFAnalyticsLogging.h"
 
 @class MWKSavedPageList, MWKTitle, MWKSavedPageList;
 
@@ -19,5 +20,10 @@
 - (instancetype)initWithBarButtonItem:(UIBarButtonItem*)barButtonItem
                         savedPageList:(MWKSavedPageList*)savedPageList
                                 title:(MWKTitle*)title;
+
+/**
+ *  Set to provide a source for logging saved pages
+ */
+@property (weak, nonatomic) id<WMFAnalyticsLogging> analyticsSource;
 
 @end

--- a/Wikipedia/Code/WMFSaveButtonController.m
+++ b/Wikipedia/Code/WMFSaveButtonController.m
@@ -4,6 +4,7 @@
 #import "MWKArticle.h"
 #import "MWKUserDataStore.h"
 #import "SavedPagesFunnel.h"
+#import "PiwikTracker+WMFExtensions.h"
 
 @interface WMFSaveButtonController ()
 
@@ -137,8 +138,10 @@
     BOOL isSaved = [self.savedPageList isSaved:self.title];
     if (isSaved) {
         [self.savedPagesFunnel logSaveNew];
+        [[PiwikTracker sharedInstance] wmf_logActionSaveTitle:self.title fromSource:self.analyticsSource];
     } else {
         [self.savedPagesFunnel logDelete];
+        [[PiwikTracker sharedInstance] wmf_logActionUnsaveTitle:self.title fromSource:self.analyticsSource];
     }
 
     [self observeSavedPages];

--- a/Wikipedia/Code/WMFSavedPagesDataSource.m
+++ b/Wikipedia/Code/WMFSavedPagesDataSource.m
@@ -8,6 +8,8 @@
 #import "UIView+WMFDefaultNib.h"
 #import "NSString+Extras.h"
 #import "UITableViewCell+WMFLayout.h"
+#import "WMFSaveButtonController.h"
+
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -40,6 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
             cell.snippetText     = [article summary];
             [cell setImage:[article bestThumbnailImage]];
             [cell wmf_layoutIfNeededIfOperatingSystemVersionLessThan9_0_0];
+            cell.saveButtonController.analyticsSource = self;
         };
 
         self.tableDeletionBlock = ^(WMFSavedPagesDataSource* dataSource,

--- a/Wikipedia/Code/WMFSavedPagesDataSource.m
+++ b/Wikipedia/Code/WMFSavedPagesDataSource.m
@@ -144,6 +144,10 @@ NS_ASSUME_NONNULL_BEGIN
     return MWKHistoryDiscoveryMethodSaved;
 }
 
+- (NSString*)analyticsName {
+    return @"Saved";
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFSearchDataSource.m
+++ b/Wikipedia/Code/WMFSearchDataSource.m
@@ -105,4 +105,9 @@
     return 60.f;
 }
 
+- (NSString*)analyticsName {
+    return @"Search";
+}
+
+
 @end

--- a/Wikipedia/Code/WMFSearchViewController.h
+++ b/Wikipedia/Code/WMFSearchViewController.h
@@ -1,11 +1,12 @@
 #import <UIKit/UIKit.h>
 #import "WMFArticleSelectionDelegate.h"
+#import "WMFAnalyticsLogging.h"
 
 @class MWKSite, MWKDataStore;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface WMFSearchViewController : UIViewController
+@interface WMFSearchViewController : UIViewController<WMFAnalyticsLogging>
 
 @property (nonatomic, strong, readonly) MWKSite* searchSite;
 @property (nonatomic, strong, readonly) MWKDataStore* dataStore;

--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -16,7 +16,6 @@
 
 #import <Masonry/Masonry.h>
 #import <BlocksKit/BlocksKit+UIKit.h>
-#import <PiwikTracker/PiwikTracker.h>
 #import "Wikipedia-Swift.h"
 
 #import "UIViewController+WMFStoryboardUtilities.h"
@@ -217,7 +216,6 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    [[PiwikTracker sharedInstance] sendView:@"Search"];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
@@ -569,6 +567,10 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
     [self updateLanguageButtonsToPreferredLanguages];
     [self selectLanguageForSite:language.site];
     [controller dismissViewControllerAnimated:YES completion:NULL];
+}
+
+- (NSString*)analyticsName {
+    return @"Search";
 }
 
 @end

--- a/Wikipedia/Code/WMFTitleListDataSource.h
+++ b/Wikipedia/Code/WMFTitleListDataSource.h
@@ -1,10 +1,11 @@
 #import <Foundation/Foundation.h>
 #import "MWKHistoryEntry.h"
+#import "WMFAnalyticsLogging.h"
 
 NS_ASSUME_NONNULL_BEGIN
 @class MWKSavedPageList;
 
-@protocol WMFTitleListDataSource <NSObject>
+@protocol WMFTitleListDataSource <WMFAnalyticsLogging>
 
 - (nullable NSString*)displayTitle;
 


### PR DESCRIPTION
Did some cleanup and improved general logging as well:

- Moved all piwik logic to a category
- Generalized page tracking to take a "source" - so we know where the view came from (home, search, saved, recent)
- Added events for saving (also takes a source)
- Added events for home impression tracking (also takes a source)
- Re-added some preview tracking that was removed when we changed the preview logic