### PR TITLE
Update explore header styling.

### DIFF
--- a/Wikipedia/Code/NSDateFormatter+WMFExtensions.h
+++ b/Wikipedia/Code/NSDateFormatter+WMFExtensions.h
@@ -41,4 +41,6 @@
 
 + (instancetype)wmf_englishHyphenatedYearMonthDayFormatter;
 
++ (instancetype)wmf_dayNameMonthNameDayOfMonthNumberDateFormatter;
+
 @end

--- a/Wikipedia/Code/NSDateFormatter+WMFExtensions.m
+++ b/Wikipedia/Code/NSDateFormatter+WMFExtensions.m
@@ -74,4 +74,15 @@ static NSString* const WMF_ISO8601_FORMAT = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'";
     return _dateFormatter;
 }
 
++ (instancetype)wmf_dayNameMonthNameDayOfMonthNumberDateFormatter {
+    static NSDateFormatter* _dateFormatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _dateFormatter = [[NSDateFormatter alloc] init];
+        _dateFormatter.dateFormat = @"EEEE MMMM dd";
+        _dateFormatter.locale = [NSLocale currentLocale];
+    });
+    return _dateFormatter;
+}
+
 @end

--- a/Wikipedia/Code/NSDateFormatter+WMFExtensions.m
+++ b/Wikipedia/Code/NSDateFormatter+WMFExtensions.m
@@ -79,8 +79,7 @@ static NSString* const WMF_ISO8601_FORMAT = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'";
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         _dateFormatter = [[NSDateFormatter alloc] init];
-        _dateFormatter.dateFormat = @"EEEE MMMM dd";
-        _dateFormatter.locale = [NSLocale currentLocale];
+        [_dateFormatter setLocalizedDateFormatFromTemplate:@"EEEEMMMMdd"];
     });
     return _dateFormatter;
 }

--- a/Wikipedia/Code/TabularScrollView.m
+++ b/Wikipedia/Code/TabularScrollView.m
@@ -113,16 +113,16 @@
     } else {
         tappedView = sender;
     }
-    
+
     if (!tappedView) {
         return;
     }
-    
-    NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithObject:tappedView forKey:@"tappedItem"];
+
+    NSMutableDictionary* userInfo = [NSMutableDictionary dictionaryWithObject:tappedView forKey:@"tappedItem"];
     if (tappedChildView) {
         [userInfo setObject:tappedChildView forKey:@"tappedChild"];
     }
-    
+
     [[NSNotificationCenter defaultCenter] postNotificationName:@"TabularScrollViewItemTapped" object:self userInfo:userInfo];
 }
 

--- a/Wikipedia/Code/UIColor+WMFStyle.h
+++ b/Wikipedia/Code/UIColor+WMFStyle.h
@@ -27,11 +27,17 @@
 
 + (instancetype)wmf_tableOfContentsSubsectionTextColor;
 
-+ (instancetype)wmf_homeSectionHeaderTextColor;
++ (instancetype)wmf_exploreSectionHeaderTitleColor;
 
-+ (instancetype)wmf_homeSectionFooterTextColor;
++ (instancetype)wmf_exploreSectionHeaderSubTitleColor;
 
