### PR TITLE
Fix bug where sections were reloading infinitely

### DIFF
--- a/Wikipedia/Code/WMFExploreSection.h
+++ b/Wikipedia/Code/WMFExploreSection.h
@@ -52,6 +52,23 @@ typedef NS_ENUM (NSUInteger, WMFExploreSectionType){
 + (instancetype)randomSection;
 
 /**
+ *  Returns the max number of sections for a section type
+ *
+ *  @param type The type of sections
+ *
+ *  @return The max number of sections
+ */
++ (NSUInteger)maxNumberOfSectionsForType:(WMFExploreSectionType)type;
+
+/**
+ *  Returns the max number of all sections
+ *
+ *  @return The total max number of ALL sections types
+ */
++ (NSUInteger)totalMaxNumberOfSections;
+
+
+/**
  *  The type of section.
  *
  *  Determines which metadata properties are available.

--- a/Wikipedia/Code/WMFExploreSection.m
+++ b/Wikipedia/Code/WMFExploreSection.m
@@ -178,6 +178,37 @@ NS_ASSUME_NONNULL_BEGIN
     return item;
 }
 
++ (NSUInteger)maxNumberOfSectionsForType:(WMFExploreSectionType)type{
+    switch (type) {
+        case WMFExploreSectionTypeHistory:
+        case WMFExploreSectionTypeSaved:
+        case WMFExploreSectionTypeFeaturedArticle:
+        case WMFExploreSectionTypeMostRead:
+            return 10;
+            break;
+        case WMFExploreSectionTypePictureOfTheDay:
+        case WMFExploreSectionTypeNearby:
+        case WMFExploreSectionTypeContinueReading:
+        case WMFExploreSectionTypeRandom:
+        case WMFExploreSectionTypeMainPage:
+            return 1;
+            break;
+    }
+}
+
++ (NSUInteger)totalMaxNumberOfSections{
+    return [self maxNumberOfSectionsForType:WMFExploreSectionTypeHistory] +
+    [self maxNumberOfSectionsForType:WMFExploreSectionTypeSaved] +
+    [self maxNumberOfSectionsForType:WMFExploreSectionTypeFeaturedArticle] +
+    [self maxNumberOfSectionsForType:WMFExploreSectionTypePictureOfTheDay] +
+    [self maxNumberOfSectionsForType:WMFExploreSectionTypeMostRead] +
+    [self maxNumberOfSectionsForType:WMFExploreSectionTypeNearby] +
+    [self maxNumberOfSectionsForType:WMFExploreSectionTypeContinueReading] +
+    [self maxNumberOfSectionsForType:WMFExploreSectionTypeRandom] +
+    [self maxNumberOfSectionsForType:WMFExploreSectionTypeMainPage];
+}
+
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFExploreSectionControllerCache.m
+++ b/Wikipedia/Code/WMFExploreSectionControllerCache.m
@@ -25,8 +25,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSUInteger const WMFExploreSectionControllerCacheLimit = 35;
-
 
 @interface WMFExploreSectionControllerCache ()
 
@@ -48,7 +46,7 @@ static NSUInteger const WMFExploreSectionControllerCacheLimit = 35;
         self.site                                   = site;
         self.dataStore                              = dataStore;
         self.sectionControllersBySection            = [[NSCache alloc] init];
-        self.sectionControllersBySection.countLimit = WMFExploreSectionControllerCacheLimit;
+        self.sectionControllersBySection.countLimit = [WMFExploreSection totalMaxNumberOfSections];
         self.sectionsBySectionController            = [NSMapTable mapTableWithKeyOptions:NSMapTableWeakMemory | NSMapTableObjectPointerPersonality
                                                                             valueOptions:NSMapTableWeakMemory];
     }
@@ -56,7 +54,8 @@ static NSUInteger const WMFExploreSectionControllerCacheLimit = 35;
 }
 
 - (nullable id<WMFExploreSectionController>)controllerForSection:(WMFExploreSection*)section {
-    id<WMFExploreSectionController> controller = [self.sectionControllersBySection objectForKey:section];    return controller;
+    id<WMFExploreSectionController> controller = [self.sectionControllersBySection objectForKey:section];
+    return controller;
 }
 
 - (nullable WMFExploreSection*)sectionForController:(id<WMFExploreSectionController>)controller {


### PR DESCRIPTION
The bug was caused because the cache was too small and the first section repeated unloaded and had to refetch.

Fixed by adding the section limit as an API to the section item.