### PR TITLE
Fix builds not being uploaded to iTunes connect

### DIFF
--- a/scripts/process_plist.sh
+++ b/scripts/process_plist.sh
@@ -12,11 +12,10 @@ set -e
 
 if [[ "${CONFIGURATION}" != "Release" || $WMF_FORCE_ITUNES_FILE_SHARING == "1" ]]; then
   echo "Enabling iTunes File Sharing for ${CONFIGURATION} build."
-  defaults write "${INFO_PLIST}" UIFileSharingEnabled true
+  defaults write "${INFO_PLIST}" UIFileSharingEnabled -bool YES
 fi
 
 if [[ "${CONFIGURATION}" != "Release" || $WMF_FORCE_DEBUG_MENU == "1" ]]; then
   echo "Showing debug menu for ${CONFIGURATION} build."
-  defaults write "${INFO_PLIST}" WMFShowDebugMenu true
+  defaults write "${INFO_PLIST}" WMFShowDebugMenu -bool YES
 fi
-


### PR DESCRIPTION
We were writing strings for booleans.
This only recently started breaking the build, so it likely due to Apple has tightening up the checks when uploading binaries.