-+ (instancetype)wmf_homeSectionHeaderLinkTextColor;
++ (instancetype)wmf_exploreSectionFooterTextColor;
+
++ (instancetype)wmf_exploreSectionHeaderLinkTextColor;
+
++ (instancetype)wmf_exploreSectionHeaderIconTintColor;
+
++ (instancetype)wmf_exploreSectionHeaderIconBackgroundColor;
 
 /**
  *  Color which is used in places like cell separators & various 1px lines in the interface.

--- a/Wikipedia/Code/UIColor+WMFStyle.m
+++ b/Wikipedia/Code/UIColor+WMFStyle.m
@@ -127,7 +127,7 @@
     return c;
 }
 
-+ (instancetype)wmf_homeSectionHeaderTextColor {
++ (instancetype)wmf_exploreSectionHeaderTitleColor {
     static UIColor* c = nil;
 
     static dispatch_once_t onceToken;
@@ -137,8 +137,30 @@
     return c;
 }
 
-+ (instancetype)wmf_homeSectionFooterTextColor {
-    return [self wmf_homeSectionHeaderTextColor];
++ (instancetype)wmf_exploreSectionHeaderSubTitleColor {
+    static UIColor* c = nil;
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        c = [UIColor colorWithRed:0.6 green:0.6 blue:0.6 alpha:1];
+    });
+    return c;
+}
+
++ (instancetype)wmf_exploreSectionFooterTextColor {
+    return [self wmf_exploreSectionHeaderTitleColor];
+}
+
++ (instancetype)wmf_exploreSectionHeaderIconTintColor {
+    return [UIColor wmf_colorWithHex:0x9CA1A7 alpha:1.0];
+}
+
++ (instancetype)wmf_exploreSectionHeaderIconBackgroundColor {
+    return [UIColor wmf_colorWithHex:0xF5F5F5 alpha:1.0];
+}
+
++ (instancetype)wmf_exploreSectionHeaderLinkTextColor {
+    return [self wmf_blueTintColor];
 }
 
 + (instancetype)wmf_blueTintColor {
@@ -159,10 +181,6 @@
         c = [UIColor colorWithRed:238.0f / 255.0f green:238.0f / 255.0f blue:238.0f / 255.0f alpha:1];
     });
     return c;
-}
-
-+ (instancetype)wmf_homeSectionHeaderLinkTextColor {
-    return [self wmf_blueTintColor];
 }
 
 + (instancetype)wmf_nearbyArrowColor {

--- a/Wikipedia/Code/UIColor+WMFStyle.m
+++ b/Wikipedia/Code/UIColor+WMFStyle.m
@@ -139,7 +139,7 @@
 
 + (instancetype)wmf_exploreSectionHeaderSubTitleColor {
     static UIColor* c = nil;
-    
+
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         c = [UIColor colorWithRed:0.6 green:0.6 blue:0.6 alpha:1];
@@ -221,7 +221,7 @@
 
 + (instancetype)wmf_customGray {
     static UIColor* c = nil;
-    
+
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         c = [UIColor wmf_colorWithHex:0x9AA0A7 alpha:1.0];

--- a/Wikipedia/Code/UIColor+WMFStyle.m
+++ b/Wikipedia/Code/UIColor+WMFStyle.m
@@ -128,27 +128,15 @@
 }
 
 + (instancetype)wmf_exploreSectionHeaderTitleColor {
-    static UIColor* c = nil;
-
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        c = [UIColor colorWithRed:0.6 green:0.6 blue:0.6 alpha:1];
-    });
-    return c;
+    return [UIColor wmf_customGray];
 }
 
 + (instancetype)wmf_exploreSectionHeaderSubTitleColor {
-    static UIColor* c = nil;
-
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        c = [UIColor colorWithRed:0.6 green:0.6 blue:0.6 alpha:1];
-    });
-    return c;
+    return [UIColor wmf_customGray];
 }
 
 + (instancetype)wmf_exploreSectionFooterTextColor {
-    return [self wmf_exploreSectionHeaderTitleColor];
+    return [self wmf_customGray];
 }
 
 + (instancetype)wmf_exploreSectionHeaderIconTintColor {

--- a/Wikipedia/Code/UIFont+WMFStyle.h
+++ b/Wikipedia/Code/UIFont+WMFStyle.h
@@ -24,6 +24,7 @@
 + (instancetype)wmf_nearbyDescriptionFont;
 + (instancetype)wmf_nearbyDistanceFont;
 
-+ (instancetype)wmf_homeSectionHeaderFont;
++ (instancetype)wmf_homeSectionHeaderTitleFont;
++ (instancetype)wmf_homeSectionHeaderSubTitleFont;
 
 @end

--- a/Wikipedia/Code/UIFont+WMFStyle.h
+++ b/Wikipedia/Code/UIFont+WMFStyle.h
@@ -24,7 +24,7 @@
 + (instancetype)wmf_nearbyDescriptionFont;
 + (instancetype)wmf_nearbyDistanceFont;
 
-+ (instancetype)wmf_homeSectionHeaderTitleFont;
-+ (instancetype)wmf_homeSectionHeaderSubTitleFont;
++ (instancetype)wmf_exploreSectionHeaderTitleFont;
++ (instancetype)wmf_exploreSectionHeaderSubTitleFont;
 
 @end

--- a/Wikipedia/Code/UIFont+WMFStyle.m
+++ b/Wikipedia/Code/UIFont+WMFStyle.m
@@ -57,8 +57,12 @@
     return [UIFont systemFontOfSize:12.0f];
 }
 
-+ (instancetype)wmf_homeSectionHeaderFont {
-    return [UIFont systemFontOfSize:16.0];
++ (instancetype)wmf_homeSectionHeaderTitleFont {
+    return [UIFont boldSystemFontOfSize:12.0];
+}
+
++ (instancetype)wmf_homeSectionHeaderSubTitleFont {
+    return [UIFont boldSystemFontOfSize:15.0];
 }
 
 @end

--- a/Wikipedia/Code/UIFont+WMFStyle.m
+++ b/Wikipedia/Code/UIFont+WMFStyle.m
@@ -57,11 +57,11 @@
     return [UIFont systemFontOfSize:12.0f];
 }
 
-+ (instancetype)wmf_homeSectionHeaderTitleFont {
++ (instancetype)wmf_exploreSectionHeaderTitleFont {
     return [UIFont boldSystemFontOfSize:12.0];
 }
 
-+ (instancetype)wmf_homeSectionHeaderSubTitleFont {
++ (instancetype)wmf_exploreSectionHeaderSubTitleFont {
     return [UIFont boldSystemFontOfSize:15.0];
 }
 

--- a/Wikipedia/Code/UIFont+WMFStyle.m
+++ b/Wikipedia/Code/UIFont+WMFStyle.m
@@ -58,11 +58,11 @@
 }
 
 + (instancetype)wmf_exploreSectionHeaderTitleFont {
-    return [UIFont boldSystemFontOfSize:12.0];
+    return [UIFont systemFontOfSize:12.0];
 }
 
 + (instancetype)wmf_exploreSectionHeaderSubTitleFont {
-    return [UIFont boldSystemFontOfSize:15.0];
+    return [UIFont boldSystemFontOfSize:14.0];
 }
 
 @end

--- a/Wikipedia/Code/UINavigationController+WMFHideEmptyToolbar.h
+++ b/Wikipedia/Code/UINavigationController+WMFHideEmptyToolbar.h
@@ -2,6 +2,6 @@
 
 @interface UINavigationController (WMFHideEmptyToolbar)
 
--(void)wmf_hideToolbarIfViewControllerHasNoToolbarItems:(UIViewController*)viewController;
+- (void)wmf_hideToolbarIfViewControllerHasNoToolbarItems:(UIViewController*)viewController;
 
 @end

--- a/Wikipedia/Code/UINavigationController+WMFHideEmptyToolbar.m
+++ b/Wikipedia/Code/UINavigationController+WMFHideEmptyToolbar.m
@@ -2,7 +2,7 @@
 
 @implementation UINavigationController (WMFHideEmptyToolbar)
 
--(void)wmf_hideToolbarIfViewControllerHasNoToolbarItems:(UIViewController*)viewController; {
+- (void)wmf_hideToolbarIfViewControllerHasNoToolbarItems:(UIViewController*)viewController; {
     BOOL isToolbarEmpty = [viewController toolbarItems].count == 0;
     [self setToolbarHidden:isToolbarEmpty];
 }

--- a/Wikipedia/Code/UIViewController+WMFEmptyView.m
+++ b/Wikipedia/Code/UIViewController+WMFEmptyView.m
@@ -76,9 +76,8 @@ static NSString * WMFEmptyViewKey = @"WMFEmptyView";
     [self bk_associateValue:nil withKey:(__bridge const void*)(WMFEmptyViewKey)];
 }
 
-- (BOOL)wmf_isShowingEmptyView{
+- (BOOL)wmf_isShowingEmptyView {
     return [self wmf_emptyView] != nil;
 }
-
 
 @end

--- a/Wikipedia/Code/UIViewController+WMFEmptyView.m
+++ b/Wikipedia/Code/UIViewController+WMFEmptyView.m
@@ -15,8 +15,8 @@
 static NSString * WMFEmptyViewKey = @"WMFEmptyView";
 
 - (UIView*)wmf_emptyView {
-    id valueToReturn = [self bk_associatedValueForKey:(__bridge const void *)(WMFEmptyViewKey)];
-    
+    id valueToReturn = [self bk_associatedValueForKey:(__bridge const void*)(WMFEmptyViewKey)];
+
     return valueToReturn;
 }
 
@@ -63,7 +63,7 @@ static NSString * WMFEmptyViewKey = @"WMFEmptyView";
         make.bottom.equalTo(container);
         make.leading.and.trailing.equalTo(container);
     }];
-    [self bk_associateValue:view withKey:(__bridge const void *)(WMFEmptyViewKey)];
+    [self bk_associateValue:view withKey:(__bridge const void*)(WMFEmptyViewKey)];
 }
 
 - (void)wmf_hideEmptyView {
@@ -73,7 +73,7 @@ static NSString * WMFEmptyViewKey = @"WMFEmptyView";
     UIView* view = [self wmf_emptyView];
     [view removeFromSuperview];
 
-    [self bk_associateValue:nil withKey:(__bridge const void *)(WMFEmptyViewKey)];
+    [self bk_associateValue:nil withKey:(__bridge const void*)(WMFEmptyViewKey)];
 }
 
 - (BOOL)wmf_isShowingEmptyView{

--- a/Wikipedia/Code/UIWebView+LoadAssetsHtml.m
+++ b/Wikipedia/Code/UIWebView+LoadAssetsHtml.m
@@ -23,8 +23,8 @@
     NSString* path = [[self getAssetsPath] stringByAppendingPathComponent:fileName];
 
     NSString* fileContents = [NSMutableString stringWithContentsOfFile:path
-                                                        encoding:NSUTF8StringEncoding
-                                                           error:nil];
+                                                              encoding:NSUTF8StringEncoding
+                                                                 error:nil];
 
     [self loadHTMLString:[NSString stringWithFormat:fileContents, string]
                  baseURL:[NSURL URLWithString:path]];

--- a/Wikipedia/Code/WMFArticleContainerViewController.m
+++ b/Wikipedia/Code/WMFArticleContainerViewController.m
@@ -528,7 +528,6 @@ NS_ASSUME_NONNULL_BEGIN
     self.navigationItem.titleView.isAccessibilityElement = YES;
     self.navigationItem.titleView.accessibilityLabel     = MWLocalizedString(@"home-button-accessibility-label", nil);
     self.navigationItem.titleView.accessibilityTraits   |= UIAccessibilityTraitButton;
-
 }
 
 #pragma mark - ViewController

--- a/Wikipedia/Code/WMFArticleFooterMenuViewController.m
+++ b/Wikipedia/Code/WMFArticleFooterMenuViewController.m
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)showDisambiguationItems {
     WMFDisambiguationPagesViewController* articleListVC = [[WMFDisambiguationPagesViewController alloc] initWithArticle:self.article dataStore:self.dataStore];
     articleListVC.title = MWLocalizedString(@"page-similar-titles", nil);
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:articleListVC];
+    UINavigationController* navController = [[UINavigationController alloc] initWithRootViewController:articleListVC];
     navController.delegate = self;
     [self presentViewController:navController animated:YES completion:nil];
 }

--- a/Wikipedia/Code/WMFArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFArticleListTableViewController.m
@@ -142,12 +142,11 @@ NS_ASSUME_NONNULL_BEGIN
         MWKTitle* otherTitle = [self.dataSource titleForIndexPath:indexPath];
         return [title isEqualToTitle:otherTitle];
     }];
-    
+
     //update cells in place. Updating with relaod method causes the tableview to scroll
-    [indexPathsToRefresh enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+    [indexPathsToRefresh enumerateObjectsUsingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL* _Nonnull stop) {
         self.dataSource.cellConfigureBlock([self.tableView cellForRowAtIndexPath:obj], [self.dataSource itemAtIndexPath:obj], self.tableView, obj);
     }];
-    
 }
 
 #pragma mark - Previewing

--- a/Wikipedia/Code/WMFArticlePreviewDataSource.m
+++ b/Wikipedia/Code/WMFArticlePreviewDataSource.m
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
             [cell setImageURL:searchResult.thumbnailURL];
 
             [cell setSaveableTitle:title savedPageList:self.savedPageList];
-            
+
             [cell wmf_layoutIfNeededIfOperatingSystemVersionLessThan9_0_0];
         };
     }

--- a/Wikipedia/Code/WMFBaseExploreSectionController.m
+++ b/Wikipedia/Code/WMFBaseExploreSectionController.m
@@ -156,7 +156,7 @@ static NSString* const WMFExploreSectionControllerException = @"WMFExploreSectio
     return [self fetchDataIgnoreError:NO ignoreCurrentItems:NO];
 }
 
-- (AnyPromise*)fetchDataIfError{
+- (AnyPromise*)fetchDataIfError {
     return [self fetchDataIgnoreError:YES ignoreCurrentItems:NO];
 }
 

--- a/Wikipedia/Code/WMFContinueReadingSectionController.m
+++ b/Wikipedia/Code/WMFContinueReadingSectionController.m
@@ -65,8 +65,9 @@ static NSString* const WMFContinueReadingSectionIdentifier = @"WMFContinueReadin
 }
 
 - (NSAttributedString*)headerSubTitle {
-    NSString* relativeTimeString = [WikipediaAppUtils relativeTimestamp:[[NSUserDefaults standardUserDefaults] wmf_appResignActiveDate]];
-    return [[NSAttributedString alloc] initWithString:relativeTimeString attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderSubTitleColor]}];
+    NSDate* resignActiveDate     = [[NSUserDefaults standardUserDefaults] wmf_appResignActiveDate];
+    NSString* relativeTimeString = [WikipediaAppUtils relativeTimestamp:resignActiveDate];
+    return [[NSAttributedString alloc] initWithString:[relativeTimeString wmf_stringByCapitalizingFirstCharacter] attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderSubTitleColor]}];
 }
 
 - (NSString*)cellIdentifier {

--- a/Wikipedia/Code/WMFContinueReadingSectionController.m
+++ b/Wikipedia/Code/WMFContinueReadingSectionController.m
@@ -16,6 +16,8 @@
 #import "UITableViewCell+WMFLayout.h"
 #import "MWKSection.h"
 #import "MWKSectionList.h"
+#import "WikipediaAppUtils.h"
+#import "Wikipedia-Swift.h"
 
 static NSString* const WMFContinueReadingSectionIdentifier = @"WMFContinueReadingSectionIdentifier";
 
@@ -50,8 +52,21 @@ static NSString* const WMFContinueReadingSectionIdentifier = @"WMFContinueReadin
     return [UIImage imageNamed:@"home-continue-reading-mini"];
 }
 
-- (NSAttributedString*)headerText {
-    return [[NSAttributedString alloc] initWithString:MWLocalizedString(@"home-continue-reading-heading", nil) attributes:@{NSForegroundColorAttributeName: [UIColor wmf_homeSectionHeaderTextColor]}];
+- (UIColor*)headerIconTintColor {
+    return [UIColor wmf_exploreSectionHeaderIconTintColor];
+}
+
+- (UIColor*)headerIconBackgroundColor {
+    return [UIColor wmf_exploreSectionHeaderIconBackgroundColor];
+}
+
+- (NSAttributedString*)headerTitle {
+    return [[NSAttributedString alloc] initWithString:MWLocalizedString(@"explore-continue-reading-heading", nil) attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderTitleColor]}];
+}
+
+- (NSAttributedString*)headerSubTitle {
+    NSString* relativeTimeString = [WikipediaAppUtils relativeTimestamp:[[NSUserDefaults standardUserDefaults] wmf_appResignActiveDate]];
+    return [[NSAttributedString alloc] initWithString:relativeTimeString attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderSubTitleColor]}];
 }
 
 - (NSString*)cellIdentifier {

--- a/Wikipedia/Code/WMFExploreSectionController.h
+++ b/Wikipedia/Code/WMFExploreSectionController.h
@@ -47,13 +47,36 @@ NS_ASSUME_NONNULL_BEGIN
 - (UIImage*)headerIcon;
 
 /**
- *  The text to be displayed in the header.
+ *  Color used for icon tint
+ *
+ *  @return A color
+ */
+- (UIColor*)headerIconTintColor;
+
+/**
+ *  Background color of section's header icon container view
+ *
+ *  @return A color
+ */
+- (UIColor*)headerIconBackgroundColor;
+
+/**
+ *  The text to be displayed on the first line of the header.
  *  Note this is an attributed stirng to allow links to be embeded
  *  Additional styling will be added before display time.
  *
- *  @return The header string
+ *  @return The header title string
  */
