### PR TITLE
Create concrete list view subclasses

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		041EFC371996A1F800B2CB28 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 041EFC361996A1F800B2CB28 /* MapKit.framework */; };
 		0493C2D419526A0100EBB973 /* WikiFont-Glyphs.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0493C2D319526A0100EBB973 /* WikiFont-Glyphs.ttf */; };
 		04D34DB21863D39000610A87 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D34DB11863D39000610A87 /* libxml2.dylib */; };
+		0E0361741C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */; };
 		0E26B0721C0F4F550004D687 /* WMFAppViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0E26B0701C0F4F550004D687 /* WMFAppViewController.storyboard */; };
 		0E26B0731C0F4F550004D687 /* WMFTabBarUI.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0E26B0711C0F4F550004D687 /* WMFTabBarUI.storyboard */; };
 		0E26B07F1C0F4F720004D687 /* WMFWelcome.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0E26B0741C0F4F720004D687 /* WMFWelcome.storyboard */; };
@@ -623,6 +624,8 @@
 		04D34DB11863D39000610A87 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
 		04E9A78218F73C7200F7ECF7 /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; path = www; sourceTree = "<group>"; };
 		08F646F7D0488CE3C6D6A763 /* Pods.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.beta.xcconfig; path = "Pods/Target Support Files/Pods/Pods.beta.xcconfig"; sourceTree = "<group>"; };
+		0E0361721C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFSelfSizingArticleListTableViewController.h; path = Wikipedia/Code/WMFSelfSizingArticleListTableViewController.h; sourceTree = SOURCE_ROOT; };
+		0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFSelfSizingArticleListTableViewController.m; path = Wikipedia/Code/WMFSelfSizingArticleListTableViewController.m; sourceTree = SOURCE_ROOT; };
 		0E26B0701C0F4F550004D687 /* WMFAppViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = WMFAppViewController.storyboard; path = Wikipedia/Code/WMFAppViewController.storyboard; sourceTree = SOURCE_ROOT; };
 		0E26B0711C0F4F550004D687 /* WMFTabBarUI.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = WMFTabBarUI.storyboard; path = Wikipedia/Code/WMFTabBarUI.storyboard; sourceTree = SOURCE_ROOT; };
 		0E26B0741C0F4F720004D687 /* WMFWelcome.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = WMFWelcome.storyboard; path = Wikipedia/Code/WMFWelcome.storyboard; sourceTree = SOURCE_ROOT; };
@@ -2366,6 +2369,8 @@
 			children = (
 				B0E803331C0CD7430065EBC0 /* WMFArticleListTableViewController.h */,
 				B0E803341C0CD7430065EBC0 /* WMFArticleListTableViewController.m */,
+				0E0361721C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.h */,
+				0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */,
 				B0E803A81C0CDB8D0065EBC0 /* WMFTitleListDataSource.h */,
 				BC550B081B977C730082F298 /* Cells */,
 				0E2B06F71B2D126700EA2F53 /* Data Sources */,
@@ -5428,6 +5433,7 @@
 				BCA15AF41C0E724E00D0A3EA /* SSBaseDataSource+WMFLayoutDirectionUtilities.m in Sources */,
 				B0E805551C0CE0DC0065EBC0 /* UIView+IBExtras.swift in Sources */,
 				B0E807291C0CED530065EBC0 /* MWLanguageInfo.m in Sources */,
+				0E0361741C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m in Sources */,
 				BC45FF531C1B829B00BAE501 /* UIViewController+WMFSearchButton_Testing.m in Sources */,
 				B0E805961C0CE2C60065EBC0 /* WMFHamburgerMenuFunnel.m in Sources */,
 				B0E807B01C0CEFF70065EBC0 /* MWKHistoryList.m in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0493C2D419526A0100EBB973 /* WikiFont-Glyphs.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0493C2D319526A0100EBB973 /* WikiFont-Glyphs.ttf */; };
 		04D34DB21863D39000610A87 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D34DB11863D39000610A87 /* libxml2.dylib */; };
 		0E0361741C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */; };
+		0E0361771C4488BC00FD9642 /* WMFLocationSearchListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361761C4488BC00FD9642 /* WMFLocationSearchListViewController.m */; };
 		0E09EAC31C4426470058F2D8 /* WMFSearchResultsTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EABD1C4426470058F2D8 /* WMFSearchResultsTableViewController.m */; };
 		0E09EAC41C4426470058F2D8 /* WMFSavedArticleTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EABF1C4426470058F2D8 /* WMFSavedArticleTableViewController.m */; };
 		0E09EAC51C4426470058F2D8 /* WMFHistoryTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EAC11C4426470058F2D8 /* WMFHistoryTableViewController.m */; };
@@ -629,6 +630,8 @@
 		08F646F7D0488CE3C6D6A763 /* Pods.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.beta.xcconfig; path = "Pods/Target Support Files/Pods/Pods.beta.xcconfig"; sourceTree = "<group>"; };
 		0E0361721C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFSelfSizingArticleListTableViewController.h; path = Wikipedia/Code/WMFSelfSizingArticleListTableViewController.h; sourceTree = SOURCE_ROOT; };
 		0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFSelfSizingArticleListTableViewController.m; path = Wikipedia/Code/WMFSelfSizingArticleListTableViewController.m; sourceTree = SOURCE_ROOT; };
+		0E0361751C4488BC00FD9642 /* WMFLocationSearchListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFLocationSearchListViewController.h; path = Wikipedia/Code/WMFLocationSearchListViewController.h; sourceTree = SOURCE_ROOT; };
+		0E0361761C4488BC00FD9642 /* WMFLocationSearchListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFLocationSearchListViewController.m; path = Wikipedia/Code/WMFLocationSearchListViewController.m; sourceTree = SOURCE_ROOT; };
 		0E09EABD1C4426470058F2D8 /* WMFSearchResultsTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFSearchResultsTableViewController.m; path = Code/WMFSearchResultsTableViewController.m; sourceTree = "<group>"; };
 		0E09EABE1C4426470058F2D8 /* WMFSearchResultsTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFSearchResultsTableViewController.h; path = Code/WMFSearchResultsTableViewController.h; sourceTree = "<group>"; };
 		0E09EABF1C4426470058F2D8 /* WMFSavedArticleTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFSavedArticleTableViewController.m; sourceTree = "<group>"; };
@@ -1849,7 +1852,7 @@
 				B0E806B21C0CEB160065EBC0 /* LanguagesViewController.storyboard */,
 			);
 			name = Languages;
-			path = Wikipedia/Code/Languages;
+			path = Wikipedia/Code;
 			sourceTree = SOURCE_ROOT;
 		};
 		041C55CF1950B260006CE0EF /* EditSummary */ = {
@@ -2221,6 +2224,18 @@
 			path = Wikipedia/Code/PageHistory;
 			sourceTree = SOURCE_ROOT;
 		};
+		};
+		0E03617D1C44948300FD9642 /* More */ = {
+			isa = PBXGroup;
+			children = (
+				0E0361751C4488BC00FD9642 /* WMFLocationSearchListViewController.h */,
+				0E0361761C4488BC00FD9642 /* WMFLocationSearchListViewController.m */,
+				B0E803B21C0CDBE20065EBC0 /* WMFNearbyTitleListDataSource.h */,
+				B0E803B31C0CDBE20065EBC0 /* WMFNearbyTitleListDataSource.m */,
+			);
+			name = More;
+			sourceTree = "<group>";
+		};
 		0E03E27E1B82EF7600C1FBD7 /* Fetcher */ = {
 			isa = PBXGroup;
 			children = (
@@ -2278,6 +2293,15 @@
 			);
 			name = "Results List";
 			path = ..;
+			sourceTree = "<group>";
+		};
+		0E09EAC71C442A130058F2D8 /* Container VC */ = {
+			isa = PBXGroup;
+			children = (
+				B0E803391C0CD76B0065EBC0 /* WMFSearchViewController.h */,
+				B0E8033A1C0CD76B0065EBC0 /* WMFSearchViewController.m */,
+			);
+			name = "Container VC";
 			sourceTree = "<group>";
 		};
 		0E1B049F1BC59DEF00506F7D /* Continue Reading */ = {
@@ -2436,10 +2460,6 @@
 				0E8E9A571BFA501E0054A242 /* Featured Article */,
 				0EA1791D1BD95910004FF529 /* Random */,
 				0ED6897C1B8246F400B30427 /* Nearby */,
-				B0E802F61C0CD4D70065EBC0 /* WMFNearbySectionController.h */,
-				B0E802F71C0CD4D70065EBC0 /* WMFNearbySectionController.m */,
-				B0E803B21C0CDBE20065EBC0 /* WMFNearbyTitleListDataSource.h */,
-				B0E803B31C0CDBE20065EBC0 /* WMFNearbyTitleListDataSource.m */,
 				0E2691031B86BBC0009B8605 /* Related */,
 			);
 			name = Sections;
@@ -2618,6 +2638,9 @@
 			children = (
 				BC305C2E1BA0C97400E414B8 /* View Model */,
 				0E03E2A21B85310400C1FBD7 /* Views */,
+				B0E802F61C0CD4D70065EBC0 /* WMFNearbySectionController.h */,
+				B0E802F71C0CD4D70065EBC0 /* WMFNearbySectionController.m */,
+				0E03617D1C44948300FD9642 /* More */,
 			);
 			name = Nearby;
 			path = Wikipedia/Code/Nearby;
@@ -5276,6 +5299,7 @@
 				BC62FFC01C11064200533DA9 /* MWKImageInfoFetcher+PicOfTheDayInfo.m in Sources */,
 				B0E8076C1C0CEE3A0065EBC0 /* Saved.m in Sources */,
 				B0E806341C0CE7680065EBC0 /* MWKImageInfoResponseSerializer.m in Sources */,
+				0E0361771C4488BC00FD9642 /* WMFLocationSearchListViewController.m in Sources */,
 				B0E805C91C0CE5250065EBC0 /* UIImage+Debug.swift in Sources */,
 				B0E807A91C0CEFE30065EBC0 /* MWKRecentSearchEntry.m in Sources */,
 				B0E8066A1C0CE9030065EBC0 /* MWKImageInfoFetcher.m in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0E0361741C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */; };
 		0E0361771C4488BC00FD9642 /* WMFLocationSearchListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361761C4488BC00FD9642 /* WMFLocationSearchListViewController.m */; };
 		0E03617A1C44905400FD9642 /* WMFRelatedTitleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361791C44905400FD9642 /* WMFRelatedTitleViewController.m */; };
+		0E0361801C456C4600FD9642 /* WMFReadMoreViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E03617F1C456C4600FD9642 /* WMFReadMoreViewController.m */; };
 		0E09EAC31C4426470058F2D8 /* WMFSearchResultsTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EABD1C4426470058F2D8 /* WMFSearchResultsTableViewController.m */; };
 		0E09EAC41C4426470058F2D8 /* WMFSavedArticleTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EABF1C4426470058F2D8 /* WMFSavedArticleTableViewController.m */; };
 		0E09EAC51C4426470058F2D8 /* WMFHistoryTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EAC11C4426470058F2D8 /* WMFHistoryTableViewController.m */; };
