### PR TITLE
Move VoiceOver cursor to place in article on TOC item selection (rebased)

### DIFF
--- a/Wikipedia/Code/WMFArticleContainerViewController+TOC.swift
+++ b/Wikipedia/Code/WMFArticleContainerViewController+TOC.swift
@@ -19,19 +19,29 @@ extension WMFArticleViewController : WMFTableOfContentsViewControllerDelegate {
 
     public func tableOfContentsController(controller: WMFTableOfContentsViewController,
                                           didSelectItem item: TableOfContentsItem) {
-
+        var dismissVCCompletionHandler: (() -> Void)?
         if let section = item as? MWKSection {
             // HAX: webview has issues scrolling when browser view is out of bounds, disable animation if needed
             self.webViewController.scrollToSection(section, animated: self.webViewController.isWebContentVisible)
+            dismissVCCompletionHandler = {
+                // HAX: This is terrible, but iOS events not under our control would steal our focus if we didn't wait long enough here and due to problems in UIWebView, we cannot work around it either.
+                dispatchOnMainQueueAfterDelayInSeconds(1) {
+                    self.webViewController.accessibilityCursorToSection(section)
+                }
+            }
         } else if let footerItem = item as? TableOfContentsFooterItem {
-            self.webViewController.scrollToFooterAtIndex(UInt(footerItem.footerViewIndex.rawValue))
+            let footerIndex = UInt(footerItem.footerViewIndex.rawValue)
+            self.webViewController.scrollToFooterAtIndex(footerIndex)
+            dismissVCCompletionHandler = {
+                self.webViewController.accessibilityCursorToFooterAtIndex(footerIndex)
+            }
         } else {
             assertionFailure("Unsupported selection of TOC item \(item)")
         }
 
         // Don't dismiss immediately - it looks jarring - let the user see the ToC selection before dismissing
         dispatchOnMainQueueAfterDelayInSeconds(0.25) {
-            self.dismissViewControllerAnimated(true, completion: nil)
+            self.dismissViewControllerAnimated(true, completion: dismissVCCompletionHandler)
         }
     }
 

--- a/Wikipedia/Code/WebViewController.h
+++ b/Wikipedia/Code/WebViewController.h
@@ -58,6 +58,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)scrollToSection:(MWKSection*)section animated:(BOOL)animated;
 
+- (void)accessibilityCursorToSection:(MWKSection*)section;
+
 - (nullable MWKSection*)currentVisibleSection;
 
 - (void)scrollToVerticalOffset:(CGFloat)offset;
@@ -90,7 +92,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong, nullable) NSArray<UIViewController*>* footerViewControllers;
 
+- (UIView*)footerAtIndex:(NSUInteger)index;
 - (void)scrollToFooterAtIndex:(NSUInteger)index;
+- (void)accessibilityCursorToFooterAtIndex:(NSUInteger)index;
 
 - (NSInteger)visibleFooterIndex;
 

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -182,15 +182,23 @@ NSString* const WMFLicenseTitleOnENWiki =
 
 #pragma mark - Headers & Footers
 