-- (NSAttributedString*)headerText;
+- (NSAttributedString*)headerTitle;
+
+/**
+ *  The text to be displayed on the second line of the header.
+ *  Note this is an attributed stirng to allow links to be embeded
+ *  Additional styling will be added bfore display time.
+ *
+ *  @return The header sub-title string
+ */
+- (NSAttributedString*)headerSubTitle;
 
 /**
  *  Called to allow the controller to register cells in the table view

--- a/Wikipedia/Code/WMFExploreSectionControllerCache.m
+++ b/Wikipedia/Code/WMFExploreSectionControllerCache.m
@@ -42,12 +42,12 @@ static NSUInteger const WMFExploreSectionControllerCacheLimit = 35;
                    dataStore:(MWKDataStore*)dataStore {
     self = [super init];
     if (self) {
-        self.site                        = site;
-        self.dataStore                   = dataStore;
-        self.sectionControllersBySection = [[NSCache alloc] init];
+        self.site                                   = site;
+        self.dataStore                              = dataStore;
+        self.sectionControllersBySection            = [[NSCache alloc] init];
         self.sectionControllersBySection.countLimit = WMFExploreSectionControllerCacheLimit;
-        self.sectionsBySectionController = [NSMapTable mapTableWithKeyOptions:NSMapTableWeakMemory|NSMapTableObjectPointerPersonality
-                                                     valueOptions:NSMapTableWeakMemory];
+        self.sectionsBySectionController            = [NSMapTable mapTableWithKeyOptions:NSMapTableWeakMemory | NSMapTableObjectPointerPersonality
+                                                                            valueOptions:NSMapTableWeakMemory];
     }
     return self;
 }

--- a/Wikipedia/Code/WMFExploreSectionFooter.xib
+++ b/Wikipedia/Code/WMFExploreSectionFooter.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15A284" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
@@ -34,8 +34,8 @@
                         <constraint firstAttribute="trailing" secondItem="t3v-Hx-SzU" secondAttribute="trailing" constant="16" id="AD6-HR-9wr"/>
                         <constraint firstItem="t3v-Hx-SzU" firstAttribute="leading" secondItem="CED-ZN-Pd2" secondAttribute="trailing" constant="8" id="As2-Qf-2rf"/>
                         <constraint firstItem="t3v-Hx-SzU" firstAttribute="centerY" secondItem="CED-ZN-Pd2" secondAttribute="centerY" id="Ocx-y5-eLV"/>
-                        <constraint firstAttribute="bottom" secondItem="CED-ZN-Pd2" secondAttribute="bottom" constant="16" id="Y2J-jz-vqq"/>
-                        <constraint firstItem="CED-ZN-Pd2" firstAttribute="top" secondItem="hIg-YX-yCN" secondAttribute="top" constant="16" id="rfs-DV-bTi"/>
+                        <constraint firstAttribute="bottom" secondItem="CED-ZN-Pd2" secondAttribute="bottom" priority="999" constant="16" id="Y2J-jz-vqq"/>
+                        <constraint firstItem="CED-ZN-Pd2" firstAttribute="top" secondItem="hIg-YX-yCN" secondAttribute="top" priority="999" constant="16" id="rfs-DV-bTi"/>
                     </constraints>
                 </view>
             </subviews>

--- a/Wikipedia/Code/WMFExploreSectionHeader.h
+++ b/Wikipedia/Code/WMFExploreSectionHeader.h
@@ -3,8 +3,13 @@
 
 @interface WMFExploreSectionHeader : UITableViewHeaderFooterView
 
-@property (strong, nonatomic) IBOutlet UIImageView* icon;
-@property (strong, nonatomic) IBOutlet UILabel* titleView;
+@property (strong, nonatomic) UIImage* image;
+@property (strong, nonatomic) UIColor* imageTintColor;
+@property (strong, nonatomic) UIColor* imageBackgroundColor;
+
+@property (strong, nonatomic) NSAttributedString* title;
+@property (strong, nonatomic) NSAttributedString* subTitle;
+
 @property (strong, nonatomic) IBOutlet UIButton* rightButton;
 
 @property (assign, nonatomic) BOOL rightButtonEnabled;

--- a/Wikipedia/Code/WMFExploreSectionHeader.h
+++ b/Wikipedia/Code/WMFExploreSectionHeader.h
@@ -3,12 +3,12 @@
 
 @interface WMFExploreSectionHeader : UITableViewHeaderFooterView
 
-@property (strong, nonatomic) UIImage* image;
-@property (strong, nonatomic) UIColor* imageTintColor;
-@property (strong, nonatomic) UIColor* imageBackgroundColor;
+- (void)setImage:(UIImage*)image;
+- (void)setImageTintColor:(UIColor*)imageTintColor;
+- (void)setImageBackgroundColor:(UIColor*)imageBackgroundColor;
 
-@property (strong, nonatomic) NSAttributedString* title;
-@property (strong, nonatomic) NSAttributedString* subTitle;
+- (void)setTitle:(NSAttributedString*)title;
+- (void)setSubTitle:(NSAttributedString*)subTitle;
 
 @property (strong, nonatomic) IBOutlet UIButton* rightButton;
 

--- a/Wikipedia/Code/WMFExploreSectionHeader.m
+++ b/Wikipedia/Code/WMFExploreSectionHeader.m
@@ -7,12 +7,18 @@
 @property (strong, nonatomic) IBOutlet NSLayoutConstraint* rightButtonWidthConstraint;
 @property (assign, nonatomic) CGFloat rightButtonWidthConstraintConstant;
 
+@property (strong, nonatomic) IBOutlet UIImageView* icon;
+@property (strong, nonatomic) IBOutlet UIView* iconContainerView;
+@property (strong, nonatomic) IBOutlet UILabel* titleLabel;
+@property (strong, nonatomic) IBOutlet UILabel* subTitleLabel;
+
 @end
 
 @implementation WMFExploreSectionHeader
 
 - (void)awakeFromNib {
     [super awakeFromNib];
+    [self reset];
     self.tintColor                          = [UIColor wmf_blueTintColor];
     self.rightButtonWidthConstraintConstant = self.rightButtonWidthConstraint.constant;
     self.rightButton.hidden                 = YES;
@@ -26,8 +32,40 @@
     }];
 }
 
+-(void)setImage:(UIImage *)image {
+    _image = image;
+    self.icon.image = image;
+}
+
+-(void)setImageTintColor:(UIColor *)imageTintColor {
+    _imageTintColor = imageTintColor;
+    self.icon.tintColor = imageTintColor;
+}
+
+-(void)setImageBackgroundColor:(UIColor *)imageBackgroundColor {
+    _imageBackgroundColor = imageBackgroundColor;
+    self.iconContainerView.backgroundColor = imageBackgroundColor;
+}
+
+-(void)setTitle:(NSAttributedString *)title {
+    _title = title;
+    self.titleLabel.attributedText = title;
+}
+
+-(void)setSubTitle:(NSAttributedString *)subTitle {
+    _subTitle = subTitle;
+    self.subTitleLabel.attributedText = subTitle;
+}
+
 - (void)prepareForReuse {
     [super prepareForReuse];
+    [self reset];
+}
+
+
+-(void)reset {
+    self.titleLabel.text = @"";
+    self.subTitleLabel.text = @"";
     self.rightButtonEnabled = NO;
 }
 

--- a/Wikipedia/Code/WMFExploreSectionHeader.m
+++ b/Wikipedia/Code/WMFExploreSectionHeader.m
@@ -33,27 +33,22 @@
 }
 
 - (void)setImage:(UIImage*)image {
-    _image          = image;
     self.icon.image = image;
 }
 
 - (void)setImageTintColor:(UIColor*)imageTintColor {
-    _imageTintColor     = imageTintColor;
     self.icon.tintColor = imageTintColor;
 }
 
 - (void)setImageBackgroundColor:(UIColor*)imageBackgroundColor {
-    _imageBackgroundColor                  = imageBackgroundColor;
     self.iconContainerView.backgroundColor = imageBackgroundColor;
 }
 
 - (void)setTitle:(NSAttributedString*)title {
-    _title                         = title;
     self.titleLabel.attributedText = title;
 }
 
 - (void)setSubTitle:(NSAttributedString*)subTitle {
-    _subTitle                         = subTitle;
     self.subTitleLabel.attributedText = subTitle;
 }
 

--- a/Wikipedia/Code/WMFExploreSectionHeader.m
+++ b/Wikipedia/Code/WMFExploreSectionHeader.m
@@ -32,28 +32,28 @@
     }];
 }
 
--(void)setImage:(UIImage *)image {
-    _image = image;
+- (void)setImage:(UIImage*)image {
+    _image          = image;
     self.icon.image = image;
 }
 
--(void)setImageTintColor:(UIColor *)imageTintColor {
-    _imageTintColor = imageTintColor;
+- (void)setImageTintColor:(UIColor*)imageTintColor {
+    _imageTintColor     = imageTintColor;
     self.icon.tintColor = imageTintColor;
 }
 
--(void)setImageBackgroundColor:(UIColor *)imageBackgroundColor {
-    _imageBackgroundColor = imageBackgroundColor;
+- (void)setImageBackgroundColor:(UIColor*)imageBackgroundColor {
+    _imageBackgroundColor                  = imageBackgroundColor;
     self.iconContainerView.backgroundColor = imageBackgroundColor;
 }
 
--(void)setTitle:(NSAttributedString *)title {
-    _title = title;
+- (void)setTitle:(NSAttributedString*)title {
+    _title                         = title;
     self.titleLabel.attributedText = title;
 }
 
--(void)setSubTitle:(NSAttributedString *)subTitle {
-    _subTitle = subTitle;
+- (void)setSubTitle:(NSAttributedString*)subTitle {
+    _subTitle                         = subTitle;
     self.subTitleLabel.attributedText = subTitle;
 }
 
@@ -62,9 +62,8 @@
     [self reset];
 }
 
-
--(void)reset {
-    self.titleLabel.text = @"";
+- (void)reset {
+    self.titleLabel.text    = @"";
     self.subTitleLabel.text = @"";
     self.rightButtonEnabled = NO;
 }

--- a/Wikipedia/Code/WMFExploreSectionHeader.xib
+++ b/Wikipedia/Code/WMFExploreSectionHeader.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
@@ -8,46 +8,72 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="z8g-C6-qUw" customClass="WMFExploreSectionHeader">
-            <rect key="frame" x="0.0" y="0.0" width="332" height="52"/>
+            <rect key="frame" x="0.0" y="0.0" width="332" height="82"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="B56-ez-iTW" userLabel="Background">
-                    <rect key="frame" x="0.0" y="0.0" width="332" height="52"/>
+                    <rect key="frame" x="0.0" y="0.0" width="332" height="82"/>
                     <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Cbn-lY-3mh">
-                            <rect key="frame" x="15" y="15" width="22" height="22"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qGx-DZ-vQ1">
+                            <rect key="frame" x="13" y="21" width="40" height="40"/>
+                            <subviews>
+                                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Cbn-lY-3mh">
+                                    <rect key="frame" x="9" y="9" width="22" height="22"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="22" id="5mC-1s-Snv"/>
+                                        <constraint firstAttribute="height" constant="22" id="7fi-nm-ScX"/>
+                                    </constraints>
+                                </imageView>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="22" id="5mC-1s-Snv"/>
-                                <constraint firstAttribute="height" constant="22" id="7fi-nm-ScX"/>
+                                <constraint firstItem="Cbn-lY-3mh" firstAttribute="centerX" secondItem="qGx-DZ-vQ1" secondAttribute="centerX" id="Fpy-Br-hJy"/>
+                                <constraint firstItem="Cbn-lY-3mh" firstAttribute="centerY" secondItem="qGx-DZ-vQ1" secondAttribute="centerY" id="Got-Yk-Tr2"/>
+                                <constraint firstAttribute="height" constant="40" id="VGZ-E0-7sV"/>
+                                <constraint firstAttribute="width" constant="40" id="kW5-qf-EQq"/>
                             </constraints>
-                        </imageView>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                    <real key="value" value="2"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                        </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hJc-u6-CpG">
-                            <rect key="frame" x="282" y="8" width="50" height="36"/>
+                            <rect key="frame" x="282" y="23" width="50" height="36"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="50" id="DUK-XE-zns"/>
                                 <constraint firstAttribute="height" constant="36" id="Mmu-OC-4Yn"/>
                             </constraints>
                             <state key="normal" image="refresh-mini"/>
                         </button>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6te-x5-5hY">
-                            <rect key="frame" x="41" y="10" width="233" height="32"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6te-x5-5hY">
+                            <rect key="frame" x="68" y="16" width="206" height="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <color key="textColor" red="0.59993284940000002" green="0.60003882649999996" blue="0.59992617370000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0GT-CP-nAd">
+                            <rect key="frame" x="68" y="49" width="204" height="17"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                     </subviews>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="6te-x5-5hY" secondAttribute="trailing" priority="750" constant="8" id="00o-4K-VUO"/>
-                        <constraint firstItem="6te-x5-5hY" firstAttribute="top" secondItem="B56-ez-iTW" secondAttribute="top" constant="10" id="Kue-hR-y7L"/>
+                        <constraint firstItem="0GT-CP-nAd" firstAttribute="top" secondItem="6te-x5-5hY" secondAttribute="bottom" constant="3" id="1wt-iw-oZP"/>
+                        <constraint firstAttribute="bottom" secondItem="0GT-CP-nAd" secondAttribute="bottom" constant="16" id="Egm-9T-aX9"/>
+                        <constraint firstItem="6te-x5-5hY" firstAttribute="top" secondItem="B56-ez-iTW" secondAttribute="top" constant="16" id="Kue-hR-y7L"/>
+                        <constraint firstItem="0GT-CP-nAd" firstAttribute="leading" secondItem="6te-x5-5hY" secondAttribute="leading" id="LNg-8n-FHG"/>
+                        <constraint firstItem="qGx-DZ-vQ1" firstAttribute="leading" secondItem="B56-ez-iTW" secondAttribute="leading" constant="13" id="QeU-Q1-fiX"/>
                         <constraint firstItem="hJc-u6-CpG" firstAttribute="leading" secondItem="6te-x5-5hY" secondAttribute="trailing" constant="8" id="Rv4-B8-YIm"/>
-                        <constraint firstAttribute="bottom" secondItem="6te-x5-5hY" secondAttribute="bottom" constant="10" id="VlD-vf-O8A"/>
-                        <constraint firstItem="Cbn-lY-3mh" firstAttribute="centerY" secondItem="B56-ez-iTW" secondAttribute="centerY" id="X6B-Jh-4dE"/>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="52" id="Yob-aj-guA"/>
-                        <constraint firstItem="Cbn-lY-3mh" firstAttribute="leading" secondItem="B56-ez-iTW" secondAttribute="leading" constant="15" id="cFe-Gl-HZQ"/>
-                        <constraint firstItem="6te-x5-5hY" firstAttribute="leading" secondItem="Cbn-lY-3mh" secondAttribute="trailing" constant="4" id="ctc-Qd-Cwf"/>
+                        <constraint firstItem="6te-x5-5hY" firstAttribute="leading" secondItem="qGx-DZ-vQ1" secondAttribute="trailing" constant="15" id="Yv4-Hp-UFw"/>
+                        <constraint firstItem="hJc-u6-CpG" firstAttribute="centerY" secondItem="B56-ez-iTW" secondAttribute="centerY" id="alL-7Y-XUp"/>
+                        <constraint firstItem="hJc-u6-CpG" firstAttribute="leading" secondItem="0GT-CP-nAd" secondAttribute="trailing" constant="10" id="jhs-rj-dVX"/>
+                        <constraint firstItem="qGx-DZ-vQ1" firstAttribute="centerY" secondItem="B56-ez-iTW" secondAttribute="centerY" id="nix-mT-QRe"/>
                         <constraint firstAttribute="trailing" secondItem="hJc-u6-CpG" secondAttribute="trailing" id="rBq-9W-XvZ"/>
-                        <constraint firstItem="hJc-u6-CpG" firstAttribute="centerY" secondItem="Cbn-lY-3mh" secondAttribute="centerY" id="yo7-Dh-ZjF"/>
                     </constraints>
                 </view>
             </subviews>
@@ -63,11 +89,13 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="icon" destination="Cbn-lY-3mh" id="Cef-Qu-vzm"/>
+                <outlet property="iconContainerView" destination="qGx-DZ-vQ1" id="EFc-Q2-AXo"/>
                 <outlet property="rightButton" destination="hJc-u6-CpG" id="UFV-QM-AWn"/>
                 <outlet property="rightButtonWidthConstraint" destination="DUK-XE-zns" id="yks-EU-JKV"/>
-                <outlet property="titleView" destination="6te-x5-5hY" id="END-Eg-cW1"/>
+                <outlet property="subTitleLabel" destination="0GT-CP-nAd" id="T3x-tF-K6T"/>
+                <outlet property="titleLabel" destination="6te-x5-5hY" id="pvl-AH-sEf"/>
             </connections>
-            <point key="canvasLocation" x="213" y="325"/>
+            <point key="canvasLocation" x="213" y="344"/>
         </view>
     </objects>
     <resources>

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -366,11 +366,11 @@ NS_ASSUME_NONNULL_BEGIN
     header.imageBackgroundColor = [controller headerIconBackgroundColor];
 
     NSMutableAttributedString* title = [[controller headerTitle] mutableCopy];
-    [title addAttribute:NSFontAttributeName value:[UIFont wmf_homeSectionHeaderTitleFont] range:NSMakeRange(0, title.length)];
+    [title addAttribute:NSFontAttributeName value:[UIFont wmf_exploreSectionHeaderTitleFont] range:NSMakeRange(0, title.length)];
     header.title = title;
 
     NSMutableAttributedString* subTitle = [[controller headerSubTitle] mutableCopy];
-    [subTitle addAttribute:NSFontAttributeName value:[UIFont wmf_homeSectionHeaderSubTitleFont] range:NSMakeRange(0, subTitle.length)];
+    [subTitle addAttribute:NSFontAttributeName value:[UIFont wmf_exploreSectionHeaderSubTitleFont] range:NSMakeRange(0, subTitle.length)];
     header.subTitle = subTitle;
 }
 

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -211,9 +211,9 @@ NS_ASSUME_NONNULL_BEGIN
     self.tableView.dataSource                   = nil;
     self.tableView.delegate                     = nil;
     self.tableView.sectionHeaderHeight          = UITableViewAutomaticDimension;
-    self.tableView.estimatedSectionHeaderHeight = 52.0;
+    self.tableView.estimatedSectionHeaderHeight = 66.0;
     self.tableView.sectionFooterHeight          = UITableViewAutomaticDimension;
-    self.tableView.estimatedSectionFooterHeight = 78.0;
+    self.tableView.estimatedSectionFooterHeight = 50.0;
 
     [self.tableView registerNib:[WMFExploreSectionHeader wmf_classNib]
      forHeaderFooterViewReuseIdentifier:[WMFExploreSectionHeader wmf_nibName]];
@@ -360,6 +360,20 @@ NS_ASSUME_NONNULL_BEGIN
     return UITableViewCellEditingStyleNone;
 }
 
+-(void)configureHeader:(WMFExploreSectionHeader*)header withStylingFromController:(id<WMFExploreSectionController>)controller {
+    header.image     = [[controller headerIcon] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    header.imageTintColor = [controller headerIconTintColor];
+    header.imageBackgroundColor = [controller headerIconBackgroundColor];
+    
+    NSMutableAttributedString* title = [[controller headerTitle] mutableCopy];
+    [title addAttribute:NSFontAttributeName value:[UIFont wmf_homeSectionHeaderTitleFont] range:NSMakeRange(0, title.length)];
+    header.title = title;
+    
+    NSMutableAttributedString* subTitle = [[controller headerSubTitle] mutableCopy];
+    [subTitle addAttribute:NSFontAttributeName value:[UIFont wmf_homeSectionHeaderSubTitleFont] range:NSMakeRange(0, subTitle.length)];
+    header.subTitle = subTitle;
+}
+
 - (nullable UIView*)tableView:(UITableView*)tableView viewForHeaderInSection:(NSInteger)section; {
     id<WMFExploreSectionController> controller = [self sectionControllerForSectionAtIndex:section];
     if (!controller) {
@@ -368,13 +382,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     WMFExploreSectionHeader* header = (id)[tableView dequeueReusableHeaderFooterViewWithIdentifier:[WMFExploreSectionHeader wmf_nibName]];
 
-    header.icon.image     = [[controller headerIcon] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-    header.icon.tintColor = [UIColor wmf_homeSectionHeaderTextColor];
-    NSMutableAttributedString* title = [[controller headerText] mutableCopy];
-    [title addAttribute:NSFontAttributeName value:[UIFont wmf_homeSectionHeaderFont] range:NSMakeRange(0, title.length)];
-    header.titleView.attributedText = title;
-    header.titleView.tintColor      = [UIColor wmf_homeSectionHeaderLinkTextColor];
-
+    [self configureHeader:header withStylingFromController:controller];
+    
     @weakify(self);
     header.whenTapped = ^{
         @strongify(self);
@@ -412,7 +421,7 @@ NS_ASSUME_NONNULL_BEGIN
     if ([controller conformsToProtocol:@protocol(WMFMoreFooterProviding)]) {
         footer.visibleBackgroundView.alpha = 1.0;
         footer.moreLabel.text              = [(id < WMFMoreFooterProviding >)controller footerText];
-        footer.moreLabel.textColor         = [UIColor wmf_homeSectionFooterTextColor];
+        footer.moreLabel.textColor         = [UIColor wmf_exploreSectionFooterTextColor];
         @weakify(self);
         footer.whenTapped = ^{
             @strongify(self);

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -360,15 +360,15 @@ NS_ASSUME_NONNULL_BEGIN
     return UITableViewCellEditingStyleNone;
 }
 
--(void)configureHeader:(WMFExploreSectionHeader*)header withStylingFromController:(id<WMFExploreSectionController>)controller {
-    header.image     = [[controller headerIcon] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-    header.imageTintColor = [controller headerIconTintColor];
+- (void)configureHeader:(WMFExploreSectionHeader*)header withStylingFromController:(id<WMFExploreSectionController>)controller {
+    header.image                = [[controller headerIcon] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    header.imageTintColor       = [controller headerIconTintColor];
     header.imageBackgroundColor = [controller headerIconBackgroundColor];
-    
+
     NSMutableAttributedString* title = [[controller headerTitle] mutableCopy];
     [title addAttribute:NSFontAttributeName value:[UIFont wmf_homeSectionHeaderTitleFont] range:NSMakeRange(0, title.length)];
     header.title = title;
-    
+
     NSMutableAttributedString* subTitle = [[controller headerSubTitle] mutableCopy];
     [subTitle addAttribute:NSFontAttributeName value:[UIFont wmf_homeSectionHeaderSubTitleFont] range:NSMakeRange(0, subTitle.length)];
     header.subTitle = subTitle;
@@ -383,7 +383,7 @@ NS_ASSUME_NONNULL_BEGIN
     WMFExploreSectionHeader* header = (id)[tableView dequeueReusableHeaderFooterViewWithIdentifier:[WMFExploreSectionHeader wmf_nibName]];
 
     [self configureHeader:header withStylingFromController:controller];
-    
+
     @weakify(self);
     header.whenTapped = ^{
         @strongify(self);

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -308,10 +308,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)showOfflineEmptyViewAndReloadWhenReachable {
     NSParameterAssert(self.isViewLoaded && self.view.superview);
-    if(![self wmf_isShowingEmptyView]){
+    if (![self wmf_isShowingEmptyView]) {
         return;
     }
-    
+
     [self wmf_showEmptyViewOfType:WMFEmptyViewTypeNoFeed];
 
     @weakify(self);
@@ -596,7 +596,7 @@ NS_ASSUME_NONNULL_BEGIN
         @weakify(self);
         [controller fetchDataIfNeeded].catch(^(NSError* error){
             @strongify(self);
-            if([error wmf_isNetworkConnectionError]){
+            if ([error wmf_isNetworkConnectionError]) {
                 [self showOfflineEmptyViewAndReloadWhenReachable];
             }
         }).finally(^{

--- a/Wikipedia/Code/WMFFeaturedArticleSectionController.m
+++ b/Wikipedia/Code/WMFFeaturedArticleSectionController.m
@@ -13,7 +13,8 @@
 #import "UITableViewCell+WMFLayout.h"
 #import "WMFSaveButtonController.h"
 
-#import "NSString+FormattedAttributedString.h"
+#import "NSDateFormatter+WMFExtensions.h"
+#import "UIColor+WMFHexColor.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -75,11 +76,20 @@ static NSString* const WMFFeaturedArticleSectionIdentifierPrefix = @"WMFFeatured
     return [UIImage imageNamed:@"featured-mini"];
 }
 
-- (NSAttributedString*)headerText {
-    return
-        [MWLocalizedString(@"home-featured-article-heading", nil) attributedStringWithAttributes:@{NSForegroundColorAttributeName: [UIColor wmf_homeSectionHeaderTextColor]}
-                                                                             substitutionStrings:@[[[[self class] dateFormatter] stringFromDate:self.date]]
-                                                                          substitutionAttributes:@[@{NSForegroundColorAttributeName: [UIColor wmf_homeSectionHeaderTextColor]}]];
+- (UIColor*)headerIconTintColor {
+    return [UIColor wmf_colorWithHex:0xE6B84F alpha:1.0];
+}
+
+- (UIColor*)headerIconBackgroundColor {
+    return [UIColor wmf_colorWithHex:0xFCF5E4 alpha:1.0];
+}
+
+- (NSAttributedString*)headerTitle {
+    return [[NSAttributedString alloc] initWithString:MWLocalizedString(@"explore-featured-article-heading", nil) attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderTitleColor]}];
+}
+
+- (NSAttributedString*)headerSubTitle {
+    return [[NSAttributedString alloc] initWithString:[[NSDateFormatter wmf_dayNameMonthNameDayOfMonthNumberDateFormatter] stringFromDate:self.date] attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderSubTitleColor]}];
 }
 
 - (NSString*)cellIdentifier {

--- a/Wikipedia/Code/WMFImageURLParsing.m
+++ b/Wikipedia/Code/WMFImageURLParsing.m
@@ -30,18 +30,18 @@ NSString* WMFParseImageNameFromSourceURL(NSString* sourceURL)  __attribute__((ov
     }
 
     /*
-     For URLs in form "https://upload.wikimedia.org/.../Filename.jpg/XXXpx-Filename.jpg" try to acquire filename via
-     the second to last path component, which has only one extension.
-    */
+       For URLs in form "https://upload.wikimedia.org/.../Filename.jpg/XXXpx-Filename.jpg" try to acquire filename via
+       the second to last path component, which has only one extension.
+     */
     NSString* filenameComponent = pathComponents[pathComponents.count - 2];
     if ([[filenameComponent.pathExtension wmf_asMIMEType] hasPrefix:@"image"]) {
         return filenameComponent;
     }
 
     NSString* thumbOrFileComponent = [pathComponents lastObject];