@@ -635,6 +636,8 @@
 		0E0361761C4488BC00FD9642 /* WMFLocationSearchListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFLocationSearchListViewController.m; path = Wikipedia/Code/WMFLocationSearchListViewController.m; sourceTree = SOURCE_ROOT; };
 		0E0361781C44905400FD9642 /* WMFRelatedTitleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFRelatedTitleViewController.h; path = Wikipedia/Code/WMFRelatedTitleViewController.h; sourceTree = SOURCE_ROOT; };
 		0E0361791C44905400FD9642 /* WMFRelatedTitleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFRelatedTitleViewController.m; path = Wikipedia/Code/WMFRelatedTitleViewController.m; sourceTree = SOURCE_ROOT; };
+		0E03617E1C456C4600FD9642 /* WMFReadMoreViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFReadMoreViewController.h; path = Wikipedia/Code/WMFReadMoreViewController.h; sourceTree = SOURCE_ROOT; };
+		0E03617F1C456C4600FD9642 /* WMFReadMoreViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFReadMoreViewController.m; path = Wikipedia/Code/WMFReadMoreViewController.m; sourceTree = SOURCE_ROOT; };
 		0E09EABD1C4426470058F2D8 /* WMFSearchResultsTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFSearchResultsTableViewController.m; path = Code/WMFSearchResultsTableViewController.m; sourceTree = "<group>"; };
 		0E09EABE1C4426470058F2D8 /* WMFSearchResultsTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFSearchResultsTableViewController.h; path = Code/WMFSearchResultsTableViewController.h; sourceTree = "<group>"; };
 		0E09EABF1C4426470058F2D8 /* WMFSavedArticleTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFSavedArticleTableViewController.m; sourceTree = "<group>"; };
@@ -2744,6 +2747,8 @@
 				B0E803661C0CD91D0065EBC0 /* WMFArticleContainerViewController.m */,
 				B0E803681C0CD9300065EBC0 /* WMFArticleContainerViewController_Private.h */,
 				B0E803691C0CD9300065EBC0 /* WMFArticleContainerViewController_Transitioning.h */,
+				0E03617E1C456C4600FD9642 /* WMFReadMoreViewController.h */,
+				0E03617F1C456C4600FD9642 /* WMFReadMoreViewController.m */,
 			);
 			name = Article;
 			path = Wikipedia/Code/Article;
@@ -5506,6 +5511,7 @@
 				B0E806B71C0CEB160065EBC0 /* LanguagesViewController.m in Sources */,
 				B0E805521C0CE0DC0065EBC0 /* UITableViewCell+WMFLayout.m in Sources */,
 				BCAE0DFA1C247E7E006DDF51 /* UITableView+WMFLockedUpdates.m in Sources */,
+				0E0361801C456C4600FD9642 /* WMFReadMoreViewController.m in Sources */,
 				0E03617A1C44905400FD9642 /* WMFRelatedTitleViewController.m in Sources */,
 				B0E804BE1C0CE0B40065EBC0 /* CLLocation+WMFBearing.m in Sources */,
 				B0E8030A1C0CD5320065EBC0 /* WMFSearchResultDistanceProvider.m in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		04D34DB21863D39000610A87 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D34DB11863D39000610A87 /* libxml2.dylib */; };
 		0E0361741C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */; };
 		0E0361771C4488BC00FD9642 /* WMFLocationSearchListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361761C4488BC00FD9642 /* WMFLocationSearchListViewController.m */; };
+		0E03617A1C44905400FD9642 /* WMFRelatedTitleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361791C44905400FD9642 /* WMFRelatedTitleViewController.m */; };
 		0E09EAC31C4426470058F2D8 /* WMFSearchResultsTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EABD1C4426470058F2D8 /* WMFSearchResultsTableViewController.m */; };
 		0E09EAC41C4426470058F2D8 /* WMFSavedArticleTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EABF1C4426470058F2D8 /* WMFSavedArticleTableViewController.m */; };
 		0E09EAC51C4426470058F2D8 /* WMFHistoryTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EAC11C4426470058F2D8 /* WMFHistoryTableViewController.m */; };
@@ -632,6 +633,8 @@
 		0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFSelfSizingArticleListTableViewController.m; path = Wikipedia/Code/WMFSelfSizingArticleListTableViewController.m; sourceTree = SOURCE_ROOT; };
 		0E0361751C4488BC00FD9642 /* WMFLocationSearchListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFLocationSearchListViewController.h; path = Wikipedia/Code/WMFLocationSearchListViewController.h; sourceTree = SOURCE_ROOT; };
 		0E0361761C4488BC00FD9642 /* WMFLocationSearchListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFLocationSearchListViewController.m; path = Wikipedia/Code/WMFLocationSearchListViewController.m; sourceTree = SOURCE_ROOT; };
+		0E0361781C44905400FD9642 /* WMFRelatedTitleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFRelatedTitleViewController.h; path = Wikipedia/Code/WMFRelatedTitleViewController.h; sourceTree = SOURCE_ROOT; };
+		0E0361791C44905400FD9642 /* WMFRelatedTitleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFRelatedTitleViewController.m; path = Wikipedia/Code/WMFRelatedTitleViewController.m; sourceTree = SOURCE_ROOT; };
 		0E09EABD1C4426470058F2D8 /* WMFSearchResultsTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFSearchResultsTableViewController.m; path = Code/WMFSearchResultsTableViewController.m; sourceTree = "<group>"; };
 		0E09EABE1C4426470058F2D8 /* WMFSearchResultsTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFSearchResultsTableViewController.h; path = Code/WMFSearchResultsTableViewController.h; sourceTree = "<group>"; };
 		0E09EABF1C4426470058F2D8 /* WMFSavedArticleTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFSavedArticleTableViewController.m; sourceTree = "<group>"; };
@@ -2224,6 +2227,14 @@
 			path = Wikipedia/Code/PageHistory;
 			sourceTree = SOURCE_ROOT;
 		};
+		0E03617B1C44945300FD9642 /* More */ = {
+			isa = PBXGroup;
+			children = (
+				0E0361781C44905400FD9642 /* WMFRelatedTitleViewController.h */,
+				0E0361791C44905400FD9642 /* WMFRelatedTitleViewController.m */,
+			);
+			name = More;
+			sourceTree = "<group>";
 		};
 		0E03617D1C44948300FD9642 /* More */ = {
 			isa = PBXGroup;
@@ -2322,6 +2333,9 @@
 			children = (
 				B0E8031D1C0CD69B0065EBC0 /* WMFRelatedSectionController.h */,
 				B0E8031E1C0CD69B0065EBC0 /* WMFRelatedSectionController.m */,
+				B0E803B41C0CDBE20065EBC0 /* WMFRelatedTitleListDataSource.h */,
+				B0E803B51C0CDBE20065EBC0 /* WMFRelatedTitleListDataSource.m */,
+				0E03617B1C44945300FD9642 /* More */,
 				0E2691041B86BBD1009B8605 /* Fetcher */,
 			);
 			name = Related;
@@ -2395,18 +2409,6 @@
 			name = Analytics;
 			sourceTree = "<group>";
 		};
-		0E2B06F71B2D126700EA2F53 /* Data Sources */ = {
-			isa = PBXGroup;
-			children = (
-				B0E803B41C0CDBE20065EBC0 /* WMFRelatedTitleListDataSource.h */,
-				B0E803B51C0CDBE20065EBC0 /* WMFRelatedTitleListDataSource.m */,
-				B065315E1C220921003BD7DC /* WMFArticlePreviewDataSource.h */,
-				B065315F1C220921003BD7DC /* WMFArticlePreviewDataSource.m */,
-			);
-			name = "Data Sources";
-			path = "Wikipedia/Code/Data Sources";
-			sourceTree = SOURCE_ROOT;
-		};
 		0E2B06F81B2D127A00EA2F53 /* Article List */ = {
 			isa = PBXGroup;
 			children = (
@@ -2416,7 +2418,6 @@
 				0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */,
 				B0E803A81C0CDB8D0065EBC0 /* WMFTitleListDataSource.h */,
 				BC550B081B977C730082F298 /* Cells */,
-				0E2B06F71B2D126700EA2F53 /* Data Sources */,
 			);
 			name = "Article List";
 			path = "Wikipedia/Code/Article List";
@@ -3723,6 +3724,8 @@
 			children = (
 				B06531701C237538003BD7DC /* WMFDisambiguationPagesViewController.h */,
 				B06531711C237538003BD7DC /* WMFDisambiguationPagesViewController.m */,
+				B065315E1C220921003BD7DC /* WMFArticlePreviewDataSource.h */,
+				B065315F1C220921003BD7DC /* WMFArticlePreviewDataSource.m */,
 			);
 			name = Disambiguation;
 			sourceTree = "<group>";
@@ -5503,6 +5506,7 @@
 				B0E806B71C0CEB160065EBC0 /* LanguagesViewController.m in Sources */,
 				B0E805521C0CE0DC0065EBC0 /* UITableViewCell+WMFLayout.m in Sources */,
 				BCAE0DFA1C247E7E006DDF51 /* UITableView+WMFLockedUpdates.m in Sources */,
+				0E03617A1C44905400FD9642 /* WMFRelatedTitleViewController.m in Sources */,
 				B0E804BE1C0CE0B40065EBC0 /* CLLocation+WMFBearing.m in Sources */,
 				B0E8030A1C0CD5320065EBC0 /* WMFSearchResultDistanceProvider.m in Sources */,
 				B0E807221C0CECE30065EBC0 /* CommunicationBridge.m in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		0493C2D419526A0100EBB973 /* WikiFont-Glyphs.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0493C2D319526A0100EBB973 /* WikiFont-Glyphs.ttf */; };
 		04D34DB21863D39000610A87 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D34DB11863D39000610A87 /* libxml2.dylib */; };
 		0E0361741C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */; };
+		0E09EAC41C4426470058F2D8 /* WMFSavedArticleTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EABF1C4426470058F2D8 /* WMFSavedArticleTableViewController.m */; };
+		0E09EAC51C4426470058F2D8 /* WMFHistoryTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EAC11C4426470058F2D8 /* WMFHistoryTableViewController.m */; };
 		0E26B0721C0F4F550004D687 /* WMFAppViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0E26B0701C0F4F550004D687 /* WMFAppViewController.storyboard */; };
 		0E26B0731C0F4F550004D687 /* WMFTabBarUI.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0E26B0711C0F4F550004D687 /* WMFTabBarUI.storyboard */; };
 		0E26B07F1C0F4F720004D687 /* WMFWelcome.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0E26B0741C0F4F720004D687 /* WMFWelcome.storyboard */; };
