### PR TITLE
Trending articles!

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -541,6 +541,8 @@
 		B0EF42D01C43FDD200D125A8 /* UIApplicationShortcutItem+WMFShortcutItem.m in Sources */ = {isa = PBXBuildFile; fileRef = B0EF42CF1C43FDD200D125A8 /* UIApplicationShortcutItem+WMFShortcutItem.m */; };
 		B0F956A91C481BC000691810 /* WMFArticleFooterMenuCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B0F956A81C481BC000691810 /* WMFArticleFooterMenuCell.m */; };
 		B0F956AB1C481C2100691810 /* WMFArticleFooterMenuCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B0F956AA1C481C2100691810 /* WMFArticleFooterMenuCell.xib */; };
+		B0F956AE1C484E0500691810 /* WMFTrendingFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = B0F956AD1C484E0500691810 /* WMFTrendingFetcher.m */; };
+		B0F956B21C4859EE00691810 /* WMFTrendingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B0F956B11C4859EE00691810 /* WMFTrendingViewController.m */; };
 		BC070C2F1C1F2C0200CAE9E2 /* MWKImage+CanonicalFilenames.m in Sources */ = {isa = PBXBuildFile; fileRef = BC070C2E1C1F2C0200CAE9E2 /* MWKImage+CanonicalFilenames.m */; };
 		BC070C311C1F682400CAE9E2 /* WMFArticleImageGalleryDataSourceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC070C301C1F682400CAE9E2 /* WMFArticleImageGalleryDataSourceTests.m */; };
 		BC15E74A1BF4377C00679AA9 /* MonetPrefixSearch.json in Resources */ = {isa = PBXBuildFile; fileRef = BC15E7491BF4377C00679AA9 /* MonetPrefixSearch.json */; };
@@ -1588,6 +1590,10 @@
 		B0F956A71C481BC000691810 /* WMFArticleFooterMenuCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFArticleFooterMenuCell.h; path = Wikipedia/Code/WMFArticleFooterMenuCell.h; sourceTree = SOURCE_ROOT; };
 		B0F956A81C481BC000691810 /* WMFArticleFooterMenuCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFArticleFooterMenuCell.m; path = Wikipedia/Code/WMFArticleFooterMenuCell.m; sourceTree = SOURCE_ROOT; };
 		B0F956AA1C481C2100691810 /* WMFArticleFooterMenuCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = WMFArticleFooterMenuCell.xib; path = Wikipedia/Code/WMFArticleFooterMenuCell.xib; sourceTree = SOURCE_ROOT; };
+		B0F956AC1C484E0500691810 /* WMFTrendingFetcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFTrendingFetcher.h; path = Wikipedia/Code/WMFTrendingFetcher.h; sourceTree = SOURCE_ROOT; };
+		B0F956AD1C484E0500691810 /* WMFTrendingFetcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFTrendingFetcher.m; path = Wikipedia/Code/WMFTrendingFetcher.m; sourceTree = SOURCE_ROOT; };
+		B0F956B01C4859EE00691810 /* WMFTrendingViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFTrendingViewController.h; sourceTree = "<group>"; };
+		B0F956B11C4859EE00691810 /* WMFTrendingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFTrendingViewController.m; sourceTree = "<group>"; };
 		B8D04746551BF8DC9FF0160F /* Pods_WikipediaUnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WikipediaUnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC070C2D1C1F2C0200CAE9E2 /* MWKImage+CanonicalFilenames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "MWKImage+CanonicalFilenames.h"; path = "Wikipedia/Code/MWKImage+CanonicalFilenames.h"; sourceTree = SOURCE_ROOT; };
 		BC070C2E1C1F2C0200CAE9E2 /* MWKImage+CanonicalFilenames.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "MWKImage+CanonicalFilenames.m"; path = "Wikipedia/Code/MWKImage+CanonicalFilenames.m"; sourceTree = SOURCE_ROOT; };
@@ -2783,6 +2789,17 @@
 			name = "Footer Menu";
 			sourceTree = "<group>";
 		};
+		B0F956AF1C48598800691810 /* Trending */ = {
+			isa = PBXGroup;
+			children = (
+				B0F956B01C4859EE00691810 /* WMFTrendingViewController.h */,
+				B0F956B11C4859EE00691810 /* WMFTrendingViewController.m */,
+				B0F956AC1C484E0500691810 /* WMFTrendingFetcher.h */,
+				B0F956AD1C484E0500691810 /* WMFTrendingFetcher.m */,
+			);
+			name = Trending;
+			sourceTree = "<group>";
+		};
 		BC22F44C1BA33CF400B64F4B /* Value Providers */ = {
 			isa = PBXGroup;
 			children = (
@@ -3433,6 +3450,7 @@
 				BCD67E7E1C1F1433005179E1 /* Saved Pages */,
 				0E2B06F91B2D128D00EA2F53 /* Search */,
 				BC45D5871C32F849007C72F3 /* Settings */,
+				B0F956AF1C48598800691810 /* Trending */,
 				BC45D59F1C33018C007C72F3 /* User */,
 				0E26B0541C0E28E60004D687 /* Welcome */,
 			);
@@ -5256,6 +5274,7 @@
 				B0E806481C0CE7F70065EBC0 /* AccountCreator.m in Sources */,
 				B0E802CB1C0CD2F70065EBC0 /* WMFPicOfTheDayTableViewCell.m in Sources */,
 				B0E8068E1C0CEA060065EBC0 /* WMFLocalizationProtocol.m in Sources */,
+				B0F956AE1C484E0500691810 /* WMFTrendingFetcher.m in Sources */,
 				B0E807551C0CEE230065EBC0 /* NSManagedObjectContext+SimpleFetch.m in Sources */,
 				B0E806581C0CE84B0065EBC0 /* SavedArticlesFetcher.m in Sources */,
 				B0E803441C0CD7980065EBC0 /* WMFSearchFetcher.m in Sources */,
@@ -5379,6 +5398,7 @@
 				B0E802DD1C0CD3FB0065EBC0 /* WMFContinueReadingSectionController.m in Sources */,
 				B0E807741C0CEE920065EBC0 /* MWKSavedPageList+ImageMigrationTesting.m in Sources */,
 				B0E805971C0CE2C60065EBC0 /* WMFSuggestedPagesFunnel.m in Sources */,
+				B0F956B21C4859EE00691810 /* WMFTrendingViewController.m in Sources */,
 				B0E803B71C0CDBE20065EBC0 /* WMFRelatedTitleListDataSource.m in Sources */,
 				B0E804491C0CDF850065EBC0 /* WMFCollectionViewPageLayout.m in Sources */,
 				B0E804D51C0CE0B40065EBC0 /* NSObject+ConstraintsScale.m in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		041EFC371996A1F800B2CB28 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 041EFC361996A1F800B2CB28 /* MapKit.framework */; };
 		0493C2D419526A0100EBB973 /* WikiFont-Glyphs.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0493C2D319526A0100EBB973 /* WikiFont-Glyphs.ttf */; };
 		04D34DB21863D39000610A87 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D34DB11863D39000610A87 /* libxml2.dylib */; };