-    NSArray* matches   = [WMFImageURLParsingRegex() matchesInString:thumbOrFileComponent
-                                                            options:0
-                                                              range:NSMakeRange(0, [thumbOrFileComponent length])];
+    NSArray* matches               = [WMFImageURLParsingRegex() matchesInString:thumbOrFileComponent
+                                                                        options:0
+                                                                          range:NSMakeRange(0, [thumbOrFileComponent length])];
 
     if (matches.count > 0) {
         // Found a "XXXpx-" prefix, extract substring and return as filename

--- a/Wikipedia/Code/WMFLocationManager.m
+++ b/Wikipedia/Code/WMFLocationManager.m
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (BOOL)isDeniedOrDisabled {
-    return [CLLocationManager authorizationStatus] == kCLAuthorizationStatusDenied || [CLLocationManager authorizationStatus] == kCLAuthorizationStatusRestricted ;
+    return [CLLocationManager authorizationStatus] == kCLAuthorizationStatusDenied || [CLLocationManager authorizationStatus] == kCLAuthorizationStatusRestricted;
 }
 
 - (BOOL)requestAuthorizationIfNeeded {

--- a/Wikipedia/Code/WMFMainPageSectionController.m
+++ b/Wikipedia/Code/WMFMainPageSectionController.m
@@ -13,6 +13,7 @@
 #import "WMFMainPagePlaceholderTableViewCell.h"
 #import "UIView+WMFDefaultNib.h"
 #import "UITableViewCell+WMFLayout.h"
+#import "NSDateFormatter+WMFExtensions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -50,17 +51,6 @@ static NSString* const WMFMainPageSectionIdentifier = @"WMFMainPageSectionIdenti
     return _siteInfoFetcher;
 }
 
-+ (NSDateFormatter*)dateFormatter {
-    static NSDateFormatter* dateFormatter;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        dateFormatter = [[NSDateFormatter alloc] init];
-        dateFormatter.dateStyle = NSDateFormatterMediumStyle;
-        dateFormatter.timeStyle = NSDateFormatterNoStyle;
-    });
-    return dateFormatter;
-}
-
 #pragma mark - HomeSectionController
 
 - (id)sectionIdentifier {
@@ -71,8 +61,20 @@ static NSString* const WMFMainPageSectionIdentifier = @"WMFMainPageSectionIdenti
     return [UIImage imageNamed:@"featured-mini"];
 }
 
