### PR TITLE
TOC on left for RTL layout direction.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .DS_Store
 
 # Vim
-*.sw*
+*.sw
 
 # Xcode/ObjC ignores, copied from https://github.com/github/gitignore/blob/master/Objective-C.gitignore
 build/

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		0EF863511C19E4F100006D2D /* WMFEmptyView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EF863501C19E4F100006D2D /* WMFEmptyView.m */; };
 		222B052ECD9AB4BCC885B932 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8A04642A54B737002D28D70 /* Pods.framework */; };
 		AA61D5DAA39C2A7CB97B4791 /* Pods_WikipediaUnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D04746551BF8DC9FF0160F /* Pods_WikipediaUnitTests.framework */; };
+		B00050141C52D73800515F70 /* UIApplication+RTL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00050131C52D73800515F70 /* UIApplication+RTL.swift */; };
 		B01162E81C24D3B200C3B52B /* WMFPageIssuesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B01162E71C24D3B200C3B52B /* WMFPageIssuesViewController.m */; };
 		B06531601C220921003BD7DC /* WMFArticlePreviewDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = B065315F1C220921003BD7DC /* WMFArticlePreviewDataSource.m */; };
 		B06531631C221BC4003BD7DC /* WMFArticlePreviewFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = B06531621C221BC4003BD7DC /* WMFArticlePreviewFetcher.m */; };
@@ -694,6 +695,7 @@
 		429C152FC8B093B59D18CAD3 /* Pods-WikipediaUnitTests.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WikipediaUnitTests.beta.xcconfig"; path = "Pods/Target Support Files/Pods-WikipediaUnitTests/Pods-WikipediaUnitTests.beta.xcconfig"; sourceTree = "<group>"; };
 		59CB2F41D52F438BED356EF4 /* Pods-WikipediaUnitTests.adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WikipediaUnitTests.adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-WikipediaUnitTests/Pods-WikipediaUnitTests.adhoc.xcconfig"; sourceTree = "<group>"; };
 		644C62F6A8B8E2ED7DFA53D5 /* Pods.adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.adhoc.xcconfig; path = "Pods/Target Support Files/Pods/Pods.adhoc.xcconfig"; sourceTree = "<group>"; };
+		B00050131C52D73800515F70 /* UIApplication+RTL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+RTL.swift"; sourceTree = "<group>"; };
 		B01162E61C24D3B200C3B52B /* WMFPageIssuesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFPageIssuesViewController.h; path = WikipediaUnitTests/Code/WMFPageIssuesViewController.h; sourceTree = SOURCE_ROOT; };
 		B01162E71C24D3B200C3B52B /* WMFPageIssuesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFPageIssuesViewController.m; path = WikipediaUnitTests/Code/WMFPageIssuesViewController.m; sourceTree = SOURCE_ROOT; };
 		B065315E1C220921003BD7DC /* WMFArticlePreviewDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFArticlePreviewDataSource.h; path = Wikipedia/Code/WMFArticlePreviewDataSource.h; sourceTree = SOURCE_ROOT; };
@@ -2961,6 +2963,7 @@
 				B0E8047F1C0CE0B40065EBC0 /* NSArray+WMFLayoutDirectionUtilities.m */,
 				BCA15AF21C0E724E00D0A3EA /* SSBaseDataSource+WMFLayoutDirectionUtilities.h */,
 				BCA15AF31C0E724E00D0A3EA /* SSBaseDataSource+WMFLayoutDirectionUtilities.m */,
+				B00050131C52D73800515F70 /* UIApplication+RTL.swift */,
 			);
 			name = "RTL Utilities";
 			sourceTree = "<group>";
@@ -5251,6 +5254,7 @@
 				B0E804251C0CDF350065EBC0 /* WMFAssetsFile.m in Sources */,
 				B0E805BE1C0CE4D40065EBC0 /* MWKDataHousekeeping.m in Sources */,
 				B0E8030D1C0CD5E00065EBC0 /* WMFNearbyArticleTableViewCell.m in Sources */,
