### PR TITLE
Fix Siri crash

### DIFF
--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -292,27 +292,46 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 
 - (IBAction)textFieldDidChange {
     NSString* query = self.searchField.text;
-
-    DDLogDebug(@"Search field text changed to: %@", query);
-
-    BOOL isFieldEmpty = [query wmf_trim].length == 0;
-    [self setSeparatorViewHidden:isFieldEmpty animated:YES];
-
-    if (isFieldEmpty) {
-        [self didCancelSearch];
-        return;
-    }
-
-    [self setRecentSearchesHidden:YES animated:YES];
-
+    
     dispatchOnMainQueueAfterDelayInSeconds(0.4, ^{
-        if ([query isEqualToString:self.searchField.text]) {
-            DDLogDebug(@"Searching for %@ after delay.", query);
-            [self searchForSearchTerm:query];
-        } else {
+        
+        DDLogDebug(@"Search field text changed to: %@", query);
+        
+        /**
+         *  This check must performed before checking isEmpty and calling didCancelSearch
+         *  This is to work around a "feature" of Siri which sets the textfield.text to nil
+         *  when cancelling the Siri interface, and then immediately sets the text to its original value
+         *
+         *  The sequence of events is like so:
+         *  Say "Mountain" to Siri
+         *  "Mountain" is typed in the text field by Siri
+         *  textFieldDidChange fires with textfield.text="Mountain"
+         *  Tap a search result (which "cancels" the Siri UI)
+         *  textFieldDidChange fires with textfield.text="" (This is the offending event!)
+         *  textFieldDidChange fires with textfield.text="Mountain"
+         *  
+         *  The event setting the textfield.text == nil causes many side effects which can cause crashes like:
+         *  https://phabricator.wikimedia.org/T123241
+         */
+        if (![query isEqualToString:self.searchField.text]) {
             DDLogInfo(@"Aborting search for %@ since query has changed to %@", query, self.searchField.text);
+            return;
         }
+
+        BOOL isFieldEmpty = [query wmf_trim].length == 0;
+        [self setSeparatorViewHidden:isFieldEmpty animated:YES];
+
+        if (isFieldEmpty) {
+            [self didCancelSearch];
+            return;
+        }
+        
+        [self setRecentSearchesHidden:YES animated:YES];
+
+        DDLogDebug(@"Searching for %@ after delay.", query);
+        [self searchForSearchTerm:query];
     });
+    
 }
 
 - (BOOL)textFieldShouldReturn:(UITextField*)textField {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T123241

This was caused by UITextField emitting an extra event when a user cancels the Siri interface.
The work around was to move all checking of the text field in the dispatch block and after checking if the original query is still equal to the contents of the textfield