-- (NSAttributedString*)headerText {
-    return [[NSAttributedString alloc] initWithString:MWLocalizedString(@"home-main-page-heading", nil) attributes:@{NSForegroundColorAttributeName: [UIColor wmf_homeSectionHeaderTextColor]}];
+- (UIColor*)headerIconTintColor {
+    return [UIColor wmf_exploreSectionHeaderIconTintColor];
+}
+
+- (UIColor*)headerIconBackgroundColor {
+    return [UIColor wmf_exploreSectionHeaderIconBackgroundColor];
+}
+
+- (NSAttributedString*)headerTitle {
+    return [[NSAttributedString alloc] initWithString:MWLocalizedString(@"explore-main-page-heading", nil) attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderTitleColor]}];
+}
+
+- (NSAttributedString*)headerSubTitle {
+    return [[NSAttributedString alloc] initWithString:[[NSDateFormatter wmf_dayNameMonthNameDayOfMonthNumberDateFormatter] stringFromDate:[NSDate date]] attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderSubTitleColor]}];
 }
 
 - (NSString*)cellIdentifier {

--- a/Wikipedia/Code/WMFModalImageGalleryViewController.m
+++ b/Wikipedia/Code/WMFModalImageGalleryViewController.m
@@ -399,11 +399,11 @@ static NSString* const WMFImageGalleryCollectionViewCellReuseId = @"WMFImageGall
     return gestureRecognizer == self.chromeTapGestureRecognizer;
 }
 