@@ -626,6 +628,10 @@
 		08F646F7D0488CE3C6D6A763 /* Pods.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.beta.xcconfig; path = "Pods/Target Support Files/Pods/Pods.beta.xcconfig"; sourceTree = "<group>"; };
 		0E0361721C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFSelfSizingArticleListTableViewController.h; path = Wikipedia/Code/WMFSelfSizingArticleListTableViewController.h; sourceTree = SOURCE_ROOT; };
 		0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFSelfSizingArticleListTableViewController.m; path = Wikipedia/Code/WMFSelfSizingArticleListTableViewController.m; sourceTree = SOURCE_ROOT; };
+		0E09EABF1C4426470058F2D8 /* WMFSavedArticleTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFSavedArticleTableViewController.m; sourceTree = "<group>"; };
+		0E09EAC01C4426470058F2D8 /* WMFSavedArticleTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFSavedArticleTableViewController.h; sourceTree = "<group>"; };
+		0E09EAC11C4426470058F2D8 /* WMFHistoryTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFHistoryTableViewController.m; sourceTree = "<group>"; };
+		0E09EAC21C4426470058F2D8 /* WMFHistoryTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFHistoryTableViewController.h; sourceTree = "<group>"; };
 		0E26B0701C0F4F550004D687 /* WMFAppViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = WMFAppViewController.storyboard; path = Wikipedia/Code/WMFAppViewController.storyboard; sourceTree = SOURCE_ROOT; };
 		0E26B0711C0F4F550004D687 /* WMFTabBarUI.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = WMFTabBarUI.storyboard; path = Wikipedia/Code/WMFTabBarUI.storyboard; sourceTree = SOURCE_ROOT; };
 		0E26B0741C0F4F720004D687 /* WMFWelcome.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = WMFWelcome.storyboard; path = Wikipedia/Code/WMFWelcome.storyboard; sourceTree = SOURCE_ROOT; };
@@ -3658,6 +3664,8 @@
 		BC45D5B01C330B95007C72F3 /* History */ = {
 			isa = PBXGroup;
 			children = (
+				0E09EAC11C4426470058F2D8 /* WMFHistoryTableViewController.m */,
+				0E09EAC21C4426470058F2D8 /* WMFHistoryTableViewController.h */,
 				0EAAAFC91B43301C00E65A95 /* Model */,
 				B0E803AC1C0CDBC00065EBC0 /* WMFRecentPagesDataSource.h */,
 				B0E803AD1C0CDBC00065EBC0 /* WMFRecentPagesDataSource.m */,
@@ -4367,6 +4375,8 @@
 		BCD67E7E1C1F1433005179E1 /* Saved Pages */ = {
 			isa = PBXGroup;
 			children = (
+				0E09EAC01C4426470058F2D8 /* WMFSavedArticleTableViewController.h */,
+				0E09EABF1C4426470058F2D8 /* WMFSavedArticleTableViewController.m */,
 				0EAAAFC81B43301500E65A95 /* Models */,
 				BCD67E821C1F14C5005179E1 /* Event Logging */,
 				BCD67E801C1F1471005179E1 /* Fetchers */,
@@ -5290,6 +5300,7 @@
 				B0E804DF1C0CE0B40065EBC0 /* NSURL+WMFLinkParsing.m in Sources */,
 				B0E806CF1C0CEB6E0065EBC0 /* PageHistoryLabel.m in Sources */,
 				0E26B0831C0F4F720004D687 /* WMFWelcomeLanguageViewController.m in Sources */,
+				0E09EAC51C4426470058F2D8 /* WMFHistoryTableViewController.m in Sources */,
 				B0E806691C0CE9030065EBC0 /* LoginTokenFetcher.m in Sources */,
 				B0E802B81C0CD2140065EBC0 /* UIBarButtonItem+WMFButtonConvenience.m in Sources */,
 				B0E806991C0CEAC20065EBC0 /* AccountCreationViewController.m in Sources */,
@@ -5395,6 +5406,7 @@
 				B0E805501C0CE0DC0065EBC0 /* UITableView+DynamicCellHeight.m in Sources */,
 				B0E805CC1C0CE5250065EBC0 /* WMFImageDownload.swift in Sources */,
 				B0E805581C0CE0DC0065EBC0 /* UIView+WMFDefaultNib.m in Sources */,
+				0E09EAC41C4426470058F2D8 /* WMFSavedArticleTableViewController.m in Sources */,
 				B0E803481C0CD7AA0065EBC0 /* WMFSearchResults.m in Sources */,
 				B0E807981C0CEF970065EBC0 /* MWKSection+HTMLImageExtraction.m in Sources */,
 				B0E802D21C0CD35B0065EBC0 /* WMFHomeSection.m in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0493C2D419526A0100EBB973 /* WikiFont-Glyphs.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0493C2D319526A0100EBB973 /* WikiFont-Glyphs.ttf */; };
 		04D34DB21863D39000610A87 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D34DB11863D39000610A87 /* libxml2.dylib */; };
 		0E0361741C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */; };
+		0E09EAC31C4426470058F2D8 /* WMFSearchResultsTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EABD1C4426470058F2D8 /* WMFSearchResultsTableViewController.m */; };
 		0E09EAC41C4426470058F2D8 /* WMFSavedArticleTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EABF1C4426470058F2D8 /* WMFSavedArticleTableViewController.m */; };
 		0E09EAC51C4426470058F2D8 /* WMFHistoryTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E09EAC11C4426470058F2D8 /* WMFHistoryTableViewController.m */; };
 		0E26B0721C0F4F550004D687 /* WMFAppViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0E26B0701C0F4F550004D687 /* WMFAppViewController.storyboard */; };
@@ -628,6 +629,8 @@
 		08F646F7D0488CE3C6D6A763 /* Pods.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.beta.xcconfig; path = "Pods/Target Support Files/Pods/Pods.beta.xcconfig"; sourceTree = "<group>"; };
 		0E0361721C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFSelfSizingArticleListTableViewController.h; path = Wikipedia/Code/WMFSelfSizingArticleListTableViewController.h; sourceTree = SOURCE_ROOT; };
 		0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFSelfSizingArticleListTableViewController.m; path = Wikipedia/Code/WMFSelfSizingArticleListTableViewController.m; sourceTree = SOURCE_ROOT; };
+		0E09EABD1C4426470058F2D8 /* WMFSearchResultsTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFSearchResultsTableViewController.m; path = Code/WMFSearchResultsTableViewController.m; sourceTree = "<group>"; };
+		0E09EABE1C4426470058F2D8 /* WMFSearchResultsTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFSearchResultsTableViewController.h; path = Code/WMFSearchResultsTableViewController.h; sourceTree = "<group>"; };
 		0E09EABF1C4426470058F2D8 /* WMFSavedArticleTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFSavedArticleTableViewController.m; sourceTree = "<group>"; };
 		0E09EAC01C4426470058F2D8 /* WMFSavedArticleTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFSavedArticleTableViewController.h; sourceTree = "<group>"; };
 		0E09EAC11C4426470058F2D8 /* WMFHistoryTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFHistoryTableViewController.m; sourceTree = "<group>"; };
@@ -2267,6 +2270,16 @@
 			path = Wikipedia/Code/Views;
 			sourceTree = SOURCE_ROOT;
 		};
+		0E09EAC61C4426AC0058F2D8 /* Results List */ = {
+			isa = PBXGroup;
+			children = (
+				0E09EABE1C4426470058F2D8 /* WMFSearchResultsTableViewController.h */,
+				0E09EABD1C4426470058F2D8 /* WMFSearchResultsTableViewController.m */,
+			);
+			name = "Results List";
+			path = ..;
+			sourceTree = "<group>";
+		};
 		0E1B049F1BC59DEF00506F7D /* Continue Reading */ = {
 			isa = PBXGroup;
 			children = (
@@ -2395,7 +2408,7 @@
 				BC45FF521C1B829B00BAE501 /* UIViewController+WMFSearchButton_Testing.m */,
 			);
 			name = Search;
-			path = Wikipedia/Code/Search;
+			path = Wikipedia/Code;
 			sourceTree = SOURCE_ROOT;
 		};
 		0E4500B91B97A26800A33B55 /* Schema */ = {
@@ -2590,14 +2603,14 @@
 				BC45D5A21C330480007C72F3 /* Model */,
 				0EAED8551BE9507C006B01E6 /* Networking */,
 				04C757621A1A9DC50084AC39 /* RecentSearches */,
-				B0E803391C0CD76B0065EBC0 /* WMFSearchViewController.h */,
-				B0E8033A1C0CD76B0065EBC0 /* WMFSearchViewController.m */,
+				0E09EAC71C442A130058F2D8 /* Container VC */,
+				0E09EAC61C4426AC0058F2D8 /* Results List */,
 				B0E803AF1C0CDBCF0065EBC0 /* WMFSearchDataSource.h */,
 				B0E803B01C0CDBCF0065EBC0 /* WMFSearchDataSource.m */,
 				B0E8033B1C0CD76B0065EBC0 /* WMFSearchViewController.storyboard */,
 			);
 			name = "View Controller";
-			path = "Wikipedia/Code/View Controller";
+			path = Wikipedia/Code;
 			sourceTree = SOURCE_ROOT;
 		};
 		0ED6897C1B8246F400B30427 /* Nearby */ = {
@@ -5302,6 +5315,7 @@
 				0E26B0831C0F4F720004D687 /* WMFWelcomeLanguageViewController.m in Sources */,
 				0E09EAC51C4426470058F2D8 /* WMFHistoryTableViewController.m in Sources */,
 				B0E806691C0CE9030065EBC0 /* LoginTokenFetcher.m in Sources */,
+				0E09EAC31C4426470058F2D8 /* WMFSearchResultsTableViewController.m in Sources */,
 				B0E802B81C0CD2140065EBC0 /* UIBarButtonItem+WMFButtonConvenience.m in Sources */,
 				B0E806991C0CEAC20065EBC0 /* AccountCreationViewController.m in Sources */,
 				B08E7E9B1C1FA57A00EC3C99 /* UIViewController+WMFEmptyView.m in Sources */,

--- a/Wikipedia/Code/UIViewController+WMFEmptyView.h
+++ b/Wikipedia/Code/UIViewController+WMFEmptyView.h
@@ -9,6 +9,7 @@
 #import <UIKit/UIKit.h>
 
 typedef NS_ENUM (NSUInteger, WMFEmptyViewType) {
+    WMFEmptyViewTypeNone,
     WMFEmptyViewTypeNoFeed,
     WMFEmptyViewTypeArticleDidNotLoad,
     WMFEmptyViewTypeNoSearchResults,

--- a/Wikipedia/Code/UIViewController+WMFEmptyView.m
+++ b/Wikipedia/Code/UIViewController+WMFEmptyView.m
@@ -38,6 +38,9 @@ static NSString * WMFEmptyViewKey = @"WMFEmptyView";
         case WMFEmptyViewTypeNoHistory:
             view = [WMFEmptyView noHistoryEmptyView];
             break;
+        default:
+            return;
+    
     }
 
     UIView* container = self.view.superview;

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -19,8 +19,6 @@
 
 // Model
 #import "MediaWikiKit.h"
-#import "WMFSavedPagesDataSource.h"
-#import "WMFRecentPagesDataSource.h"
 
 // Views
 #import "UIViewController+WMFStoryboardUtilities.h"
@@ -101,8 +99,8 @@ static dispatch_once_t launchToken;
     self.rootTabBarController = tabBar;
     [self configureTabController];
     [self configureHomeViewController];
-    [self configureSavedViewController];
-    [self configureRecentViewController];
+    [self configureArticleListController:self.savedArticlesViewController];
+    [self configureArticleListController:self.recentArticlesViewController];
 }
 
 - (void)configureTabController {
@@ -123,22 +121,6 @@ static dispatch_once_t launchToken;
 
 - (void)configureArticleListController:(WMFArticleListTableViewController*)controller {
     controller.dataStore = self.session.dataStore;
-}
-
-- (void)configureSavedViewController {
-    [self configureArticleListController:self.savedArticlesViewController];
-    if (!self.savedArticlesViewController.dataSource) {
-        self.savedArticlesViewController.dataSource =
-            [[WMFSavedPagesDataSource alloc] initWithSavedPagesList:[self userDataStore].savedPageList];
-    }
-}
-
-- (void)configureRecentViewController {
-    [self configureArticleListController:self.recentArticlesViewController];
-    if (!self.recentArticlesViewController.dataSource) {
-        self.recentArticlesViewController.dataSource =
-            [[WMFRecentPagesDataSource alloc] initWithRecentPagesList:[self userDataStore].historyList savedPages:[self userDataStore].savedPageList];
-    }
 }
 
 #pragma mark - Notifications
@@ -443,7 +425,7 @@ static NSString* const WMFDidShowOnboarding = @"DidShowOnboarding5.0";
 - (void)tabBarController:(UITabBarController*)tabBarController didSelectViewController:(UIViewController*)viewController {
     [self wmf_hideKeyboard];
     WMFAppTabType tab = [[tabBarController viewControllers] indexOfObject:viewController];
-    [[PiwikTracker sharedInstance] wmf_logView:[self rootViewControllerForTab:tab]];
+//    [[PiwikTracker sharedInstance] wmf_logView:[self rootViewControllerForTab:tab]];
 }
 
 #pragma mark - Notifications

--- a/Wikipedia/Code/WMFArticleContainerViewController.m
+++ b/Wikipedia/Code/WMFArticleContainerViewController.m
@@ -12,7 +12,7 @@
 #import "WMFArticleContainerViewController_Transitioning.h"
 #import "WMFArticleHeaderImageGalleryViewController.h"
 #import "WMFRelatedTitleListDataSource.h"
-#import "WMFArticleListTableViewController.h"
+#import "WMFSelfSizingArticleListTableViewController.h"
 #import "WMFShareOptionsController.h"
 #import "WMFModalImageGalleryViewController.h"
 #import "UIViewController+WMFSearchButton.h"
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Children
 @property (nonatomic, strong) WMFArticleHeaderImageGalleryViewController* headerGallery;
-@property (nonatomic, strong) WMFArticleListTableViewController* readMoreListViewController;
+@property (nonatomic, strong) WMFSelfSizingArticleListTableViewController* readMoreListViewController;
 @property (nonatomic, strong) WMFSaveButtonController* saveButtonController;
 
 // Logging
@@ -216,13 +216,12 @@ NS_ASSUME_NONNULL_BEGIN
         _readMoreDataSource =
             [[WMFRelatedTitleListDataSource alloc] initWithTitle:self.articleTitle
                                                        dataStore:self.dataStore
-                                                   savedPageList:self.savedPages
                                                      resultLimit:3];
     }
     return _readMoreDataSource;
 }
 
