### PR TITLE
Disable system share item in contextual text selection menu

### DIFF
--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -898,3 +898,21 @@ NSString* const WMFLicenseTitleOnENWiki =
 }
 
 @end
+
+
+@interface WMFWebView : UIWebView
+
+@end
+
+
+@implementation WMFWebView
+
+//Disable OS share menu when selecting text
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
+    if (action == NSSelectorFromString(@"_share:")) {
+        return NO;
+    }
+    return [super canPerformAction:action withSender:sender];
+}
+
+@end

--- a/Wikipedia/Code/WebViewController.storyboard
+++ b/Wikipedia/Code/WebViewController.storyboard
@@ -18,7 +18,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <webView clipsSubviews="YES" contentMode="scaleToFill" allowsInlineMediaPlayback="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WeL-Mj-Zsh">
+                            <webView clipsSubviews="YES" contentMode="scaleToFill" allowsInlineMediaPlayback="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WeL-Mj-Zsh" customClass="WMFWebView">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <dataDetectorType key="dataDetectorTypes"/>


### PR DESCRIPTION
Disables the system share menu by returning NO for being able to perform the system share action.