### PR TITLE
Add "About this article" header above footer menu

### DIFF
--- a/Wikipedia/Code/WMFArticleContainerViewController.m
+++ b/Wikipedia/Code/WMFArticleContainerViewController.m
@@ -713,6 +713,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString*)webViewController:(WebViewController*)controller titleForFooterViewController:(UIViewController*)footerViewController {
     if (footerViewController == self.readMoreListViewController) {
         return [MWSiteLocalizedString(self.articleTitle.site, @"article-read-more-title", nil) uppercaseStringWithLocale:[NSLocale currentLocale]];
+    }else if(footerViewController == self.footerMenuViewController){
+        return [MWSiteLocalizedString(self.articleTitle.site, @"article-about-title", nil) uppercaseStringWithLocale:[NSLocale currentLocale]];
     }
     return nil;
 }

--- a/Wikipedia/Code/WMFArticleFooterMenuViewController.m
+++ b/Wikipedia/Code/WMFArticleFooterMenuViewController.m
@@ -39,6 +39,16 @@
     [self.tableView deselectRowAtIndexPath:[self.tableView indexPathForSelectedRow] animated:YES];
 }
 
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
+    // HAX: collapses space between grouped table sections
+    return 0.00001;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section {
+    // HAX: collapses space between grouped table sections
+    return 0.00001;
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
 

--- a/Wikipedia/Code/WMFArticleFooterViewHeader.xib
+++ b/Wikipedia/Code/WMFArticleFooterViewHeader.xib
@@ -1,45 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="WMFArticleFooterViewHeader" customModule="Wikipedia">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="57"/>
+            <rect key="frame" x="0.0" y="0.0" width="600" height="82"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="320" translatesAutoresizingMaskIntoConstraints="NO" id="Pko-xi-BUp">
-                    <rect key="frame" x="15" y="25" width="570" height="32"/>
-                    <animations/>
+                    <rect key="frame" x="15" y="35" width="570" height="43"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                     <color key="textColor" red="0.27058823529411763" green="0.27058823529411763" blue="0.27058823529411763" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
-            <animations/>
             <constraints>
-                <constraint firstItem="Pko-xi-BUp" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="68M-20-Esp"/>
-                <constraint firstAttribute="bottom" secondItem="Pko-xi-BUp" secondAttribute="bottom" id="T4a-NP-tFo"/>
+                <constraint firstAttribute="bottom" secondItem="Pko-xi-BUp" secondAttribute="bottom" constant="4" id="T4a-NP-tFo"/>
                 <constraint firstAttribute="trailing" secondItem="Pko-xi-BUp" secondAttribute="trailing" constant="15" id="cRz-gJ-cvX"/>
                 <constraint firstItem="Pko-xi-BUp" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="15" id="pRv-Qh-Vx4"/>
-                <constraint firstItem="Pko-xi-BUp" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="25" id="wDV-En-6nH"/>
+                <constraint firstItem="Pko-xi-BUp" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="35" id="wDV-En-6nH"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <variation key="default">
-                <mask key="constraints">
-                    <exclude reference="68M-20-Esp"/>
-                </mask>
-            </variation>
             <connections>
                 <outlet property="headerLabel" destination="Pko-xi-BUp" id="8Ch-Wm-pBn"/>
             </connections>
-            <point key="canvasLocation" x="198" y="224.5"/>
+            <point key="canvasLocation" x="198" y="237"/>
         </view>
     </objects>
 </document>

--- a/Wikipedia/Code/WMFTableOfContentsCell.xib
+++ b/Wikipedia/Code/WMFTableOfContentsCell.xib
@@ -1,34 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="uO4-kI-VPN" customClass="WMFTableOfContentsCell" customModule="Wikipedia" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="77" id="uO4-kI-VPN" customClass="WMFTableOfContentsCell" customModule="Wikipedia" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="77"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uO4-kI-VPN" id="KCX-Ys-ehz">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="76.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bfs-Qt-Ofl">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
-                        <animations/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="77"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ew3-L9-lHp">
-                        <rect key="frame" x="34" y="15" width="278" height="13"/>
-                        <animations/>
+                        <rect key="frame" x="34" y="15" width="278" height="47"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" red="0.19997376203536987" green="0.20001503825187683" blue="0.19997122883796692" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WnM-xO-Ywd">
-                        <rect key="frame" x="14" y="16" width="10" height="10"/>
-                        <animations/>
+                        <rect key="frame" x="14" y="33" width="10" height="10"/>
                         <color key="backgroundColor" red="0.18405178189277649" green="0.33496212959289551" blue="0.82250326871871948" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="10" id="AUf-YD-XQT"/>
@@ -41,29 +38,26 @@
                         </userDefinedRuntimeAttributes>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rjc-ni-9zr">
-                        <rect key="frame" x="34" y="42" width="286" height="1"/>
-                        <animations/>
+                        <rect key="frame" x="34" y="76" width="286" height="1"/>
                         <color key="backgroundColor" red="0.92931067943572998" green="0.92946994304656982" blue="0.92930072546005249" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="Xca-Js-lUH"/>
                         </constraints>
                     </view>
                 </subviews>
-                <animations/>
                 <constraints>
                     <constraint firstItem="rjc-ni-9zr" firstAttribute="leading" secondItem="KCX-Ys-ehz" secondAttribute="leading" id="0fd-Ez-aH6"/>
                     <constraint firstAttribute="bottom" secondItem="rjc-ni-9zr" secondAttribute="bottom" id="7VV-AZ-SDF"/>
                     <constraint firstAttribute="trailing" secondItem="rjc-ni-9zr" secondAttribute="trailing" id="Fst-Ae-20o"/>
-                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ew3-L9-lHp" secondAttribute="bottom" constant="15" id="IjA-fh-GRc"/>
+                    <constraint firstAttribute="bottom" secondItem="ew3-L9-lHp" secondAttribute="bottom" priority="999" constant="15" id="IjA-fh-GRc"/>
                     <constraint firstItem="rjc-ni-9zr" firstAttribute="leading" secondItem="ew3-L9-lHp" secondAttribute="leading" id="LdV-Fa-7uu"/>
-                    <constraint firstItem="ew3-L9-lHp" firstAttribute="leading" secondItem="WnM-xO-Ywd" secondAttribute="trailing" constant="10" id="Tr2-mk-KE5"/>
+                    <constraint firstItem="ew3-L9-lHp" firstAttribute="leading" secondItem="WnM-xO-Ywd" secondAttribute="trailing" priority="999" constant="10" id="Tr2-mk-KE5"/>
                     <constraint firstAttribute="bottom" secondItem="Bfs-Qt-Ofl" secondAttribute="bottom" id="UqM-FY-QuJ"/>
                     <constraint firstItem="Bfs-Qt-Ofl" firstAttribute="leading" secondItem="KCX-Ys-ehz" secondAttribute="leading" id="VIr-yC-IiC"/>
-                    <constraint firstAttribute="trailing" secondItem="ew3-L9-lHp" secondAttribute="trailing" constant="8" id="VmJ-Qh-cO8"/>
-                    <constraint firstItem="ew3-L9-lHp" firstAttribute="centerY" secondItem="KCX-Ys-ehz" secondAttribute="centerY" id="YvD-kf-ajm"/>
+                    <constraint firstAttribute="trailing" secondItem="ew3-L9-lHp" secondAttribute="trailing" priority="999" constant="8" id="VmJ-Qh-cO8"/>
                     <constraint firstAttribute="trailing" secondItem="Bfs-Qt-Ofl" secondAttribute="trailing" id="g7K-oD-Wpv"/>
                     <constraint firstItem="ew3-L9-lHp" firstAttribute="centerY" secondItem="WnM-xO-Ywd" secondAttribute="centerY" id="lrX-Jk-Lsp"/>
-                    <constraint firstItem="ew3-L9-lHp" firstAttribute="top" secondItem="KCX-Ys-ehz" secondAttribute="top" constant="15" id="tkc-3N-nXV"/>
+                    <constraint firstItem="ew3-L9-lHp" firstAttribute="top" secondItem="KCX-Ys-ehz" secondAttribute="top" priority="999" constant="15" id="tkc-3N-nXV"/>
                     <constraint firstItem="Bfs-Qt-Ofl" firstAttribute="top" secondItem="KCX-Ys-ehz" secondAttribute="top" id="x5g-e2-QgP"/>
                     <constraint firstItem="WnM-xO-Ywd" firstAttribute="leading" secondItem="KCX-Ys-ehz" secondAttribute="leading" constant="14" id="zHI-TZ-cZu"/>
                 </constraints>
@@ -73,7 +67,6 @@
                     </mask>
                 </variation>
             </tableViewCellContentView>
-            <animations/>
             <connections>
                 <outlet property="indentationConstraint" destination="Tr2-mk-KE5" id="t2k-NA-mrW"/>
                 <outlet property="sectionBorder" destination="rjc-ni-9zr" id="piG-GU-mwL"/>
@@ -83,7 +76,7 @@
                 <outlet property="sectionTitle" destination="ew3-L9-lHp" id="09m-Wa-PKk"/>
                 <outlet property="selectedSectionIndicator" destination="WnM-xO-Ywd" id="oAl-20-dvE"/>
             </connections>
-            <point key="canvasLocation" x="425" y="357"/>
+            <point key="canvasLocation" x="425" y="373.5"/>
         </tableViewCell>
     </objects>
 </document>

--- a/Wikipedia/Code/WMFTableOfContentsHeader.swift
+++ b/Wikipedia/Code/WMFTableOfContentsHeader.swift
@@ -22,10 +22,4 @@ public class WMFTableOfContentsHeader: UIView {
         }
         return headerString
     }
