### PR TITLE
Fix T124595: Improve accessibility lang attributes

### DIFF
--- a/Wikipedia/Code/LanguageCell.h
+++ b/Wikipedia/Code/LanguageCell.h
@@ -8,6 +8,7 @@
 @property (strong, nonatomic) NSString* articleTitle;
 @property (strong, nonatomic) NSString* languageName;
 @property (strong, nonatomic) NSString* languageCode;
+@property (strong, nonatomic) NSString* languageID;
 
 @property (nonatomic) BOOL isPreferred;
 

--- a/Wikipedia/Code/LanguageCell.m
+++ b/Wikipedia/Code/LanguageCell.m
@@ -66,6 +66,12 @@ static CGFloat const WMFLanguageNameLabelHeight   = 18.f;
     self.languageCodeLabel.text = languageCode;
 }
 
+- (void)setLanguageID:(NSString *)languageID {
+    _languageID = languageID;
+    _articleTitleLabel.accessibilityLanguage = languageID;
+    _languageNameLabel.accessibilityLanguage = languageID;
+}
+
 - (void)awakeFromNib {
     [super awakeFromNib];
     [self prepareForReuse];

--- a/Wikipedia/Code/LanguagesViewController.m
+++ b/Wikipedia/Code/LanguagesViewController.m
@@ -219,6 +219,7 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
     cell.languageName          = langLink.name;
     cell.articleTitle          = langLink.pageTitleText;
     cell.languageCode          = [self stringForLanguageCode:langLink.languageCode];
+    cell.languageID            = langLink.languageCode;
 }
 
 - (NSString*)stringForLanguageCode:(NSString*)code {

--- a/Wikipedia/Code/WMFSearchResultsTableViewController.m
+++ b/Wikipedia/Code/WMFSearchResultsTableViewController.m
@@ -35,7 +35,10 @@
         @strongify(self);
         MWKTitle* title = [self.dataSource titleForIndexPath:indexPath];
         [cell wmf_setTitleText:title.text highlightingText:self.searchResults.searchTerm];
+        cell.titleLabel.accessibilityLanguage = self.dataSource.searchSite.language;
         cell.descriptionText = [self descriptionForSearchResult:result];
+        // TODO: In "Redirected from: $1", "$1" can be in any language; need to handle that too, currently (continuing) doing nothing for such cases
+        cell.descriptionLabel.accessibilityLanguage = [self redirectMappingForResult:result] == nil ? self.dataSource.searchSite.language : nil;
         [cell setImageURL:result.thumbnailURL];
     };
 


### PR DESCRIPTION
- **Languages** chooser screen (takes effect in article language picker's
  "Add more languages" screen, search view's "More" screen, article's
  language switching screen)
- **Article search**; This is incomplete, as sometimes "Redirected from:
  $1" is displayed and sometimes "$1" is in searchSite's language,
  sometimes in other language, and there does not seem a way to get at
  `MWKSearchRedirectMapping.redirectFromTitle`'s language; this is
  reported in a separate bug -
  [T124604](https://phabricator.wikimedia.org/T124604)

Fixes [T124595](https://phabricator.wikimedia.org/T124595)

Patch submitted by [A11Y LTD.](http://accessibility.expert)