### PR TITLE
Fix wikitext RTL behavior in iOS 8 and 9.

### DIFF
--- a/Wikipedia/Code/SectionEditorViewController.m
+++ b/Wikipedia/Code/SectionEditorViewController.m
@@ -155,14 +155,6 @@
                 self.unmodifiedWikiText          = revision;
                 self.editTextView.attributedText = [self getAttributedString:revision];
                 //[self.editTextView performSelector:@selector(becomeFirstResponder) withObject:nil afterDelay:0.4f];
-
-                MWLanguageInfo* lang = [MWLanguageInfo languageInfoForCode:wikiTextSectionFetcher.section.article.site.domain];
-                UITextRange* range   = [self.editTextView textRangeFromPosition:self.editTextView.beginningOfDocument toPosition:self.editTextView.endOfDocument];
-                if ([lang.dir isEqualToString:@"rtl"]) {
-                    [self.editTextView setBaseWritingDirection:UITextWritingDirectionRightToLeft forRange:range];
-                } else {
-                    [self.editTextView setBaseWritingDirection:UITextWritingDirectionLeftToRight forRange:range];
-                }
             }
             break;
             case FETCH_FINAL_STATUS_CANCELLED: {

--- a/Wikipedia/Code/SectionEditorViewController.storyboard
+++ b/Wikipedia/Code/SectionEditorViewController.storyboard
@@ -18,7 +18,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ohj-LA-82c">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ohj-LA-82c">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                                 <color key="backgroundColor" red="0.98039215690000003" green="0.98039215690000003" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>


### PR DESCRIPTION
**Wikitext RTL** (this PR only fixes the text below, not the buttons at the top)
- [x] iOS 8
![screen shot 2016-01-15 at 8 03 35 am](https://cloud.githubusercontent.com/assets/3143487/12357930/a35cba52-bb5f-11e5-92b4-4e23e1db2909.png)

- [x] iOS 9
![screen shot 2016-01-15 at 8 04 09 am](https://cloud.githubusercontent.com/assets/3143487/12357999/fff7c1c6-bb5f-11e5-8d8f-bf74d33f875a.png)

**Edit preview RTL** (the text at the bottom of the screenshots below)
- [x] iOS 8
![screen shot 2016-01-15 at 8 09 09 am](https://cloud.githubusercontent.com/assets/3143487/12358002/035648a6-bb60-11e5-82d7-581fd07b6735.png)

- [x] iOS 9
![screen shot 2016-01-15 at 8 09 44 am](https://cloud.githubusercontent.com/assets/3143487/12358005/0700ca8a-bb60-11e5-827b-558b239fca53.png)