-    
-    public override func layoutSubviews() {
-        //See WMFTableOfContentsViewController.forceUpdateHeaderFrame for explanation
-        super.layoutSubviews()
-        self.contentsLabel.preferredMaxLayoutWidth = CGRectGetWidth(self.contentsLabel.frame);
-    }
 }

--- a/Wikipedia/Code/WMFTableOfContentsHeader.xib
+++ b/Wikipedia/Code/WMFTableOfContentsHeader.xib
@@ -1,59 +1,48 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="WMFTableOfContentsHeader" customModule="Wikipedia" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="306" height="27"/>
+            <rect key="frame" x="0.0" y="0.0" width="306" height="53"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oF1-jo-N7w">
-                    <rect key="frame" x="20" y="5" width="266" height="17"/>
-                    <animations/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oF1-jo-N7w">
+                    <rect key="frame" x="20" y="15" width="266" height="23"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <color key="textColor" red="0.199973762" green="0.2000150383" blue="0.19997122880000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xgW-Kh-UzN">
-                    <rect key="frame" x="0.0" y="26" width="306" height="1"/>
-                    <animations/>
+                    <rect key="frame" x="0.0" y="52" width="306" height="1"/>
                     <color key="backgroundColor" red="0.92931067943572998" green="0.92946994304656982" blue="0.92930072546005249" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="ZIu-t0-Msp"/>
                     </constraints>
                 </view>
             </subviews>
