### PR TITLE
Fix feed jumping & remove table view update queueing

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -587,6 +587,7 @@
 		BCA15AF41C0E724E00D0A3EA /* SSBaseDataSource+WMFLayoutDirectionUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = BCA15AF31C0E724E00D0A3EA /* SSBaseDataSource+WMFLayoutDirectionUtilities.m */; };
 		BCA15B011C0E896700D0A3EA /* WMFModalArticleImageGalleryDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = BCA15B001C0E896700D0A3EA /* WMFModalArticleImageGalleryDataSource.m */; };
 		BCA15B171C0F48EF00D0A3EA /* UIScreen+WMFImageWidth.m in Sources */ = {isa = PBXBuildFile; fileRef = BCA15B161C0F48EF00D0A3EA /* UIScreen+WMFImageWidth.m */; };
+		BCAE0DFA1C247E7E006DDF51 /* UITableView+WMFLockedUpdates.m in Sources */ = {isa = PBXBuildFile; fileRef = BCAE0DF91C247E7E006DDF51 /* UITableView+WMFLockedUpdates.m */; };
 		BCB6081C1BC80DE00088086A /* Spider-Man_actors.jpg in Resources */ = {isa = PBXBuildFile; fileRef = BCB6081B1BC80DE00088086A /* Spider-Man_actors.jpg */; };
 		BCC4D3551C11F39700F00D58 /* NSDate+WMFPOTDTitleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BCC4D3541C11F39700F00D58 /* NSDate+WMFPOTDTitleTests.m */; };
 		BCCB813D1C110702008BC602 /* NSDate+WMFDateRanges.m in Sources */ = {isa = PBXBuildFile; fileRef = BCCB813A1C110702008BC602 /* NSDate+WMFDateRanges.m */; };
@@ -1715,6 +1716,8 @@
 		BCA15B051C0E91C600D0A3EA /* WMFModalImageGalleryViewController_Subclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFModalImageGalleryViewController_Subclass.h; path = Wikipedia/Code/WMFModalImageGalleryViewController_Subclass.h; sourceTree = SOURCE_ROOT; };
 		BCA15B151C0F48EF00D0A3EA /* UIScreen+WMFImageWidth.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIScreen+WMFImageWidth.h"; path = "Wikipedia/Code/UIScreen+WMFImageWidth.h"; sourceTree = SOURCE_ROOT; };
 		BCA15B161C0F48EF00D0A3EA /* UIScreen+WMFImageWidth.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIScreen+WMFImageWidth.m"; path = "Wikipedia/Code/UIScreen+WMFImageWidth.m"; sourceTree = SOURCE_ROOT; };
+		BCAE0DF81C247E7E006DDF51 /* UITableView+WMFLockedUpdates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UITableView+WMFLockedUpdates.h"; path = "Wikipedia/Code/UITableView+WMFLockedUpdates.h"; sourceTree = SOURCE_ROOT; };
+		BCAE0DF91C247E7E006DDF51 /* UITableView+WMFLockedUpdates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UITableView+WMFLockedUpdates.m"; path = "Wikipedia/Code/UITableView+WMFLockedUpdates.m"; sourceTree = SOURCE_ROOT; };
 		BCB6081B1BC80DE00088086A /* Spider-Man_actors.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "Spider-Man_actors.jpg"; sourceTree = "<group>"; };
 		BCC4D3541C11F39700F00D58 /* NSDate+WMFPOTDTitleTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSDate+WMFPOTDTitleTests.m"; path = "WikipediaUnitTests/Code/NSDate+WMFPOTDTitleTests.m"; sourceTree = SOURCE_ROOT; };
 		BCCB81391C110702008BC602 /* NSDate+WMFDateRanges.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSDate+WMFDateRanges.h"; path = "Wikipedia/Code/NSDate+WMFDateRanges.h"; sourceTree = SOURCE_ROOT; };
@@ -2245,6 +2248,8 @@
 		04C43AB7183442FC006C643B /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				BCAE0DF81C247E7E006DDF51 /* UITableView+WMFLockedUpdates.h */,
