### PR TITLE
Make sure we highlight cells when touching down in the ToC

### DIFF
--- a/Wikipedia/Code/WMFTableOfContentsCell.swift
+++ b/Wikipedia/Code/WMFTableOfContentsCell.swift
@@ -59,6 +59,12 @@ public class WMFTableOfContentsCell: UITableViewCell {
     }
     
     public func setSectionSelected(selected: Bool, animated: Bool) {
+        if(selected && self.sectionSelectionBackground.alpha > 0){
+            return;
+        }
+        if(!selected && self.sectionSelectionBackground.alpha == 0){
+            return;
+        }
         UIView.animateWithDuration(animated ? 0.3 : 0.0) {
             if (selected) {
                 self.sectionSelectionBackground.alpha = 1.0
@@ -91,6 +97,16 @@ public class WMFTableOfContentsCell: UITableViewCell {
             selectedSectionIndicator.alpha = 0.0
         }
     }
+    
+//    public override func setHighlighted(highlighted: Bool, animated: Bool) {
+//        UIView.animateWithDuration(animated ? 0.3 : 0.0) {
+//            if (highlighted) {
+//                self.sectionSelectionBackground.alpha = 1.0
+//            } else {
+//                self.sectionSelectionBackground.alpha = 0.0
+//            }
+//        }
+//    }
 
     // MARK: - Indentation
 

--- a/Wikipedia/Code/WMFTableOfContentsCell.swift
+++ b/Wikipedia/Code/WMFTableOfContentsCell.swift
@@ -98,16 +98,6 @@ public class WMFTableOfContentsCell: UITableViewCell {
         }
     }
     
-//    public override func setHighlighted(highlighted: Bool, animated: Bool) {
-//        UIView.animateWithDuration(animated ? 0.3 : 0.0) {
-//            if (highlighted) {
-//                self.sectionSelectionBackground.alpha = 1.0
-//            } else {
-//                self.sectionSelectionBackground.alpha = 0.0
-//            }
-//        }
-//    }
-
     // MARK: - Indentation
 
     static let minimumIndentationWidth: CGFloat = 10

--- a/Wikipedia/Code/WMFTableOfContentsViewController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsViewController.swift
@@ -78,12 +78,29 @@ public class WMFTableOfContentsViewController: UITableViewController, WMFTableOf
     }
 
     // MARK: - Selection
-    public func deselectAllRows() {
-        guard let selectedIndexPaths = tableView.indexPathsForSelectedRows else {
+    func deselectAllRows() {
+        guard let visibleIndexPaths = tableView.indexPathsForVisibleRows else {
             return
         }
-        for (_, element) in selectedIndexPaths.enumerate() {
+        for (_, element) in visibleIndexPaths.enumerate() {
             if let cell: WMFTableOfContentsCell = tableView.cellForRowAtIndexPath(element) as? WMFTableOfContentsCell  {
+                cell.setSectionSelected(false, animated: false)
+            }
+        }
+    }
+    func deselectAllRowsExceptForIndexPath(indexpath: NSIndexPath?, animated: Bool) {
+        guard let visibleIndexPaths = tableView.indexPathsForVisibleRows else {
+            return
+        }
+        for (_, element) in visibleIndexPaths.enumerate() {
+            
+            if let cell: WMFTableOfContentsCell = tableView.cellForRowAtIndexPath(element) as? WMFTableOfContentsCell  {
+                if let indexpath = indexpath{
+                    if element.isEqual(indexpath){
+                        cell.setSectionSelected(true, animated: false)
+                        continue
+                    }
+                }
                 cell.setSectionSelected(false, animated: false)
             }
         }
@@ -169,9 +186,15 @@ public class WMFTableOfContentsViewController: UITableViewController, WMFTableOf
     }
 
     // MARK: - UITableViewDelegate
+    public override func tableView(tableView: UITableView, shouldHighlightRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        let item = items[indexPath.row]
+        addHighlightOfItemsRelatedTo(item, animated: true)
+        return true
+    }
+    
     public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let item = items[indexPath.row]
-        deselectAllRows()
+        deselectAllRowsExceptForIndexPath(indexPath, animated: false)
         tableOfContentsFunnel.logClick()
         addHighlightOfItemsRelatedTo(item, animated: true)
         delegate?.tableOfContentsController(self, didSelectItem: item)
@@ -181,6 +204,12 @@ public class WMFTableOfContentsViewController: UITableViewController, WMFTableOf
         tableOfContentsFunnel.logClose()
         delegate?.tableOfContentsControllerDidCancel(self)
     }
+
+    // MARK: - UIScrollViewDelegate
+    public override func scrollViewWillBeginDragging(scrollView: UIScrollView) {
+        deselectAllRowsExceptForIndexPath(self.tableView.indexPathForSelectedRow, animated: false)
+    }
+    
 
 }
 

--- a/Wikipedia/Code/WMFTableOfContentsViewController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsViewController.swift
@@ -207,9 +207,11 @@ public class WMFTableOfContentsViewController: UITableViewController, WMFTableOf
 
     // MARK: - UIScrollViewDelegate
     public override func scrollViewWillBeginDragging(scrollView: UIScrollView) {
-        deselectAllRowsExceptForIndexPath(self.tableView.indexPathForSelectedRow, animated: false)
+        if let indexPath = self.tableView.indexPathForSelectedRow {
+            let item = items[indexPath.row]
+            addHighlightOfItemsRelatedTo(item, animated: true)
+        }
     }
-    
 
 }
 

--- a/Wikipedia/Code/WMFTableOfContentsViewController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsViewController.swift
@@ -118,6 +118,13 @@ public class WMFTableOfContentsViewController: UITableViewController, WMFTableOf
         }
     }
 
+    public func addHighlightToItem(item: TableOfContentsItem, animated: Bool) {
+        if let indexPath = indexPathForItem(item){
+            if let cell: WMFTableOfContentsCell = tableView.cellForRowAtIndexPath(indexPath) as? WMFTableOfContentsCell  {
+                cell.setSectionSelected(true, animated: animated)
+            }
+        }
+    }
     // MARK: - Header
     func forceUpdateHeaderFrame(){
         //See reason for fix here: http://stackoverflow.com/questions/16471846/is-it-possible-to-use-autolayout-with-uitableviews-tableheaderview
@@ -188,7 +195,7 @@ public class WMFTableOfContentsViewController: UITableViewController, WMFTableOf
     // MARK: - UITableViewDelegate
     public override func tableView(tableView: UITableView, shouldHighlightRowAtIndexPath indexPath: NSIndexPath) -> Bool {
         let item = items[indexPath.row]
-        addHighlightOfItemsRelatedTo(item, animated: true)
+        addHighlightToItem(item, animated: true)
         return true
     }
     


### PR DESCRIPTION
Because we use some custom selection logic - its a bit complicated
we have to apply the highlights manually when getting delegate callbacks
also have to handle the deselection when a user scrolls after touching down (which uitableview uses to cancel the existing highlight)