-            <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstItem="xgW-Kh-UzN" firstAttribute="top" secondItem="oF1-jo-N7w" secondAttribute="bottom" constant="5" id="NtV-xo-U8A"/>
                 <constraint firstAttribute="trailing" secondItem="oF1-jo-N7w" secondAttribute="trailing" constant="20" id="S5z-Bd-dAa"/>
-                <constraint firstItem="oF1-jo-N7w" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="5" id="V9E-eY-960"/>
+                <constraint firstItem="oF1-jo-N7w" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="15" id="V9E-eY-960"/>
                 <constraint firstItem="xgW-Kh-UzN" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="WdN-Ka-72p"/>
                 <constraint firstAttribute="trailing" secondItem="xgW-Kh-UzN" secondAttribute="trailing" id="ZCk-XN-QZX"/>
-                <constraint firstAttribute="bottom" secondItem="oF1-jo-N7w" secondAttribute="bottom" constant="5" id="ayl-SF-Uiv"/>
+                <constraint firstAttribute="bottom" secondItem="oF1-jo-N7w" secondAttribute="bottom" constant="15" id="ayl-SF-Uiv"/>
                 <constraint firstItem="oF1-jo-N7w" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" id="j0J-ho-Jo4"/>
                 <constraint firstAttribute="bottom" secondItem="xgW-Kh-UzN" secondAttribute="bottom" id="rUj-u7-JKw"/>
