### PR TITLE
Show localized language names in welcome screen and use article language for article footer menu localized strings.

### DIFF
--- a/Wikipedia/Code/MWKArticle.h
+++ b/Wikipedia/Code/MWKArticle.h
@@ -153,9 +153,9 @@ static const NSInteger kMWKArticleSectionNone = -1;
  */
 - (NSString*)articleHTML;
 
-- (/*nullable */NSArray<MWKTitle*>*)disambiguationTitles;
+- (/*nullable */ NSArray<MWKTitle*>*)disambiguationTitles;
 
-- (/*nullable */NSArray<NSString*>*)pageIssues;
+- (/*nullable */ NSArray<NSString*>*)pageIssues;
 
 @end
 

--- a/Wikipedia/Code/WMFArticleContainerViewController.m
+++ b/Wikipedia/Code/WMFArticleContainerViewController.m
@@ -713,7 +713,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString*)webViewController:(WebViewController*)controller titleForFooterViewController:(UIViewController*)footerViewController {
     if (footerViewController == self.readMoreListViewController) {
         return [MWSiteLocalizedString(self.articleTitle.site, @"article-read-more-title", nil) uppercaseStringWithLocale:[NSLocale currentLocale]];
-    }else if(footerViewController == self.footerMenuViewController){
+    } else if (footerViewController == self.footerMenuViewController) {
         return [MWSiteLocalizedString(self.articleTitle.site, @"article-about-title", nil) uppercaseStringWithLocale:[NSLocale currentLocale]];
     }
     return nil;

--- a/Wikipedia/Code/WMFArticleFooterMenuDataSource.m
+++ b/Wikipedia/Code/WMFArticleFooterMenuDataSource.m
@@ -3,6 +3,7 @@
 #import "MWKArticle.h"
 #import "NSDate+Utilities.h"
 #import "WMFArticleFooterMenuCell.h"
+#import "MWKTitle.h"
 
 @interface WMFArticleFooterMenuDataSource ()
 
@@ -42,25 +43,25 @@
 
     if (article.languagecount > 0) {
         [menuItems addObject:makeItem(WMFArticleFooterMenuItemTypeLanguages,
-                                      [MWLocalizedString(@"page-read-in-other-languages", nil) stringByReplacingOccurrencesOfString:@"$1" withString:[NSString stringWithFormat:@"%d", article.languagecount]],
+                                      [MWSiteLocalizedString(article.title.site, @"page-read-in-other-languages", nil) stringByReplacingOccurrencesOfString:@"$1" withString:[NSString stringWithFormat:@"%d", article.languagecount]],
                                       nil, @"footer-switch-language")];
     }
 
     [menuItems addObject:makeItem(WMFArticleFooterMenuItemTypeLastEdited,
-                                  [MWLocalizedString(@"page-last-edited", nil) stringByReplacingOccurrencesOfString:@"$1" withString:[NSString stringWithFormat:@"%ld", [[NSDate date] daysAfterDate:article.lastmodified]]],
-                                  MWLocalizedString(@"page-edit-history", nil),
+                                  [MWSiteLocalizedString(article.title.site, @"page-last-edited", nil) stringByReplacingOccurrencesOfString:@"$1" withString:[NSString stringWithFormat:@"%ld", [[NSDate date] daysAfterDate:article.lastmodified]]],
+                                  MWSiteLocalizedString(article.title.site, @"page-edit-history", nil),
                                   @"footer-edit-history")];
 
     if (article.pageIssues.count > 0) {
         [menuItems addObject:makeItem(WMFArticleFooterMenuItemTypePageIssues,
-                                      MWLocalizedString(@"page-issues", nil),
+                                      MWSiteLocalizedString(article.title.site, @"page-issues", nil),
                                       nil,
                                       @"footer-warnings")];
     }
 
     if (article.disambiguationTitles.count > 0) {
         [menuItems addObject:makeItem(WMFArticleFooterMenuItemTypeDisambiguation,
-                                      MWLocalizedString(@"page-similar-titles", nil),
+                                      MWSiteLocalizedString(article.title.site, @"page-similar-titles", nil),
                                       nil,
                                       @"footer-similar-pages")];
     }

--- a/Wikipedia/Code/WMFArticleFooterMenuViewController.m
+++ b/Wikipedia/Code/WMFArticleFooterMenuViewController.m
@@ -39,12 +39,12 @@
     [self.tableView deselectRowAtIndexPath:[self.tableView indexPathForSelectedRow] animated:YES];
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
+- (CGFloat)tableView:(UITableView*)tableView heightForHeaderInSection:(NSInteger)section {
     // HAX: collapses space between grouped table sections
     return 0.00001;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section {
+- (CGFloat)tableView:(UITableView*)tableView heightForFooterInSection:(NSInteger)section {
     // HAX: collapses space between grouped table sections
     return 0.00001;
 }
@@ -53,7 +53,7 @@
     [super viewDidLoad];
 
     NSAssert(self.tableView.style == UITableViewStyleGrouped, @"Use grouped UITableView layout so we get separator above first cell and below last cell without having to implement any special logic");
-    
+
     self.tableView.estimatedRowHeight = 52.0;
     self.tableView.rowHeight          = UITableViewAutomaticDimension;
 

--- a/Wikipedia/Code/WMFWelcomeLanguageViewController.m
+++ b/Wikipedia/Code/WMFWelcomeLanguageViewController.m
@@ -60,7 +60,7 @@
                                                                                 forIndexPath:indexPath];
     MWKLanguageLink* langLink = [MWKLanguageLinkController sharedInstance].preferredLanguages[indexPath.row];
     cell.numberLabel.text       = [NSString stringWithFormat:@"%li", indexPath.row + 1];
-    cell.languageNameLabel.text = langLink.name;
+    cell.languageNameLabel.text = langLink.localizedName;
 
     //can only delete non-OS languages
     if (![[MWKLanguageLinkController sharedInstance] languageIsOSLanguage:langLink]) {

--- a/WikipediaUnitTests/Code/WMFArticleImageInjectionTests.m
+++ b/WikipediaUnitTests/Code/WMFArticleImageInjectionTests.m
@@ -101,17 +101,17 @@
 }
 
 - (void)testImportsAllExpectedImagesFromFixture {
-        self.dataStore = [MWKDataStore temporaryDataStore];
+    self.dataStore = [MWKDataStore temporaryDataStore];
 
-        MWKArticle* article = [[MWKArticle alloc] initWithTitle:[MWKTitle random] dataStore:self.dataStore];
+    MWKArticle* article = [[MWKArticle alloc] initWithTitle:[MWKTitle random] dataStore:self.dataStore];
 
-        [article importMobileViewJSON:[[self wmf_bundle] wmf_jsonFromContentsOfFile:@"Obama"][@"mobileview"]];
+    [article importMobileViewJSON:[[self wmf_bundle] wmf_jsonFromContentsOfFile:@"Obama"][@"mobileview"]];
 
-        [article importAndSaveImagesFromSectionHTML];
+    [article importAndSaveImagesFromSectionHTML];
 
-        // expected number is observed & recorded,
-        assertThat(@(article.images.count), is(@95));
-        [self.dataStore removeFolderAtBasePath];
+    // expected number is observed & recorded,
+    assertThat(@(article.images.count), is(@95));
+    [self.dataStore removeFolderAtBasePath];
 }
 
 @end


### PR DESCRIPTION
https://phabricator.wikimedia.org/T122352
https://phabricator.wikimedia.org/T122353

**Welcome screen:**
![screen shot 2015-12-23 at 1 13 05 pm](https://cloud.githubusercontent.com/assets/3143487/11985166/ecf4bcb4-a976-11e5-98ae-7debb97b73fa.png)

**Article footer:**
We don't have translations back for these yet. I faked out the strings in Hebrew and it worked, but I forgot to take a screen shot.