-#pragma mark - WMFPagingCollectionViewController 
+#pragma mark - WMFPagingCollectionViewController
 
 - (void)primitiveSetCurrentPage:(NSUInteger)page {
-   [super primitiveSetCurrentPage:page];
-   [self updateInfoButtonVisibility];
+    [super primitiveSetCurrentPage:page];
+    [self updateInfoButtonVisibility];
 }
 
 #pragma mark - CollectionView

--- a/Wikipedia/Code/WMFNearbySectionController.m
+++ b/Wikipedia/Code/WMFNearbySectionController.m
@@ -81,8 +81,20 @@ static NSUInteger const WMFNearbySectionFetchCount = 3;
     return [UIImage imageNamed:@"home-nearby"];
 }
 
-- (NSAttributedString*)headerText {
-    return [[NSAttributedString alloc] initWithString:MWLocalizedString(@"main-menu-nearby", nil) attributes:@{NSForegroundColorAttributeName: [UIColor wmf_homeSectionHeaderTextColor]}];
+- (UIColor*)headerIconTintColor {
+    return [UIColor wmf_exploreSectionHeaderIconTintColor];
+}
+
+- (UIColor*)headerIconBackgroundColor {
+    return [UIColor wmf_exploreSectionHeaderIconBackgroundColor];
+}
+
+- (NSAttributedString*)headerTitle {
+    return [[NSAttributedString alloc] initWithString:MWLocalizedString(@"explore-nearby-heading", nil) attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderTitleColor]}];
+}
+
+- (NSAttributedString*)headerSubTitle {
+    return [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%f, %f", self.location.coordinate.latitude, self.location.coordinate.longitude] attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderSubTitleColor]}];
 }
 
 - (NSString*)cellIdentifier {

--- a/Wikipedia/Code/WMFPictureOfTheDaySectionController.m
+++ b/Wikipedia/Code/WMFPictureOfTheDaySectionController.m
@@ -58,12 +58,20 @@ static NSString* WMFPlaceholderImageInfoTitle = @"WMFPlaceholderImageInfoTitle";
     return [UIImage imageNamed:@"potd-mini"];
 }
 
-- (NSAttributedString*)headerText {
-    return [[NSAttributedString alloc] initWithString:
-            [MWLocalizedString(@"home-potd-heading", nil) stringByReplacingOccurrencesOfString:@"$1"
-                                                                                    withString:[[NSDateFormatter wmf_mediumDateFormatterWithoutTime] stringFromDate:self.fetchedDate]]
-                                           attributes:@{NSForegroundColorAttributeName: [UIColor wmf_homeSectionHeaderTextColor]}
-    ];
+- (UIColor*)headerIconTintColor {
+    return [UIColor wmf_exploreSectionHeaderIconTintColor];
+}
+
+- (UIColor*)headerIconBackgroundColor {
+    return [UIColor wmf_exploreSectionHeaderIconBackgroundColor];
+}
+
+- (NSAttributedString*)headerTitle {
+    return [[NSAttributedString alloc] initWithString:MWLocalizedString(@"explore-potd-heading", nil) attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderTitleColor]}];
+}
+
+- (NSAttributedString*)headerSubTitle {
+    return [[NSAttributedString alloc] initWithString:[[NSDateFormatter wmf_dayNameMonthNameDayOfMonthNumberDateFormatter] stringFromDate:self.fetchedDate] attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderSubTitleColor]}];
 }
 
 - (NSString*)cellIdentifier {

--- a/Wikipedia/Code/WMFRandomSectionController.m
+++ b/Wikipedia/Code/WMFRandomSectionController.m
@@ -56,8 +56,20 @@ NSString* const WMFRandomSectionIdentifier = @"WMFRandomSectionIdentifier";
     return [UIImage imageNamed:@"random-mini"];
 }
 
