### PR TITLE
Fix bug where explore would not reload on network connect

### DIFF
--- a/Wikipedia/Code/WMFBaseExploreSectionController.h
+++ b/Wikipedia/Code/WMFBaseExploreSectionController.h
@@ -81,13 +81,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface WMFBaseExploreSectionController (WMFEmptyCellSupport)
 
 /**
- *  Return Yes to show an empty cell when there are no results
- *
- *  @return Return YES to show empty cells, otherwise NO. Default = NO
- */
-- (BOOL)showsEmptyCell;
-
-/**
  *  Configure the empty cell
  *
  *  @param cell The cell to configure

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -320,7 +320,7 @@ NS_ASSUME_NONNULL_BEGIN
     @weakify(self);
     SCNetworkReachability().then(^{
         @strongify(self);
-        [self wmf_hideEmptyView];
+        [self.tableView reloadData];
         [[self visibleSectionControllers] enumerateObjectsUsingBlock:^(id<WMFExploreSectionController>  _Nonnull obj, NSUInteger idx, BOOL* _Nonnull stop) {
             @weakify(self);
             [obj fetchDataIfError].catch(^(NSError* error){
@@ -328,6 +328,7 @@ NS_ASSUME_NONNULL_BEGIN
                 [self showOfflineEmptyViewAndReloadWhenReachable];
             });
         }];
+        [self wmf_hideEmptyView];
     });
 }
 

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -324,8 +324,8 @@ NS_ASSUME_NONNULL_BEGIN
     [self wmf_showEmptyViewOfType:WMFEmptyViewTypeNoFeed];
     @weakify(self);
     SCNetworkReachability().then(^{
-        self.isWaitingForNetworkToReconnect = NO;
         @strongify(self);
+        self.isWaitingForNetworkToReconnect = NO;
         [self.tableView reloadData];
         [[self visibleSectionControllers] enumerateObjectsUsingBlock:^(id<WMFExploreSectionController>  _Nonnull obj, NSUInteger idx, BOOL* _Nonnull stop) {
             @weakify(self);

--- a/Wikipedia/Code/WMFMainPageSectionController.m
+++ b/Wikipedia/Code/WMFMainPageSectionController.m
@@ -17,6 +17,7 @@
 #import "WMFArticleBrowserViewController.h"
 #import "NSDateFormatter+WMFExtensions.h"
 
+
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString* const WMFMainPageSectionIdentifier = @"WMFMainPageSectionIdentifier";

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -338,6 +338,8 @@
 "mwk-empty-title-error" = "Unable to perform operation with empty title.";
 
 "home-title" = "Explore";
+"home-empty-section" = "No results";
+"home-empty-section-check-again" = "Try again";
 "home-continue-reading-heading" = "Continue Reading";
 "home-continue-related-heading" = "Because you read $1";
 "home-more-like-footer" = "More like $1";

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -372,4 +372,4 @@
 "explore-random-article-sub-heading" = "Subtext beneath the 'Random article' header with name of language Wikipedia";
 "explore-potd-heading" = "Text for 'Picture of the day' header";
 "home-empty-section" = "Text shown when a section of the home screen has no results";
-"home-empty-section-check-again" = "Button title to relaod a section when it has no results";
+"home-empty-section-check-again" = "Button title to reload a section when it has no results";

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -371,3 +371,5 @@
 "explore-random-article-heading" = "Text for 'Random article' header";
 "explore-random-article-sub-heading" = "Subtext beneath the 'Random article' header with name of language Wikipedia";
 "explore-potd-heading" = "Text for 'Picture of the day' header";
+"home-empty-section" = "Text shown when a section of the home screen has no results";
+"home-empty-section-check-again" = "Button title to relaod a section when it has no results";


### PR DESCRIPTION
Fixes:
https://phabricator.wikimedia.org/T126302

Also fixing this one as well:
https://phabricator.wikimedia.org/T121924

A confluence of issues fixed by the following:

- Be sure to reload table on reconnect
- All sections need to have an empty cell - this is necessary because if a section doesn't have a cell on screen, then it isn't "visible"
- Always report 1 row per section (even if empty, see above)

Also some minor refactors