+				BCAE0DF91C247E7E006DDF51 /* UITableView+WMFLockedUpdates.m */,
 				BCCB81471C1109BD008BC602 /* SSBaseDataSource+WMFLayoutDirectionUtilities.h */,
 				BCCB81481C1109BD008BC602 /* SSBaseDataSource+WMFLayoutDirectionUtilities.m */,
 				BCCB81391C110702008BC602 /* NSDate+WMFDateRanges.h */,
@@ -5161,6 +5166,7 @@
 				B0E8066D1C0CE9030065EBC0 /* PageHistoryFetcher.m in Sources */,
 				B0E806B71C0CEB160065EBC0 /* LanguagesViewController.m in Sources */,
 				B0E805521C0CE0DC0065EBC0 /* UITableViewCell+WMFLayout.m in Sources */,
+				BCAE0DFA1C247E7E006DDF51 /* UITableView+WMFLockedUpdates.m in Sources */,
 				B0E804BE1C0CE0B40065EBC0 /* CLLocation+WMFBearing.m in Sources */,
 				B0E8030A1C0CD5320065EBC0 /* WMFSearchResultDistanceProvider.m in Sources */,
 				B0E807221C0CECE30065EBC0 /* CommunicationBridge.m in Sources */,

--- a/Wikipedia/Code/UITableView+WMFLockedUpdates.h
+++ b/Wikipedia/Code/UITableView+WMFLockedUpdates.h
@@ -1,6 +1,6 @@
 //
 //  UITableView+WMFLockedUpdates.h
-//  
+//
 //
 //  Created by Brian Gerstle on 12/18/15.
 //
@@ -10,7 +10,7 @@
 
 @interface UITableView (WMFLockedUpdates)
 
-- (void)wmf_performUpdates:(dispatch_block_t)updates
+- (void)      wmf_performUpdates:(dispatch_block_t)updates
     withoutMovingCellAtIndexPath:(NSIndexPath*)lockedIndexPath;
 
 @end

--- a/Wikipedia/Code/UITableView+WMFLockedUpdates.h
+++ b/Wikipedia/Code/UITableView+WMFLockedUpdates.h
@@ -1,0 +1,16 @@
+//
+//  UITableView+WMFLockedUpdates.h
+//  
+//
+//  Created by Brian Gerstle on 12/18/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UITableView (WMFLockedUpdates)
+
+- (void)wmf_performUpdates:(dispatch_block_t)updates
+    withoutMovingCellAtIndexPath:(NSIndexPath*)lockedIndexPath;
+
+@end

--- a/Wikipedia/Code/UITableView+WMFLockedUpdates.m
+++ b/Wikipedia/Code/UITableView+WMFLockedUpdates.m
@@ -15,17 +15,17 @@
     NSParameterAssert(lockedIndexPath);
     NSParameterAssert(updates);
     if (self.contentSize.height <= self.frame.size.height) {
+        DDLogVerbose(@"Content size not large enough to need adjusting, skipping.");
         updates();
         return;
     }
 
     UITableViewCell* oldLockedCell = [self cellForRowAtIndexPath:lockedIndexPath];
     if (!oldLockedCell) {
+        DDLogVerbose(@"Cell at %@ not visible, skipping.", lockedIndexPath);
         updates();
         return;
     }
-
-    __block BOOL shouldScrollAfterUpdates = NO;
 
     CGPoint oldOrigin = [self.window convertPoint:oldLockedCell.frame.origin
                                          fromView:oldLockedCell.superview];
@@ -33,13 +33,13 @@
         updates();
 
         if (self.contentSize.height <= self.frame.size.height) {
-            DDLogInfo(@"Content size too small, not adjusting content offset.");
+            DDLogVerbose(@"Content size too small after updates, not adjusting content offset.");
             return;
         }
 
         UITableViewCell* newLockedCell = [self cellForRowAtIndexPath:lockedIndexPath];
         if (!newLockedCell) {
-            shouldScrollAfterUpdates = YES;
+            DDLogVerbose(@"Can't find cell to lock for %@ after updates, skipping adjustment.", lockedIndexPath);
             return;
         }
 