-- (NSAttributedString*)headerText {
-    return [[NSAttributedString alloc] initWithString:MWLocalizedString(@"main-menu-random", nil) attributes:@{NSForegroundColorAttributeName: [UIColor wmf_homeSectionHeaderTextColor]}];
+- (UIColor*)headerIconTintColor {
+    return [UIColor wmf_exploreSectionHeaderIconTintColor];
+}
+
+- (UIColor*)headerIconBackgroundColor {
+    return [UIColor wmf_exploreSectionHeaderIconBackgroundColor];
+}
+
+- (NSAttributedString*)headerTitle {
+    return [[NSAttributedString alloc] initWithString:MWLocalizedString(@"explore-random-article-heading", nil) attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderTitleColor]}];
+}
+
+- (NSAttributedString*)headerSubTitle {
+    return [[NSAttributedString alloc] initWithString:MWLocalizedString(@"explore-random-article-sub-heading", nil) attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderSubTitleColor]}];
 }
 
 - (NSString*)cellIdentifier {

--- a/Wikipedia/Code/WMFRelatedSectionController.m
+++ b/Wikipedia/Code/WMFRelatedSectionController.m
@@ -26,7 +26,6 @@
 
 // Style
 #import "UIFont+WMFStyle.h"
-#import "NSString+FormattedAttributedString.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -91,12 +90,20 @@ static NSUInteger const WMFRelatedSectionMaxResults      = 3;
     return [UIImage imageNamed:@"recent-mini"];
 }
 