+		08186C8A1C4EA23100839DBA /* WMFTrendingSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 08186C891C4EA23100839DBA /* WMFTrendingSectionController.m */; };
 		0E0361741C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */; };
 		0E0361771C4488BC00FD9642 /* WMFLocationSearchListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361761C4488BC00FD9642 /* WMFLocationSearchListViewController.m */; };
 		0E03617A1C44905400FD9642 /* WMFRelatedTitleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0361791C44905400FD9642 /* WMFRelatedTitleViewController.m */; };
@@ -633,6 +634,8 @@
 		0493C2D319526A0100EBB973 /* WikiFont-Glyphs.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "WikiFont-Glyphs.ttf"; sourceTree = "<group>"; };
 		04D34DB11863D39000610A87 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
 		04E9A78218F73C7200F7ECF7 /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; path = www; sourceTree = "<group>"; };
+		08186C881C4EA23100839DBA /* WMFTrendingSectionController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFTrendingSectionController.h; path = wikipedia/Code/WMFTrendingSectionController.h; sourceTree = SOURCE_ROOT; };
+		08186C891C4EA23100839DBA /* WMFTrendingSectionController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFTrendingSectionController.m; path = wikipedia/Code/WMFTrendingSectionController.m; sourceTree = SOURCE_ROOT; };
 		08F646F7D0488CE3C6D6A763 /* Pods.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.beta.xcconfig; path = "Pods/Target Support Files/Pods/Pods.beta.xcconfig"; sourceTree = "<group>"; };
 		0E0361721C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFSelfSizingArticleListTableViewController.h; path = Wikipedia/Code/WMFSelfSizingArticleListTableViewController.h; sourceTree = SOURCE_ROOT; };
 		0E0361731C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFSelfSizingArticleListTableViewController.m; path = Wikipedia/Code/WMFSelfSizingArticleListTableViewController.m; sourceTree = SOURCE_ROOT; };
@@ -2241,6 +2244,15 @@
 			path = Wikipedia/Code/PageHistory;
 			sourceTree = SOURCE_ROOT;
 		};
+		08186C871C4EA1F000839DBA /* Trending */ = {
+			isa = PBXGroup;
+			children = (
+				08186C881C4EA23100839DBA /* WMFTrendingSectionController.h */,
+				08186C891C4EA23100839DBA /* WMFTrendingSectionController.m */,
+			);
+			name = Trending;
+			sourceTree = "<group>";
+		};
 		0E03617B1C44945300FD9642 /* More */ = {
 			isa = PBXGroup;
 			children = (
@@ -2465,6 +2477,7 @@
 		0E4500BB1B97A28C00A33B55 /* Sections */ = {
 			isa = PBXGroup;
 			children = (
+				08186C871C4EA1F000839DBA /* Trending */,
 				0E4500B91B97A26800A33B55 /* Schema */,
 				B0E802D71C0CD3A30065EBC0 /* WMFExploreSectionController.h */,
 				B0E802D41C0CD3940065EBC0 /* SSSectionedDataSource+WMFSectionConvenience.h */,
@@ -5523,6 +5536,7 @@
 				B0E805551C0CE0DC0065EBC0 /* UIView+IBExtras.swift in Sources */,
 				B0E807291C0CED530065EBC0 /* MWLanguageInfo.m in Sources */,
 				0E0361741C4485FA00FD9642 /* WMFSelfSizingArticleListTableViewController.m in Sources */,
+				08186C8A1C4EA23100839DBA /* WMFTrendingSectionController.m in Sources */,
 				BC45FF531C1B829B00BAE501 /* UIViewController+WMFSearchButton_Testing.m in Sources */,
 				B0E805961C0CE2C60065EBC0 /* WMFHamburgerMenuFunnel.m in Sources */,
 				B0E807B01C0CEFF70065EBC0 /* MWKHistoryList.m in Sources */,

--- a/Wikipedia/Code/NSDateFormatter+WMFExtensions.h
+++ b/Wikipedia/Code/NSDateFormatter+WMFExtensions.h
@@ -41,4 +41,6 @@
 
 + (instancetype)wmf_englishHyphenatedYearMonthDayFormatter;
 
++ (instancetype)wmf_englishSlashDelimitedYearMonthDayFormatter;
+
 @end

--- a/Wikipedia/Code/NSDateFormatter+WMFExtensions.m
+++ b/Wikipedia/Code/NSDateFormatter+WMFExtensions.m
@@ -67,11 +67,26 @@ static NSString* const WMF_ISO8601_FORMAT = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'";
     static NSDateFormatter* _dateFormatter;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        _dateFormatter = [[NSDateFormatter alloc] init];
-        _dateFormatter.dateFormat = @"yyyy'-'MM'-'dd'";
-        _dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en"];
+        _dateFormatter = [self wmf_newEnglishYearMonthDayFormatterWithSeparator:@"-"];
     });
     return _dateFormatter;
+}
+
++ (instancetype)wmf_englishSlashDelimitedYearMonthDayFormatter {
+    static NSDateFormatter* _dateFormatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _dateFormatter = [self wmf_newEnglishYearMonthDayFormatterWithSeparator:@"/"];
+    });
+    return _dateFormatter;
+}
+
++ (instancetype)wmf_newEnglishYearMonthDayFormatterWithSeparator:(NSString*)separator {
+    NSString* quotedSeparator      = [@[@"'", separator, @"'"] componentsJoinedByString: @""];
+    NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
+    dateFormatter.dateFormat = [@[@"yyyy", @"MM", @"dd"] componentsJoinedByString: quotedSeparator];
+    dateFormatter.locale     = [NSLocale localeWithLocaleIdentifier:@"en"];
+    return dateFormatter;
 }
 
 @end

