### PR TITLE
Fix crash due to citation being parsed into title for disambiguations

### DIFF
--- a/Wikipedia/Code/MWKSection.m
+++ b/Wikipedia/Code/MWKSection.m
@@ -280,7 +280,7 @@ static NSString* const WMFSectionDisambiguationTitlesXPathSelector = @"//div[@cl
 - (nullable NSArray<MWKTitle*>*)disambiguationTitles {
     NSArray* textNodes = [self elementsInTextMatchingXPath:WMFSectionDisambiguationTitlesXPathSelector];
     return [textNodes wmf_mapAndRejectNil:^id (TFHppleElement* node) {
-        if (node.text.length == 0 || [node.text containsString:@"redlink=1"]) {
+        if (node.text.length == 0 || [node.text containsString:@"redlink=1"] || [node.text containsString:@"cite_note"]) {
             return nil;
         }
         return [[MWKTitle alloc] initWithInternalLink:node.text site:self.site];

--- a/Wikipedia/Code/MWKSection.m
+++ b/Wikipedia/Code/MWKSection.m
@@ -280,7 +280,7 @@ static NSString* const WMFSectionDisambiguationTitlesXPathSelector = @"//div[@cl
 - (nullable NSArray<MWKTitle*>*)disambiguationTitles {
     NSArray* textNodes = [self elementsInTextMatchingXPath:WMFSectionDisambiguationTitlesXPathSelector];
     return [textNodes wmf_mapAndRejectNil:^id (TFHppleElement* node) {
-        if (node.text.length == 0 || [node.text containsString:@"redlink=1"] || [node.text containsString:@"cite_note"]) {
+        if (node.text.length == 0 || [node.text containsString:@"redlink=1"] || ![node.text containsString:WMFInternalLinkPathPrefix]) {
             return nil;
         }
         return [[MWKTitle alloc] initWithInternalLink:node.text site:self.site];


### PR DESCRIPTION
- Ignoring text that contains "cite_note"

https://rink.hockeyapp.net/manage/apps/152725/app_versions/42/crash_reasons/101251146