+				B00050141C52D73800515F70 /* UIApplication+RTL.swift in Sources */,
 				BCD557B31C455F840060A51A /* WMFTextualSaveButton.m in Sources */,
 				B0E803B11C0CDBCF0065EBC0 /* WMFSearchDataSource.m in Sources */,
 				B0E8065A1C0CE84B0065EBC0 /* WikipediaZeroMessageFetcher.m in Sources */,

--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
@@ -92,8 +92,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      language = "he">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
@@ -92,7 +92,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "YES"
+      language = "he">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Wikipedia/Code/AboutViewController.m
+++ b/Wikipedia/Code/AboutViewController.m
@@ -243,7 +243,7 @@ static NSString* const kWMFContributorsKey = @"contributors";
                                                                                withString:foundation];
     setDivHTML(@"footer", footer);
 
-    NSString* textDirection   = ([WikipediaAppUtils isDeviceLanguageRTL] ? @"rtl" : @"ltr");
+    NSString* textDirection   = ([WikipediaAppUtils isDeviceLayoutDirectionRTL] ? @"rtl" : @"ltr");
     NSString* textDirectionJS = [NSString stringWithFormat:@"document.body.style.direction = '%@'", textDirection];
     [webView stringByEvaluatingJavaScriptFromString:textDirectionJS];
 

--- a/Wikipedia/Code/AboutViewController.m
+++ b/Wikipedia/Code/AboutViewController.m
@@ -10,6 +10,7 @@
 #import "NSBundle+WMFInfoUtils.h"
 #import "UIBarButtonItem+WMFButtonConvenience.h"
 #import "UIViewController+WMFOpenExternalUrl.h"
+#import "Wikipedia-Swift.h"
 
 static NSString* const kWMFAboutHTMLFile  = @"about.html";
 static NSString* const kWMFAboutPlistName = @"AboutViewController";
@@ -243,7 +244,7 @@ static NSString* const kWMFContributorsKey = @"contributors";
                                                                                withString:foundation];
     setDivHTML(@"footer", footer);
 
-    NSString* textDirection   = ([WikipediaAppUtils isDeviceLayoutDirectionRTL] ? @"rtl" : @"ltr");
+    NSString* textDirection   = ([[UIApplication sharedApplication] wmf_isRTL] ? @"rtl" : @"ltr");
     NSString* textDirectionJS = [NSString stringWithFormat:@"document.body.style.direction = '%@'", textDirection];
     [webView stringByEvaluatingJavaScriptFromString:textDirectionJS];
 

--- a/Wikipedia/Code/PaddedLabel.m
+++ b/Wikipedia/Code/PaddedLabel.m
@@ -4,6 +4,7 @@
 #import "PaddedLabel.h"
 #import "WikipediaAppUtils.h"
 #import "Defines.h"
+#import "Wikipedia-Swift.h"
 
 @implementation PaddedLabel
 
@@ -89,7 +90,7 @@
         );
 
     // Adjust for RTL langs.
