### PR TITLE
Fix T124593: Implement accessibility escape

### DIFF
--- a/Wikipedia/Code/LanguagesViewController.m
+++ b/Wikipedia/Code/LanguagesViewController.m
@@ -304,4 +304,11 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
     [searchBar resignFirstResponder];
 }
 
+#pragma mark - UIAccessibilityAction
+
+- (BOOL)accessibilityPerformEscape {
+    [self dismissViewControllerAnimated:YES completion:nil];
+    return true;
+}
+
 @end

--- a/Wikipedia/Code/SectionEditorViewController.m
+++ b/Wikipedia/Code/SectionEditorViewController.m
@@ -292,4 +292,11 @@
     // Dispose of any resources that can be recreated.
 }
 
+#pragma mark Accessibility
+
+- (BOOL)accessibilityPerformEscape {
+    [self.navigationController popViewControllerAnimated:YES];
+    return YES;
+}
+
 @end

--- a/Wikipedia/Code/WMFModalImageGalleryViewController.m
+++ b/Wikipedia/Code/WMFModalImageGalleryViewController.m
@@ -345,7 +345,7 @@ static NSString* const WMFImageGalleryCollectionViewCellReuseId = @"WMFImageGall
 
 #pragma mark - Dismissal
 
-- (void)closeButtonTapped:(id)sender {
+- (BOOL)didRequestDismiss {
     if ([self.delegate respondsToSelector:@selector(willDismissGalleryController:)]) {
         [self.delegate willDismissGalleryController:self];
     }
@@ -354,6 +354,15 @@ static NSString* const WMFImageGalleryCollectionViewCellReuseId = @"WMFImageGall
             [self.delegate didDismissGalleryController:self];
         }
     }];
+    return YES;
+}
+
+- (void)closeButtonTapped:(id)sender {
+    [self didRequestDismiss];
+}
+
+- (BOOL)accessibilityPerformEscape {
+    return [self didRequestDismiss];
 }
 
 #pragma mark - File Info

--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -278,9 +278,18 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 
 #pragma mark - Dismissal
 
-- (IBAction)didTapCloseButton:(id)sender {
+- (void)dismiss {
     [self.searchField resignFirstResponder];
     [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (IBAction)didTapCloseButton:(id)sender {
+    [self dismiss];
+}
+
+- (BOOL)accessibilityPerformEscape {
+    [self dismiss];
+    return YES;
 }
 
 #pragma mark - UITextFieldDelegate

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -686,4 +686,11 @@ static SecondaryMenuRowIndex const WMFDebugSections[WMFDebugSectionCount] = {
     [self wmf_hideKeyboard];
 }
 
+#pragma mark - UIAccessibilityAction
+
+- (BOOL)accessibilityPerformEscape {
+    [self dismissViewControllerAnimated:YES completion:nil];
+    return YES;
+}
+
 @end

--- a/Wikipedia/Code/WMFTableOfContentsViewController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsViewController.swift
@@ -136,6 +136,12 @@ public class WMFTableOfContentsViewController: UIViewController,
         }
     }
 
+    private func didRequestClose(controller: WMFTableOfContentsAnimator?) -> Bool {
+        tableOfContentsFunnel.logClose()
+        delegate?.tableOfContentsControllerDidCancel(self)
+        return delegate != nil
+    }
+
     public override func loadView() {
         super.loadView()
         tableView = UITableView(frame: self.view.bounds, style: .Grouped)
@@ -217,8 +223,7 @@ public class WMFTableOfContentsViewController: UIViewController,
     }
 
     public func tableOfContentsAnimatorDidTapBackground(controller: WMFTableOfContentsAnimator) {
-        tableOfContentsFunnel.logClose()
-        delegate?.tableOfContentsControllerDidCancel(self)
+        didRequestClose(controller)
     }
 
     // MARK: - UIScrollViewDelegate
@@ -229,5 +234,9 @@ public class WMFTableOfContentsViewController: UIViewController,
         }
     }
 
+    // MARK: - UIAccessibilityAction
+    public override func accessibilityPerformEscape() -> Bool {
+        return didRequestClose(nil)
+    }
 }
 


### PR DESCRIPTION
This is implemented in:
- **Settings** (alternative to Close button)
- **Search** (alternative to Close button)
- **Languages** (alternative to Close button)
- **Image viewer** (alternative to Close button)
- **Table of Contents** (currently not possible in any other way)
- **Section Editor** (alternative to Back button; truth to be told,
                      Section Editor cannot be entered with VoiceOver
                      and Switch Control currently; but that is for
                      another bug)

Tested with VoiceOver and Switch Control on iOS 9.2.1 (13D15).

Fixes [T124593](https://phabricator.wikimedia.org/T124593)

Patch provided by [A11Y LTD.](http://accessibility.expert)