### PR TITLE
Nearby cell styling update

### DIFF
--- a/Wikipedia/Code/UIColor+WMFStyle.m
+++ b/Wikipedia/Code/UIColor+WMFStyle.m
@@ -186,7 +186,7 @@
 }
 
 + (instancetype)wmf_nearbyTickColor {
-    return [UIColor blackColor];
+    return [UIColor lightGrayColor];
 }
 
 + (instancetype)wmf_nearbyTitleColor {
@@ -205,7 +205,7 @@
 }
 
 + (instancetype)wmf_nearbyDistanceBackgroundColor {
-    return [UIColor clearColor];
+    return [UIColor wmf_colorWithHex:0xAAAAAA alpha:1.0];
 }
 
 + (instancetype)wmf_999999Color {
@@ -220,7 +220,7 @@
 }
 
 + (instancetype)wmf_nearbyDistanceTextColor {
-    return [self wmf_999999Color];
+    return [UIColor whiteColor];
 }
 
 + (instancetype)wmf_emptyGrayTextColor {

--- a/Wikipedia/Code/UIColor+WMFStyle.m
+++ b/Wikipedia/Code/UIColor+WMFStyle.m
@@ -186,7 +186,7 @@
 }
 
 + (instancetype)wmf_nearbyTickColor {
-    return [UIColor lightGrayColor];
+    return [UIColor wmf_999999Color];
 }
 
 + (instancetype)wmf_nearbyTitleColor {

--- a/Wikipedia/Code/UIFont+WMFStyle.m
+++ b/Wikipedia/Code/UIFont+WMFStyle.m
@@ -54,7 +54,7 @@
 }
 
 + (instancetype)wmf_nearbyDistanceFont {
-    return [UIFont systemFontOfSize:14.0f];
+    return [UIFont systemFontOfSize:12.0f];
 }
 
 + (instancetype)wmf_homeSectionHeaderFont {

--- a/Wikipedia/Code/WMFEmptyNearbyTableViewCell.xib
+++ b/Wikipedia/Code/WMFEmptyNearbyTableViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15A284" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
@@ -12,25 +12,22 @@
             <rect key="frame" x="0.0" y="0.0" width="260" height="260"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="260" height="259"/>
+                <rect key="frame" x="0.0" y="0.0" width="260" height="259.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Nothing Nearby" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ENx-R8-yeN">
                         <rect key="frame" x="8" y="100" width="244" height="21"/>
-                        <animations/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PHo-Uq-Vpu">
                         <rect key="frame" x="8" y="129" width="244" height="30"/>
-                        <animations/>
                         <state key="normal" title="Check Again">
                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                         </state>
                     </button>
                 </subviews>
-                <animations/>
                 <constraints>
                     <constraint firstItem="ENx-R8-yeN" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" constant="-20" id="8iT-ls-nDv"/>
                     <constraint firstItem="ENx-R8-yeN" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="B52-dT-OQo"/>
@@ -47,7 +44,6 @@
                     </mask>
                 </variation>
             </tableViewCellContentView>
-            <animations/>
             <connections>
                 <outlet property="emptyTextLabel" destination="ENx-R8-yeN" id="YUy-6L-8F6"/>
                 <outlet property="reloadButton" destination="PHo-Uq-Vpu" id="uAj-Vz-oCH"/>

--- a/Wikipedia/Code/WMFNearbyArticleTableViewCell.xib
+++ b/Wikipedia/Code/WMFNearbyArticleTableViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15A284" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,12 +11,11 @@
             <rect key="frame" x="0.0" y="0.0" width="392" height="120"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="392" height="119"/>
+                <rect key="frame" x="0.0" y="0.0" width="392" height="119.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="NGT-X1-Lla">
                         <rect key="frame" x="24" y="24" width="72" height="72"/>
-                        <animations/>
                         <constraints>
                             <constraint firstAttribute="width" constant="104" id="8wy-1w-f7b"/>
                             <constraint firstAttribute="height" constant="104" id="jVt-yx-d5w"/>
@@ -30,7 +29,6 @@
                     </imageView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lbm-mF-DF1" customClass="WMFCompassView">
                         <rect key="frame" x="8" y="8" width="104" height="104"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="104" id="5gP-en-MIh"/>
@@ -38,32 +36,28 @@
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7Gw-jF-gnd">
-                        <rect key="frame" x="120" y="39" width="264" height="41"/>
+                        <rect key="frame" x="120" y="37" width="264" height="45.5"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Title" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="afs-yA-rJY">
-                                <rect key="frame" x="0.0" y="0.0" width="264" height="21"/>
-                                <animations/>
+                                <rect key="frame" x="0.0" y="0.0" width="264" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AWn-WJ-c4e" userLabel="Background">
-                                <rect key="frame" x="0.0" y="21" width="53" height="20"/>
-                                <animations/>
+                                <rect key="frame" x="0.0" y="25.5" width="63" height="20"/>
                                 <color key="backgroundColor" red="0.0" green="0.69642215969999999" blue="0.5386427641" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Distance" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f45-0M-DJe">
-                                <rect key="frame" x="0.0" y="23" width="53" height="16"/>
-                                <animations/>
+                                <rect key="frame" x="5" y="27.5" width="53" height="16"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="AWn-WJ-c4e" firstAttribute="top" secondItem="afs-yA-rJY" secondAttribute="bottom" id="1HB-vp-Pep"/>
+                            <constraint firstItem="AWn-WJ-c4e" firstAttribute="top" secondItem="afs-yA-rJY" secondAttribute="bottom" constant="5" id="1HB-vp-Pep"/>
                             <constraint firstItem="f45-0M-DJe" firstAttribute="top" secondItem="AWn-WJ-c4e" secondAttribute="top" constant="2" id="4IT-UQ-mPG"/>
                             <constraint firstItem="afs-yA-rJY" firstAttribute="leading" secondItem="f45-0M-DJe" secondAttribute="leading" id="DMq-qN-qce"/>
                             <constraint firstItem="f45-0M-DJe" firstAttribute="bottom" secondItem="AWn-WJ-c4e" secondAttribute="bottom" constant="-2" id="Dwc-gG-EOK"/>
@@ -71,8 +65,8 @@
                             <constraint firstItem="AWn-WJ-c4e" firstAttribute="top" secondItem="7Gw-jF-gnd" secondAttribute="top" constant="20" symbolic="YES" id="NvZ-7S-b0H"/>
                             <constraint firstItem="f45-0M-DJe" firstAttribute="bottom" secondItem="AWn-WJ-c4e" secondAttribute="bottom" constant="-7" id="PNa-nD-iGs"/>
                             <constraint firstAttribute="bottom" secondItem="AWn-WJ-c4e" secondAttribute="bottom" id="QD1-rB-b8B"/>
-                            <constraint firstItem="f45-0M-DJe" firstAttribute="trailing" secondItem="AWn-WJ-c4e" secondAttribute="trailing" id="UHg-vh-YJs"/>
-                            <constraint firstItem="f45-0M-DJe" firstAttribute="leading" secondItem="AWn-WJ-c4e" secondAttribute="leading" id="VQK-80-GSY"/>
+                            <constraint firstItem="f45-0M-DJe" firstAttribute="trailing" secondItem="AWn-WJ-c4e" secondAttribute="trailing" constant="-5" id="UHg-vh-YJs"/>
+                            <constraint firstItem="f45-0M-DJe" firstAttribute="leading" secondItem="AWn-WJ-c4e" secondAttribute="leading" constant="5" id="VQK-80-GSY"/>
                             <constraint firstItem="afs-yA-rJY" firstAttribute="leading" secondItem="7Gw-jF-gnd" secondAttribute="leading" id="WlA-RY-ic2"/>
                             <constraint firstAttribute="trailing" secondItem="afs-yA-rJY" secondAttribute="trailing" id="iln-48-Agf"/>
                             <constraint firstItem="f45-0M-DJe" firstAttribute="bottom" secondItem="AWn-WJ-c4e" secondAttribute="bottom" id="k7u-od-YOV"/>
@@ -98,7 +92,6 @@
                         </variation>
                     </view>
                 </subviews>
-                <animations/>
                 <constraints>
                     <constraint firstItem="7Gw-jF-gnd" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="6I9-YY-eaY"/>
                     <constraint firstAttribute="bottom" secondItem="Lbm-mF-DF1" secondAttribute="bottom" priority="250" constant="8" id="M6S-Jr-2Z6"/>
@@ -113,7 +106,6 @@
                     <constraint firstItem="NGT-X1-Lla" firstAttribute="trailing" secondItem="Lbm-mF-DF1" secondAttribute="trailing" constant="-16" id="z5Z-Op-SwL"/>
                 </constraints>
             </tableViewCellContentView>
-            <animations/>
             <connections>
                 <outlet property="articleImageView" destination="NGT-X1-Lla" id="5Rw-Bq-NHf"/>
                 <outlet property="compassView" destination="Lbm-mF-DF1" id="5Wo-tr-G5C"/>


### PR DESCRIPTION
nearby cell update 

1. the dashed border should be grey and the needle should be black so as it not interfere visually

2. the label background creates a better separation between very similar type sizes and colors used for wikidata descriptor 
