### PR TITLE
Add accessibility to CompassView and NearbyTableViewCell

### DIFF
--- a/Wikipedia/Code/WMFCompassView.m
+++ b/Wikipedia/Code/WMFCompassView.m
@@ -223,4 +223,17 @@ static CGFloat const WMFCompassOppositeLineWidth = 2.0;
     }
 }
 
+#pragma mark - Accessibility
+
+- (BOOL)isAccessibilityElement {
+    return YES;
+}
+
+- (NSString *)accessibilityLabel {
+    NSInteger clockDirection = WMFRadiansToClock(self.angleRadians);
+    NSString* label = MWLocalizedString(@"compass-direction", nil);
+    label = [label stringByReplacingOccurrencesOfString:@"$1" withString:[NSString localizedStringWithFormat:@"%@", @(clockDirection)]];
+    return label;
+}
+
 @end

--- a/Wikipedia/Code/WMFMath.h
+++ b/Wikipedia/Code/WMFMath.h
@@ -54,6 +54,20 @@ extern double RoundWithPrecision(double (* rounder)(double), double x, unsigned 
  */
 extern double WMFFlooredPercentage(double x) __attribute__((const)) __attribute__((pure));
 
+/**
+ *  Convert angle in radians into hours on a clockface.
+ *
+ *  If we imagine a clockface instead of a unit circle (the hour 12 is aligned with 0 radians),
+ *  then we set the clock pointer to the given the degree, this function returns the number
+ *  of the nearest hour.
+ *
+ *  @param radians Angle in radians
+ *
+ *  @return NSInteger representing the corresponding reading on the clockface.
+ */
+
+NSInteger WMFRadiansToClock(double radians);
+
 ///
 /// @name Geometry
 ///

--- a/Wikipedia/Code/WMFMath.m
+++ b/Wikipedia/Code/WMFMath.m
@@ -10,3 +10,12 @@ double WMFFlooredPercentage(double x) {
     return WMFRoundedPercentage(floor, x, 100);
 }
 
+NSInteger WMFRadiansToClock(double radians) {
+    double unitRadians = fmod(radians, 2*M_PI);
+    double positiveRadians = unitRadians >= 0 ? unitRadians : unitRadians + 2*M_PI;
+    NSInteger clockDirection = lroundf(positiveRadians / (M_PI / 6));
+    if (clockDirection == 0) {
+        clockDirection = 12;
+    }
+    return clockDirection;
+}

--- a/Wikipedia/Code/WMFNearbyArticleTableViewCell.m
+++ b/Wikipedia/Code/WMFNearbyArticleTableViewCell.m
@@ -201,4 +201,20 @@
     [self.articleImageView wmf_setImageWithMetadata:image detectFaces:YES];
 }
 
+#pragma mark - Accessibility
+
+- (BOOL)isAccessibilityElement {
+    return YES;
+}
+
+- (NSString*)accessibilityLabel {
+    NSString *titleAndDescription;
+    if (self.descriptionText) {
+        titleAndDescription = [NSString stringWithFormat:@"%@, %@", self.titleText, self.descriptionText];
+    } else {
+        titleAndDescription = self.titleText;
+    }
+    return [NSString stringWithFormat: @"%@, %@ %@", titleAndDescription, self.distanceLabel.text, self.compassView.accessibilityLabel];
+}
+
 @end

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -403,3 +403,6 @@
 
 "close-button-accessibility-label" = "Close";
 "back-button-accessibility-label" = "Back";
+
+"compass-direction" = "at $1 o'clock";
+

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -359,3 +359,5 @@
 "icon-shortcut-nearby-title" = "Title for app icon force touch shortcut to quickly open the nearby articles interface.";
 "close-button-accessibility-label" = "Accessibility label for a button that closes a dialog.";
 "back-button-accessibility-label" = "Accessibility label for a button to navigate back.";
+"compass-direction" = "Spoken description of compass direction, e.g. 'at 3 o'clock' means 'to the right'";
+

--- a/WikipediaUnitTests/Code/WMFMathTests.m
+++ b/WikipediaUnitTests/Code/WMFMathTests.m
@@ -54,4 +54,18 @@ static BOOL didAssert = NO;
     XCTAssertEqual(WMFClamp(2, 1, 0), WMFClamp(0, 1, 2));
 }
 
+- (void)testRadiansToClock {
+    XCTAssertEqual(WMFRadiansToClock(0), 12);
+    XCTAssertEqual(WMFRadiansToClock(M_PI/6), 1);
+    XCTAssertEqual(WMFRadiansToClock(M_PI/2), 3);
+    XCTAssertEqual(WMFRadiansToClock(M_PI), 6);
+    XCTAssertEqual(WMFRadiansToClock(1.5*M_PI), 9);
+    XCTAssertEqual(WMFRadiansToClock(2*M_PI), 12);
+    XCTAssertEqual(WMFRadiansToClock(-M_PI/2), 9);
+    XCTAssertEqual(WMFRadiansToClock(-M_PI), 6);
+    XCTAssertEqual(WMFRadiansToClock(4*M_PI), 12);
+    XCTAssertEqual(WMFRadiansToClock(-3.5*M_PI), 3);
+    XCTAssertEqual(WMFRadiansToClock(M_PI/6-0.001), 1);
+}
+
 @end


### PR DESCRIPTION
Treat the whole NearbyTableViewCell as one accessibility element and add distance and direction descriptions to its label.