@@ -55,13 +55,6 @@
                      lockedIndexPath);
         self.contentOffset = newContentOffset;
     }];
-
-    if (shouldScrollAfterUpdates) {
-        DDLogWarn(@"Couldn't find locked cell after updates, scrolling");
-        [self scrollToRowAtIndexPath:lockedIndexPath
-                    atScrollPosition:UITableViewScrollPositionMiddle
-                            animated:YES];
-    }
 }
 
 @end

--- a/Wikipedia/Code/UITableView+WMFLockedUpdates.m
+++ b/Wikipedia/Code/UITableView+WMFLockedUpdates.m
@@ -1,6 +1,6 @@
 //
 //  UITableView+WMFLockedUpdates.m
-//  
+//
 //
 //  Created by Brian Gerstle on 12/18/15.
 //
@@ -10,8 +10,8 @@
 
 @implementation UITableView (WMFLockedUpdates)
 
-- (void)wmf_performUpdates:(dispatch_block_t)updates
-withoutMovingCellAtIndexPath:(NSIndexPath*)lockedIndexPath {
+- (void)      wmf_performUpdates:(dispatch_block_t)updates
+    withoutMovingCellAtIndexPath:(NSIndexPath*)lockedIndexPath {
     NSParameterAssert(lockedIndexPath);
     NSParameterAssert(updates);
     if (self.contentSize.height <= self.frame.size.height) {
@@ -51,8 +51,8 @@ withoutMovingCellAtIndexPath:(NSIndexPath*)lockedIndexPath {
         // ???: if deleting from above selected/focused row, do we need to limit auto-scrolling to contentInset?
 
         DDLogVerbose(@"Adjusting content offset to %@ to prevent updates from moving cell at %@.",
-                  NSStringFromCGPoint(newContentOffset),
-                  lockedIndexPath);
+                     NSStringFromCGPoint(newContentOffset),
+                     lockedIndexPath);
         self.contentOffset = newContentOffset;
     }];
 

--- a/Wikipedia/Code/UITableView+WMFLockedUpdates.m
+++ b/Wikipedia/Code/UITableView+WMFLockedUpdates.m
@@ -1,0 +1,67 @@
+//
+//  UITableView+WMFLockedUpdates.m
+//  
+//
+//  Created by Brian Gerstle on 12/18/15.
+//
+//
+
+#import "UITableView+WMFLockedUpdates.h"
+
+@implementation UITableView (WMFLockedUpdates)
+
+- (void)wmf_performUpdates:(dispatch_block_t)updates
+withoutMovingCellAtIndexPath:(NSIndexPath*)lockedIndexPath {
+    NSParameterAssert(lockedIndexPath);
+    NSParameterAssert(updates);
+    if (self.contentSize.height <= self.frame.size.height) {
+        updates();
+        return;
+    }
+
+    UITableViewCell* oldLockedCell = [self cellForRowAtIndexPath:lockedIndexPath];
+    if (!oldLockedCell) {
+        updates();
+        return;
+    }
+
+    __block BOOL shouldScrollAfterUpdates = NO;
+
+    CGPoint oldOrigin = [self.window convertPoint:oldLockedCell.frame.origin
+                                         fromView:oldLockedCell.superview];
+    [UIView performWithoutAnimation:^{
+        updates();
+
+        if (self.contentSize.height <= self.frame.size.height) {
+            DDLogInfo(@"Content size too small, not adjusting content offset.");
+            return;
+        }
+
+        UITableViewCell* newLockedCell = [self cellForRowAtIndexPath:lockedIndexPath];
+        if (!newLockedCell) {
+            shouldScrollAfterUpdates = YES;
+            return;
+        }
+
+        CGPoint currentOrigin = [self.window convertPoint:newLockedCell.frame.origin
+                                                 fromView:newLockedCell.superview];
+        CGPoint newContentOffset = self.contentOffset;
+
+        newContentOffset.y += currentOrigin.y - oldOrigin.y;
+        // ???: if deleting from above selected/focused row, do we need to limit auto-scrolling to contentInset?
+
+        DDLogVerbose(@"Adjusting content offset to %@ to prevent updates from moving cell at %@.",
+                  NSStringFromCGPoint(newContentOffset),
+                  lockedIndexPath);
+        self.contentOffset = newContentOffset;
+    }];
+
+    if (shouldScrollAfterUpdates) {
+        DDLogWarn(@"Couldn't find locked cell after updates, scrolling");
+        [self scrollToRowAtIndexPath:lockedIndexPath
+                    atScrollPosition:UITableViewScrollPositionMiddle
+                            animated:YES];
+    }
+}
+
+@end

--- a/Wikipedia/Code/WMFArticleContainerViewController.m
+++ b/Wikipedia/Code/WMFArticleContainerViewController.m
@@ -614,6 +614,10 @@ NS_ASSUME_NONNULL_BEGIN
     [self.readMoreDataSource fetch]
     .then(^(WMFRelatedSearchResults* readMoreResults) {
         @strongify(self);
+        if (!self) {
+            // NOTE(bgerstle): must bail here to prevent creating placeholder array w/ nil below
+            return;
+        }
         if ([readMoreResults.results count] > 0) {
             [self.webViewController setFooterViewControllers:@[self.readMoreListViewController]];
             [self appendReadMoreTableOfContentsItem];

--- a/Wikipedia/Code/WMFHomeViewController.m
+++ b/Wikipedia/Code/WMFHomeViewController.m
@@ -320,7 +320,6 @@ NS_ASSUME_NONNULL_BEGIN
     [self.schemaManager update:forceUpdate];
 }
 
-
 - (void)reloadSectionControllers {
     [self unloadAllSections];
     [self loadSections];
@@ -607,10 +606,10 @@ NS_ASSUME_NONNULL_BEGIN
     }
     DDLogVerbose(@"Updating items in section %ld: %@", sectionIndex, controller);
     [self.tableView wmf_performUpdates:^{
-        /* 
-         HAX: must reload entire table, otherwise UITableView crashes due to inserting nil in an internal array
-         
-         This is true even when we tried wrapping in (nested) begin/endUpdate calls and asynchronous queueing of updates.
+        /*
+           HAX: must reload entire table, otherwise UITableView crashes due to inserting nil in an internal array
+
+           This is true even when we tried wrapping in (nested) begin/endUpdate calls and asynchronous queueing of updates.
          */
         [self.tableView reloadData];
     } withoutMovingCellAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:sectionIndex]];

--- a/Wikipedia/Code/WMFHomeViewController.m
+++ b/Wikipedia/Code/WMFHomeViewController.m
@@ -400,7 +400,11 @@ NS_ASSUME_NONNULL_BEGIN
     [section.items setArray:controller.items];
 
     [self.tableView wmf_performUpdates:^{
-        // HAX: must reload entire table, otherwise UITableView crashes due to inserting nil in an internal array
+        /*
+           HAX: must reload entire table, otherwise UITableView crashes due to inserting nil in an internal array
+
+           This is true even when we tried wrapping in (nested) begin/endUpdate calls and asynchronous queueing of updates.
+         */
         [self.tableView reloadData];
     } withoutMovingCellAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:sectionIndex]];
 }
