### PR TITLE
Fix similar pages not responding to "Save for later" taps.

### DIFF
--- a/Wikipedia/Code/WMFArticlePreviewDataSource.h
+++ b/Wikipedia/Code/WMFArticlePreviewDataSource.h
@@ -11,14 +11,17 @@ NS_ASSUME_NONNULL_BEGIN
 @class WMFArticlePreviewFetcher;
 @class MWKSavedPageList;
 @class MWKTitle;
+@class MWKDataStore;
 
 @interface WMFArticlePreviewDataSource : SSArrayDataSource
     <WMFTitleListDataSource>
 
 @property (nonatomic, strong, readonly, nullable) NSArray<MWKSearchResult*>* previewResults;
+@property (nonatomic, strong, readonly) MWKDataStore* dataStore;
 
 - (instancetype)initWithTitles:(NSArray<MWKTitle*>*)titles
                           site:(MWKSite*)site
+                     dataStore:(MWKDataStore*)dataStore
                        fetcher:(WMFArticlePreviewFetcher*)fetcher NS_DESIGNATED_INITIALIZER;
 
 - (void)fetch;

--- a/Wikipedia/Code/WMFArticlePreviewDataSource.m
+++ b/Wikipedia/Code/WMFArticlePreviewDataSource.m
@@ -19,6 +19,7 @@
 #import "MWKArticle.h"
 #import "MWKSearchResult.h"
 #import "MWKHistoryEntry.h"
+#import "MWKDataStore.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -30,6 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSArray<MWKTitle*>* titles;
 @property (nonatomic, assign) NSUInteger resultLimit;
 
+@property (nonatomic, strong) MWKDataStore* dataStore;
+
 @end
 
 @implementation WMFArticlePreviewDataSource
@@ -40,11 +43,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithTitles:(NSArray<MWKTitle*>*)titles
                           site:(MWKSite*)site
+                     dataStore:(MWKDataStore*)dataStore
                        fetcher:(WMFArticlePreviewFetcher*)fetcher {
     NSParameterAssert(titles);
     NSParameterAssert(fetcher);
+    NSParameterAssert(dataStore);
     self = [super initWithItems:nil];
     if (self) {
+        self.dataStore           = dataStore;
         self.titles              = titles;
         self.site                = site;
         self.titlesSearchFetcher = fetcher;
@@ -63,10 +69,17 @@ NS_ASSUME_NONNULL_BEGIN
             cell.descriptionText = searchResult.wikidataDescription;
             cell.snippetText     = searchResult.extract;
             [cell setImageURL:searchResult.thumbnailURL];
+
+            [cell setSaveableTitle:title savedPageList:self.savedPageList];
+            
             [cell wmf_layoutIfNeededIfOperatingSystemVersionLessThan9_0_0];
         };
     }
     return self;
+}
+
+- (MWKSavedPageList*)savedPageList {
+    return self.dataStore.userDataStore.savedPageList;
 }
 
 - (void)setTableView:(nullable UITableView*)tableView {

--- a/Wikipedia/Code/WMFReadMoreViewController.m
+++ b/Wikipedia/Code/WMFReadMoreViewController.m
@@ -22,8 +22,7 @@
 
 @dynamic dataSource;
 
-- (instancetype)initWithTitle:(MWKTitle*)title dataStore:(MWKDataStore*)dataStore;
-{
+- (instancetype)initWithTitle:(MWKTitle*)title dataStore:(MWKDataStore*)dataStore {
     NSParameterAssert(title);
     NSParameterAssert(dataStore);
     self = [super init];

--- a/WikipediaUnitTests/Code/WMFDisambiguationPagesViewController.m
+++ b/WikipediaUnitTests/Code/WMFDisambiguationPagesViewController.m
@@ -19,7 +19,11 @@
     if (self) {
         self.article              = article;
         self.dataStore            = dataStore;
-        self.dataSource           = [[WMFArticlePreviewDataSource alloc] initWithTitles:self.article.disambiguationTitles site:self.article.site fetcher:[[WMFArticlePreviewFetcher alloc] init]];
+        self.dataSource           =
+        [[WMFArticlePreviewDataSource alloc] initWithTitles:self.article.disambiguationTitles
+                                                       site:self.article.site
+                                                  dataStore:dataStore
+                                                    fetcher:[[WMFArticlePreviewFetcher alloc] init]];
         self.dataSource.tableView = self.tableView;
     }
     return self;


### PR DESCRIPTION
Part of:
https://phabricator.wikimedia.org/T124517

Repro steps:
- Load an article in the web view and scroll to the bottom menu and tap "Similar pages" (if it has any).
- When the list of similar pages loads, if you tapped "Save for later" nothing was happening.