--- a/Wikipedia/Code/WMFArticlePreviewDataSource.h
+++ b/Wikipedia/Code/WMFArticlePreviewDataSource.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
                           site:(MWKSite*)site
                        fetcher:(WMFArticlePreviewFetcher*)fetcher NS_DESIGNATED_INITIALIZER;
 
-- (void)fetch;
+- (AnyPromise*)fetch;
 
 @end
 

--- a/Wikipedia/Code/WMFArticlePreviewDataSource.m
+++ b/Wikipedia/Code/WMFArticlePreviewDataSource.m
@@ -76,17 +76,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Fetching
 
-- (void)fetch {
-    @weakify(self);
-    [self.titlesSearchFetcher fetchArticlePreviewResultsForTitles:self.titles site:self.site]
-    .then(^(NSArray<MWKSearchResult*>* searchResults) {
-        @strongify(self);
-        if (!self) {
-            return;
-        }
-        self.previewResults = searchResults;
-        [self updateItems:searchResults];
-    });
+- (AnyPromise*)fetch {
+    return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
+        @weakify(self);
+        [self.titlesSearchFetcher fetchArticlePreviewResultsForTitles:self.titles site:self.site]
+        .then(^(NSArray<MWKSearchResult*>* searchResults) {
+            @strongify(self);
+            if (!self) {
+                resolve((id)nil);
+            }
+            self.previewResults = searchResults;
+            [self updateItems:searchResults];
+            resolve((id)searchResults);
+        })
+        .catch(^(NSError* error){
+            resolve(error);
+        });
+    }];
 }
 
 #pragma mark - WMFArticleListDataSource

