### PR TITLE
Fix gallery info button visibility & image URL parsing

### DIFF
--- a/Wikipedia/Code/WMFImageURLParsing.m
+++ b/Wikipedia/Code/WMFImageURLParsing.m
@@ -1,4 +1,5 @@
 #import "WMFImageURLParsing.h"
+#import "NSString+WMFExtras.h"
 
 static NSRegularExpression* WMFImageURLParsingRegex() {
     static NSRegularExpression* imageNameFromURLRegex = nil;
@@ -6,7 +7,7 @@ static NSRegularExpression* WMFImageURLParsingRegex() {
     dispatch_once(&onceToken, ^{
         // TODO: try to read serialized regex from disk to prevent needless pattern compilation on next app run
         NSError* patternCompilationError;
-        imageNameFromURLRegex = [NSRegularExpression regularExpressionWithPattern:@"^\\d+px-([^.]*(\\.[^.$]{4,})*\\.[^.]*).*$"
+        imageNameFromURLRegex = [NSRegularExpression regularExpressionWithPattern:@"^\\d+px-(.*)"
                                                                           options:0
                                                                             error:&patternCompilationError];
         NSCParameterAssert(!patternCompilationError);
@@ -22,11 +23,33 @@ NSString* WMFParseImageNameFromSourceURL(NSString* sourceURL)  __attribute__((ov
     if (!sourceURL) {
         return nil;
     }
-    NSString* fileName = [sourceURL lastPathComponent];
-    NSArray* matches   = [WMFImageURLParsingRegex() matchesInString:fileName
+    NSArray* pathComponents = [sourceURL componentsSeparatedByString:@"/"];
+    if (pathComponents.count < 2) {
+        DDLogWarn(@"Unable to parse source URL with too few path components: %@", pathComponents);
+        return nil;
+    }
+
+    /*
+     For URLs in form "https://upload.wikimedia.org/.../Filename.jpg/XXXpx-Filename.jpg" try to acquire filename via
+     the second to last path component, which has only one extension.
+    */
+    NSString* filenameComponent = pathComponents[pathComponents.count - 2];
+    if ([[filenameComponent.pathExtension wmf_asMIMEType] hasPrefix:@"image"]) {
+        return filenameComponent;
+    }
+
+    NSString* thumbOrFileComponent = [pathComponents lastObject];
+    NSArray* matches   = [WMFImageURLParsingRegex() matchesInString:thumbOrFileComponent
                                                             options:0
-                                                              range:NSMakeRange(0, [fileName length])];
-    return matches.count ? [fileName substringWithRange : [matches[0] rangeAtIndex:1]] : fileName;
+                                                              range:NSMakeRange(0, [thumbOrFileComponent length])];
+
+    if (matches.count > 0) {
+        // Found a "XXXpx-" prefix, extract substring and return as filename
+        return [thumbOrFileComponent substringWithRange:[matches[0] rangeAtIndex:1]];
+    } else {
+        // No "XXXpx-" prefix found, return the entire last component, as the URL is (probably) in the form //.../Filename.jpg
+        return thumbOrFileComponent;
+    }
 }
 
 NSInteger WMFParseSizePrefixFromSourceURL(NSString* sourceURL)  __attribute__((overloadable)){

--- a/Wikipedia/Code/WMFPageCollectionViewController.h
+++ b/Wikipedia/Code/WMFPageCollectionViewController.h
@@ -23,6 +23,21 @@
 
 - (void)setCurrentPage:(NSUInteger)currentPage animated:(BOOL)animated;
 
+///
+/// Subclass Overrides
+///
+
+/**
+ *  Called whenever the page is changed programmatically or by the user scrolling.
+ *
+ *  Override this method to do additional UI updates or logic when the page changes.
+ *
+ *  @warning Your implementation must call @c super.
+ *
+ *  @param page The new value of current page.
+ */
+- (void)primitiveSetCurrentPage:(NSUInteger)page;
+
 /**
  * Flag which dictates whether or not the current `currentPage` has been applied.
  *

--- a/Wikipedia/Code/WMFPageCollectionViewController.m
+++ b/Wikipedia/Code/WMFPageCollectionViewController.m
@@ -97,12 +97,12 @@
 
 - (void)scrollViewDidEndDragging:(UIScrollView*)scrollView willDecelerate:(BOOL)decelerate {
     if (!decelerate) {
-        _currentPage = [self mostVisibleItemIndex];
+        [self primitiveSetCurrentPage:[self mostVisibleItemIndex]];
     }
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView*)scrollView {
-    _currentPage = [self mostVisibleItemIndex];
+    [self primitiveSetCurrentPage:[self mostVisibleItemIndex]];
 }
 
 @end

--- a/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
+++ b/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
@@ -43,6 +43,13 @@
                is(equalTo(@"Claude_Monet%2C_1870%2C_Le_port_de_Trouville_%28Breakwater_at_Trouville%2C_Low_Tide%29%2C_oil_on_canvas%2C_54_x_65.7_cm%2C_Museum_of_Fine_Arts%2C_Budapest.jpg")));
 }
 
+- (void)testImageWithMultiplePeriodsInFilename {
+    NSString* testURLString =
+    @"//upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Blacksmith%27s_tools_-_geograph.org.uk_-_1483374.jpg/440px-Blacksmith%27s_tools_-_geograph.org.uk_-_1483374.jpg";
+    assertThat(WMFParseImageNameFromSourceURL(testURLString),
+               is(equalTo(@"Blacksmith%27s_tools_-_geograph.org.uk_-_1483374.jpg")));
+}
+
 - (void)testPrefixFromNoPrefixFileName {
     NSString* testURL = @"//upload.wikimedia.org/wikipedia/commons/thumb/4/41/Iceberg_with_hole_near_Sandersons_Hope_2007-07-28_2.jpg/Iceberg_with_hole_near_Sandersons_Hope_2007-07-28_2.jpg";
 


### PR DESCRIPTION
Phab: [T124726](https://phabricator.wikimedia.org/T124726)

---

This PR fixes two issues:

- Only showing info button when image's info is available and it has a file page URL
- Correctly parse image URLs which have multiple dot-separated components (see added test in [`WMFImageURLParsingTests`](https://github.com/wikimedia/wikipedia-ios/pull/419/files#diff-a128dce327b7690819fa2406bb2da2c5R46))

[Swaging](https://en.wikipedia.org/wiki/Swaging) only really has one image (the "lead image"), but the gallery had 3 images: the lead image (blacksmith's tools), in-article thumbnail (blacksmith's tools), and wiktionary "logo."*  The thumbnail for blacksmith's tools (second image) was being parsed incorrectly (ending with the ".org" substring of the URL instead of capturing the entire filename), which resulted in no image info, which resulted in the crash.  Not only should the info button have been hidden, but we also had image info for that image and it was identical to the previous image in the gallery.

With this change, image URLs similar to the blacksmith thumbnail will successfully have their filenames parsed and the gallery should only show the info button when we have the data necessary for the action.  Cases when we really don't have data are more difficult to find in production, so I'd like to add unit tests to confirm this functionality (at some point).

\* After the fix the gallery has two images because filtering out the Wikitionary image is out of scope since it's due to a separate issue