### PR TITLE
Fix Explore scrolling issues

### DIFF
--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -134,10 +134,7 @@ static dispatch_once_t launchToken;
 }
 
 - (void)configureExploreViewController {
-    self.exploreViewController.searchSite  = [self.session searchSite];
-    self.exploreViewController.dataStore   = self.session.dataStore;
-    self.exploreViewController.savedPages  = self.session.userDataStore.savedPageList;
-    self.exploreViewController.recentPages = self.session.userDataStore.historyList;
+    [self.exploreViewController setSearchSite:[self.session searchSite] dataStore:self.dataStore];
 }
 
 - (void)configureArticleListController:(WMFArticleListTableViewController*)controller {
@@ -548,7 +545,7 @@ static NSString* const WMFDidShowOnboarding = @"DidShowOnboarding5.0";
 - (void)tabBarController:(UITabBarController*)tabBarController didSelectViewController:(UIViewController*)viewController {
     [self wmf_hideKeyboard];
     WMFAppTabType tab = [[tabBarController viewControllers] indexOfObject:viewController];
-//    [[PiwikTracker sharedInstance] wmf_logView:[self rootViewControllerForTab:tab]];
+    [[PiwikTracker sharedInstance] wmf_logView:[self rootViewControllerForTab:tab]];
 }
 
 #pragma mark - Notifications

--- a/Wikipedia/Code/WMFArticlePreviewTableViewCell.h
+++ b/Wikipedia/Code/WMFArticlePreviewTableViewCell.h
@@ -9,6 +9,8 @@
 
 @property (nonatomic, strong) NSString* snippetText;
 
++ (CGFloat)estimatedRowHeight;
+
 /**
  *  Wire up the save button with the title and saved page list
  *  to enable saving.

--- a/Wikipedia/Code/WMFArticlePreviewTableViewCell.m
+++ b/Wikipedia/Code/WMFArticlePreviewTableViewCell.m
@@ -184,4 +184,10 @@
     self.saveButtonController.title         = title;
 }
 
+#pragma mark - Height Estimation
+
++ (CGFloat)estimatedRowHeight {
+    return 345.f;
+}
+
 @end

--- a/Wikipedia/Code/WMFContinueReadingSectionController.m
+++ b/Wikipedia/Code/WMFContinueReadingSectionController.m
@@ -95,4 +95,8 @@ static NSString* const WMFContinueReadingSectionIdentifier = @"WMFContinueReadin
     return @"Continue Reading";
 }
 
+- (CGFloat)estimatedRowHeight {
+    return [WMFContinueReadingTableViewCell estimatedRowHeight];
+}
+
 @end

--- a/Wikipedia/Code/WMFContinueReadingTableViewCell.h
+++ b/Wikipedia/Code/WMFContinueReadingTableViewCell.h
@@ -1,9 +1,10 @@
-
 #import <SSDataSources/SSDataSources.h>
 
 @interface WMFContinueReadingTableViewCell : SSBaseTableCell
 
 @property (strong, nonatomic) IBOutlet UILabel* title;
 @property (strong, nonatomic) IBOutlet UILabel* summary;
+
++ (CGFloat)estimatedRowHeight;
 
 @end

--- a/Wikipedia/Code/WMFContinueReadingTableViewCell.m
+++ b/Wikipedia/Code/WMFContinueReadingTableViewCell.m
@@ -10,4 +10,8 @@
 
 @implementation WMFContinueReadingTableViewCell
 
++ (CGFloat)estimatedRowHeight {
+    return 82.f;
+}
+
 @end

--- a/Wikipedia/Code/WMFContinueReadingTableViewCell.xib
+++ b/Wikipedia/Code/WMFContinueReadingTableViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,25 +11,22 @@
             <rect key="frame" x="0.0" y="0.0" width="345" height="82"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="345" height="81.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="345" height="81"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KPL-Nb-HiO">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" ambiguous="YES" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KPL-Nb-HiO">
                         <rect key="frame" x="15" y="15" width="322" height="25"/>
-                        <animations/>
                         <fontDescription key="fontDescription" name="Georgia" family="Georgia" pointSize="22"/>
-                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Summary" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IBP-na-wl2">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" ambiguous="YES" misplaced="YES" text="Summary" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IBP-na-wl2">
                         <rect key="frame" x="15" y="50" width="322" height="17"/>
-                        <animations/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <color key="textColor" red="0.59993284940000002" green="0.60003882649999996" blue="0.59992617370000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
-                <animations/>
                 <constraints>
                     <constraint firstItem="KPL-Nb-HiO" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="15" id="6Me-MP-GhV"/>
                     <constraint firstAttribute="trailing" secondItem="KPL-Nb-HiO" secondAttribute="trailing" constant="8" id="cf1-tN-ghs"/>
@@ -40,7 +37,6 @@
                     <constraint firstItem="IBP-na-wl2" firstAttribute="leading" secondItem="KPL-Nb-HiO" secondAttribute="leading" id="u2O-su-gT0"/>
                 </constraints>
             </tableViewCellContentView>
-            <animations/>
             <connections>
                 <outlet property="summary" destination="IBP-na-wl2" id="TCo-C3-PfD"/>
                 <outlet property="title" destination="KPL-Nb-HiO" id="oZ3-KG-svA"/>

--- a/Wikipedia/Code/WMFEmptyNearbyTableViewCell.xib
+++ b/Wikipedia/Code/WMFEmptyNearbyTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15A284" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
@@ -12,7 +12,7 @@
             <rect key="frame" x="0.0" y="0.0" width="260" height="260"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="260" height="259.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="260" height="259"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Nothing Nearby" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ENx-R8-yeN">
@@ -48,7 +48,7 @@
                 <outlet property="emptyTextLabel" destination="ENx-R8-yeN" id="YUy-6L-8F6"/>
                 <outlet property="reloadButton" destination="PHo-Uq-Vpu" id="uAj-Vz-oCH"/>
             </connections>
-            <point key="canvasLocation" x="359" y="577"/>
+            <point key="canvasLocation" x="272" y="532"/>
         </tableViewCell>
     </objects>
 </document>

--- a/Wikipedia/Code/WMFExploreSectionController.h
+++ b/Wikipedia/Code/WMFExploreSectionController.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSArray*)items;
 
+- (CGFloat)estimatedRowHeight;
+
 @optional
 
 /**

--- a/Wikipedia/Code/WMFExploreSectionFooter.xib
+++ b/Wikipedia/Code/WMFExploreSectionFooter.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>

--- a/Wikipedia/Code/WMFExploreSectionHeader.xib
+++ b/Wikipedia/Code/WMFExploreSectionHeader.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>

--- a/Wikipedia/Code/WMFExploreSectionSchema.m
+++ b/Wikipedia/Code/WMFExploreSectionSchema.m
@@ -97,13 +97,13 @@ static NSString* const WMFExploreSectionsFileExtension = @"plist";
     return self;
 }
 
-- (void)setBlackList:(WMFRelatedSectionBlackList *)blackList{
-    if(_blackList){
+- (void)setBlackList:(WMFRelatedSectionBlackList*)blackList {
+    if (_blackList) {
         [self.KVOController unobserve:_blackList];
     }
-    
+
     _blackList = blackList;
-    
+
     [self.KVOController observe:_blackList keyPath:WMF_SAFE_KEYPATH(_blackList, blackListTitles) options:0 block:^(WMFExploreSectionSchema* observer, WMFRelatedSectionBlackList* object, NSDictionary* change) {
         [observer updateWithChangesInBlackList:object];
     }];
@@ -199,9 +199,9 @@ static NSString* const WMFExploreSectionsFileExtension = @"plist";
     [WMFExploreSectionSchema saveSchemaToDisk:self];
 }
 
-- (void)removeSection:(WMFExploreSection*)section{
+- (void)removeSection:(WMFExploreSection*)section {
     NSUInteger index = [self.sections indexOfObject:section];
-    if(index == NSNotFound){
+    if (index == NSNotFound) {
         return;
     }
     NSMutableArray* sections = [self.sections mutableCopy];
@@ -265,9 +265,9 @@ static NSString* const WMFExploreSectionsFileExtension = @"plist";
 
 - (void)updateWithChangesInBlackList:(WMFRelatedSectionBlackList*)blackList {
     //enumerate in reverse so that indexes are always correct
-    [[blackList.blackListTitles wmf_mapAndRejectNil:^id(MWKTitle * obj) {
+    [[blackList.blackListTitles wmf_mapAndRejectNil:^id (MWKTitle* obj) {
         return [self existingSectionForTitle:obj];
-    }] enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(WMFExploreSection*  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+    }] enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(WMFExploreSection* _Nonnull obj, NSUInteger idx, BOOL* _Nonnull stop) {
         [self removeSection:obj];
     }];
 }
@@ -438,7 +438,7 @@ static NSString* const WMFExploreSectionsFileExtension = @"plist";
     NSArray<MWKHistoryEntry*>* entries = [self.historyPages.entries bk_select:^BOOL (MWKHistoryEntry* obj) {
         return obj.titleWasSignificantlyViewed;
     }];
-    
+
     entries = [entries bk_reject:^BOOL (MWKHistoryEntry* obj) {
         return [self.blackList titleIsBlackListed:obj.title];
     }];

--- a/Wikipedia/Code/WMFExploreViewController.h
+++ b/Wikipedia/Code/WMFExploreViewController.h
@@ -12,9 +12,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface WMFExploreViewController : UITableViewController<WMFSearchPresentationDelegate>
 
 @property (nonatomic, strong) MWKSite* searchSite;
-@property (nonatomic, strong) MWKDataStore* dataStore;
-@property (nonatomic, strong) MWKSavedPageList* savedPages;
-@property (nonatomic, strong) MWKHistoryList* recentPages;
+@property (nonatomic, strong, readonly) MWKDataStore* dataStore;
+
+- (void)setSearchSite:(MWKSite * _Nonnull)searchSite dataStore:(MWKDataStore* _Nonnull)dataStore;
 
 @end
 

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -66,6 +66,9 @@ NS_ASSUME_NONNULL_BEGIN
  UIViewControllerPreviewingDelegate,
  WMFAnalyticsLogging>
 
+@property (nonatomic, strong, readonly) MWKSavedPageList* savedPages;
+@property (nonatomic, strong, readonly) MWKHistoryList* recentPages;
+
 @property (nonatomic, strong, null_resettable) WMFExploreSectionSchema* schemaManager;
 
 @property (nonatomic, strong, null_resettable) WMFNearbySectionController* nearbySectionController;
@@ -101,6 +104,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Accessors
 
+- (MWKSavedPageList*)savedPages {
+    return self.dataStore.userDataStore.savedPageList;
+}
+
+- (MWKHistoryList*)recentPages {
+    return self.dataStore.userDataStore.historyList;
+}
+
 - (UIBarButtonItem*)settingsBarButtonItem {
     return [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"settings"]
                                             style:UIBarButtonItemStylePlain
@@ -108,11 +119,21 @@ NS_ASSUME_NONNULL_BEGIN
                                            action:@selector(didTapSettingsButton:)];
 }
 
-- (void)setSearchSite:(MWKSite* __nonnull)searchSite {
+- (void)setSearchSite:(MWKSite *)searchSite {
+    NSParameterAssert(self.dataStore);
+    [self setSearchSite:self.searchSite dataStore:self.dataStore];
+}
+
+- (void)setSearchSite:(MWKSite* __nonnull)searchSite dataStore:(MWKDataStore* _Nonnull)dataStore {
     if ([_searchSite isEqualToSite:searchSite]) {
         return;
     }
+
+    NSParameterAssert(searchSite);
+    NSParameterAssert(dataStore);
+
     _searchSite = searchSite;
+    _dataStore = dataStore;
 
     self.schemaManager           = nil;
     self.nearbySectionController = nil;

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -395,7 +395,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)resetRefreshControlWithCompletion:(nullable dispatch_block_t)completion {
-
     //Don't hide the spinner so quickly - so users can see the change
     dispatchOnMainQueueAfterDelayInSeconds(1.0, ^{
         [CATransaction begin];
@@ -418,7 +417,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateSectionSchemaForce:(BOOL)force {
     [self.refreshControl beginRefreshing];
-    self.sectionLoadErrors              = [NSMutableDictionary dictionary];
+    self.sectionLoadErrors = [NSMutableDictionary dictionary];
     [self.schemaManager update:force];
 }
 
@@ -491,7 +490,7 @@ NS_ASSUME_NONNULL_BEGIN
     if ([self isDisplayingCellsForSectionController:controller]) {
         [self resetRefreshControlWithCompletion:NULL];
         if ([controller conformsToProtocol:@protocol(WMFFetchingExploreSectionController)]) {
-            [(NSObject < WMFFetchingExploreSectionController >*)controller performSelector:@selector(fetchDataIfNeeded) withObject:nil afterDelay:0.25];
+            [(NSObject < WMFFetchingExploreSectionController > *)controller performSelector:@selector(fetchDataIfNeeded) withObject:nil afterDelay:0.25];
         }
     }
 }
@@ -600,7 +599,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - UITableViewDelegate
 
-- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath {
+- (CGFloat)tableView:(UITableView*)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath*)indexPath {
     id<WMFExploreSectionController> controller = [self sectionControllerForSectionAtIndex:indexPath.section];
     NSParameterAssert(controller);
     return [controller estimatedRowHeight];
@@ -688,8 +687,8 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)tableView:(UITableView *)tableView didEndDisplayingCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
-    NSArray<NSIndexPath*>* visibleIndexPathsInSection = [tableView.indexPathsForVisibleRows bk_select:^BOOL(NSIndexPath* i) {
+- (void)tableView:(UITableView*)tableView didEndDisplayingCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
+    NSArray<NSIndexPath*>* visibleIndexPathsInSection = [tableView.indexPathsForVisibleRows bk_select:^BOOL (NSIndexPath* i) {
         return i.section == indexPath.section;
     }];
     if (visibleIndexPathsInSection.count == 0) {

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -54,9 +54,9 @@
 #import "WMFRelatedSectionBlackList.h"
 #import "UIViewController+WMFArticlePresentation.h"
 
-static DDLogLevel const WMFHomeVCLogLevel = DDLogLevelVerbose;
+static DDLogLevel const WMFExploreVCLogLevel = DDLogLevelInfo;
 #undef LOG_LEVEL_DEF
-#define LOG_LEVEL_DEF WMFHomeVCLogLevel
+#define LOG_LEVEL_DEF WMFExploreVCLogLevel
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -725,7 +725,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sectionSchema:(WMFExploreSectionSchema*)schema didRemoveSection:(WMFExploreSection*)section atIndex:(NSUInteger)index {
-//    id<WMFExploreSectionController> controller = [self sectionControllerForSectionAtIndex:index];
     [self.dataSource.sections removeObjectAtIndex:index];
     [self.tableView reloadData];
 }

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -202,9 +202,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.tableView.dataSource                   = nil;
     self.tableView.delegate                     = nil;
-    self.tableView.estimatedRowHeight           = 345.0;
     self.tableView.sectionHeaderHeight          = UITableViewAutomaticDimension;
-    self.tableView.estimatedSectionHeaderHeight = 78.0;
+    self.tableView.estimatedSectionHeaderHeight = 52.0;
     self.tableView.sectionFooterHeight          = UITableViewAutomaticDimension;
     self.tableView.estimatedSectionFooterHeight = 78.0;
 
@@ -589,6 +588,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 #pragma mark - UITableViewDelegate
+
+- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    id<WMFExploreSectionController> controller = [self sectionControllerForSectionAtIndex:indexPath.section];
+    NSParameterAssert(controller);
+    return [controller estimatedRowHeight];
+}
 
 - (UITableViewCellEditingStyle)tableView:(UITableView*)tableView editingStyleForRowAtIndexPath:(NSIndexPath*)indexPath {
     return UITableViewCellEditingStyleNone;

--- a/Wikipedia/Code/WMFFeaturedArticleSectionController.m
+++ b/Wikipedia/Code/WMFFeaturedArticleSectionController.m
@@ -142,13 +142,17 @@ static NSString* const WMFFeaturedArticleSectionIdentifierPrefix = @"WMFFeatured
         @strongify(self);
         self.featuredArticlePreview = nil;
         [self.delegate controller:self didFailToUpdateWithError:error];
-        WMF_TECH_DEBT_TODO(show empty view)
-        [self.delegate controller : self didSetItems : self.items];
+        WMF_TECH_DEBT_TODO(show empty view);
+        [self.delegate controller:self didSetItems:self.items];
     });
 }
 
 - (NSString*)analyticsName {
     return @"Featured Article";
+}
+
+- (CGFloat)estimatedRowHeight {
+    return [WMFArticlePreviewTableViewCell estimatedRowHeight];
 }
 
 @end

--- a/Wikipedia/Code/WMFMainPageSectionController.m
+++ b/Wikipedia/Code/WMFMainPageSectionController.m
@@ -139,6 +139,10 @@ static NSString* const WMFMainPageSectionIdentifier = @"WMFMainPageSectionIdenti
     return @"Main Page";
 }
 
+- (CGFloat)estimatedRowHeight {
+    return [WMFMainPageTableViewCell estimatedRowHeight];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFMainPageTableViewCell.h
+++ b/Wikipedia/Code/WMFMainPageTableViewCell.h
@@ -6,4 +6,6 @@
 
 @property (nonatomic, strong) IBOutlet UILabel* mainPageTitle;
 
++ (CGFloat)estimatedRowHeight;
+
 @end

--- a/Wikipedia/Code/WMFMainPageTableViewCell.m
+++ b/Wikipedia/Code/WMFMainPageTableViewCell.m
@@ -3,5 +3,8 @@
 
 @implementation WMFMainPageTableViewCell
 
++ (CGFloat)estimatedRowHeight {
+    return 60.f;
+}
 
 @end

--- a/Wikipedia/Code/WMFMainPageTableViewCell.xib
+++ b/Wikipedia/Code/WMFMainPageTableViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,18 +11,16 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="59.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="59"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m4s-Pa-7L1" userLabel="Title Label">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="1000" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m4s-Pa-7L1" userLabel="Title Label">
                         <rect key="frame" x="18" y="14" width="284" height="32"/>
-                        <animations/>
                         <fontDescription key="fontDescription" name="Georgia" family="Georgia" pointSize="25"/>
                         <nil key="highlightedColor"/>
                         <size key="shadowOffset" width="0.0" height="0.0"/>
                     </label>
                 </subviews>
-                <animations/>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="m4s-Pa-7L1" secondAttribute="trailing" constant="18" id="8Tc-nh-5MN"/>
                     <constraint firstItem="m4s-Pa-7L1" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="14" id="ceC-VK-gFO"/>
@@ -30,7 +28,6 @@
                     <constraint firstItem="m4s-Pa-7L1" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="18" id="oRK-cJ-fRP"/>
                 </constraints>
             </tableViewCellContentView>
-            <animations/>
             <connections>
                 <outlet property="mainPageTitle" destination="m4s-Pa-7L1" id="OHV-V2-iBI"/>
             </connections>

--- a/Wikipedia/Code/WMFNearbyArticleTableViewCell.h
+++ b/Wikipedia/Code/WMFNearbyArticleTableViewCell.h
@@ -26,4 +26,6 @@
 
 - (void)setBearingProvider:(WMFSearchResultBearingProvider*)bearingProvider;
 
++ (CGFloat)estimatedRowHeight;
+
 @end

--- a/Wikipedia/Code/WMFNearbyArticleTableViewCell.m
+++ b/Wikipedia/Code/WMFNearbyArticleTableViewCell.m
@@ -74,6 +74,10 @@
     [self.articleImageView wmf_configureWithDefaultPlaceholder];
 }
 
++ (CGFloat)estimatedRowHeight {
+    return 120.f;
+}
+
 #pragma mark - Compass
 
 - (void)setBearingProvider:(WMFSearchResultBearingProvider*)bearingProvider {

--- a/Wikipedia/Code/WMFNearbyArticleTableViewCell.xib
+++ b/Wikipedia/Code/WMFNearbyArticleTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15A284" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
@@ -11,7 +11,7 @@
             <rect key="frame" x="0.0" y="0.0" width="392" height="120"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="392" height="119.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="392" height="119"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="NGT-X1-Lla">
@@ -36,20 +36,20 @@
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7Gw-jF-gnd">
-                        <rect key="frame" x="120" y="37" width="264" height="45.5"/>
+                        <rect key="frame" x="120" y="37" width="264" height="46"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Title" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="afs-yA-rJY">
-                                <rect key="frame" x="0.0" y="0.0" width="264" height="20.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="264" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AWn-WJ-c4e" userLabel="Background">
-                                <rect key="frame" x="0.0" y="25.5" width="63" height="20"/>
+                                <rect key="frame" x="0.0" y="26" width="63" height="20"/>
                                 <color key="backgroundColor" red="0.0" green="0.69642215969999999" blue="0.5386427641" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Distance" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f45-0M-DJe">
-                                <rect key="frame" x="5" y="27.5" width="53" height="16"/>
+                                <rect key="frame" x="5" y="28" width="53" height="16"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
@@ -113,7 +113,7 @@
                 <outlet property="distanceLabelBackground" destination="AWn-WJ-c4e" id="bsH-xo-qWF"/>
                 <outlet property="titleLabel" destination="afs-yA-rJY" id="G7T-fy-vSe"/>
             </connections>
-            <point key="canvasLocation" x="639" y="250"/>
+            <point key="canvasLocation" x="445" y="246"/>
         </tableViewCell>
     </objects>
 </document>

--- a/Wikipedia/Code/WMFNearbySectionController.m
+++ b/Wikipedia/Code/WMFNearbySectionController.m
@@ -234,6 +234,10 @@ NSString* const WMFNearbySectionIdentifier = @"WMFNearbySectionIdentifier";
     return @"Nearby";
 }
 
+- (CGFloat)estimatedRowHeight {
+    return [WMFNearbyArticleTableViewCell estimatedRowHeight];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFPicOfTheDayTableViewCell.h
+++ b/Wikipedia/Code/WMFPicOfTheDayTableViewCell.h
@@ -14,4 +14,6 @@
 
 - (void)setDisplayTitle:(NSString*)displayTitle;
 
++ (CGFloat)estimatedRowHeight;
+
 @end

--- a/Wikipedia/Code/WMFPicOfTheDayTableViewCell.m
+++ b/Wikipedia/Code/WMFPicOfTheDayTableViewCell.m
@@ -26,6 +26,10 @@
     [self.KVOControllerNonRetaining unobserve:self.potdImageView];
 }
 
++ (CGFloat)estimatedRowHeight {
+    return 346.f;
+}
+
 - (void)setDisplayTitle:(NSString*)displayTitle {
     self.displayTitleLabel.text = displayTitle;
 }

--- a/Wikipedia/Code/WMFPicOfTheDayTableViewCell.xib
+++ b/Wikipedia/Code/WMFPicOfTheDayTableViewCell.xib
@@ -11,7 +11,7 @@
             <rect key="frame" x="0.0" y="0.0" width="492" height="346"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ofU-eP-5V9" id="E91-bY-Lac">
-                <rect key="frame" x="0.0" y="0.0" width="492" height="345.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="492" height="345"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bOH-zT-k0A">

--- a/Wikipedia/Code/WMFPictureOfTheDaySectionController.m
+++ b/Wikipedia/Code/WMFPictureOfTheDaySectionController.m
@@ -147,6 +147,10 @@ static NSString* WMFPlaceholderImageInfoTitle = @"WMFPlaceholderImageInfoTitle";
     return @"Picture of the Day";
 }
 
+- (CGFloat)estimatedRowHeight {
+    return [WMFPicOfTheDayTableViewCell estimatedRowHeight];
+}
+
 @end
 
 @implementation MWKImageInfo (Feed)

--- a/Wikipedia/Code/WMFRandomSectionController.m
+++ b/Wikipedia/Code/WMFRandomSectionController.m
@@ -159,5 +159,9 @@ NSString* const WMFRandomSectionIdentifier = @"WMFRandomSectionIdentifier";
     return @"Random";
 }
 
+- (CGFloat)estimatedRowHeight {
+    return [WMFArticlePreviewTableViewCell estimatedRowHeight];
+}
+
 @end
 

--- a/Wikipedia/Code/WMFRelatedSectionController.m
+++ b/Wikipedia/Code/WMFRelatedSectionController.m
@@ -156,7 +156,7 @@ static NSUInteger const WMFRelatedSectionMaxResults      = 3;
 }
 
 - (void)configureCell:(UITableViewCell*)cell withObject:(id)object inTableView:(UITableView*)tableView atIndexPath:(NSIndexPath*)indexPath {
-    if ([cell isKindOfClass:[WMFArticlePreviewTableViewCell class]]) {
+    if ([cell isKindOfClass:[WMFArticlePreviewTableViewCell class]] && [object isKindOfClass:[MWKSearchResult class]]) {
         WMFArticlePreviewTableViewCell* previewCell = (id)cell;
         MWKSearchResult* result                     = object;
         previewCell.titleText       = result.displayTitle;
@@ -200,6 +200,10 @@ static NSUInteger const WMFRelatedSectionMaxResults      = 3;
 
 - (BOOL)hasResults {
     return self.searchResults && self.searchResults.results && self.searchResults.results.count > 0;
+}
+
+- (CGFloat)estimatedRowHeight {
+    return [WMFArticlePreviewTableViewCell estimatedRowHeight];
 }
 
 #pragma mark - Fetch

--- a/Wikipedia/Code/WMFSaveButtonController.m
+++ b/Wikipedia/Code/WMFSaveButtonController.m
@@ -42,7 +42,7 @@
 }
 
 - (void)dealloc {
-      [self unobserveSavedPages];
+    [self unobserveSavedPages];
 }
 
 #pragma mark - Accessors


### PR DESCRIPTION
Phab: [T124424](https://phabricator.wikimedia.org/T124424), [T123248](https://phabricator.wikimedia.org/T123248)

---

Before: https://vid.me/aB0l
After: https://vid.me/mXTd

## Problem

Our Explore `UITableView` was estimating all rows at the same height, resulting in a lot of extra room at the bottom of the table before content was loaded and actual row heights were calculated.  In addition, we weren't able to calculate row heights quickly because the CPU was overloaded by redundantly rendering the same content to the screen when offscreen section data were downloaded.

## Solution

Made each section controller dictate its estimated row height.  This makes the estimated height of the entire table much more accurate, so there's less jumpiness after content loads.  However, this didn't appear to be enough to fully resolve the issue, as noted in the second part of the problem.  Even though the esitmates were more accurate, calculating the actual row heights & rendering the currently visible cells was delayed due to CPU cost of downloading section content which wasn't even going to be displayed.  To address this, the lazy fetching is now deferred by 250ms and then only triggered if the section is still visible.  This is similar to the approach we take with rate-limiting search queries:

- When a section is about to be come visible (`tableView:willDisplayCell:forRowAtIndexPath:`) we defer a call to `fetchSectionIfShowing:` for the section (if it's a fetching section)
  - If the section is scrolled away (`tableView:didEndDisplayingCell:forRowAtIndexPath:`), we cancel the deferred call to `fetchSectionIfShowing:` for that section
- When the deferred `fetchSectionIfShowing:` call fires **and** the section is still visible, that section is sent a `fetchDataIfNeeded` message

This prevents sections from fetching their data when the user scrolls quickly past them (in either direction), while still allowing them to be fetched almost instantly if the user remains in that section.