--- a/Wikipedia/Code/WMFArticlePreviewFetcher.m
+++ b/Wikipedia/Code/WMFArticlePreviewFetcher.m
@@ -76,6 +76,9 @@ NS_ASSUME_NONNULL_BEGIN
                 return [preview.displayTitle isEqualToString:title.text];
             }];
         }];
+    })
+           .catch(^(NSError* error){
+        return error;
     });
 }
 

--- a/Wikipedia/Code/WMFExploreSection.h
+++ b/Wikipedia/Code/WMFExploreSection.h
@@ -22,7 +22,8 @@ typedef NS_ENUM (NSUInteger, WMFExploreSectionType){
     WMFExploreSectionTypeHistory         = 4,
     WMFExploreSectionTypeSaved           = 5,
     WMFExploreSectionTypeFeaturedArticle = 6,
-    WMFExploreSectionTypePictureOfTheDay = 7
+    WMFExploreSectionTypePictureOfTheDay = 7,
+    WMFExploreSectionTypeTrending        = 8
 };
 
 @interface WMFExploreSection : MTLModel
@@ -31,6 +32,7 @@ typedef NS_ENUM (NSUInteger, WMFExploreSectionType){
 + (nullable instancetype)nearbySectionWithLocation:(nullable CLLocation*)location;
 + (instancetype)historySectionWithHistoryEntry:(MWKHistoryEntry*)entry;
 + (instancetype)savedSectionWithSavedPageEntry:(MWKSavedPageEntry*)entry;
++ (instancetype)trendingSectionForDate:(NSDate*)date;
 
 /**
  *  Create a section which displays the featured article of the day for a specific site.

--- a/Wikipedia/Code/WMFExploreSection.m
+++ b/Wikipedia/Code/WMFExploreSection.m
@@ -52,19 +52,21 @@ NS_ASSUME_NONNULL_BEGIN
             return 0;
         case WMFExploreSectionTypeFeaturedArticle:
             return 1;
-        case WMFExploreSectionTypeMainPage:
+        case WMFExploreSectionTypeTrending:
             return 2;
-        case WMFExploreSectionTypePictureOfTheDay:
+        case WMFExploreSectionTypeMainPage:
             return 3;
-        case WMFExploreSectionTypeRandom:
+        case WMFExploreSectionTypePictureOfTheDay:
             return 4;
-        case WMFExploreSectionTypeNearby:
+        case WMFExploreSectionTypeRandom:
             return 5;
+        case WMFExploreSectionTypeNearby:
+            return 6;
 
         case WMFExploreSectionTypeSaved:
         case WMFExploreSectionTypeHistory:
             // Saved & History have identical same-day sorting behavior
-            return 6;
+            return 7;
     }
 }
 
@@ -98,6 +100,13 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 #pragma mark - Factory Methods
+
++ (instancetype)trendingSectionForDate:(NSDate *)date {
+    WMFExploreSection* trending = [[WMFExploreSection alloc] init];
+    trending.type = WMFExploreSectionTypeTrending;
+    trending.dateCreated = date;
+    return trending;
+}
 
 + (instancetype)pictureOfTheDaySection {
     WMFExploreSection* item = [[WMFExploreSection alloc] init];

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -19,6 +19,7 @@
 #import "WMFExploreSectionSchema.h"
 #import "WMFExploreSection.h"
 #import "WMFPictureOfTheDaySectionController.h"
+#import "WMFTrendingSectionController.h"
 
 // Models
 #import "WMFAsyncBlockOperation.h"
@@ -54,7 +55,6 @@
 #import "UIViewController+WMFArticlePresentation.h"
 
 #import "MWKSite.h"
-#import "WMFTrendingViewController.h"
 #import "SessionSingleton.h"
 #import "NSDate+Utilities.h"
 
@@ -88,16 +88,6 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation WMFExploreViewController
-
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-
-    WMFTrendingViewController* trendingVC = [[WMFTrendingViewController alloc] initWithSite:[SessionSingleton sharedInstance].searchSite date:[NSDate dateWithDaysBeforeNow:0] dataStore:self.dataStore];
-
-    [self presentViewController:[[UINavigationController alloc] initWithRootViewController:trendingVC]
-                       animated:YES
-                     completion:nil];
-}
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
@@ -379,6 +369,12 @@ NS_ASSUME_NONNULL_BEGIN
     return [[WMFFeaturedArticleSectionController alloc] initWithSite:item.site date:item.dateCreated savedPageList:self.savedPages];
 }
 
+- (WMFTrendingSectionController*)trendingSectionControllerForItem:(WMFExploreSection*)section {
+    return [[WMFTrendingSectionController alloc] initWithDate:section.dateCreated
+                                                         site:self.searchSite
+                                                    dataStore:self.dataStore];
+}
+
 #pragma mark - Section Update
 
 - (NSString*)lastUpdatedString {
@@ -457,6 +453,9 @@ NS_ASSUME_NONNULL_BEGIN
                 break;
             case WMFExploreSectionTypePictureOfTheDay:
                 [self loadSectionForSectionController:[self picOfTheDaySectionController]];
+                break;
+            case WMFExploreSectionTypeTrending:
+                [self loadSectionForSectionController:[self trendingSectionControllerForItem:obj]];
                 break;
                 /*
                    !!!: do not add a default case, it is intentionally omitted so an error/warning is triggered when
@@ -579,6 +578,7 @@ NS_ASSUME_NONNULL_BEGIN
         case WMFExploreSectionTypeFeaturedArticle:
         case WMFExploreSectionTypePictureOfTheDay:
         case WMFExploreSectionTypeRandom:
+        case WMFExploreSectionTypeTrending:
             [self selectFirstRowInSection:section];
             break;
         case WMFExploreSectionTypeNearby:

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -53,6 +53,11 @@
 #import "WMFLocationManager.h"
 #import "UIViewController+WMFArticlePresentation.h"
 
+#import "MWKSite.h"
+#import "WMFTrendingViewController.h"
+#import "SessionSingleton.h"
+#import "NSDate+Utilities.h"
+
 static DDLogLevel const WMFHomeVCLogLevel = DDLogLevelVerbose;
 #undef LOG_LEVEL_DEF
 #define LOG_LEVEL_DEF WMFHomeVCLogLevel
@@ -83,6 +88,16 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation WMFExploreViewController
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+
+    WMFTrendingViewController* trendingVC = [[WMFTrendingViewController alloc] initWithSite:[SessionSingleton sharedInstance].searchSite date:[NSDate dateWithDaysBeforeNow:0] dataStore:self.dataStore];
+
+    [self presentViewController:[[UINavigationController alloc] initWithRootViewController:trendingVC]
+                       animated:YES
+                     completion:nil];
+}
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];

--- a/Wikipedia/Code/WMFTrendingFetcher.h
+++ b/Wikipedia/Code/WMFTrendingFetcher.h
@@ -1,0 +1,16 @@
+
+@import Foundation;
+
+@class MWKSite;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WMFTrendingFetcher : NSObject
+
+- (AnyPromise*)fetchTrendingForSite:(MWKSite*)site date:(NSDate*)date;
+
+@property (nonatomic, assign, readonly) BOOL isFetching;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFTrendingFetcher.m
+++ b/Wikipedia/Code/WMFTrendingFetcher.m
@@ -5,6 +5,7 @@
 #import "AFHTTPRequestOperationManager+WMFConfig.h"
 #import "WMFNetworkUtilities.h"
 #import "MWKSite.h"
+#import "NSDateFormatter+WMFExtensions.h"
 
 @interface WMFTrendingFetcher ()
 @property (nonatomic, strong) AFHTTPRequestOperationManager* operationManager;
@@ -47,10 +48,10 @@
 }
 
 - (NSString*)getTrendingURLStringForSite:(MWKSite*)site date:(NSDate*)date {
-    NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateFormat:@"yyyy/MM/dd"];
-    NSString* dateString = [formatter stringFromDate:date];
-    return [NSString stringWithFormat:@"https://wikimedia.org/api/rest_v1/metrics/pageviews/top/%@.wikipedia/all-access/%@", site.language, dateString];
+    return [NSString stringWithFormat:
+            @"https://wikimedia.org/api/rest_v1/metrics/pageviews/top/%@.wikipedia/all-access/%@",
+            site.language,
+            [[NSDateFormatter wmf_englishSlashDelimitedYearMonthDayFormatter] stringFromDate:date]];
 }
 
 @end

--- a/Wikipedia/Code/WMFTrendingFetcher.m
+++ b/Wikipedia/Code/WMFTrendingFetcher.m
@@ -1,0 +1,56 @@
+
+#import "WMFTrendingFetcher.h"
+#import "MWNetworkActivityIndicatorManager.h"
+#import "AFHTTPRequestOperationManager+WMFDesktopRetry.h"
+#import "AFHTTPRequestOperationManager+WMFConfig.h"
+#import "WMFNetworkUtilities.h"
+#import "MWKSite.h"
+
+@interface WMFTrendingFetcher ()
+@property (nonatomic, strong) AFHTTPRequestOperationManager* operationManager;
+@end
+
+@implementation WMFTrendingFetcher
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        AFHTTPRequestOperationManager* manager = [AFHTTPRequestOperationManager wmf_createDefaultManager];
+        self.operationManager = manager;
+    }
+    return self;
+}
+
+- (BOOL)isFetching {
+    return [[self.operationManager operationQueue] operationCount] > 0;
+}
+
+- (AnyPromise*)fetchTrendingForSite:(MWKSite*)site date:(NSDate*)date {
+    NSParameterAssert(site);
+    NSParameterAssert(date);
+    return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
+        [self.operationManager GET:[self getTrendingURLStringForSite:site date:date]
+                        parameters:nil
+                           success:^(AFHTTPRequestOperation* operation, id responseObject) {
+            [[MWNetworkActivityIndicatorManager sharedManager] pop];
+            NSArray* articles = [[responseObject valueForKeyPath:@"items.articles"] firstObject];
+
+            NSArray* topArticles = [articles subarrayWithRange:NSMakeRange(0, MIN(30, articles.count))];
+
+            resolve(topArticles);
+        }
+                           failure:^(AFHTTPRequestOperation* operation, NSError* error) {
+            [[MWNetworkActivityIndicatorManager sharedManager] pop];
+            resolve(error);
+        }];
+    }];
+}
+
+- (NSString*)getTrendingURLStringForSite:(MWKSite*)site date:(NSDate*)date {
+    NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
+    [formatter setDateFormat:@"yyyy/MM/dd"];
+    NSString* dateString = [formatter stringFromDate:date];
+    return [NSString stringWithFormat:@"https://wikimedia.org/api/rest_v1/metrics/pageviews/top/%@.wikipedia/all-access/%@", site.language, dateString];
+}
+
+@end

--- a/Wikipedia/Code/WMFTrendingViewController.h
+++ b/Wikipedia/Code/WMFTrendingViewController.h
@@ -1,0 +1,10 @@
+#import "WMFArticleListTableViewController.h"
+
+@interface WMFTrendingViewController : WMFArticleListTableViewController
+
+@property (nonatomic, strong, readonly) MWKSite* site;
+@property (nonatomic, strong, readonly) NSDate* date;
+
+- (instancetype)initWithSite:(MWKSite*)site date:(NSDate*)date dataStore:(MWKDataStore*)dataStore;
+
+@end

--- a/Wikipedia/Code/WMFTrendingViewController.m
+++ b/Wikipedia/Code/WMFTrendingViewController.m
@@ -1,0 +1,151 @@
+#import "WMFTrendingViewController.h"
+#import "WMFArticlePreviewDataSource.h"
+#import "MWKArticle.h"
+#import "WMFArticlePreviewFetcher.h"
+#import "UIBarButtonItem+WMFButtonConvenience.h"
+#import "WMFArticlePreviewFetcher.h"
+#import "MWKDataStore.h"
+#import "MWKTitle.h"
+#import "WMFTrendingFetcher.h"
+#import "NSDate+Utilities.h"
+
+@interface WMFTrendingViewController ()
+
+@property (nonatomic, strong, readwrite) MWKSite* site;
+@property (nonatomic, strong, readwrite) NSDate* date;
+
+@end
+
+@implementation WMFTrendingViewController
+
+- (instancetype)initWithSite:(MWKSite*)site date:(NSDate*)date dataStore:(MWKDataStore*)dataStore {
+    self = [super init];
+    if (self) {
+        self.site                 = site;
+        self.date                 = date;
+        self.dataStore            = dataStore;
+        self.dataSource.tableView = self.tableView;
+    }
+    return self;
+}
+
+- (NSString*)title {
+    //TODO: localize
+    return @"Trending Articles";
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    [self getTrendingTitles];
+}
+
+- (NSArray<NSString*>*)titleExclusions {
+    return @[
+        @"Main_Page",       // TODO: exclude name of main page for site language
+        @"-",
+        @"Test_card",
+        @"XHamster",
+        @"Web_scraping"
+    ];
+}
+
+- (NSArray<NSString*>*)titlePrefixExclusions {
+    return @[
+        @"User:",           // maybe just exclude if title has a ":"
+        @"Special:",        // Are these prefixes the same in every lang?
+        @"File:"            //
+    ];
+}
+
+- (BOOL)isTitleExcluded:(NSString*)title {
+    for (NSString* excludedPrefix in [self titlePrefixExclusions]) {
+        if ([title hasPrefix:excludedPrefix]) {
+            return YES;
+        }
+    }
+    return [[self titleExclusions] containsObject:title];
+}
+
+- (void)getTrendingTitles {
+    // Try to first fetch trending for today's date.
+    [[[WMFTrendingFetcher alloc] init] fetchTrendingForSite:self.site date:self.date]
+    .then(^(NSArray* results) {
+        return results;
+    })
+    .catch(^(NSError* error){
+        // If a "today" fetch failed, try to fetch yesterday's trending data.
+        // Needed because trending data is compiled once daily, and local date may or
+        // may not be +1 days from last trending compilation date (think times zones).
+        if ([self.date isToday]) {
+            return [[[WMFTrendingFetcher alloc] init] fetchTrendingForSite:self.site date:[NSDate dateYesterday]].then(^(NSArray* results) {
+                return results;
+            })
+            .catch(^(NSError* error){
+                NSLog(@"Error = %@", error);
+                return error;
+            });
+        } else {
+            return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
+                resolve(error);
+            }];
+        }
+    })
+    .catch(^(NSError* error){
+        NSLog(@"Error = %@", error);
+        return error;
+    })
+    .then(^(NSArray* results){
+        return [self getMWKTitlesFromResults:results];
+    })
+    .then(^(NSArray<MWKTitle*>* titles){
+        return [self getArticlePreviewDataSourceForTitles:titles];
+    })
+    .catch(^(NSError* error){
+        NSLog(@"Error = %@", error);
+        return error;
+    })
+    .then(^(WMFArticlePreviewDataSource* previewsDataSource){
+        self.dataSource = previewsDataSource;
+        [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] atScrollPosition:UITableViewScrollPositionTop animated:NO];
+    });
+}
+
+- (AnyPromise*)getMWKTitlesFromResults:(NSArray*)results {
+    return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
+        NSArray<MWKTitle*>* titles = [[results bk_select:^BOOL (NSDictionary* result) {
+            return ![self isTitleExcluded:result[@"article"]];
+        }] bk_map:^id (NSDictionary* result) {
+            return [[MWKTitle alloc] initWithString:result[@"article"] site:self.site];
+        }];
+        resolve(titles);
+    }];
+}
+
+- (AnyPromise*)getArticlePreviewDataSourceForTitles:(NSArray<MWKTitle*>*)titles {
+    return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
+        WMFArticlePreviewDataSource* previewsDataSource =
+            [[WMFArticlePreviewDataSource alloc] initWithTitles:titles site:self.site fetcher:[[WMFArticlePreviewFetcher alloc] init]];
+
+        [((WMFArticlePreviewDataSource*)previewsDataSource) fetch]
+        .then(^(NSArray<MWKSearchResult*>* searchResults){
+            resolve(previewsDataSource);
+        })
+        .catch(^(NSError* error){
+            resolve(error);
+        });
+    }];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    @weakify(self);
+    UIBarButtonItem* xButton = [UIBarButtonItem wmf_buttonType:WMFButtonTypeX handler:^(id sender){
+        @strongify(self)
+        [self.presentingViewController dismissViewControllerAnimated : YES completion : nil];
+    }];
+    self.navigationItem.leftBarButtonItem  = xButton;
+    self.navigationItem.rightBarButtonItem = nil;
+}
+
+@end

--- a/wikipedia/Code/WMFTrendingSectionController.h
+++ b/wikipedia/Code/WMFTrendingSectionController.h
@@ -1,0 +1,19 @@
+//
+//  WMFTrendingSectionController.h
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 1/19/16.
+//  Copyright © 2016 Wikimedia Foundation. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "WMFExploreSectionController.h"
+
+@class MWKDataStore, MWKSite;
+
+@interface WMFTrendingSectionController : NSObject
+<WMFArticleExploreSectionController, WMFFetchingExploreSectionController>
+
+- (instancetype)initWithDate:(NSDate*)date site:(MWKSite*)site dataStore:(MWKDataStore*)dataStore;
+
+@end

--- a/wikipedia/Code/WMFTrendingSectionController.m
+++ b/wikipedia/Code/WMFTrendingSectionController.m
@@ -1,0 +1,134 @@
+//
+//  WMFTrendingSectionController.m
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 1/19/16.
+//  Copyright © 2016 Wikimedia Foundation. All rights reserved.
+//
+
+#import "WMFTrendingSectionController.h"
+#import "Wikipedia-Swift.h"
+
+#import "MWKSite.h"
+#import "MWKDataStore.h"
+#import "WMFTrendingFetcher.h"
+#import "NSDateFormatter+WMFExtensions.h"
+#import "WMFTrendingFetcher.h"
+
+#import "WMFArticlePreviewTableViewCell.h"
+#import "WMFArticlePlaceholderTableViewCell.h"
+
+static NSString* const WMFTrendingSectionIdentifierPrefix = @"WMFTrendingSectionIdentifier";
+
+@interface WMFTrendingSectionController ()
+
+@property (nonatomic, strong) MWKSite* site;
+@property (nonatomic, strong) MWKDataStore* dataStore;
+@property (nonatomic, strong) NSDate* date;
+
+@property (nonatomic, strong) WMFTrendingFetcher* fetcher;
+@property (nonatomic, strong, nullable) NSArray* results;
+
+@end
+
+@implementation WMFTrendingSectionController
+@synthesize delegate=_delegate;
+
+- (instancetype)initWithDate:(NSDate *)date site:(MWKSite *)site dataStore:(MWKDataStore *)dataStore {
+    self = [super init];
+    if (self) {
+        self.site = site;
+        self.dataStore = dataStore;
+        self.date = date;
+    }
+    return self;
+}
+
+- (WMFTrendingFetcher*)fetcher {
+    if (!_fetcher) {
+        _fetcher = [[WMFTrendingFetcher alloc] init];
+    }
+    return _fetcher;
+}
+
+#pragma mark - WMFExploreArticleSectionController
+
+- (UITableViewCell*)dequeueCellForTableView:(UITableView *)tableView atIndexPath:(NSIndexPath *)indexPath {
+    if (self.results.count) {
+        return [tableView dequeueReusableCellWithIdentifier:[WMFArticlePreviewTableViewCell wmf_nibName]];
+    } else {
+        return [tableView dequeueReusableCellWithIdentifier:[WMFArticlePlaceholderTableViewCell wmf_nibName]];
+    }
+}
+
+- (void)registerCellsInTableView:(UITableView *)tableView {
+    [tableView registerNib:[WMFArticlePreviewTableViewCell wmf_classNib]
+    forCellReuseIdentifier:[WMFArticlePreviewTableViewCell wmf_nibName]];
+    [tableView registerNib:[WMFArticlePlaceholderTableViewCell wmf_classNib]
+    forCellReuseIdentifier:[WMFArticlePlaceholderTableViewCell wmf_nibName]];
+}
+
+- (void)configureCell:(UITableViewCell *)cell
+           withObject:(id)object
+          inTableView:(UITableView *)tableView
+          atIndexPath:(NSIndexPath *)indexPath {
+    if ([object isKindOfClass:[NSDictionary class]]) {
+        NSParameterAssert([cell isKindOfClass:[WMFArticlePreviewTableViewCell class]]);
+        WMFArticlePreviewTableViewCell* previewCell = (WMFArticlePreviewTableViewCell*)cell;
+        previewCell.titleText = self.results[indexPath.row][@"article"];
+    }
+}
+
+- (MWKTitle*)titleForItemAtIndex:(NSUInteger)index {
+    if (!self.results || index > self.results.count - 1) {
+        return nil;
+    } else {
+        return [[MWKTitle alloc] initWithSite:self.site
+                              normalizedTitle:self.results[index][@"article"]
+                                     fragment:nil];
+    }
+}
+
+- (id)sectionIdentifier {
+    return [WMFTrendingSectionIdentifierPrefix stringByAppendingString:
+            [[NSDateFormatter wmf_englishSlashDelimitedYearMonthDayFormatter] stringFromDate:self.date]];
+}
+
+- (UIImage*)headerIcon {
+    return [UIImage imageNamed:@"trending-mini"];
+}
+
+- (NSAttributedString*)headerText {
+    return [[NSAttributedString alloc] initWithString:MWLocalizedString(@"home-trending-heading", nil)
+                                           attributes:nil];
+}
+
+- (NSArray*)items {
+    if (self.results.count > 0) {
+        return [self.results wmf_safeSubarrayWithRange:NSMakeRange(0, 3)];
+    } else {
+        return @[@0, @1, @2];
+    }
+}
+
+- (NSString*)analyticsName {
+    return @"Trending";
+}
+
+#pragma mark - Fetching
+
+- (void)fetchDataIfNeeded {
+    if (self.fetcher.isFetching || self.results) {
+        return;
+    }
+
+    @weakify(self);
+    [self.fetcher fetchTrendingForSite:self.site date:self.date]
+    .then(^(NSArray* results) {
+        @strongify(self);
+        self.results = results;
+        [self.delegate controller:self didSetItems:self.items];
+    });
+}
+
+@end


### PR DESCRIPTION
Weekend fun ticket.
Implemented the fetching and list displaying logic - see image below.
If we just use a regular feed "group" with a "*More trending articles*" footer the remaining work is pretty easy.

----


To see the list of currently trending articles (WIP) trigger a memory warning in the simulator (`cmd-shift-m`).

----

TODO:
- [ ] Chat with Kevin (I think) to see if we can request smaller title count and to confirm how often the list is updated. Also ask about stability / whether we can send it lots of requests etc.
- [ ] Change titleExclusions string for "Main_page" to use proper main page name for site lang.
- [ ] Add to feed, showing first 3(?) with footer tap to call up full list of 50(?) or so.
- [ ] Remove "didReceiveMemoryWarning" testing stub.
- [ ] Localize some strings.

----

![untitled mov](https://cloud.githubusercontent.com/assets/3143487/12375587/e62466d6-bc7d-11e5-9a70-96f78fc69a3c.gif)


