### PR TITLE
Fix broken kvo on explore VC

### DIFF
--- a/Wikipedia/Code/WMFExploreSectionControllerCache.h
+++ b/Wikipedia/Code/WMFExploreSectionControllerCache.h
@@ -14,9 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithSite:(MWKSite*)site
                    dataStore:(MWKDataStore*)dataStore;
 
-- (id<WMFExploreSectionController>)controllerForSection:(WMFExploreSection*)section;
+- (nullable id<WMFExploreSectionController>)controllerForSection:(WMFExploreSection*)section;
 
 - (nullable WMFExploreSection*)sectionForController:(id<WMFExploreSectionController>)controller;
+
+- (id<WMFExploreSectionController>)newControllerForSection:(WMFExploreSection*)section;
 
 @end
 

--- a/Wikipedia/Code/WMFExploreSectionControllerCache.m
+++ b/Wikipedia/Code/WMFExploreSectionControllerCache.m
@@ -52,46 +52,51 @@ static NSUInteger const WMFExploreSectionControllerCacheLimit = 35;
     return self;
 }
 
-- (id<WMFExploreSectionController>)controllerForSection:(WMFExploreSection*)section {
-    id<WMFExploreSectionController> controller = [self.sectionControllersBySection objectForKey:section];
-    if (!controller) {
-        switch (section.type) {
-            case WMFExploreSectionTypeHistory:
-            case WMFExploreSectionTypeSaved:
-                controller = [self relatedSectionControllerForSectionSchemaItem:section];
-                break;
-            case WMFExploreSectionTypeNearby:
-                controller = [self nearbySectionControllerForSchemaItem:section];
-                break;
-            case WMFExploreSectionTypeContinueReading:
-                controller = [self continueReadingSectionControllerForSchemaItem:section];
-                break;
-            case WMFExploreSectionTypeRandom:
-                controller = [self randomSectionControllerForSchemaItem:section];
-                break;
-            case WMFExploreSectionTypeMainPage:
-                controller = [self mainPageSectionControllerForSchemaItem:section];
-                break;
-            case WMFExploreSectionTypeFeaturedArticle:
-                controller = [self featuredArticleSectionControllerForSchemaItem:section];
-                break;
-            case WMFExploreSectionTypePictureOfTheDay:
-                controller = [self picOfTheDaySectionController];
-                break;
-                /*
-                   !!!: do not add a default case, it is intentionally omitted so an error/warning is triggered when
-                   a new case is added to the enum, enforcing that all sections are handled here.
-                 */
-        }
-        [self.sectionControllersBySection setObject:controller forKey:section];
-        [self.sectionsBySectionController setObject:section forKey:controller];
-    }
-    return controller;
+- (nullable id<WMFExploreSectionController>)controllerForSection:(WMFExploreSection*)section {
+    id<WMFExploreSectionController> controller = [self.sectionControllersBySection objectForKey:section];    return controller;
 }
 
 - (nullable WMFExploreSection*)sectionForController:(id<WMFExploreSectionController>)controller {
     return [self.sectionsBySectionController objectForKey:controller];
 }
+
+- (id<WMFExploreSectionController>)newControllerForSection:(WMFExploreSection*)section{
+    id<WMFExploreSectionController> controller;
+    switch (section.type) {
+        case WMFExploreSectionTypeHistory:
+        case WMFExploreSectionTypeSaved:
+            controller = [self relatedSectionControllerForSectionSchemaItem:section];
+            break;
+        case WMFExploreSectionTypeNearby:
+            controller = [self nearbySectionControllerForSchemaItem:section];
+            break;
+        case WMFExploreSectionTypeContinueReading:
+            controller = [self continueReadingSectionControllerForSchemaItem:section];
+            break;
+        case WMFExploreSectionTypeRandom:
+            controller = [self randomSectionControllerForSchemaItem:section];
+            break;
+        case WMFExploreSectionTypeMainPage:
+            controller = [self mainPageSectionControllerForSchemaItem:section];
+            break;
+        case WMFExploreSectionTypeFeaturedArticle:
+            controller = [self featuredArticleSectionControllerForSchemaItem:section];
+            break;
+        case WMFExploreSectionTypePictureOfTheDay:
+            controller = [self picOfTheDaySectionController];
+            break;
+            /*
+             !!!: do not add a default case, it is intentionally omitted so an error/warning is triggered when
+             a new case is added to the enum, enforcing that all sections are handled here.
+             */
+    }
+
+    [self.sectionControllersBySection setObject:controller forKey:section];
+    [self.sectionsBySectionController setObject:section forKey:controller];
+
+    return controller;
+}
+
 
 #pragma mark - Section Controller Creation
 


### PR DESCRIPTION
Section controllers were being disposed of in the section cache - but the explore vc was unaware.
These section controllers were being recreated as needed, but were never re-observed
This change makes sure that the explore VC always observes any newly created section controllers.

https://phabricator.wikimedia.org/T125921