@@ -606,11 +610,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
     DDLogVerbose(@"Updating items in section %ld: %@", sectionIndex, controller);
     [self.tableView wmf_performUpdates:^{
-        /*
-           HAX: must reload entire table, otherwise UITableView crashes due to inserting nil in an internal array
-
-           This is true even when we tried wrapping in (nested) begin/endUpdate calls and asynchronous queueing of updates.
-         */
+        // see comment in reloadSectionController
         [self.tableView reloadData];
     } withoutMovingCellAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:sectionIndex]];
 }

--- a/Wikipedia/Code/WMFHomeViewController.m
+++ b/Wikipedia/Code/WMFHomeViewController.m
@@ -401,6 +401,7 @@ NS_ASSUME_NONNULL_BEGIN
     [section.items setArray:controller.items];
 
     [self.tableView wmf_performUpdates:^{
+        // HAX: must reload entire table, otherwise UITableView crashes due to inserting nil in an internal array
         [self.tableView reloadData];
     } withoutMovingCellAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:sectionIndex]];
 }
@@ -606,6 +607,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     DDLogVerbose(@"Updating items in section %ld: %@", sectionIndex, controller);
     [self.tableView wmf_performUpdates:^{
+        /* 
+         HAX: must reload entire table, otherwise UITableView crashes due to inserting nil in an internal array
+         
+         This is true even when we tried wrapping in (nested) begin/endUpdate calls and asynchronous queueing of updates.
+         */
         [self.tableView reloadData];
     } withoutMovingCellAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:sectionIndex]];
 }

