### PR TITLE
Fix weird iOS 8 search result animation.

### DIFF
--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -359,9 +359,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 
         self.resultsListController.dataSource = dataSource;
 
-        [UIView animateWithDuration:0.25 animations:^{
-            [self updateUIWithResults:results];
-        }];
+        [self updateUIWithResults:results];
 
         if ([results.results count] < kWMFMinResultsBeforeAutoFullTextSearch) {
             return [self.fetcher fetchArticlesForSearchTerm:searchTerm


### PR DESCRIPTION
The RTL text alignment issue from https://phabricator.wikimedia.org/T121680 was already fixed, but there remained a weird iOS 8 search results animation issue:

**Weird animation bug:** 

*BEFORE*
![untitled1 mov](https://cloud.githubusercontent.com/assets/3143487/12360235/9f29bc1c-bb6b-11e5-88d9-0a9318a97496.gif)

*AFTER*
![untitled2 mov](https://cloud.githubusercontent.com/assets/3143487/12360238/a20068aa-bb6b-11e5-94ef-6e45ee6ba143.gif)