-- (WMFArticleListTableViewController*)readMoreListViewController {
+- (WMFSelfSizingArticleListTableViewController*)readMoreListViewController {
     if (!_readMoreListViewController) {
         _readMoreListViewController            = [[WMFSelfSizingArticleListTableViewController alloc] init];
         _readMoreListViewController.dataStore  = self.dataStore;

--- a/Wikipedia/Code/WMFArticleContainerViewController.m
+++ b/Wikipedia/Code/WMFArticleContainerViewController.m
@@ -11,8 +11,7 @@
 #import "WMFSaveButtonController.h"
 #import "WMFArticleContainerViewController_Transitioning.h"
 #import "WMFArticleHeaderImageGalleryViewController.h"
-#import "WMFRelatedTitleListDataSource.h"
-#import "WMFSelfSizingArticleListTableViewController.h"
+#import "WMFReadMoreViewController.h"
 #import "WMFShareOptionsController.h"
 #import "WMFModalImageGalleryViewController.h"
 #import "UIViewController+WMFSearchButton.h"
@@ -40,7 +39,6 @@
 #import "MWKSectionList.h"
 #import "MWKLanguageLink.h"
 #import "MWKHistoryList.h"
-#import "WMFRelatedSearchResults.h"
 
 // Networking
 #import "WMFArticleFetcher.h"
@@ -84,15 +82,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) MWKSavedPageList* savedPages;
 @property (nonatomic, strong, readonly) MWKHistoryList* recentPages;
 
-@property (nonatomic, strong) WMFRelatedTitleListDataSource* readMoreDataSource;
-
 // Fetchers
 @property (nonatomic, strong) WMFArticleFetcher* articleFetcher;
 @property (nonatomic, strong, nullable) AnyPromise* articleFetcherPromise;
 
 // Children
 @property (nonatomic, strong) WMFArticleHeaderImageGalleryViewController* headerGallery;
-@property (nonatomic, strong) WMFSelfSizingArticleListTableViewController* readMoreListViewController;
+@property (nonatomic, strong) WMFReadMoreViewController* readMoreListViewController;
 @property (nonatomic, strong) WMFSaveButtonController* saveButtonController;
 
 // Logging
@@ -211,21 +207,9 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.recentPages entryForTitle:self.articleTitle];
 }
 
-- (WMFRelatedTitleListDataSource*)readMoreDataSource {
-    if (!_readMoreDataSource) {
-        _readMoreDataSource =
-            [[WMFRelatedTitleListDataSource alloc] initWithTitle:self.articleTitle
-                                                       dataStore:self.dataStore
-                                                     resultLimit:3];
-    }
-    return _readMoreDataSource;
-}
-
-- (WMFSelfSizingArticleListTableViewController*)readMoreListViewController {
+- (WMFReadMoreViewController*)readMoreListViewController {
     if (!_readMoreListViewController) {
-        _readMoreListViewController            = [[WMFSelfSizingArticleListTableViewController alloc] init];
-        _readMoreListViewController.dataStore  = self.dataStore;
-        _readMoreListViewController.dataSource = self.readMoreDataSource;
+        _readMoreListViewController = [[WMFReadMoreViewController alloc] initWithTitle:self.articleTitle dataStore:self.dataStore];
     }
     return _readMoreListViewController;
 }
@@ -419,7 +403,7 @@ NS_ASSUME_NONNULL_BEGIN
         self.footerMenuViewController = [[WMFArticleFooterMenuViewController alloc] initWithArticle:self.article];
     }
     NSMutableArray* footerVCs = [NSMutableArray arrayWithObject:self.footerMenuViewController];
