### PR TITLE
Fix article restore logic

### DIFF
--- a/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
+++ b/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
@@ -26,8 +26,12 @@ extension NSUserDefaults {
         return self.wmf_dateForKey(WMFAppBecomeActiveDateKey)
     }
     
-    public func wmf_setAppBecomeActiveDate(date: NSDate) {
-        self.setObject(date, forKey: WMFAppBecomeActiveDateKey)
+    public func wmf_setAppBecomeActiveDate(date: NSDate?) {
+        if let date = date {
+            self.setObject(date, forKey: WMFAppBecomeActiveDateKey)
+        }else{
+            self.removeObjectForKey(WMFAppBecomeActiveDateKey)
+        }
         self.synchronize()
     }
     
@@ -35,8 +39,12 @@ extension NSUserDefaults {
         return self.wmf_dateForKey(WMFAppResignActiveDateKey)
     }
     
-    public func wmf_setAppResignActiveDate(date: NSDate) {
-        self.setObject(date, forKey: WMFAppResignActiveDateKey)
+    public func wmf_setAppResignActiveDate(date: NSDate?) {
+        if let date = date {
+            self.setObject(date, forKey: WMFAppResignActiveDateKey)
+        }else{
+            self.removeObjectForKey(WMFAppResignActiveDateKey)
+        }
         self.synchronize()
     }
     

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -459,8 +459,8 @@ static NSString* const WMFDidShowOnboarding = @"DidShowOnboarding5.0";
 
 - (WMFArticleBrowserViewController*)currentlyDisplayedArticleBrowser {
     UINavigationController* navVC = [self navigationControllerForTab:self.rootTabBarController.selectedIndex];
-    if (navVC.presentedViewController && [navVC.presentedViewController isKindOfClass:[UINavigationController class]] && [[[(UINavigationController*)navVC.presentedViewController viewControllers] lastObject] isKindOfClass:[WMFArticleBrowserViewController class]]) {
-        WMFArticleBrowserViewController* vc = [[(UINavigationController*)navVC.presentedViewController viewControllers] lastObject];
+    if (navVC.presentedViewController && [navVC.presentedViewController isKindOfClass:[WMFArticleBrowserViewController class]]) {
+        WMFArticleBrowserViewController* vc = (id)navVC.presentedViewController;
         return vc;
     }
     return nil;
@@ -468,7 +468,7 @@ static NSString* const WMFDidShowOnboarding = @"DidShowOnboarding5.0";
 
 - (BOOL)articleBrowserIsBeingDisplayed {
     UINavigationController* navVC = [self navigationControllerForTab:self.rootTabBarController.selectedIndex];
-    if (navVC.presentedViewController && [navVC.presentedViewController isKindOfClass:[UINavigationController class]] && [[[(UINavigationController*)navVC.presentedViewController viewControllers] lastObject] isKindOfClass:[WMFArticleBrowserViewController class]]) {
+    if (navVC.presentedViewController && [navVC.presentedViewController isKindOfClass:[WMFArticleBrowserViewController class]]) {
         return YES;
     }
 
@@ -481,8 +481,8 @@ static NSString* const WMFDidShowOnboarding = @"DidShowOnboarding5.0";
         return ((WMFArticleViewController*)navVC.topViewController).articleTitle;
     }
 
-    if (navVC.presentedViewController && [navVC.presentedViewController isKindOfClass:[UINavigationController class]] && [[[(UINavigationController*)navVC.presentedViewController viewControllers] lastObject] isKindOfClass:[WMFArticleBrowserViewController class]]) {
-        WMFArticleBrowserViewController* vc = [[(UINavigationController*)navVC.presentedViewController viewControllers] lastObject];
+    if (navVC.presentedViewController && [navVC.presentedViewController isKindOfClass:[WMFArticleBrowserViewController class]]) {
+        WMFArticleBrowserViewController* vc = (id)navVC.presentedViewController;
         return [vc titleOfCurrentArticle];
     }
     return nil;

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -185,10 +185,10 @@ static dispatch_once_t launchToken;
 
     if ([self shouldProcessAppShortcutOnLaunch]) {
         [self processApplicationShortcutItem];
-    } else if ([self shouldShowExploreScreenOnLaunch]) {
-        [self showExplore];
     } else if ([self shouldShowLastReadArticleOnLaunch]) {
         [self showLastReadArticleAnimated:YES];
+    } else if ([self shouldShowExploreScreenOnLaunch]) {
+        [self showExplore];
     }
 
     if (FBTweakValue(@"Alerts", @"General", @"Show error on launch", NO)) {
@@ -284,7 +284,7 @@ static dispatch_once_t launchToken;
         return NO;
     }
 
-    if (fabs([resignActiveDate timeIntervalSinceNow]) <= WMFTimeBeforeRefreshingExploreScreen) {
+    if (fabs([resignActiveDate timeIntervalSinceNow]) < WMFTimeBeforeRefreshingExploreScreen) {
         if (![self exploreViewControllerIsDisplayingContent] && [self.rootTabBarController selectedIndex] == WMFAppTabTypeExplore) {
             return YES;
         }


### PR DESCRIPTION
I wasn't able to reproduce the bug here:
https://phabricator.wikimedia.org/T124381

This is quite possible due to the recent navigation refactor…

However I did notice that the logic for restoring articles wasn't quite right since we started processing the shortcuts. So I did fix that here.

@montehurd can you test this to see if indeed you can still cause the crash?