--- a/Wikipedia/Code/WMFHomeViewController.m
+++ b/Wikipedia/Code/WMFHomeViewController.m
@@ -68,8 +68,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) WMFLocationManager* locationManager;
 @property (nonatomic, strong) SSSectionedDataSource* dataSource;
 
-@property (nonatomic, strong) NSOperationQueue* collectionViewUpdateQueue;
-
 @property (nonatomic, weak) id<UIViewControllerPreviewing> previewingContext;
 
 @property (nonatomic, strong) NSMutableDictionary* sectionLoadErrors;
@@ -172,11 +170,6 @@ NS_ASSUME_NONNULL_BEGIN
     [super viewDidLoad];
 
     self.title = MWLocalizedString(@"home-title", nil);
-
-    NSOperationQueue* queue = [[NSOperationQueue alloc] init];
-    queue.maxConcurrentOperationCount = 1;
-    queue.qualityOfService            = NSQualityOfServiceUserInteractive;
-    self.collectionViewUpdateQueue    = queue;
 
     self.tableView.dataSource                   = nil;
     self.tableView.delegate                     = nil;

--- a/Wikipedia/Code/WMFLocationManager.m
+++ b/Wikipedia/Code/WMFLocationManager.m
@@ -68,11 +68,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)requestAuthorizationIfNeeded {
     CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
     if (status == kCLAuthorizationStatusNotDetermined) {
-        DDLogInfo(@"%@ is requesting authorization to access location when in use.", self);
+        DDLogVerbose(@"%@ is requesting authorization to access location when in use.", self);
         [self.locationManager requestWhenInUseAuthorization];
         return YES;
     }
-    DDLogInfo(@"%@ is skipping authorization request because status is %d.", self, status);
+    DDLogVerbose(@"%@ is skipping authorization request because status is %d.", self, status);
     return NO;
 }
 
@@ -180,7 +180,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
 
         case kCLAuthorizationStatusAuthorizedWhenInUse: {
-            DDLogInfo(@"%@ was granted access to location when in use, attempting to monitor location.", self);
+            DDLogVerbose(@"%@ was granted access to location when in use, attempting to monitor location.", self);
             [self startMonitoringLocation];
             break;
         }
@@ -200,7 +200,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (locations.count == 0) {
         return;
     }
-    DDLogInfo(@"%@ updated location: %@", self, manager.location);
+    DDLogVerbose(@"%@ updated location: %@", self, manager.location);
     [self.delegate nearbyController:self didUpdateLocation:manager.location];
 }
 
@@ -214,12 +214,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)locationManager:(CLLocationManager*)manager didFailWithError:(NSError*)error {
     if (self.locationUpdatesStopped) {
-        DDLogInfo(@"Suppressing error received after call to stop monitoring location: %@", error);
+        DDLogVerbose(@"Suppressing error received after call to stop monitoring location: %@", error);
         return;
     }
     #if TARGET_IPHONE_SIMULATOR
     else if (error.domain == kCLErrorDomain && error.code == kCLErrorLocationUnknown) {
-        DDLogInfo(@"Suppressing unknown location error.");
+        DDLogVerbose(@"Suppressing unknown location error.");
         return;
     }
     #endif

--- a/Wikipedia/Code/WMFRandomSectionController.m
+++ b/Wikipedia/Code/WMFRandomSectionController.m
@@ -113,8 +113,6 @@ static NSString* const WMFRandomSectionIdentifier = @"WMFRandomSectionIdentifier
         return;
     }
 