-    if ([WikipediaAppUtils isDeviceLayoutDirectionRTL]) {
+    if ([[UIApplication sharedApplication] wmf_isRTL]) {
         _padding = UIEdgeInsetsMake(padding.top, padding.right, padding.bottom, padding.left);
     } else {
         _padding = padding;

--- a/Wikipedia/Code/PaddedLabel.m
+++ b/Wikipedia/Code/PaddedLabel.m
@@ -89,7 +89,7 @@
         );
 
     // Adjust for RTL langs.
-    if ([WikipediaAppUtils isDeviceLanguageRTL]) {
+    if ([WikipediaAppUtils isDeviceLayoutDirectionRTL]) {
         _padding = UIEdgeInsetsMake(padding.top, padding.right, padding.bottom, padding.left);
     } else {
         _padding = padding;

--- a/Wikipedia/Code/PreviewAndSaveViewController.m
+++ b/Wikipedia/Code/PreviewAndSaveViewController.m
@@ -472,7 +472,7 @@ typedef NS_ENUM (NSInteger, WMFPreviewAndSaveMode) {
                 error:(NSError*)error {
     if ([sender isKindOfClass:[PreviewHtmlFetcher class]]) {
         MWLanguageInfo* languageInfo = [MWLanguageInfo languageInfoForCode:self.section.site.language];
-        NSString* uidir              = ([WikipediaAppUtils isDeviceLanguageRTL] ? @"rtl" : @"ltr");
+        NSString* uidir              = ([WikipediaAppUtils isDeviceLayoutDirectionRTL] ? @"rtl" : @"ltr");
 
         switch (status) {
             case FETCH_FINAL_STATUS_SUCCEEDED: {

--- a/Wikipedia/Code/PreviewAndSaveViewController.m
+++ b/Wikipedia/Code/PreviewAndSaveViewController.m
@@ -472,7 +472,7 @@ typedef NS_ENUM (NSInteger, WMFPreviewAndSaveMode) {
                 error:(NSError*)error {
     if ([sender isKindOfClass:[PreviewHtmlFetcher class]]) {
         MWLanguageInfo* languageInfo = [MWLanguageInfo languageInfoForCode:self.section.site.language];
-        NSString* uidir              = ([WikipediaAppUtils isDeviceLayoutDirectionRTL] ? @"rtl" : @"ltr");
+        NSString* uidir              = ([[UIApplication sharedApplication] wmf_isRTL] ? @"rtl" : @"ltr");
 
         switch (status) {
             case FETCH_FINAL_STATUS_SUCCEEDED: {

--- a/Wikipedia/Code/ReferencesVC.m
+++ b/Wikipedia/Code/ReferencesVC.m
@@ -114,7 +114,7 @@
     self.xButton.userInteractionEnabled = YES;
     [self.topContainerView addSubview:self.xButton];
 
-    BOOL isRTL = [WikipediaAppUtils isDeviceLanguageRTL];
+    BOOL isRTL = [WikipediaAppUtils isDeviceLayoutDirectionRTL];
 
     self.nextButton                                           = [[WikiGlyphButton alloc] init];
     self.nextButton.translatesAutoresizingMaskIntoConstraints = NO;
@@ -267,7 +267,7 @@
 - (NSDictionary*)reversePayloadArraysIfRTL:(NSDictionary*)payload {
     //NSString *domain = [SessionSingleton sharedInstance].currentArticleDomain;
     //MWLanguageInfo *languageInfo = [MWLanguageInfo languageInfoForCode:domain];
-    BOOL isRTL = [WikipediaAppUtils isDeviceLanguageRTL];
+    BOOL isRTL = [WikipediaAppUtils isDeviceLayoutDirectionRTL];
     if (isRTL) {
         //if ([languageInfo.dir isEqualToString:@"ltr"]) {
         NSArray* a = payload[@"linkId"];
@@ -484,7 +484,7 @@
             return;
         }
 
-        BOOL isRTL = [WikipediaAppUtils isDeviceLanguageRTL];
+        BOOL isRTL = [WikipediaAppUtils isDeviceLayoutDirectionRTL];
 
         UIPageViewControllerNavigationDirection dir = isRTL
                                                       ?
@@ -505,7 +505,7 @@
             return;
         }
 
-        BOOL isRTL = [WikipediaAppUtils isDeviceLanguageRTL];
+        BOOL isRTL = [WikipediaAppUtils isDeviceLayoutDirectionRTL];
 
         UIPageViewControllerNavigationDirection dir = isRTL
                                                       ?

--- a/Wikipedia/Code/ReferencesVC.m
+++ b/Wikipedia/Code/ReferencesVC.m
@@ -16,6 +16,7 @@
 #import "UIWebView+ElementLocation.h"
 #import "Defines.h"
 #import "NSObject+ConstraintsScale.h"
+#import "Wikipedia-Swift.h"
 
 // Show prev-next buttons instead of page dots if number of refs exceeds this number.
 #define PAGE_CONTROL_MAX_REFS 10
@@ -114,7 +115,7 @@
     self.xButton.userInteractionEnabled = YES;
     [self.topContainerView addSubview:self.xButton];
 
-    BOOL isRTL = [WikipediaAppUtils isDeviceLayoutDirectionRTL];
+    BOOL isRTL = [[UIApplication sharedApplication] wmf_isRTL];
 
     self.nextButton                                           = [[WikiGlyphButton alloc] init];
     self.nextButton.translatesAutoresizingMaskIntoConstraints = NO;
@@ -267,7 +268,7 @@
 - (NSDictionary*)reversePayloadArraysIfRTL:(NSDictionary*)payload {
     //NSString *domain = [SessionSingleton sharedInstance].currentArticleDomain;
     //MWLanguageInfo *languageInfo = [MWLanguageInfo languageInfoForCode:domain];
-    BOOL isRTL = [WikipediaAppUtils isDeviceLayoutDirectionRTL];
+    BOOL isRTL = [[UIApplication sharedApplication] wmf_isRTL];
     if (isRTL) {
         //if ([languageInfo.dir isEqualToString:@"ltr"]) {
         NSArray* a = payload[@"linkId"];
@@ -484,7 +485,7 @@
             return;
         }
 
-        BOOL isRTL = [WikipediaAppUtils isDeviceLayoutDirectionRTL];
+        BOOL isRTL = [[UIApplication sharedApplication] wmf_isRTL];
 
         UIPageViewControllerNavigationDirection dir = isRTL
                                                       ?
@@ -505,7 +506,7 @@
             return;
         }
 
-        BOOL isRTL = [WikipediaAppUtils isDeviceLayoutDirectionRTL];
+        BOOL isRTL = [[UIApplication sharedApplication] wmf_isRTL];
 
         UIPageViewControllerNavigationDirection dir = isRTL
                                                       ?

--- a/Wikipedia/Code/SecondaryMenuRowView.m
+++ b/Wikipedia/Code/SecondaryMenuRowView.m
@@ -41,7 +41,7 @@
     [super awakeFromNib];
     self.insetTopBorderView.backgroundColor = BORDER_COLOR;
 
-    BOOL isRTL = [WikipediaAppUtils isDeviceLanguageRTL];
+    BOOL isRTL = [WikipediaAppUtils isDeviceLayoutDirectionRTL];
 
     self.iconLabel.textAlignment = isRTL ? NSTextAlignmentLeft : NSTextAlignmentRight;
 

--- a/Wikipedia/Code/SecondaryMenuRowView.m
+++ b/Wikipedia/Code/SecondaryMenuRowView.m
@@ -8,6 +8,7 @@
 #import "WikipediaAppUtils.h"
 #import "NSObject+ConstraintsScale.h"
 #import "MediaWikiKit.h"
+#import "Wikipedia-Swift.h"
 
 #define MENU_HEADING_FONT_SIZE (13.0 * MENUS_SCALE_MULTIPLIER)
 #define MENU_SUB_TITLE_TEXT_COLOR [UIColor colorWithWhite:0.5f alpha:1.0f]
@@ -41,7 +42,7 @@
     [super awakeFromNib];
     self.insetTopBorderView.backgroundColor = BORDER_COLOR;
 
-    BOOL isRTL = [WikipediaAppUtils isDeviceLayoutDirectionRTL];
+    BOOL isRTL = [[UIApplication sharedApplication] wmf_isRTL];
 
     self.iconLabel.textAlignment = isRTL ? NSTextAlignmentLeft : NSTextAlignmentRight;
 

--- a/Wikipedia/Code/UIApplication+RTL.swift
+++ b/Wikipedia/Code/UIApplication+RTL.swift
@@ -1,0 +1,18 @@
+
+import Foundation
+
+extension UIApplication {
+    var wmf_tocShouldBeOnLeft: Bool {
+        get { return self.wmf_isRTL && !NSProcessInfo.processInfo().wmf_isOperatingSystemVersionLessThan9_0_0() }
+    }
+    
+    var wmf_tocRTLMultiplier: CGFloat {
+        get {
+            return self.wmf_tocShouldBeOnLeft ? -1.0 : 1.0
+        }
+    }
+    
+    var wmf_isRTL: Bool {
+        get { return self.userInterfaceLayoutDirection == .RightToLeft }
+    }
+}

--- a/Wikipedia/Code/WMFTableOfContentsAnimator.swift
+++ b/Wikipedia/Code/WMFTableOfContentsAnimator.swift
@@ -185,8 +185,8 @@ public class WMFTableOfContentsAnimator: UIPercentDrivenInteractiveTransition, U
             self.presentingViewController?.presentViewController(self.presentedViewController!, animated: true, completion: nil)
         case (.Changed):
             let position = gesture.locationInView(gesture.view);
-            let distance = WikipediaAppUtils.isDeviceLayoutDirectionRTL() ? position.x : CGRectGetMaxX(gesture.view!.bounds) - position.x
-            let transitionProgress = distance / CGRectGetMaxX(gesture.view!.bounds)
+            let distanceFromSide = WikipediaAppUtils.isDeviceLayoutDirectionRTL() ? position.x : CGRectGetMaxX(gesture.view!.bounds) - position.x
+            let transitionProgress = distanceFromSide / CGRectGetMaxX(gesture.view!.bounds)
             self.updateInteractiveTransition(transitionProgress)
         case (.Ended):
             self.isInteractive = false

--- a/Wikipedia/Code/WMFTableOfContentsAnimator.swift
+++ b/Wikipedia/Code/WMFTableOfContentsAnimator.swift
@@ -105,14 +105,14 @@ public class WMFTableOfContentsAnimator: UIPercentDrivenInteractiveTransition, U
         
         // Position the presented view off the top of the container view
         var f = transitionContext.finalFrameForViewController(presentedController)
-        f.origin.x += f.size.width
+        f.origin.x -= f.size.width
         presentedControllerView.frame = f
         
         containerView.addSubview(presentedControllerView)
         
         animateTransition(self.isInteractive, duration: self.transitionDuration(transitionContext), animations: { () -> Void in
             var f = presentedControllerView.frame
-            f.origin.x -= f.size.width
+            f.origin.x += f.size.width
             presentedControllerView.frame = f
             }, completion: {(completed: Bool) -> Void in
                 transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
@@ -124,7 +124,7 @@ public class WMFTableOfContentsAnimator: UIPercentDrivenInteractiveTransition, U
         
         animateTransition(self.isInteractive, duration: self.transitionDuration(transitionContext), animations: { () -> Void in
             var f = presentedControllerView.frame
-            f.origin.x += f.size.width
+            f.origin.x -= f.size.width
             presentedControllerView.frame = f
 
             }, completion: {(completed: Bool) -> Void in
@@ -154,7 +154,7 @@ public class WMFTableOfContentsAnimator: UIPercentDrivenInteractiveTransition, U
     // MARK: - Gestures
     lazy var presentationGesture: UIScreenEdgePanGestureRecognizer = {
         let gesture = UIScreenEdgePanGestureRecognizer.init(target: self, action: Selector("handlePresentationGesture:"))
-        gesture.edges = .Right
+        gesture.edges = .Left
         return gesture
     }()
     
@@ -183,15 +183,19 @@ public class WMFTableOfContentsAnimator: UIPercentDrivenInteractiveTransition, U
         case (.Changed):
             let position = gesture.locationInView(gesture.view);
             let distanceFromRight = CGRectGetMaxX(gesture.view!.bounds) - position.x
-            let transitionProgress = distanceFromRight / CGRectGetMaxX(gesture.view!.bounds)
+            let distanceFromLeft = position.x
+
+let distance = distanceFromLeft //distanceFromRight
+
+            let transitionProgress = distance / CGRectGetMaxX(gesture.view!.bounds)
             self.updateInteractiveTransition(transitionProgress)
         case (.Ended):
             self.isInteractive = false
-            let velocityRequiredToPresent = -CGRectGetWidth(gesture.view!.bounds)
+            let velocityRequiredToPresent = CGRectGetWidth(gesture.view!.bounds)
             let velocityRequiredToDismiss = CGRectGetWidth(gesture.view!.bounds)
             
             let velocityX = gesture.velocityInView(gesture.view).x
-            if velocityX > velocityRequiredToDismiss{
+            if velocityX < velocityRequiredToDismiss{
                 self.cancelInteractiveTransition()
                 return
             }
@@ -227,12 +231,12 @@ public class WMFTableOfContentsAnimator: UIPercentDrivenInteractiveTransition, U
             self.presentingViewController?.dismissViewControllerAnimated(true, completion: nil)
         case .Changed:
             let translation = gesture.translationInView(gesture.view)
-            let transitionProgress = translation.x / CGRectGetMaxX(self.presentedViewController!.view.bounds)
+            let transitionProgress = -translation.x / CGRectGetMaxX(self.presentedViewController!.view.bounds)
             self.updateInteractiveTransition(transitionProgress)
             DDLogVerbose("TOC transition progress: \(transitionProgress)")
         case .Ended:
             self.isInteractive = false
-            let velocityRequiredToPresent = -CGRectGetMaxX(gesture.view!.bounds)
+            let velocityRequiredToPresent = CGRectGetMaxX(gesture.view!.bounds)
             let velocityRequiredToDismiss = CGRectGetWidth(gesture.view!.bounds)
             
             let velocityX = gesture.velocityInView(gesture.view).x
@@ -271,7 +275,7 @@ public class WMFTableOfContentsAnimator: UIPercentDrivenInteractiveTransition, U
         }
         
         if let translation = self.dismissalGesture?.translationInView(dismissalGesture?.view) {
-            if(translation.x > 0){
+            if(translation.x < 0){
                 return true
             }else{
                 return false

--- a/Wikipedia/Code/WMFTableOfContentsAnimator.swift
+++ b/Wikipedia/Code/WMFTableOfContentsAnimator.swift
@@ -35,8 +35,12 @@ public class WMFTableOfContentsAnimator: UIPercentDrivenInteractiveTransition, U
     
     private(set) public var isInteractive: Bool
     
+    static func shouldMoveTOCToLeft() -> Bool {
+        return WikipediaAppUtils.isDeviceLayoutDirectionRTL() && !NSProcessInfo.processInfo().wmf_isOperatingSystemVersionLessThan9_0_0()
+    }
+    
     private func rtlMultiplier() -> CGFloat {
-        return WikipediaAppUtils.isDeviceLayoutDirectionRTL() ? -1.0 : 1.0
+        return WMFTableOfContentsAnimator.shouldMoveTOCToLeft() ? -1.0 : 1.0
     }
     
     // MARK: - WMFTableOfContentsPresentationControllerTapDelegate
@@ -157,7 +161,7 @@ public class WMFTableOfContentsAnimator: UIPercentDrivenInteractiveTransition, U
     // MARK: - Gestures
     lazy var presentationGesture: UIScreenEdgePanGestureRecognizer = {
         let gesture = UIScreenEdgePanGestureRecognizer.init(target: self, action: Selector("handlePresentationGesture:"))
-        gesture.edges = WikipediaAppUtils.isDeviceLayoutDirectionRTL() ? .Left : .Right
+        gesture.edges = WMFTableOfContentsAnimator.shouldMoveTOCToLeft() ? .Left : .Right
         return gesture
     }()
     
@@ -185,7 +189,7 @@ public class WMFTableOfContentsAnimator: UIPercentDrivenInteractiveTransition, U
             self.presentingViewController?.presentViewController(self.presentedViewController!, animated: true, completion: nil)
         case (.Changed):
             let position = gesture.locationInView(gesture.view);
-            let distanceFromSide = WikipediaAppUtils.isDeviceLayoutDirectionRTL() ? position.x : CGRectGetMaxX(gesture.view!.bounds) - position.x
+            let distanceFromSide = WMFTableOfContentsAnimator.shouldMoveTOCToLeft() ? position.x : CGRectGetMaxX(gesture.view!.bounds) - position.x
             let transitionProgress = distanceFromSide / CGRectGetMaxX(gesture.view!.bounds)
             self.updateInteractiveTransition(transitionProgress)
         case (.Ended):

--- a/Wikipedia/Code/WMFTableOfContentsPresentationController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsPresentationController.swift
@@ -88,7 +88,7 @@ public class WMFTableOfContentsPresentationController: UIPresentationController 
     
     override public func frameOfPresentedViewInContainerView() -> CGRect {
         var frame = self.containerView!.bounds;
-        frame.origin.x += self.visibleBackgroundWidth
+//        frame.origin.x += self.visibleBackgroundWidth
         frame.size.width -= self.visibleBackgroundWidth
         
         return frame

--- a/Wikipedia/Code/WMFTableOfContentsPresentationController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsPresentationController.swift
@@ -88,7 +88,7 @@ public class WMFTableOfContentsPresentationController: UIPresentationController 
     
     override public func frameOfPresentedViewInContainerView() -> CGRect {
         var frame = self.containerView!.bounds;
-        if !WikipediaAppUtils.isDeviceLayoutDirectionRTL(){
+        if !WMFTableOfContentsAnimator.shouldMoveTOCToLeft(){
             frame.origin.x += self.visibleBackgroundWidth
         }
         frame.size.width -= self.visibleBackgroundWidth

--- a/Wikipedia/Code/WMFTableOfContentsPresentationController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsPresentationController.swift
@@ -88,7 +88,7 @@ public class WMFTableOfContentsPresentationController: UIPresentationController 
     
     override public func frameOfPresentedViewInContainerView() -> CGRect {
         var frame = self.containerView!.bounds;
-        if !WMFTableOfContentsAnimator.shouldMoveTOCToLeft(){
+        if !UIApplication.sharedApplication().wmf_tocShouldBeOnLeft{
             frame.origin.x += self.visibleBackgroundWidth
         }
         frame.size.width -= self.visibleBackgroundWidth

--- a/Wikipedia/Code/WMFTableOfContentsPresentationController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsPresentationController.swift
@@ -88,7 +88,9 @@ public class WMFTableOfContentsPresentationController: UIPresentationController 
     
     override public func frameOfPresentedViewInContainerView() -> CGRect {
         var frame = self.containerView!.bounds;
-//        frame.origin.x += self.visibleBackgroundWidth
+        if !WikipediaAppUtils.isDeviceLayoutDirectionRTL(){
+            frame.origin.x += self.visibleBackgroundWidth
+        }
         frame.size.width -= self.visibleBackgroundWidth
         
         return frame

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -607,7 +607,7 @@ NSString* const WMFLicenseTitleOnENWiki =
     NSString* html = [self.article articleHTML];
 
     MWLanguageInfo* languageInfo = [MWLanguageInfo languageInfoForCode:self.article.site.language];
-    NSString* uidir              = ([WikipediaAppUtils isDeviceLanguageRTL] ? @"rtl" : @"ltr");
+    NSString* uidir              = ([WikipediaAppUtils isDeviceLayoutDirectionRTL] ? @"rtl" : @"ltr");
 
     // If any of these are nil, the bridge "sendMessage:" calls will crash! So catch 'em here.
     BOOL safeToCrossBridge = (languageInfo.code && languageInfo.dir && uidir && html);

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -607,7 +607,7 @@ NSString* const WMFLicenseTitleOnENWiki =
     NSString* html = [self.article articleHTML];
 
     MWLanguageInfo* languageInfo = [MWLanguageInfo languageInfoForCode:self.article.site.language];
-    NSString* uidir              = ([WikipediaAppUtils isDeviceLayoutDirectionRTL] ? @"rtl" : @"ltr");
+    NSString* uidir              = ([[UIApplication sharedApplication] wmf_isRTL] ? @"rtl" : @"ltr");
 
     // If any of these are nil, the bridge "sendMessage:" calls will crash! So catch 'em here.
     BOOL safeToCrossBridge = (languageInfo.code && languageInfo.dir && uidir && html);

--- a/Wikipedia/Code/WikipediaAppUtils.h
+++ b/Wikipedia/Code/WikipediaAppUtils.h
@@ -16,7 +16,7 @@ WMF_TECH_DEBT_DEPRECATED_MSG("This class is deprecated, its methods should be br
 + (NSString*)versionedUserAgent;
 + (NSString*)relativeTimestamp:(NSDate*)date;
 + (NSString*)languageNameForCode:(NSString*)code;
-+ (BOOL)     isDeviceLanguageRTL;
++ (BOOL)     isDeviceLayoutDirectionRTL;
 
 + (void)copyAssetsFolderToAppDataDocuments;
 

--- a/Wikipedia/Code/WikipediaAppUtils.h
+++ b/Wikipedia/Code/WikipediaAppUtils.h
@@ -16,7 +16,6 @@ WMF_TECH_DEBT_DEPRECATED_MSG("This class is deprecated, its methods should be br
 + (NSString*)versionedUserAgent;
 + (NSString*)relativeTimestamp:(NSDate*)date;
 + (NSString*)languageNameForCode:(NSString*)code;
-+ (BOOL)     isDeviceLayoutDirectionRTL;
 
 + (void)copyAssetsFolderToAppDataDocuments;
 

--- a/Wikipedia/Code/WikipediaAppUtils.m
+++ b/Wikipedia/Code/WikipediaAppUtils.m
@@ -179,10 +179,6 @@ static WMFAssetsFile* languageFile = nil;
     }
 }
 
-+ (BOOL)isDeviceLayoutDirectionRTL {
-    return [UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft;
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WikipediaAppUtils.m
+++ b/Wikipedia/Code/WikipediaAppUtils.m
@@ -179,7 +179,7 @@ static WMFAssetsFile* languageFile = nil;
     }
 }
 
-+ (BOOL)isDeviceLanguageRTL {
++ (BOOL)isDeviceLayoutDirectionRTL {
     return [UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft;
 }
 


### PR DESCRIPTION
When layout direction is RTL:
- [x] TOC appears on left side of screen.
- [x] Progressive drag from left edge.
- [x] When TOC is onscreen drag toward left edge to dismiss.
- [x] When TOC is onscreen tap on article view to dismiss.
- [x] Dynamically switch side TOC appears on based on device interface layout direction
- [x] Ensure iOS 8 doesn't explode.

----

**RTL** *New!*
![toc rtl mov](https://cloud.githubusercontent.com/assets/3143487/12499887/18abb53a-c063-11e5-867d-7415eb811b68.gif)

----

**LTR** *Still works!*
![toc ltr mov](https://cloud.githubusercontent.com/assets/3143487/12499876/0db37a46-c063-11e5-82f9-4615bc6a05a0.gif)