-                <constraint firstItem="oF1-jo-N7w" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="uRb-Vd-cmf"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <variation key="default">
-                <mask key="constraints">
-                    <exclude reference="uRb-Vd-cmf"/>
-                    <exclude reference="NtV-xo-U8A"/>
-                </mask>
-            </variation>
             <connections>
                 <outlet property="contentsLabel" destination="oF1-jo-N7w" id="an3-kd-6fN"/>
             </connections>
-            <point key="canvasLocation" x="444" y="163.5"/>
+            <point key="canvasLocation" x="444" y="176.5"/>
         </view>
     </objects>
 </document>

--- a/Wikipedia/Code/WMFTableOfContentsViewController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsViewController.swift
@@ -44,7 +44,10 @@ public class WMFTableOfContentsViewController: UITableViewController, WMFTableOf
         self.items = items
         self.delegate = delegate
         tableOfContentsFunnel = ToCInteractionFunnel()
-        super.init(nibName: nil, bundle: nil)
+        super.init(style:.Grouped)
+        let tableBackgroundView = UIView()
+        tableBackgroundView.backgroundColor = UIColor.whiteColor()
+        tableView.backgroundView = tableBackgroundView;
         self.animator = WMFTableOfContentsAnimator(presentingViewController: presentingViewController, presentedViewController: self)
         self.animator?.delegate = self
         modalPresentationStyle = .Custom
@@ -125,31 +128,17 @@ public class WMFTableOfContentsViewController: UITableViewController, WMFTableOf
             }
         }
     }
-    // MARK: - Header
-    func forceUpdateHeaderFrame(){
-        //See reason for fix here: http://stackoverflow.com/questions/16471846/is-it-possible-to-use-autolayout-with-uitableviews-tableheaderview
-        self.tableView.tableHeaderView!.setNeedsLayout()
-        self.tableView.tableHeaderView!.layoutIfNeeded()
-        let headerHeight = self.tableView.tableHeaderView!.systemLayoutSizeFittingSize(UILayoutFittingCompressedSize).height
-        var headerFrame = self.tableView.tableHeaderView!.frame;
-        headerFrame.size.height = headerHeight
-        self.tableView.tableHeaderView!.frame = headerFrame;
-        self.tableView.tableHeaderView = self.tableView.tableHeaderView
-    }
 
     // MARK: - UIViewController
     public override func viewDidLoad() {
         super.viewDidLoad()
-        let header = WMFTableOfContentsHeader.wmf_viewFromClassNib()
-        assert(delegate != nil, "TOC delegate not set!")
-        header.articleSite = delegate?.tableOfContentsArticleSite()
-        self.tableView.tableHeaderView = header
         tableView.registerNib(WMFTableOfContentsCell.wmf_classNib(),
                               forCellReuseIdentifier: WMFTableOfContentsCell.reuseIdentifier())
         clearsSelectionOnViewWillAppear = false
         tableView.estimatedRowHeight = 44.0
         tableView.rowHeight = UITableViewAutomaticDimension
-
+        tableView.sectionHeaderHeight = UITableViewAutomaticDimension
+        tableView.estimatedSectionHeaderHeight = 25
         automaticallyAdjustsScrollViewInsets = false
         tableView.contentInset = UIEdgeInsetsMake(UIApplication.sharedApplication().statusBarFrame.size.height, 0, 0, 0)
         tableView.separatorStyle = .None
@@ -157,7 +146,6 @@ public class WMFTableOfContentsViewController: UITableViewController, WMFTableOf
 
     public override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
-        self.forceUpdateHeaderFrame()
         self.delegate?.tableOfContentsControllerWillDisplay(self)
         tableOfContentsFunnel.logOpen()
     }
