### PR TITLE
Fix search field placeholder text alignment on iOS 8.

### DIFF
--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -162,6 +162,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 }
 
 - (void)configureSearchField {
+    self.searchField.textAlignment = NSTextAlignmentNatural;
     [self setSeparatorViewHidden:YES animated:NO];
     [self.searchField setPlaceholder:MWLocalizedString(@"search-field-placeholder-text", nil)];
 }
@@ -292,11 +293,10 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 
 - (IBAction)textFieldDidChange {
     NSString* query = self.searchField.text;
-    
+
     dispatchOnMainQueueAfterDelayInSeconds(0.4, ^{
-        
         DDLogDebug(@"Search field text changed to: %@", query);
-        
+
         /**
          *  This check must performed before checking isEmpty and calling didCancelSearch
          *  This is to work around a "feature" of Siri which sets the textfield.text to nil
@@ -309,7 +309,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
          *  Tap a search result (which "cancels" the Siri UI)
          *  textFieldDidChange fires with textfield.text="" (This is the offending event!)
          *  textFieldDidChange fires with textfield.text="Mountain"
-         *  
+         *
          *  The event setting the textfield.text == nil causes many side effects which can cause crashes like:
          *  https://phabricator.wikimedia.org/T123241
          */
@@ -325,13 +325,12 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
             [self didCancelSearch];
             return;
         }
-        
+
         [self setRecentSearchesHidden:YES animated:YES];
 
         DDLogDebug(@"Searching for %@ after delay.", query);
         [self searchForSearchTerm:query];
     });
-    
 }
 
 - (BOOL)textFieldShouldReturn:(UITextField*)textField {


### PR DESCRIPTION
Not sure why the "natural" setting from the storyboard doesn't work for this...

![screen shot 2016-01-15 at 1 35 15 pm](https://cloud.githubusercontent.com/assets/3143487/12365983/25cabcdc-bb8d-11e5-8489-eaa2039943bc.png)