-    [self.delegate controller:self didUpdateItemsAtIndexes:[NSIndexSet indexSetWithIndex:0]];
-
     @weakify(self);
     [self.fetcher fetchRandomArticleWithSite:self.searchSite]
     .then(^(id result){
@@ -126,6 +124,9 @@ static NSString* const WMFRandomSectionIdentifier = @"WMFRandomSectionIdentifier
         @strongify(self);
         [self.delegate controller:self didFailToUpdateWithError:error];
     });
+
+    // call after fetch starts so loading indicator displays
+    [self.delegate controller:self didUpdateItemsAtIndexes:[NSIndexSet indexSetWithIndex:0]];
 }
 
 @end

--- a/Wikipedia/Code/WMFRandomSectionController.m
+++ b/Wikipedia/Code/WMFRandomSectionController.m
@@ -94,11 +94,10 @@ static NSString* const WMFRandomSectionIdentifier = @"WMFRandomSectionIdentifier
 - (void)configureCell:(UITableViewCell*)cell withObject:(id)object inTableView:(UITableView*)tableView atIndexPath:(NSIndexPath*)indexPath {
     if ([cell isKindOfClass:[WMFArticlePreviewTableViewCell class]]) {
         WMFArticlePreviewTableViewCell* previewCell = (id)cell;
-        MWKSearchResult* result                     = object;
-        previewCell.titleText       = result.displayTitle;
-        previewCell.descriptionText = result.wikidataDescription;
-        previewCell.snippetText     = result.extract;
-        [previewCell setImageURL:result.thumbnailURL];
+        previewCell.titleText       = self.result.displayTitle;
+        previewCell.descriptionText = self.result.wikidataDescription;
+        previewCell.snippetText     = self.result.extract;
+        [previewCell setImageURL:self.result.thumbnailURL];
         [previewCell setSaveableTitle:[self titleForItemAtIndex:indexPath.row] savedPageList:self.savedPageList];
         previewCell.loading = self.fetcher.isFetching;
         [previewCell wmf_layoutIfNeededIfOperatingSystemVersionLessThan9_0_0];
@@ -114,14 +113,14 @@ static NSString* const WMFRandomSectionIdentifier = @"WMFRandomSectionIdentifier
         return;
     }
 
-    [self.delegate controller:self didSetItems:self.items];
+    [self.delegate controller:self didUpdateItemsAtIndexes:[NSIndexSet indexSetWithIndex:0]];
 
     @weakify(self);
     [self.fetcher fetchRandomArticleWithSite:self.searchSite]
     .then(^(id result){
         @strongify(self);
         self.result = result;
-        [self.delegate controller:self didSetItems:self.items];
+        [self.delegate controller:self didUpdateItemsAtIndexes:[NSIndexSet indexSetWithIndex:0]];
     })
     .catch(^(NSError* error){
         @strongify(self);


### PR DESCRIPTION
Phab: [T120474](https://phabricator.wikimedia.org/T120474)

---

Look ma, [no jumps](https://vid.me/LUHQ)!

### Important stuff

- `UITableView+WMFLockedCell` suppresses table view animations and repositions the desired cell to its previous position _in the window_
- Removing all the `reloadSections:` & `reloadRows:` calls, since
  - They were causing all kinds of weird stuff to fly around (headers, cells, etc.)
  - They were causing weird crashes from the `UITableView` implementation
    - We can investigate this further when re-architecting/writing the feed

### Plus a couple boyscouts:

- Add & silence some logs
- Fixing a bug when popping VC at the same time "read more" response comes back (could also be a cancellation race condition, didn't investigate further)