### PR TITLE
Boyscout - statuts bar fix

### DIFF
--- a/Wikipedia/Code/WMFTableOfContentsViewController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsViewController.swift
@@ -40,6 +40,8 @@ public class WMFTableOfContentsViewController: UIViewController,
             }
         }
     }
+    
+    var previousStatusbarStyle: UIStatusBarStyle?
 
     //optional becuase it requires a reference to self to inititialize
     var animator: WMFTableOfContentsAnimator?
@@ -177,13 +179,16 @@ public class WMFTableOfContentsViewController: UIViewController,
         super.viewWillAppear(animated)
         self.delegate?.tableOfContentsControllerWillDisplay(self)
         tableOfContentsFunnel.logOpen()
+        previousStatusbarStyle = UIApplication.sharedApplication().statusBarStyle
         UIApplication.sharedApplication().setStatusBarStyle(.Default, animated: animated)
     }
     
     public override func viewDidDisappear(animated: Bool) {
         super.viewDidDisappear(animated)
         deselectAllRows()
-        UIApplication.sharedApplication().setStatusBarStyle(.LightContent, animated: animated)
+        if let previousStatusbarStyle = previousStatusbarStyle {
+            UIApplication.sharedApplication().setStatusBarStyle(previousStatusbarStyle, animated: animated)
+        }
     }
     
     // MARK: - UITableViewDataSource


### PR DESCRIPTION
This is from the new aviation code last week.

Fix toc not respecting the previous status bar style (caused the status bar to "disappear" when article is not in browser mode)