-- (NSAttributedString*)headerText {
-    return
-        [MWLocalizedString(@"home-continue-related-heading", nil) attributedStringWithAttributes:@{NSForegroundColorAttributeName: [UIColor wmf_homeSectionHeaderTextColor]}
-                                                                             substitutionStrings:@[self.title.text]
-                                                                          substitutionAttributes:@[@{NSForegroundColorAttributeName: [UIColor wmf_blueTintColor]}]
-        ];
+- (UIColor*)headerIconTintColor {
+    return [UIColor wmf_exploreSectionHeaderIconTintColor];
+}
+
+- (UIColor*)headerIconBackgroundColor {
+    return [UIColor wmf_exploreSectionHeaderIconBackgroundColor];
+}
+
+- (NSAttributedString*)headerTitle {
+    return [[NSAttributedString alloc] initWithString:MWLocalizedString(@"explore-continue-related-heading", nil) attributes:@{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderTitleColor]}];
+}
+
+- (NSAttributedString*)headerSubTitle {
+    return [[NSAttributedString alloc] initWithString:self.title.text attributes:@{NSForegroundColorAttributeName: [UIColor wmf_blueTintColor]}];
 }
 
 - (NSString*)cellIdentifier {

--- a/Wikipedia/Code/WMFShareOptionsController.m
+++ b/Wikipedia/Code/WMFShareOptionsController.m
@@ -172,7 +172,7 @@ NS_ASSUME_NONNULL_BEGIN
         obj.enabled = enabled;
     }];
     self.containerViewController.navigationController.navigationBar.accessibilityElementsHidden = !enabled;
-    self.containerViewController.navigationController.toolbar.accessibilityElementsHidden = !enabled;
+    self.containerViewController.navigationController.toolbar.accessibilityElementsHidden       = !enabled;
 }
 
 #pragma mark - Share Options

--- a/Wikipedia/Code/main.m
+++ b/Wikipedia/Code/main.m
@@ -27,7 +27,7 @@
     return _window;
 }
 
-- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions {
+- (BOOL)application:(UIApplication*)application willFinishLaunchingWithOptions:(nullable NSDictionary*)launchOptions {
     // HAX: usually session singleton does this, but we need to do it manually before any tests run to ensure
     // things like languages.json are available
     [WikipediaAppUtils copyAssetsFolderToAppDataDocuments];

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -407,3 +407,11 @@
 
 "compass-direction" = "at $1 o'clock";
 
+"explore-featured-article-heading" = "Featured article";
+"explore-continue-reading-heading" = "Continue reading";
+"explore-nearby-heading" = "Nearby places";
+"explore-continue-related-heading" = "Because you read";
+"explore-main-page-heading" = "Today on Wikipedia";
+"explore-random-article-heading" = "Random article";
+"explore-random-article-sub-heading" = "English Wikipedia";
+"explore-potd-heading" = "Picture of the day";

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -361,4 +361,11 @@
 "close-button-accessibility-label" = "Accessibility label for a button that closes a dialog.";
 "back-button-accessibility-label" = "Accessibility label for a button to navigate back.";
 "compass-direction" = "Spoken description of compass direction, e.g. 'at 3 o'clock' means 'to the right'";
-
+"explore-featured-article-heading" = "Text for 'Featured article' header";
+"explore-continue-reading-heading" = "Text for 'Continue Reading' header";
+"explore-nearby-heading" = "Text for 'Nearby places' header";
+"explore-continue-related-heading" = "Text for 'Because you read' header";
+"explore-main-page-heading" = "Text for 'Today on Wikipedia' header";
+"explore-random-article-heading" = "Text for 'Random article' header";
+"explore-random-article-sub-heading" = "Subtext beneath the 'Random article' header with name of language Wikipedia";
+"explore-potd-heading" = "Text for 'Picture of the day' header";

--- a/WikipediaUnitTests/Code/WMFDisambiguationPagesViewController.m
+++ b/WikipediaUnitTests/Code/WMFDisambiguationPagesViewController.m
@@ -17,13 +17,13 @@
 - (instancetype)initWithArticle:(MWKArticle*)article dataStore:(MWKDataStore*)dataStore {
     self = [super init];
     if (self) {
-        self.article              = article;
-        self.dataStore            = dataStore;
-        self.dataSource           =
-        [[WMFArticlePreviewDataSource alloc] initWithTitles:self.article.disambiguationTitles
-                                                       site:self.article.site
-                                                  dataStore:dataStore
-                                                    fetcher:[[WMFArticlePreviewFetcher alloc] init]];
+        self.article    = article;
+        self.dataStore  = dataStore;
+        self.dataSource =
+            [[WMFArticlePreviewDataSource alloc] initWithTitles:self.article.disambiguationTitles
+                                                           site:self.article.site
+                                                      dataStore:dataStore
+                                                        fetcher:[[WMFArticlePreviewFetcher alloc] init]];
         self.dataSource.tableView = self.tableView;
     }
     return self;

--- a/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
+++ b/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
@@ -45,7 +45,7 @@
 
 - (void)testImageWithMultiplePeriodsInFilename {
     NSString* testURLString =
-    @"//upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Blacksmith%27s_tools_-_geograph.org.uk_-_1483374.jpg/440px-Blacksmith%27s_tools_-_geograph.org.uk_-_1483374.jpg";
+        @"//upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Blacksmith%27s_tools_-_geograph.org.uk_-_1483374.jpg/440px-Blacksmith%27s_tools_-_geograph.org.uk_-_1483374.jpg";
     assertThat(WMFParseImageNameFromSourceURL(testURLString),
                is(equalTo(@"Blacksmith%27s_tools_-_geograph.org.uk_-_1483374.jpg")));
 }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T125460 
(See epic for follow-on updates: https://phabricator.wikimedia.org/T124484 )

**Featured**
![screen shot 2016-01-29 at 6 18 55 pm](https://cloud.githubusercontent.com/assets/3143487/12693001/0481cc4a-c6b5-11e5-9f4d-e12fa7b9bc3e.png)

**Random**
![screen shot 2016-01-29 at 6 19 34 pm](https://cloud.githubusercontent.com/assets/3143487/12693000/0480d9d4-c6b5-11e5-8c47-ee1e2228c293.png)

**Because you read**
![screen shot 2016-01-29 at 6 20 20 pm](https://cloud.githubusercontent.com/assets/3143487/12693002/0486c290-c6b5-11e5-97e1-0270037997c7.png)

**Main page and PoTD** (needs follow-on to style PoTD without text overlay, see epic)
![screen shot 2016-01-29 at 6 19 04 pm](https://cloud.githubusercontent.com/assets/3143487/12693003/0487da7c-c6b5-11e5-9377-edf2598a05ca.png)

**Continue reading** (needs follow-on to use search result type styling so we get icon, see epic)
![screen shot 2016-01-29 at 6 41 01 pm](https://cloud.githubusercontent.com/assets/3143487/12693168/e628b986-c6b7-11e5-818f-17d52b449c60.png)

 **Nearby** (needs follow-on to convert lat/long to town, see epic)
![screen shot 2016-01-29 at 6 20 05 pm](https://cloud.githubusercontent.com/assets/3143487/12693004/048903f2-c6b5-11e5-826b-e80f0126f0c6.png)
