### PR TITLE
Fix missing featured article & POTD on clean install

### DIFF
--- a/Wikipedia/Code/MWKSection+DisplayHtml.m
+++ b/Wikipedia/Code/MWKSection+DisplayHtml.m
@@ -77,9 +77,9 @@
             self.sectionId];
 }
 
--(NSString*)getHTMLWrappedInTablesIfNeeded {
-    NSString *tableFormatString = @"<table><th>%@</th><tr><td>%@</td></tr></table>";
-    NSArray *titlesToWrap = @[@"References", @"External links", @"Notes", @"Further reading", @"Bibliography"];
+- (NSString*)getHTMLWrappedInTablesIfNeeded {
+    NSString* tableFormatString = @"<table><th>%@</th><tr><td>%@</td></tr></table>";
+    NSArray* titlesToWrap       = @[@"References", @"External links", @"Notes", @"Further reading", @"Bibliography"];
     for (NSString* sectionTitle in titlesToWrap) {
         if ([self.line isEqualToString:sectionTitle]) {
             return [NSString stringWithFormat:tableFormatString, sectionTitle, self.text];

--- a/Wikipedia/Code/UIViewController+WMFEmptyView.m
+++ b/Wikipedia/Code/UIViewController+WMFEmptyView.m
@@ -38,7 +38,6 @@ static NSString * WMFEmptyViewKey = @"WMFEmptyView";
         case WMFEmptyViewTypeNoHistory:
             view = [WMFEmptyView noHistoryEmptyView];
             break;
-
     }
 
     UIView* container = self.view.superview;
@@ -46,7 +45,7 @@ static NSString * WMFEmptyViewKey = @"WMFEmptyView";
         container = container.superview;
     }
     NSAssert(container != nil, @"Trying to add an empty view with no container view");
-    if(!container){
+    if (!container) {
         return;
     }
 

--- a/Wikipedia/Code/WMFArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFArticleListTableViewController.m
@@ -132,15 +132,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Empty State
 
-- (void)updateEmptyState{
-    if(self.view.superview == nil){
+- (void)updateEmptyState {
+    if (self.view.superview == nil) {
         return;
     }
 
     if ([self.dataSource titleCount] > 0) {
         [self wmf_hideEmptyView];
     } else {
-        if([self.dataSource respondsToSelector:@selector(emptyViewType)]){
+        if ([self.dataSource respondsToSelector:@selector(emptyViewType)]) {
             [self wmf_showEmptyViewOfType:[self.dataSource emptyViewType]];
         }
     }

--- a/Wikipedia/Code/WMFEmptyView.m
+++ b/Wikipedia/Code/WMFEmptyView.m
@@ -55,28 +55,27 @@
     return view;
 }
 
-+ (instancetype)noSavedPagesEmptyView{
++ (instancetype)noSavedPagesEmptyView {
     WMFEmptyView* view = [[self class] emptyView];
     view.imageView.image   = [UIImage imageNamed:@"saved-blank"];
     view.titleLabel.text   = MWLocalizedString(@"empty-no-saved-pages-title", nil);
     view.messageLabel.text = MWLocalizedString(@"empty-no-saved-pages-message", nil);
-    
+
     [view.actionLabel removeFromSuperview];
     [view.actionLine removeFromSuperview];
     return view;
 }
 
-+ (instancetype)noHistoryEmptyView{
++ (instancetype)noHistoryEmptyView {
     WMFEmptyView* view = [[self class] emptyView];
     view.imageView.image   = [UIImage imageNamed:@"recent-blank"];
     view.titleLabel.text   = MWLocalizedString(@"empty-no-history-title", nil);
     view.messageLabel.text = MWLocalizedString(@"empty-no-history-message", nil);
-    
+
     [view.actionLabel removeFromSuperview];
     [view.actionLine removeFromSuperview];
     return view;
 }
-
 
 - (void)layoutSubviews {
     [super layoutSubviews];

--- a/Wikipedia/Code/WMFHomeSection.h
+++ b/Wikipedia/Code/WMFHomeSection.h
@@ -31,7 +31,15 @@ typedef NS_ENUM (NSUInteger, WMFHomeSectionType){
 + (instancetype)nearbySectionWithLocation:(nullable CLLocation*)location;
 + (instancetype)historySectionWithHistoryEntry:(MWKHistoryEntry*)entry;
 + (instancetype)savedSectionWithSavedPageEntry:(MWKSavedPageEntry*)entry;
-+ (instancetype)featuredArticleSectionWithSite:(MWKSite*)site;
+
+/**
+ *  Create a section which displays the featured article of the day for a specific site.
+ *
+ *  @param site The site to retrieve the featured article from.
+ *
+ *  @return A featured article section, or @c nil if the given site doesn't support featured articles.
+ */
++ (nullable instancetype)featuredArticleSectionWithSiteIfSupported:(MWKSite*)site;
 
 ///
 /// @name Static Sections

--- a/Wikipedia/Code/WMFHomeSection.m
+++ b/Wikipedia/Code/WMFHomeSection.m
@@ -111,11 +111,11 @@ NS_ASSUME_NONNULL_BEGIN
     return item;
 }
 
-+ (nullable instancetype)featuredArticleSectionWithSiteIfSupported:(MWKSite *)site {
++ (nullable instancetype)featuredArticleSectionWithSiteIfSupported:(MWKSite*)site {
     NSParameterAssert(site);
-    if(![site.language isEqualToString:@"en"] || ![site.domain isEqualToString:@"wikipedia.org"]) {
+    if (![site.language isEqualToString:@"en"] || ![site.domain isEqualToString:@"wikipedia.org"]) {
         /*
-         HAX: "Today's Featured Article" template is only available on en.wikipedia.org.
+           HAX: "Today's Featured Article" template is only available on en.wikipedia.org.
          */
         return nil;
     }

--- a/Wikipedia/Code/WMFHomeSection.m
+++ b/Wikipedia/Code/WMFHomeSection.m
@@ -111,8 +111,14 @@ NS_ASSUME_NONNULL_BEGIN
     return item;
 }
 
-+ (instancetype)featuredArticleSectionWithSite:(MWKSite*)site {
++ (nullable instancetype)featuredArticleSectionWithSiteIfSupported:(MWKSite *)site {
     NSParameterAssert(site);
+    if(![site.language isEqualToString:@"en"] || ![site.domain isEqualToString:@"wikipedia.org"]) {
+        /*
+         HAX: "Today's Featured Article" template is only available on en.wikipedia.org.
+         */
+        return nil;
+    }
     WMFHomeSection* item = [[WMFHomeSection alloc] init];
     item.type = WMFHomeSectionTypeFeaturedArticle;
     item.site = site;

--- a/Wikipedia/Code/WMFHomeViewController.m
+++ b/Wikipedia/Code/WMFHomeViewController.m
@@ -598,7 +598,7 @@ NS_ASSUME_NONNULL_BEGIN
     id<WMFHomeSectionController> controller = [self sectionControllerForSectionAtIndex:indexPath.section];
 
     if ([controller conformsToProtocol:@protocol(WMFFetchingHomeSectionController)]) {
-        [(id<WMFFetchingHomeSectionController>)controller fetchDataIfNeeded];
+        [(id < WMFFetchingHomeSectionController >)controller fetchDataIfNeeded];
     }
 
     if ([controller respondsToSelector:@selector(shouldSelectItemAtIndex:)]

--- a/Wikipedia/Code/WMFRecentPagesDataSource.m
+++ b/Wikipedia/Code/WMFRecentPagesDataSource.m
@@ -161,7 +161,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [[self recentPageForIndexPath:indexPath] title];
 }
 
-- (WMFEmptyViewType)emptyViewType{
+- (WMFEmptyViewType)emptyViewType {
     return WMFEmptyViewTypeNoHistory;
 }
 

--- a/Wikipedia/Code/WMFSavedPagesDataSource.m
+++ b/Wikipedia/Code/WMFSavedPagesDataSource.m
@@ -110,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
     return savedEntry.title;
 }
 
-- (WMFEmptyViewType)emptyViewType{
+- (WMFEmptyViewType)emptyViewType {
     return WMFEmptyViewTypeNoSavedPages;
 }
 


### PR DESCRIPTION
TFA & POTD section weren't part of the "starting" schema nor added during `reset`. Remedied this and also refactored the "add featured article section if supported" logic into one place (as this change required it being in multiple places). Ended up moving it into featured section creation as we should always handle cases where creating a featured section for a given site isn't supported.