-- (void)scrollToFooterAtIndex:(NSUInteger)index {
+- (UIView*)footerAtIndex:(NSUInteger)index {
     UIView* footerView       = self.footerViewControllers[index].view;
     UIView* footerViewHeader = self.footerViewHeadersByIndex[@(index)];
-    UIView* viewToScrollTo   = footerViewHeader ? : footerView;
+    return footerViewHeader ? : footerView;
+}
 
+- (void)scrollToFooterAtIndex:(NSUInteger)index {
+    UIView* viewToScrollTo = [self footerAtIndex:index];
     CGPoint footerViewOrigin = [self.webView.scrollView convertPoint:viewToScrollTo.frame.origin
                                                             fromView:self.footerContainerView];
     footerViewOrigin.y -= self.webView.scrollView.contentInset.top;
     [self.webView.scrollView setContentOffset:footerViewOrigin animated:YES];
+}
+
+- (void)accessibilityCursorToFooterAtIndex:(NSUInteger)index {
+    UIView* viewToScrollTo = [self footerAtIndex:index];
+    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, viewToScrollTo);
 }
 
 - (NSInteger)visibleFooterIndex {
@@ -407,6 +415,11 @@ NSString* const WMFLicenseTitleOnENWiki =
 
 - (void)scrollToSection:(MWKSection*)section animated:(BOOL)animated {
     [self scrollToFragment:section.anchor animated:animated];
+}
+
+- (void)accessibilityCursorToSection:(MWKSection*)section {
+    NSString *js = [NSString stringWithFormat:@"focus_element = document.getElementById('%@'); other_element = document.body;  other_element.setAttribute('tabindex', 0); focus_element.setAttribute('tabindex', 0); other_element.focus(); focus_element.focus();", section.anchor];
+    [self.webView stringByEvaluatingJavaScriptFromString:js];
 }
 
 - (nullable MWKSection*)currentVisibleSection {

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -418,8 +418,12 @@ NSString* const WMFLicenseTitleOnENWiki =
 }
 
 - (void)accessibilityCursorToSection:(MWKSection*)section {
-    NSString *js = [NSString stringWithFormat:@"focus_element = document.getElementById('%@'); other_element = document.body;  other_element.setAttribute('tabindex', 0); focus_element.setAttribute('tabindex', 0); other_element.focus(); focus_element.focus();", section.anchor];
-    [self.webView stringByEvaluatingJavaScriptFromString:js];
+    // This might shift the visual scroll position. To prevent it affecting other users,
+    // we will only do it when we detect than an assistive technology which actually needs this is running.
+    if (UIAccessibilityIsVoiceOverRunning()) {
+        [self.webView.wmf_javascriptContext.globalObject invokeMethod:@"accessibilityCursorToFragment"
+                                                        withArguments:@[section.anchor]];
+    }
 }
 
 - (nullable MWKSection*)currentVisibleSection {

--- a/Wikipedia/assets/bundle.js
+++ b/Wikipedia/assets/bundle.js
@@ -359,6 +359,21 @@ function scrollToFragment(fragmentId){
 }
 
 global.scrollToFragment = scrollToFragment;
+
+function accessibilityCursorToFragment(fragmentId){
+    /* Attempt to move accessibility cursor to fragment. We need to /change/ focus,
+     in order to have the desired effect, so we first give focus to the body element,
+     then move it to the desired fragment. */
+    var focus_element = document.getElementById(fragmentId);
+    var other_element = document.body;
+    other_element.setAttribute('tabindex', 0);
+    other_element.focus();
+    focus_element.setAttribute('tabindex', 0);
+    focus_element.focus();
+}
+
+global.accessibilityCursorToFragment = accessibilityCursorToFragment;
+
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{}],7:[function(require,module,exports){
 function Transformer() {

--- a/www/js/scrollToFragment.js
+++ b/www/js/scrollToFragment.js
@@ -4,3 +4,17 @@ function scrollToFragment(fragmentId){
 }
 
 global.scrollToFragment = scrollToFragment;
+
+function accessibilityCursorToFragment(fragmentId){
+    /* Attempt to move accessibility cursor to fragment. We need to /change/ focus,
+     in order to have the desired effect, so we first give focus to the body element,
+     then move it to the desired fragment. */
+    var focus_element = document.getElementById(fragmentId);
+    var other_element = document.body;
+    other_element.setAttribute('tabindex', 0);
+    other_element.focus();
+    focus_element.setAttribute('tabindex', 0);
+    focus_element.focus();
+}
+
+global.accessibilityCursorToFragment = accessibilityCursorToFragment;


### PR DESCRIPTION
This is a rebased version of [PR439](https://github.com/wikimedia/wikipedia-ios/pull/439)

It tries to move the VoiceOver cursor to the correct place in article
when the user selects an item in the Table of Contents.

However, the handling of VoiceOver cursor receival seems to be buggy in
UIWebView and therefore this commit is only a partial solution.  It
just implements a way that resolves the situation in the majority of
cases.

Please see [T125354](https://phabricator.wikimedia.org/T125354) for more details.