@@ -165,14 +153,6 @@ public class WMFTableOfContentsViewController: UITableViewController, WMFTableOf
     public override func viewDidDisappear(animated: Bool) {
         super.viewDidDisappear(animated)
         deselectAllRows()
-    }
-    
-    public override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
-        
-        coordinator.animateAlongsideTransition({ (context) -> Void in
-            self.forceUpdateHeaderFrame()
-            }) { (context) -> Void in
-        }
     }
     
     // MARK: - UITableViewDataSource
@@ -193,6 +173,13 @@ public class WMFTableOfContentsViewController: UITableViewController, WMFTableOf
     }
 
     // MARK: - UITableViewDelegate
+    public override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let header = WMFTableOfContentsHeader.wmf_viewFromClassNib()
+        assert(delegate != nil, "TOC delegate not set!")
+        header.articleSite = delegate?.tableOfContentsArticleSite()
+        return header
+    }
+    
     public override func tableView(tableView: UITableView, shouldHighlightRowAtIndexPath indexPath: NSIndexPath) -> Bool {
         let item = items[indexPath.row]
         addHighlightToItem(item, animated: true)

--- a/Wikipedia/Code/WebViewController.h
+++ b/Wikipedia/Code/WebViewController.h
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol WMFWebViewControllerDelegate <NSObject>
 
-- (nullable NSString*)webViewController:(WebViewController*)controller titleForFooterViewController:(UIViewController*)footerViewontroller;
+- (nullable NSString*)webViewController:(WebViewController*)controller titleForFooterViewController:(UIViewController*)footerViewController;
 
 - (void)webViewController:(WebViewController*)controller didLoadArticle:(MWKArticle*)article;
 - (void)webViewController:(WebViewController*)controller didTapEditForSection:(MWKSection*)section;

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -4,6 +4,7 @@
 "article-languages-downloading" = "Loading article languages...";
 "article-languages-filter-placeholder" = "Language Filter";
 "article-read-more-title" = "Read more";
+"article-about-title" = "About this article";
 "article-unable-to-load-section" = "Unable to load this section. Try refreshing the article to see if it fixes the problem.";
 "article-unable-to-load-article" = "Unable to load article.";
 "article-related-articles-title" = "Related articles";

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -19,6 +19,7 @@
 "article-languages-downloading" = "Alert text shown when obtaining list of languages in which an article is available";
 "article-languages-filter-placeholder" = "Filter languages text box placeholder text.";
 "article-read-more-title" = "The text that is displayed before the read more section at the bottom of an article\n{{Identical|Read more}}";
+"article-about-title" = "The text that is displayed before the 'about' section at the bottom of an article";
 "article-unable-to-load-section" = "Displayed within the article content when a section fails to render for some reason.";
 "article-unable-to-load-article" = "Alert text shown when unable to load an article";
 "article-related-articles-title" = "The title shown above article titles related to the current article.";


### PR DESCRIPTION
https://phabricator.wikimedia.org/T122109
https://phabricator.wikimedia.org/T119024
https://phabricator.wikimedia.org/T115543

- [x] tweak article footer header spacing to better match mock
- [x] add "About this article" header above footer menu
- [x] fix wonky TOC header view rotation behavior
- [ ] update top of TOC to match blue background/white text from mock
- [ ] and "About this article" entry to bottom of TOC
