### PR TITLE
Add accessibility labels to some elements which were missing them.

### DIFF
--- a/Wikipedia/Code/ReferencesVC.m
+++ b/Wikipedia/Code/ReferencesVC.m
@@ -109,6 +109,7 @@
                               color:[UIColor darkGrayColor]
                                size:22.0 * MENUS_SCALE_MULTIPLIER
                      baselineOffset:0];
+    self.xButton.accessibilityLabel = MWLocalizedString(@"close-button-accessibility-label", nil);
     self.xButton.label.textAlignment    = NSTextAlignmentCenter;
     self.xButton.userInteractionEnabled = YES;
     [self.topContainerView addSubview:self.xButton];

--- a/Wikipedia/Code/SectionEditorViewController.m
+++ b/Wikipedia/Code/SectionEditorViewController.m
@@ -47,6 +47,7 @@
         @strongify(self)
         [self.navigationController popViewControllerAnimated : YES];
     }];
+    buttonX.accessibilityLabel = MWLocalizedString(@"back-button-accessibility-label", nil);
     self.navigationItem.leftBarButtonItem = buttonX;
 
 

--- a/Wikipedia/Code/WMFArticleContainerViewController.m
+++ b/Wikipedia/Code/WMFArticleContainerViewController.m
@@ -341,6 +341,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                        style:UIBarButtonItemStylePlain
                                                                       target:self
                                                                       action:@selector(didTapTableOfContentsButton:)];
+        _tableOfContentsToolbarItem.accessibilityLabel = MWLocalizedString(@"table-of-contents-button-label", nil);
         return _tableOfContentsToolbarItem;
     }
     return _tableOfContentsToolbarItem;

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -93,6 +93,9 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super initWithCoder:aDecoder];
     if (self) {
         self.navigationItem.titleView          = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"W"]];
+        self.navigationItem.titleView.isAccessibilityElement = YES;
+        self.navigationItem.titleView.accessibilityLabel = MWLocalizedString(@"home-accessibility-label", nil);
+        self.navigationItem.titleView.accessibilityTraits |= UIAccessibilityTraitHeader;
         self.navigationItem.leftBarButtonItem  = [self settingsBarButtonItem];
         self.navigationItem.rightBarButtonItem = [self wmf_searchBarButtonItemWithDelegate:self];
     }

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -265,6 +265,7 @@ static SecondaryMenuRowIndex const WMFDebugSections[WMFDebugSectionCount] = {
         rowView.iconLabel.attributedText =
             [[NSAttributedString alloc] initWithString:icon
                                             attributes:attributes];
+        rowView.iconLabel.isAccessibilityElement = NO;
 
         id title = row[@"title"];
         if ([title isKindOfClass:[NSString class]]) {

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "license-footer-name" = "CC BY-SA 3.0";
 
 "table-of-contents-heading" = "Contents";
+"table-of-contents-button-label" = "Table of Contents";
 
 "abuse-filter-warning-heading" = "This looks like an unconstructive edit, are you sure you want to save it?";
 "abuse-filter-warning-subheading" = "Your edit may contain one or more of the following:";
@@ -349,6 +350,7 @@
 "home-updating-label" = "Updating…";
 "home-hide-suggestion-prompt" = "Hide this suggestion";
 "home-hide-suggestion-cancel" = "Cancel";
+"home-accessibility-label" = "Wikipedia, Explore";
 
 "potd-empty-error-description" = "Failed to retrieve picture of the day for $1";
 "potd-description-prefix" = "Picture of the day for $1";
@@ -398,3 +400,6 @@
 "icon-shortcut-continue-reading-title" = "Continue reading";
 "icon-shortcut-random-title" = "Random article";
 "icon-shortcut-nearby-title" = "Nearby articles";
+
+"close-button-accessibility-label" = "Close";
+"back-button-accessibility-label" = "Back";

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 "license-footer-text" = "Brief footer text linking to CC-BY-SA license. '$1' is placeholder for the {{msg-wm|Wikipedia-ios-license-footer-name}} message";
 "license-footer-name" = "License short name; usually leave untranslated as CC-BY-SA 3.0\n{{Identical|CC BY-SA}}";
 "table-of-contents-heading" = "Header text appearing above the first section in the table of contents\n{{Identical|Content}}";
+"table-of-contents-button-label" = "Accessibility label for the Table of Contents button";
 "abuse-filter-warning-heading" = "Header text for unconstructive edit warning";
 "abuse-filter-warning-subheading" = "Subheading text for potentially unconstructive edit warning";
 "abuse-filter-warning-caps" = "Label text for typing in all capitals";
@@ -317,6 +318,7 @@
 "home-updating-label" = "Label that appears when a user is updating the explore feed to inform the user that an update is in progress";
 "home-hide-suggestion-prompt" = "Title of button shown for users to confirm the hiding of a suggestion in the explore feed";
 "home-hide-suggestion-cancel" = "Title of the button for cancelling the hiding of an explore feed suggestion";
+"home-accessibility-label" = "Accessibility heading for the Explore page, indicating both that this is the Wikipedia app (as in the logo that is displayed visually) and that this is the Explore page.";
 "potd-empty-error-description" = "Error message when app fails to download Commons Picture of the Day. $1 will be substitued with the date which the app attempted to retrieve.";
 "potd-description-prefix" = "Prefix to picture of the day description which states it was the picture of the day for a specific date. The $1 token is subtituted for the date.";
 "welcome-whats-new-title" = "Welcome screen title - shown when a user opens the app for the first time (or first opens version 5.0) literally: Welcome to Wikipedia";
@@ -355,3 +357,5 @@
 "icon-shortcut-continue-reading-title" = "Title for app icon force touch shortcut to quickly re-open the last article the user was reading.";
 "icon-shortcut-random-title" = "Title for app icon force touch shortcut to quickly open a random article.";
 "icon-shortcut-nearby-title" = "Title for app icon force touch shortcut to quickly open the nearby articles interface.";
+"close-button-accessibility-label" = "Accessibility label for a button that closes a dialog.";
+"back-button-accessibility-label" = "Accessibility label for a button to navigate back.";


### PR DESCRIPTION
The elements are:
- Title of Explore view
- Close button in References view
- Back button from editor
- Table of Contents button in Article view
- Icon for rows in Settings view (this was removed from accessibility elements as it seems to serve no independent purpose but illustration)

Also handle traits and isAccessibilityElement correctly for these elements.