-    if (self.readMoreDataSource.relatedSearchResults.results.count > 0) {
+    if ([self.readMoreListViewController hasResults]) {
         [footerVCs addObject:self.readMoreListViewController];
         [self appendReadMoreTableOfContentsItemIfNeeded];
     }
@@ -650,7 +634,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)fetchReadMore {
     @weakify(self);
-    [self.readMoreDataSource fetch].then(^(WMFRelatedSearchResults* readMoreResults) {
+    [self.readMoreListViewController fetch].then(^(id readMoreResults) {
+        @strongify(self);
         [self updateArticleFootersIfNeeded];
     })
     .catch(^(NSError* error){

--- a/Wikipedia/Code/WMFArticleListTableViewController.h
+++ b/Wikipedia/Code/WMFArticleListTableViewController.h
@@ -22,8 +22,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-// TODO: move to separate file in article container folder
-@interface WMFSelfSizingArticleListTableViewController : WMFArticleListTableViewController
+
+@interface WMFArticleListTableViewController (WMFSubclasses)
+
+- (MWKHistoryDiscoveryMethod)discoveryMethod;
+- (NSString*)analyticsName;
+
+- (WMFEmptyViewType)emptyViewType;
+
+- (BOOL)showsDeleteAllButton;
+- (NSString*)deleteAllConfirmationText;
+- (NSString*)deleteText;
+- (NSString*)deleteCancelText;
 
 @end
 

--- a/Wikipedia/Code/WMFHistoryTableViewController.h
+++ b/Wikipedia/Code/WMFHistoryTableViewController.h
@@ -1,0 +1,6 @@
+
+#import "WMFArticleListTableViewController.h"
+
+@interface WMFHistoryTableViewController : WMFArticleListTableViewController
+
+@end

--- a/Wikipedia/Code/WMFHistoryTableViewController.m
+++ b/Wikipedia/Code/WMFHistoryTableViewController.m
@@ -1,0 +1,82 @@
+
+#import "WMFHistoryTableViewController.h"
+
+#import "NSString+Extras.h"
+
+#import "WMFRecentPagesDataSource.h"
+#import "MWKDataStore.h"
+#import "MWKUserDataStore.h"
+
+#import "MWKArticle.h"
+#import "MWKTitle.h"
+#import "MWKSavedPageEntry.h"
+
+#import "WMFArticleListTableViewCell.h"
+#import "UIView+WMFDefaultNib.h"
+#import "UITableViewCell+WMFLayout.h"
+
+@implementation WMFHistoryTableViewController
+
+- (MWKHistoryList*)historyList {
+    return self.dataStore.userDataStore.historyList;
+}
+
+- (MWKSavedPageList*)savedPageList {
+    return self.dataStore.userDataStore.savedPageList;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.title = MWLocalizedString(@"history-title", nil);
+
+    [self.tableView registerNib:[WMFArticleListTableViewCell wmf_classNib] forCellReuseIdentifier:[WMFArticleListTableViewCell identifier]];
+
+    WMFRecentPagesDataSource* ds = [[WMFRecentPagesDataSource alloc] initWithRecentPagesList:[self historyList]];
+
+    ds.cellClass = [WMFArticleListTableViewCell class];
+
+    @weakify(self);
+    ds.cellConfigureBlock = ^(WMFArticleListTableViewCell* cell,
+                              MWKHistoryEntry* entry,
+                              UITableView* tableView,
+                              NSIndexPath* indexPath) {
+        @strongify(self);
+        MWKArticle* article = [[self dataStore] articleWithTitle:entry.title];
+        cell.titleText       = article.title.text;
+        cell.descriptionText = [article.entityDescription wmf_stringByCapitalizingFirstCharacter];
+        [cell setImage:[article bestThumbnailImage]];
+    };
+
+    self.dataSource = ds;
+}
+
+- (WMFEmptyViewType)emptyViewType {
+    return WMFEmptyViewTypeNoHistory;
+}
+
+- (MWKHistoryDiscoveryMethod)discoveryMethod {
+    return MWKHistoryDiscoveryMethodUnknown;
+}
+
+- (NSString*)analyticsName {
+    return @"Recent";
+}
+
+- (BOOL)showsDeleteAllButton {
+    return YES;
+}
+
+- (NSString*)deleteAllConfirmationText {
+    return MWLocalizedString(@"history-clear-confirmation-heading", nil);
+}
+
+- (NSString*)deleteText {
+    return MWLocalizedString(@"history-clear-delete-all", nil);
+}
+
+- (NSString*)deleteCancelText {
+    return MWLocalizedString(@"history-clear-cancel", nil);
+}
+
+@end

--- a/Wikipedia/Code/WMFHomeSectionController.h
+++ b/Wikipedia/Code/WMFHomeSectionController.h
@@ -88,9 +88,9 @@ NS_ASSUME_NONNULL_BEGIN
 @optional
 
 /**
- *  @return A data source which will provide a larger list of items from this section.
+ *  @return A view controller with will provide a more data for this section.
  */
-- (SSArrayDataSource<WMFTitleListDataSource>*)extendedListDataSource;
+- (UIViewController*)moreViewController;
 
 @end
 

--- a/Wikipedia/Code/WMFHomeViewController.m
+++ b/Wikipedia/Code/WMFHomeViewController.m
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (WMFNearbySectionController*)nearbySectionController {
     if (!_nearbySectionController) {
         _nearbySectionController = [[WMFNearbySectionController alloc] initWithSite:self.searchSite
-                                                                      savedPageList:self.savedPages
+                                                                      dataStore:self.dataStore
                                                                     locationManager:self.locationManager];
     }
     return _nearbySectionController;

--- a/Wikipedia/Code/WMFHomeViewController.m
+++ b/Wikipedia/Code/WMFHomeViewController.m
@@ -502,15 +502,14 @@ NS_ASSUME_NONNULL_BEGIN
         DDLogError(@"Unexpected footer tap for missing section %lu.", section);
         return;
     }
-    if (![controllerForSection respondsToSelector:@selector(extendedListDataSource)]) {
+    if (![controllerForSection respondsToSelector:@selector(moreViewController)]) {
         return;
     }
     id<WMFArticleHomeSectionController> articleSectionController = (id<WMFArticleHomeSectionController>)controllerForSection;
-    WMFArticleListTableViewController* extendedList              = [[WMFArticleListTableViewController alloc] init];
-    extendedList.dataStore  = self.dataStore;
-    extendedList.dataSource = [articleSectionController extendedListDataSource];
+
+    UIViewController* moreVC              = [articleSectionController moreViewController];
     [[PiwikTracker sharedInstance] wmf_logActionOpenMoreForHomeSection:articleSectionController];
-    [self.navigationController pushViewController:extendedList animated:YES];
+    [self.navigationController pushViewController:moreVC animated:YES];
 }
 
 - (void)didTapHeaderInSection:(NSUInteger)section {

--- a/Wikipedia/Code/WMFHomeViewController.m
+++ b/Wikipedia/Code/WMFHomeViewController.m
@@ -336,7 +336,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Section Controller Creation
 
 - (WMFRelatedSectionController*)relatedSectionControllerForSectionSchemaItem:(WMFHomeSection*)item {
-    return [[WMFRelatedSectionController alloc] initWithArticleTitle:item.title savedPageList:self.savedPages];
+    return [[WMFRelatedSectionController alloc] initWithArticleTitle:item.title dataStore:self.dataStore];
 }
 
 - (WMFContinueReadingSectionController*)continueReadingSectionControllerForSchemaItem:(WMFHomeSection*)item {

--- a/Wikipedia/Code/WMFLocationSearchListViewController.h
+++ b/Wikipedia/Code/WMFLocationSearchListViewController.h
@@ -2,8 +2,12 @@
 #import "WMFArticleListTableViewController.h"
 #import "WMFNearbyTitleListDataSource.h"
 
+
+
 @interface WMFLocationSearchListViewController : WMFArticleListTableViewController
 
-@property (nonatomic, strong) WMFNearbyTitleListDataSource* dataSource;
+@property (nonatomic, strong, readonly) MWKSite* site;
+
+- (instancetype)initWithSearchSite:(MWKSite*)site dataStore:(MWKDataStore*)dataStore;
 
 @end

--- a/Wikipedia/Code/WMFLocationSearchListViewController.h
+++ b/Wikipedia/Code/WMFLocationSearchListViewController.h
@@ -1,0 +1,9 @@
+
+#import "WMFArticleListTableViewController.h"
+#import "WMFNearbyTitleListDataSource.h"
+
+@interface WMFLocationSearchListViewController : WMFArticleListTableViewController
+
+@property (nonatomic, strong) WMFNearbyTitleListDataSource* dataSource;
+
+@end

--- a/Wikipedia/Code/WMFLocationSearchListViewController.m
+++ b/Wikipedia/Code/WMFLocationSearchListViewController.m
@@ -3,40 +3,48 @@
 #import "WMFNearbyArticleTableViewCell.h"
 #import "UIView+WMFDefaultNib.h"
 #import "MWKLocationSearchResult.h"
+#import "MWKSite.h"
 
 @interface WMFLocationSearchListViewController ()
-
+@property (nonatomic, strong) WMFNearbyTitleListDataSource* dataSource;
+@property (nonatomic, strong, readwrite) MWKSite* site;
 @end
 
 @implementation WMFLocationSearchListViewController
 
 @dynamic dataSource;
 
+- (instancetype)initWithSearchSite:(MWKSite*)site dataStore:(MWKDataStore*)dataStore {
+    NSParameterAssert(site);
+    NSParameterAssert(dataStore);
+    self = [super init];
+    if (self) {
+        self.site                 = site;
+        self.dataStore            = dataStore;
+        self.dataSource           = [[WMFNearbyTitleListDataSource alloc] initWithSite:self.site];
+        self.dataSource.cellClass = [WMFNearbyArticleTableViewCell class];
+
+        @weakify(self);
+        self.dataSource.cellConfigureBlock = ^(WMFNearbyArticleTableViewCell* nearbyCell,
+                                               MWKLocationSearchResult* result,
+                                               UITableView* tableView,
+                                               NSIndexPath* indexPath) {
+            @strongify(self);
+            nearbyCell.titleText       = result.displayTitle;
+            nearbyCell.descriptionText = result.wikidataDescription;
+            [nearbyCell setImageURL:result.thumbnailURL];
+            [nearbyCell setDistanceProvider:[self.dataSource distanceProviderForResultAtIndexPath:indexPath]];
+            [nearbyCell setBearingProvider:[self.dataSource bearingProviderForResultAtIndexPath:indexPath]];
+        };
+    }
+    return self;
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
 
     self.title = MWLocalizedString(@"main-menu-nearby", nil);
-
     [self.tableView registerNib:[WMFNearbyArticleTableViewCell wmf_classNib] forCellReuseIdentifier:[WMFNearbyArticleTableViewCell identifier]];
-}
-
-- (void)setDataSource:(WMFNearbyTitleListDataSource*)dataSource {
-    dataSource.cellClass = [WMFNearbyArticleTableViewCell class];
-
-    @weakify(self);
-    dataSource.cellConfigureBlock = ^(WMFNearbyArticleTableViewCell* nearbyCell,
-                                      MWKLocationSearchResult* result,
-                                      UITableView* tableView,
-                                      NSIndexPath* indexPath) {
-        @strongify(self);
-        nearbyCell.titleText       = result.displayTitle;
-        nearbyCell.descriptionText = result.wikidataDescription;
-        [nearbyCell setImageURL:result.thumbnailURL];
-        [nearbyCell setDistanceProvider:[self.dataSource distanceProviderForResultAtIndexPath:indexPath]];
-        [nearbyCell setBearingProvider:[self.dataSource bearingProviderForResultAtIndexPath:indexPath]];
-    };
-
-    [super setDataSource:dataSource];
 }
 
 - (MWKHistoryDiscoveryMethod)discoveryMethod {

--- a/Wikipedia/Code/WMFLocationSearchListViewController.m
+++ b/Wikipedia/Code/WMFLocationSearchListViewController.m
@@ -1,0 +1,50 @@
+
+#import "WMFLocationSearchListViewController.h"
+#import "WMFNearbyArticleTableViewCell.h"
+#import "UIView+WMFDefaultNib.h"
+#import "MWKLocationSearchResult.h"
+
+@interface WMFLocationSearchListViewController ()
+
+@end
+
+@implementation WMFLocationSearchListViewController
+
+@dynamic dataSource;
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.title = MWLocalizedString(@"main-menu-nearby", nil);
+
+    [self.tableView registerNib:[WMFNearbyArticleTableViewCell wmf_classNib] forCellReuseIdentifier:[WMFNearbyArticleTableViewCell identifier]];
+}
+
+- (void)setDataSource:(WMFNearbyTitleListDataSource*)dataSource {
+    dataSource.cellClass = [WMFNearbyArticleTableViewCell class];
+
+    @weakify(self);
+    dataSource.cellConfigureBlock = ^(WMFNearbyArticleTableViewCell* nearbyCell,
+                                      MWKLocationSearchResult* result,
+                                      UITableView* tableView,
+                                      NSIndexPath* indexPath) {
+        @strongify(self);
+        nearbyCell.titleText       = result.displayTitle;
+        nearbyCell.descriptionText = result.wikidataDescription;
+        [nearbyCell setImageURL:result.thumbnailURL];
+        [nearbyCell setDistanceProvider:[self.dataSource distanceProviderForResultAtIndexPath:indexPath]];
+        [nearbyCell setBearingProvider:[self.dataSource bearingProviderForResultAtIndexPath:indexPath]];
+    };
+
+    [super setDataSource:dataSource];
+}
+
+- (MWKHistoryDiscoveryMethod)discoveryMethod {
+    return MWKHistoryDiscoveryMethodSearch;
+}
+
+- (NSString*)analyticsName {
+    return @"Nearby";
+}
+
+@end

--- a/Wikipedia/Code/WMFNearbySectionController.h
+++ b/Wikipedia/Code/WMFNearbySectionController.h
@@ -1,7 +1,7 @@
 
 #import "WMFHomeSectionController.h"
 
-@class WMFLocationManager, WMFNearbyViewModel, MWKSite, MWKSavedPageList;
+@class WMFLocationManager, WMFNearbyViewModel, MWKSite, MWKDataStore;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -9,11 +9,11 @@ NS_ASSUME_NONNULL_BEGIN
     <WMFArticleHomeSectionController, WMFFetchingHomeSectionController>
 
 - (instancetype)initWithSite:(MWKSite*)site
-               savedPageList:(MWKSavedPageList*)savedPageList
+                   dataStore:(MWKDataStore*)dataStore
              locationManager:(WMFLocationManager*)locationManager;
 
 - (instancetype)initWithSite:(MWKSite*)site
-               savedPageList:(MWKSavedPageList*)savedPageList
+                   dataStore:(MWKDataStore*)dataStore
                    viewModel:(WMFNearbyViewModel*)viewModel NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, strong) MWKSite* searchSite;

--- a/Wikipedia/Code/WMFNearbySectionController.m
+++ b/Wikipedia/Code/WMFNearbySectionController.m
@@ -187,9 +187,7 @@ static NSString* const WMFNearbySectionIdentifier = @"WMFNearbySectionIdentifier
 }
 
 - (UIViewController*)moreViewController {
-    WMFLocationSearchListViewController* vc = [[WMFLocationSearchListViewController alloc] init];
-    vc.dataSource = [[WMFNearbyTitleListDataSource alloc] initWithSite:self.searchSite];
-    vc.dataStore = self.dataStore;
+    WMFLocationSearchListViewController* vc = [[WMFLocationSearchListViewController alloc] initWithSearchSite:self.searchSite dataStore:self.dataStore];
     return vc;
 }
 

--- a/Wikipedia/Code/WMFNearbyTitleListDataSource.h
+++ b/Wikipedia/Code/WMFNearbyTitleListDataSource.h
@@ -1,15 +1,8 @@
-//
-//  WMFNearbyTitleListDataSource.h
-//  Wikipedia
-//
-//  Created by Brian Gerstle on 9/8/15.
-//  Copyright (c) 2015 Wikimedia Foundation. All rights reserved.
-//
 
 #import <SSDataSources/SSArrayDataSource.h>
 #import "WMFTitleListDataSource.h"
 
-@class WMFNearbyViewModel, WMFLocationManager, MWKSite;
+@class WMFNearbyViewModel, WMFLocationManager, MWKSite, WMFSearchResultDistanceProvider, WMFSearchResultBearingProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -22,6 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSite:(MWKSite*)site
                    viewModel:(WMFNearbyViewModel*)viewModel NS_DESIGNATED_INITIALIZER;
+
+- (WMFSearchResultDistanceProvider*)distanceProviderForResultAtIndexPath:(NSIndexPath*)indexPath;
+- (WMFSearchResultBearingProvider*)bearingProviderForResultAtIndexPath:(NSIndexPath*)indexPath;
 
 @end
 

--- a/Wikipedia/Code/WMFNearbyTitleListDataSource.m
+++ b/Wikipedia/Code/WMFNearbyTitleListDataSource.m
@@ -1,10 +1,3 @@
-//
-//  WMFNearbyTitleListDataSource.m
-//  Wikipedia
-//
-//  Created by Brian Gerstle on 9/8/15.
-//  Copyright (c) 2015 Wikimedia Foundation. All rights reserved.
-//
 
 #import "WMFNearbyTitleListDataSource.h"
 
@@ -20,8 +13,6 @@
 #import "MWKHistoryEntry.h"
 
 // Views
-#import "WMFNearbyArticleTableViewCell.h"
-#import "UIView+WMFDefaultNib.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -46,28 +37,10 @@ NS_ASSUME_NONNULL_BEGIN
     NSParameterAssert([viewModel.site isEqualToSite:site]);
     self = [super initWithItems:nil];
     if (self) {
-        self.cellClass = [WMFNearbyArticleTableViewCell class];
-        @weakify(self);
-        self.cellConfigureBlock = ^(WMFNearbyArticleTableViewCell* nearbyCell,
-                                    MWKLocationSearchResult* result,
-                                    id parentView,
-                                    NSIndexPath* indexPath) {
-            @strongify(self);
-            nearbyCell.titleText       = result.displayTitle;
-            nearbyCell.descriptionText = result.wikidataDescription;
-            [nearbyCell setImageURL:result.thumbnailURL];
-            [nearbyCell setDistanceProvider:[self.viewModel distanceProviderForResultAtIndex:indexPath.item]];
-            [nearbyCell setBearingProvider:[self.viewModel bearingProviderForResultAtIndex:indexPath.item]];
-        };
         self.viewModel          = viewModel;
         self.viewModel.delegate = self;
     }
     return self;
-}
-
-- (void)setTableView:(nullable UITableView*)tableView {
-    [super setTableView:tableView];
-    [self.tableView registerNib:[WMFNearbyArticleTableViewCell wmf_classNib] forCellReuseIdentifier:[WMFNearbyArticleTableViewCell identifier]];
 }
 
 - (void)setSite:(MWKSite* __nonnull)site {
@@ -78,18 +51,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self.viewModel.site;
 }
 
-#pragma mark - WMFArticleListDynamicDataSource
-
-- (NSString* __nullable)displayTitle {
-    return MWLocalizedString(@"main-menu-nearby", nil);
+- (WMFSearchResultDistanceProvider*)distanceProviderForResultAtIndexPath:(NSIndexPath*)indexPath {
+    return [self.viewModel distanceProviderForResultAtIndex:indexPath.row];
 }
+
+- (WMFSearchResultBearingProvider*)bearingProviderForResultAtIndexPath:(NSIndexPath*)indexPath {
+    return [self.viewModel bearingProviderForResultAtIndex:indexPath.row];
+}
+
+#pragma mark - WMFArticleListDynamicDataSource
 
 - (BOOL)canDeleteItemAtIndexpath:(NSIndexPath* __nonnull)indexPath {
     return NO;
-}
-
-- (MWKHistoryDiscoveryMethod)discoveryMethod {
-    return MWKHistoryDiscoveryMethodSearch;
 }
 
 - (NSArray*)titles {
@@ -135,10 +108,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)nearbyViewModel:(WMFNearbyViewModel*)viewModel shouldFetchTitlesForLocation:(CLLocation*)location {
     return [self numberOfItems] == 0;
-}
-
-- (NSString*)analyticsName {
-    return @"Nearby";
 }
 
 @end

--- a/Wikipedia/Code/WMFReadMoreViewController.h
+++ b/Wikipedia/Code/WMFReadMoreViewController.h
@@ -1,0 +1,14 @@
+
+#import "WMFSelfSizingArticleListTableViewController.h"
+
+@interface WMFReadMoreViewController : WMFSelfSizingArticleListTableViewController
+
+@property (nonatomic, strong, readonly) MWKTitle* articleTitle;
+
+- (instancetype)initWithTitle:(MWKTitle*)title dataStore:(MWKDataStore*)dataStore;
+
+- (AnyPromise*)fetch;
+
+- (BOOL)hasResults;
+
+@end

--- a/Wikipedia/Code/WMFReadMoreViewController.m
+++ b/Wikipedia/Code/WMFReadMoreViewController.m
@@ -57,9 +57,7 @@
 }
 
 - (AnyPromise*)fetch {
-    return [self.dataSource fetch].then(^(id results){
-        [self.tableView reloadData];
-    });
+    return [self.dataSource fetch];
 }
 
 - (BOOL)hasResults {

--- a/Wikipedia/Code/WMFReadMoreViewController.m
+++ b/Wikipedia/Code/WMFReadMoreViewController.m
@@ -1,0 +1,75 @@
+
+#import "WMFReadMoreViewController.h"
+#import "MWKTitle.h"
+#import "MWKDataStore.h"
+#import "MWKUserDataStore.h"
+#import "WMFRelatedTitleListDataSource.h"
+#import "WMFRelatedSearchResults.h"
+#import "MWKSearchResult.h"
+#import "WMFArticlePreviewTableViewCell.h"
+#import "UITableViewCell+WMFLayout.h"
+#import "UIView+WMFDefaultNib.h"
+#import "WMFSaveButtonController.h"
+
+@interface WMFReadMoreViewController ()
+
+@property (nonatomic, strong, readwrite) MWKTitle* articleTitle;
+@property (nonatomic, strong) WMFRelatedTitleListDataSource* dataSource;
+
+@end
+
+@implementation WMFReadMoreViewController
+
+@dynamic dataSource;
+
+- (instancetype)initWithTitle:(MWKTitle*)title dataStore:(MWKDataStore*)dataStore;
+{
+    NSParameterAssert(title);
+    NSParameterAssert(dataStore);
+    self = [super init];
+    if (self) {
+        self.articleTitle = title;
+        self.dataStore    = dataStore;
+        self.dataSource   = [[WMFRelatedTitleListDataSource alloc] initWithTitle:self.articleTitle dataStore:self.dataStore resultLimit:3];
+        self.dataSource.cellClass = [WMFArticlePreviewTableViewCell class];
+        
+        @weakify(self);
+        self.dataSource.cellConfigureBlock = ^(WMFArticlePreviewTableViewCell* cell,
+                                               MWKSearchResult* searchResult,
+                                               UITableView* tableView,
+                                               NSIndexPath* indexPath) {
+            @strongify(self);
+            MWKTitle* title = [self.articleTitle.site titleWithString:searchResult.displayTitle];
+            [cell setSaveableTitle:title savedPageList:self.savedPageList];
+            cell.titleText       = searchResult.displayTitle;
+            cell.descriptionText = searchResult.wikidataDescription;
+            cell.snippetText     = searchResult.extract;
+            [cell setImageURL:searchResult.thumbnailURL];
+            [cell wmf_layoutIfNeededIfOperatingSystemVersionLessThan9_0_0];
+            cell.saveButtonController.analyticsSource = self;
+        };
+    }
+    return self;
+}
+
+- (MWKSavedPageList*)savedPageList {
+    return self.dataStore.userDataStore.savedPageList;
+}
+
+- (AnyPromise*)fetch {
+    return [self.dataSource fetch].then(^(id results){
+        [self.tableView reloadData];
+    });
+}
+
+- (BOOL)hasResults {
+    return [self.dataSource.relatedSearchResults.results count] > 0;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    [self.tableView registerNib:[WMFArticlePreviewTableViewCell wmf_classNib] forCellReuseIdentifier:[WMFArticlePreviewTableViewCell identifier]];
+    [self.tableView reloadData];
+}
+
+@end

--- a/Wikipedia/Code/WMFRecentPagesDataSource.h
+++ b/Wikipedia/Code/WMFRecentPagesDataSource.h
@@ -1,18 +1,17 @@
 #import <SSDataSources/SSDataSources.h>
 #import "WMFTitleListDataSource.h"
 
-@class MWKHistoryList, MWKSavedPageList;
+@class MWKHistoryList;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface WMFRecentPagesDataSource : SSSectionedDataSource<WMFTitleListDataSource, WMFArticleDeleteAllDataSource>
+@interface WMFRecentPagesDataSource : SSSectionedDataSource<WMFTitleListDataSource>
 
 @property (nonatomic, strong, readonly) NSArray* articles;
 
 @property (nonatomic, strong, readonly) MWKHistoryList* recentPages;
-@property (nonatomic, strong, readonly) MWKSavedPageList* savedPageList;
 
-- (nonnull instancetype)initWithRecentPagesList:(MWKHistoryList*)recentPages savedPages:(MWKSavedPageList*)savedPages;
+- (nonnull instancetype)initWithRecentPagesList:(MWKHistoryList*)recentPages;
 
 @end
 

--- a/Wikipedia/Code/WMFRelatedSectionController.h
+++ b/Wikipedia/Code/WMFRelatedSectionController.h
@@ -3,15 +3,15 @@
 
 @class WMFRelatedSearchFetcher;
 @class MWKTitle;
-@class MWKSavedPageList;
+@class MWKDataStore;
 
 @interface WMFRelatedSectionController : NSObject <WMFArticleHomeSectionController, WMFFetchingHomeSectionController>
 
 - (instancetype)initWithArticleTitle:(MWKTitle*)title
-                       savedPageList:(MWKSavedPageList*)savedPageList;
+                       dataStore:(MWKDataStore*)dataStore;
 
 - (instancetype)initWithArticleTitle:(MWKTitle*)title
-                       savedPageList:(MWKSavedPageList*)savedPageList
+                           dataStore:(MWKDataStore*)dataStore
                 relatedSearchFetcher:(WMFRelatedSearchFetcher*)relatedSearchFetcher NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, strong, readonly) MWKTitle* title;

--- a/Wikipedia/Code/WMFRelatedTitleListDataSource.h
+++ b/Wikipedia/Code/WMFRelatedTitleListDataSource.h
@@ -1,10 +1,3 @@
-//
-//  WMFRelatedTitleListDataSource.h
-//  Wikipedia
-//
-//  Created by Brian Gerstle on 9/4/15.
-//  Copyright (c) 2015 Wikimedia Foundation. All rights reserved.
-//
 
 #import <Foundation/Foundation.h>
 #import <SSDataSources/SSArrayDataSource.h>
@@ -22,15 +15,15 @@ NS_ASSUME_NONNULL_BEGIN
     <WMFTitleListDataSource>
 
 @property (nonatomic, strong, readonly, nullable) WMFRelatedSearchResults* relatedSearchResults;
+@property (nonatomic, copy, readonly) MWKTitle* title;
+@property (nonatomic, strong, readonly) MWKSavedPageList* savedPageList;
 
 - (instancetype)initWithTitle:(MWKTitle*)title
                     dataStore:(MWKDataStore*)dataStore
-                savedPageList:(MWKSavedPageList*)savedPageList
                   resultLimit:(NSUInteger)resultLimit;
 
 - (instancetype)initWithTitle:(MWKTitle*)title
                     dataStore:(MWKDataStore*)dataStore
-                savedPageList:(MWKSavedPageList*)savedPageList
                   resultLimit:(NSUInteger)resultLimit
                       fetcher:(WMFRelatedSearchFetcher*)fetcher NS_DESIGNATED_INITIALIZER;
 

--- a/Wikipedia/Code/WMFRelatedTitleViewController.h
+++ b/Wikipedia/Code/WMFRelatedTitleViewController.h
@@ -1,0 +1,13 @@
+
+#import "WMFArticleListTableViewController.h"
+#import "WMFRelatedTitleListDataSource.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WMFRelatedTitleViewController : WMFArticleListTableViewController
+
+@property (nonatomic, strong) WMFRelatedTitleListDataSource* dataSource;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFRelatedTitleViewController.m
+++ b/Wikipedia/Code/WMFRelatedTitleViewController.m
@@ -1,0 +1,61 @@
+
+#import "WMFRelatedTitleViewController.h"
+#import "MWKTitle.h"
+#import "MWKSearchResult.h"
+#import "WMFArticlePreviewTableViewCell.h"
+#import "UIView+WMFDefaultNib.h"
+#import "UITableViewCell+WMFLayout.h"
+#import "WMFSaveButtonController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WMFRelatedTitleViewController ()
+
+@end
+
+@implementation WMFRelatedTitleViewController
+
+@dynamic dataSource;
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    [self.tableView registerNib:[WMFArticlePreviewTableViewCell wmf_classNib] forCellReuseIdentifier:[WMFArticlePreviewTableViewCell identifier]];
+}
+
+- (void)setDataSource:(WMFRelatedTitleListDataSource*)dataSource {
+    
+    self.title = [MWLocalizedString(@"home-more-like-footer", nil) stringByReplacingOccurrencesOfString:@"$1" withString:dataSource.title.text];
+
+    dataSource.cellClass = [WMFArticlePreviewTableViewCell class];
+
+    @weakify(self);
+    dataSource.cellConfigureBlock = ^(WMFArticlePreviewTableViewCell* cell,
+                                      MWKSearchResult* searchResult,
+                                      UITableView* tableView,
+                                      NSIndexPath* indexPath) {
+        @strongify(self);
+        MWKTitle* title = [self.dataSource.title.site titleWithString:searchResult.displayTitle];
+        [cell setSaveableTitle:title savedPageList:self.dataSource.savedPageList];
+        cell.titleText       = searchResult.displayTitle;
+        cell.descriptionText = searchResult.wikidataDescription;
+        cell.snippetText     = searchResult.extract;
+        [cell setImageURL:searchResult.thumbnailURL];
+        [cell wmf_layoutIfNeededIfOperatingSystemVersionLessThan9_0_0];
+        cell.saveButtonController.analyticsSource = self;
+    };
+
+    [super setDataSource:dataSource];
+}
+
+- (MWKHistoryDiscoveryMethod)discoveryMethod {
+    return MWKHistoryDiscoveryMethodSearch;
+}
+
+- (NSString*)analyticsName {
+    return @"Related";
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFSavedArticleTableViewController.h
+++ b/Wikipedia/Code/WMFSavedArticleTableViewController.h
@@ -1,0 +1,13 @@
+//
+//  WMFSavedArticleTableViewController.h
+//  Wikipedia
+//
+//  Created by Corey Floyd on 12/22/15.
+//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import "WMFArticleListTableViewController.h"
+
+@interface WMFSavedArticleTableViewController : WMFArticleListTableViewController
+
+@end

--- a/Wikipedia/Code/WMFSavedArticleTableViewController.m
+++ b/Wikipedia/Code/WMFSavedArticleTableViewController.m
@@ -1,0 +1,92 @@
+//
+//  WMFSavedArticleTableViewController.m
+//  Wikipedia
+//
+//  Created by Corey Floyd on 12/22/15.
+//  Copyright © 2015 Wikimedia Foundation. All rights reserved.
+//
+
+#import "WMFSavedArticleTableViewController.h"
+
+#import "NSString+Extras.h"
+
+#import "WMFSavedPagesDataSource.h"
+#import "MWKDataStore.h"
+#import "MWKUserDataStore.h"
+
+#import "MWKArticle.h"
+#import "MWKTitle.h"
+#import "MWKSavedPageEntry.h"
+
+#import "WMFSaveButtonController.h"
+
+#import "WMFArticlePreviewTableViewCell.h"
+#import "UIView+WMFDefaultNib.h"
+#import "UITableViewCell+WMFLayout.h"
+
+
+@implementation WMFSavedArticleTableViewController
+
+- (MWKSavedPageList*)savedPageList {
+    return self.dataStore.userDataStore.savedPageList;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.title = MWLocalizedString(@"saved-title", nil);
+
+    [self.tableView registerNib:[WMFArticlePreviewTableViewCell wmf_classNib] forCellReuseIdentifier:[WMFArticlePreviewTableViewCell identifier]];
+
+    WMFSavedPagesDataSource* ds = [[WMFSavedPagesDataSource alloc] initWithSavedPagesList:[self savedPageList]];
+
+    ds.cellClass = [WMFArticlePreviewTableViewCell class];
+
+    @weakify(self);
+    ds.cellConfigureBlock = ^(WMFArticlePreviewTableViewCell* cell,
+                              MWKSavedPageEntry* entry,
+                              UITableView* tableView,
+                              NSIndexPath* indexPath) {
+        @strongify(self);
+        MWKArticle* article = [[self dataStore] articleWithTitle:entry.title];
+        [cell setSaveableTitle:article.title savedPageList:[self savedPageList]];
+        cell.titleText       = article.title.text;
+        cell.descriptionText = [article.entityDescription wmf_stringByCapitalizingFirstCharacter];
+        cell.snippetText     = [article summary];
+        [cell setImage:[article bestThumbnailImage]];
+        [cell wmf_layoutIfNeededIfOperatingSystemVersionLessThan9_0_0];
+        cell.saveButtonController.analyticsSource = self;
+    };
+
+    self.dataSource = ds;
+}
+
+- (WMFEmptyViewType)emptyViewType {
+    return WMFEmptyViewTypeNoSavedPages;
+}
+
+- (MWKHistoryDiscoveryMethod)discoveryMethod {
+    return MWKHistoryDiscoveryMethodSaved;
+}
+
+- (NSString*)analyticsName {
+    return @"Saved";
+}
+
+- (BOOL)showsDeleteAllButton {
+    return YES;
+}
+
+- (NSString*)deleteAllConfirmationText {
+    return MWLocalizedString(@"saved-pages-clear-confirmation-heading", nil);
+}
+
+- (NSString*)deleteText {
+    return MWLocalizedString(@"saved-pages-clear-delete-all", nil);
+}
+
+- (NSString*)deleteCancelText {
+    return MWLocalizedString(@"saved-pages-clear-cancel", nil);
+}
+
+@end

--- a/Wikipedia/Code/WMFSavedPagesDataSource.h
+++ b/Wikipedia/Code/WMFSavedPagesDataSource.h
@@ -5,7 +5,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface WMFSavedPagesDataSource : SSArrayDataSource<WMFTitleListDataSource, WMFArticleDeleteAllDataSource>
+@interface WMFSavedPagesDataSource : SSArrayDataSource<WMFTitleListDataSource>
 
 @property (nonatomic, strong, readonly) NSArray* articles;
 @property (nonatomic, strong, readonly) MWKSavedPageList* savedPageList;

--- a/Wikipedia/Code/WMFSavedPagesDataSource.m
+++ b/Wikipedia/Code/WMFSavedPagesDataSource.m
@@ -1,15 +1,7 @@
 
 #import "WMFSavedPagesDataSource.h"
-#import "MWKDataStore.h"
-#import "MWKArticle.h"
 #import "MWKSavedPageList.h"
 #import "MWKSavedPageEntry.h"
-#import "WMFArticlePreviewTableViewCell.h"
-#import "UIView+WMFDefaultNib.h"
-#import "NSString+Extras.h"
-#import "UITableViewCell+WMFLayout.h"
-#import "WMFSaveButtonController.h"
-
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -26,24 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super initWithTarget:savedPages keyPath:WMF_SAFE_KEYPATH(savedPages, entries)];
     if (self) {
         self.savedPageList = savedPages;
-
-        self.cellClass = [WMFArticlePreviewTableViewCell class];
-
-        @weakify(self);
-        self.cellConfigureBlock = ^(WMFArticlePreviewTableViewCell* cell,
-                                    MWKSavedPageEntry* entry,
-                                    UITableView* tableView,
-                                    NSIndexPath* indexPath) {
-            @strongify(self);
-            MWKArticle* article = [[self dataStore] articleWithTitle:entry.title];
-            [cell setSaveableTitle:article.title savedPageList:self.savedPageList];
-            cell.titleText       = article.title.text;
-            cell.descriptionText = [article.entityDescription wmf_stringByCapitalizingFirstCharacter];
-            cell.snippetText     = [article summary];
-            [cell setImage:[article bestThumbnailImage]];
-            [cell wmf_layoutIfNeededIfOperatingSystemVersionLessThan9_0_0];
-            cell.saveButtonController.analyticsSource = self;
-        };
 
         self.tableDeletionBlock = ^(WMFSavedPagesDataSource* dataSource,
                                     UITableView* parentView,
@@ -77,11 +51,6 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setTableView:(nullable UITableView*)tableView {
-    [super setTableView:tableView];
-    [self.tableView registerNib:[WMFArticlePreviewTableViewCell wmf_classNib] forCellReuseIdentifier:[WMFArticlePreviewTableViewCell identifier]];
-}
-
 - (NSArray*)titles {
     return [[self.savedPageList entries] bk_map:^id (MWKSavedPageEntry* obj) {
         return obj.title;
@@ -92,14 +61,6 @@ NS_ASSUME_NONNULL_BEGIN
     return [[self savedPageList] countOfEntries];
 }
 
-- (MWKDataStore*)dataStore {
-    return self.savedPageList.dataStore;
-}
-
-- (nullable NSString*)displayTitle {
-    return MWLocalizedString(@"saved-title", nil);
-}
-
 - (MWKSavedPageEntry*)savedPageForIndexPath:(NSIndexPath*)indexPath {
     MWKSavedPageEntry* savedEntry = [self.savedPageList entryAtIndex:indexPath.row];
     return savedEntry;
@@ -108,10 +69,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (MWKTitle*)titleForIndexPath:(NSIndexPath*)indexPath {
     MWKSavedPageEntry* savedEntry = [self savedPageForIndexPath:indexPath];
     return savedEntry.title;
-}
-
-- (WMFEmptyViewType)emptyViewType {
-    return WMFEmptyViewTypeNoSavedPages;
 }
 
 - (BOOL)canDeleteItemAtIndexpath:(NSIndexPath*)indexPath {
@@ -126,33 +83,9 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (BOOL)showsDeleteAllButton {
-    return YES;
-}
-
-- (NSString*)deleteAllConfirmationText {
-    return MWLocalizedString(@"saved-pages-clear-confirmation-heading", nil);
-}
-
-- (NSString*)deleteText {
-    return MWLocalizedString(@"saved-pages-clear-delete-all", nil);
-}
-
-- (NSString*)deleteCancelText {
-    return MWLocalizedString(@"saved-pages-clear-cancel", nil);
-}
-
 - (void)deleteAll {
     [self.savedPageList removeAllEntries];
     [self.savedPageList save];
-}
-
-- (MWKHistoryDiscoveryMethod)discoveryMethod {
-    return MWKHistoryDiscoveryMethodSaved;
-}
-
-- (NSString*)analyticsName {
-    return @"Saved";
 }
 
 @end

--- a/Wikipedia/Code/WMFSearchDataSource.m
+++ b/Wikipedia/Code/WMFSearchDataSource.m
@@ -3,10 +3,6 @@
 #import "MWKTitle.h"
 #import "WMFSearchResults.h"
 #import "MWKSearchResult.h"
-#import "MWKSearchRedirectMapping.h"
-#import "NSString+Extras.h"
-#import "WMFArticleListTableViewCell+WMFSearch.h"
-#import "UIView+WMFDefaultNib.h"
 
 @interface WMFSearchDataSource ()
 
@@ -24,49 +20,8 @@
     if (self) {
         self.searchSite    = site;
         self.searchResults = searchResults;
-
-        self.cellClass = [WMFArticleListTableViewCell class];
-
-        @weakify(self);
-        self.cellConfigureBlock = ^(WMFArticleListTableViewCell* cell,
-                                    MWKSearchResult* result,
-                                    UITableView* tableView,
-                                    NSIndexPath* indexPath) {
-            @strongify(self);
-            MWKTitle* title = [self titleForIndexPath:indexPath];
-            [cell setTitleText:title.text highlightingText:self.searchResults.searchTerm];
-            cell.descriptionText = [self descriptionForSearchResult:result];
-            [cell setImageURL:result.thumbnailURL];
-        };
     }
     return self;
-}
-
-- (NSString*)descriptionForSearchResult:(MWKSearchResult*)result {
-    MWKSearchRedirectMapping* mapping = [self redirectMappingForResult:result];
-    if (!mapping) {
-        return result.wikidataDescription;
-    }
-    NSString* description = result.wikidataDescription ? [@"\n" stringByAppendingString : [result.wikidataDescription wmf_stringByCapitalizingFirstCharacter]] : @"";
-    return [NSString stringWithFormat:@"Redirected from: %@%@", mapping.redirectFromTitle, description];
-}
-
-- (MWKSearchRedirectMapping*)redirectMappingForResult:(MWKSearchResult*)result {
-    return [self.searchResults.redirectMappings bk_match:^BOOL (MWKSearchRedirectMapping* obj) {
-        if ([result.displayTitle isEqualToString:obj.redirectToTitle]) {
-            return YES;
-        }
-        return NO;
-    }];
-}
-
-- (void)setTableView:(nullable UITableView*)tableView {
-    [super setTableView:tableView];
-    [self.tableView registerNib:[WMFArticleListTableViewCell wmf_classNib] forCellReuseIdentifier:[WMFArticleListTableViewCell identifier]];
-}
-
-- (nullable NSString*)displayTitle {
-    return self.searchResults.searchTerm;
 }
 
 - (NSArray*)titles {
@@ -95,18 +50,6 @@
 
 - (BOOL)noResults {
     return (self.searchResults && [self.searchResults.results count] == 0);
-}
-
-- (MWKHistoryDiscoveryMethod)discoveryMethod {
-    return MWKHistoryDiscoveryMethodSearch;
-}
-
-- (CGFloat)estimatedItemHeight {
-    return 60.f;
-}
-
-- (NSString*)analyticsName {
-    return @"Search";
 }
 
 @end

--- a/Wikipedia/Code/WMFSearchResultsTableViewController.h
+++ b/Wikipedia/Code/WMFSearchResultsTableViewController.h
@@ -1,0 +1,9 @@
+
+#import "WMFArticleListTableViewController.h"
+#import "WMFSearchDataSource.h"
+
+@interface WMFSearchResultsTableViewController : WMFArticleListTableViewController
+
+@property (nonatomic, strong) WMFSearchDataSource* dataSource;
+
+@end

--- a/Wikipedia/Code/WMFSearchResultsTableViewController.m
+++ b/Wikipedia/Code/WMFSearchResultsTableViewController.m
@@ -1,0 +1,73 @@
+
+#import "WMFSearchResultsTableViewController.h"
+#import "WMFArticleListTableViewCell+WMFSearch.h"
+#import "UIView+WMFDefaultNib.h"
+#import "MWKSearchResult.h"
+#import "MWKTitle.h"
+#import "WMFSearchResults.h"
+#import "MWKSearchRedirectMapping.h"
+#import "NSString+Extras.h"
+
+@implementation WMFSearchResultsTableViewController
+
+@dynamic dataSource;
+
+- (WMFSearchResults*)searchResults{
+    return self.dataSource.searchResults;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    [self.tableView registerNib:[WMFArticleListTableViewCell wmf_classNib] forCellReuseIdentifier:[WMFArticleListTableViewCell identifier]];
+    
+    self.tableView.estimatedRowHeight = 60.0f;
+}
+
+- (void)setDataSource:(WMFSearchDataSource*)dataSource {
+
+    dataSource.cellClass = [WMFArticleListTableViewCell class];
+    
+    @weakify(self);
+    dataSource.cellConfigureBlock = ^(WMFArticleListTableViewCell* cell,
+                                MWKSearchResult* result,
+                                UITableView* tableView,
+                                NSIndexPath* indexPath) {
+        @strongify(self);
+        MWKTitle* title = [self.dataSource titleForIndexPath:indexPath];
+        [cell setTitleText:title.text highlightingText:self.searchResults.searchTerm];
+        cell.descriptionText = [self descriptionForSearchResult:result];
+        [cell setImageURL:result.thumbnailURL];
+    };
+
+    [super setDataSource:dataSource];
+}
+
+- (MWKSearchRedirectMapping*)redirectMappingForResult:(MWKSearchResult*)result {
+    return [self.searchResults.redirectMappings bk_match:^BOOL (MWKSearchRedirectMapping* obj) {
+        if ([result.displayTitle isEqualToString:obj.redirectToTitle]) {
+            return YES;
+        }
+        return NO;
+    }];
+}
+
+- (NSString*)descriptionForSearchResult:(MWKSearchResult*)result {
+    MWKSearchRedirectMapping* mapping = [self redirectMappingForResult:result];
+    if (!mapping) {
+        return result.wikidataDescription;
+    }
+    NSString* description = result.wikidataDescription ? [@"\n" stringByAppendingString : [result.wikidataDescription wmf_stringByCapitalizingFirstCharacter]] : @"";
+    return [NSString stringWithFormat:@"Redirected from: %@%@", mapping.redirectFromTitle, description];
+}
+
+- (MWKHistoryDiscoveryMethod)discoveryMethod {
+    return MWKHistoryDiscoveryMethodSearch;
+}
+
+- (WMFEmptyViewType)emptyViewType {
+    return WMFEmptyViewTypeNoSearchResults;
+}
+
+
+@end

--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -1,7 +1,7 @@
 #import "WMFSearchViewController.h"
 
 #import "RecentSearchesViewController.h"
-#import "WMFArticleListTableViewController.h"
+#import "WMFSearchResultsTableViewController.h"
 
 #import "SessionSingleton.h"
 
@@ -42,7 +42,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 @property (nonatomic, strong) NSArray* searchLanguages;
 
 @property (nonatomic, strong) RecentSearchesViewController* recentSearchesViewController;
-@property (nonatomic, strong) WMFArticleListTableViewController* resultsListController;
+@property (nonatomic, strong) WMFSearchResultsTableViewController* resultsListController;
 
 @property (strong, nonatomic) IBOutlet UITextField* searchField;
 @property (strong, nonatomic) IBOutlet UIButton* searchSuggestionButton;
@@ -100,11 +100,11 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 #pragma mark - Accessors
 
 - (NSString*)currentSearchTerm {
-    return [[(WMFSearchDataSource*)self.resultsListController.dataSource searchResults] searchTerm];
+    return [[self.resultsListController.dataSource searchResults] searchTerm];
 }
 
 - (NSString*)searchSuggestion {
-    return [[(WMFSearchDataSource*)self.resultsListController.dataSource searchResults] searchSuggestion];
+    return [[self.resultsListController.dataSource searchResults] searchSuggestion];
 }
 
 - (WMFSearchFetcher*)fetcher {

--- a/Wikipedia/Code/WMFSearchViewController.storyboard
+++ b/Wikipedia/Code/WMFSearchViewController.storyboard
@@ -367,10 +367,10 @@
             </objects>
             <point key="canvasLocation" x="587" y="3712"/>
         </scene>
-        <!--Article List Table View Controller-->
+        <!--Search Results Table View Controller-->
         <scene sceneID="UeF-5R-zXb">
             <objects>
-                <tableViewController id="h3Q-u3-KJA" customClass="WMFArticleListTableViewController" sceneMemberID="viewController">
+                <tableViewController id="h3Q-u3-KJA" customClass="WMFSearchResultsTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="3cy-oJ-h8H">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="462"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Wikipedia/Code/WMFSelfSizingArticleListTableViewController.h
+++ b/Wikipedia/Code/WMFSelfSizingArticleListTableViewController.h
@@ -1,0 +1,10 @@
+
+#import "WMFArticleListTableViewController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WMFSelfSizingArticleListTableViewController : WMFArticleListTableViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFSelfSizingArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFSelfSizingArticleListTableViewController.m
@@ -1,0 +1,23 @@
+
+#import "WMFSelfSizingArticleListTableViewController.h"
+#import "WMFIntrinsicSizeTableView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WMFSelfSizingArticleListTableViewController ()
+
+@end
+
+@implementation WMFSelfSizingArticleListTableViewController
+
+- (void)loadView {
+    [super loadView];
+    UITableView* tv = [[WMFIntrinsicSizeTableView alloc] initWithFrame:CGRectZero];
+    tv.translatesAutoresizingMaskIntoConstraints = NO;
+    tv.delegate                                  = self;
+    self.tableView                               = tv;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFTabBarUI.storyboard
+++ b/Wikipedia/Code/WMFTabBarUI.storyboard
@@ -59,10 +59,10 @@
             </objects>
             <point key="canvasLocation" x="886" y="2881"/>
         </scene>
-        <!--Article List Table View Controller-->
+        <!--Saved Article Table View Controller-->
         <scene sceneID="Uaj-Q3-jYT">
             <objects>
-                <tableViewController id="e79-4K-3DF" customClass="WMFArticleListTableViewController" sceneMemberID="viewController">
+                <tableViewController id="e79-4K-3DF" customClass="WMFSavedArticleTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="n0h-Oz-3rH">
                         <rect key="frame" x="0.0" y="64" width="600" height="487"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -98,10 +98,10 @@
             </objects>
             <point key="canvasLocation" x="2367" y="2115"/>
         </scene>
-        <!--Article List Table View Controller-->
+        <!--History Table View Controller-->
         <scene sceneID="Wf7-qC-7Gn">
             <objects>
-                <tableViewController id="PJq-J4-m3k" customClass="WMFArticleListTableViewController" sceneMemberID="viewController">
+                <tableViewController id="PJq-J4-m3k" customClass="WMFHistoryTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="RiJ-nm-vrg">
                         <rect key="frame" x="0.0" y="64" width="600" height="487"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Wikipedia/Code/WMFTitleListDataSource.h
+++ b/Wikipedia/Code/WMFTitleListDataSource.h
@@ -1,14 +1,11 @@
 #import <Foundation/Foundation.h>
 #import "MWKHistoryEntry.h"
-#import "WMFAnalyticsLogging.h"
 #import "UIViewController+WMFEmptyView.h"
 
 NS_ASSUME_NONNULL_BEGIN
 @class MWKSavedPageList;
 
-@protocol WMFTitleListDataSource <WMFAnalyticsLogging>
-
-- (nullable NSString*)displayTitle;
+@protocol WMFTitleListDataSource
 
 @property (nonatomic, strong, readonly) NSArray* titles;
 
@@ -18,27 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)canDeleteItemAtIndexpath:(NSIndexPath*)indexPath;
 
-- (MWKHistoryDiscoveryMethod)discoveryMethod;
-
 @optional
 
 - (void)deleteArticleAtIndexPath:(NSIndexPath*)indexPath;
-
-- (CGFloat)estimatedItemHeight;
-
-- (WMFEmptyViewType)emptyViewType;
-
-@end
-
-@protocol WMFArticleDeleteAllDataSource <NSObject>
-
-- (BOOL)showsDeleteAllButton;
-
-- (NSString*)deleteAllConfirmationText;
-
-- (NSString*)deleteText;
-
-- (NSString*)deleteCancelText;
 
 - (void)deleteAll;
 

--- a/WikipediaUnitTests/Code/WMFRecentPagesDataSourceTests.m
+++ b/WikipediaUnitTests/Code/WMFRecentPagesDataSourceTests.m
@@ -30,8 +30,7 @@ __block WMFRecentPagesDataSource* recentPagesDataSource;
 configureTempDataStoreForEach(tempDataStore, ^{
     MWKUserDataStore* userDataStore = tempDataStore.userDataStore;
     historyList = userDataStore.historyList;
-    recentPagesDataSource = [[WMFRecentPagesDataSource alloc] initWithRecentPagesList:historyList
-                                                                           savedPages:userDataStore.savedPageList];
+    recentPagesDataSource = [[WMFRecentPagesDataSource alloc] initWithRecentPagesList:historyList];
 });
 
 describe(@"partitioning by date", ^{


### PR DESCRIPTION
This patch creates a concrete VC for each type of list that is displayed.

This was done to separate the view concerns from the data sources and to give more control over the presentation of the different list VCs (for instance adding pull to refresh or enabling a delete all button).

A new VC was created for the following lists:
- Saved
- History
- Search
- Nearby
- Related Titles
- Article Read More

Note:
The nearby view model / distance bearing provider architecture is making separation of view concerns a bit harder in that situation. This should be tagged for future clean up refactoring.

Other note:
At this point I'm not sure we should be subclassing the data sources. We have a "coupled class hierarchy" between data sources and list view controllers. This smells a bit to me.

I don't think we are getting a lot of code re-use here. Basically we could move the code in the data sources into the view controllers and not really duplicate ourselves. We can/should consider doing this before merging.



