### PR TITLE
T120474: Feed jumpiness

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -568,6 +568,7 @@
 		BC6E42881BA9CB930059FBF6 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = BC6E428A1BA9CB930059FBF6 /* InfoPlist.strings */; };
 		BC8210D01B4EE3FA0010BF7B /* ArticleWithoutImages.dataexport.json in Resources */ = {isa = PBXBuildFile; fileRef = BC8210CE1B4EE3F30010BF7B /* ArticleWithoutImages.dataexport.json */; };
 		BC8210D71B4F048F0010BF7B /* Barack_Obama in Resources */ = {isa = PBXBuildFile; fileRef = BC8210D61B4F048F0010BF7B /* Barack_Obama */; };
+		BC8B4F1C1C77A30C009B06F7 /* WMFBaseExploreSectionControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC8B4F1B1C77A30C009B06F7 /* WMFBaseExploreSectionControllerTests.m */; };
 		BC8E58571BF69C3F00F55225 /* NoSearchResultsWithSuggestion.json in Resources */ = {isa = PBXBuildFile; fileRef = BC8E58561BF69C3F00F55225 /* NoSearchResultsWithSuggestion.json */; };
 		BC90DE791C57C5AD007E0E81 /* WMFWelcomeLanguageViewControllerVisualTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC90DE781C57C5AD007E0E81 /* WMFWelcomeLanguageViewControllerVisualTests.m */; };
 		BC9355431BE1A71D00697CB0 /* BarackSearch.json in Resources */ = {isa = PBXBuildFile; fileRef = BC9355411BE1A71900697CB0 /* BarackSearch.json */; };
@@ -1700,6 +1701,8 @@
 		BC6E42B11BA9D1020059FBF6 /* mk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mk; path = mk.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		BC8210CE1B4EE3F30010BF7B /* ArticleWithoutImages.dataexport.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ArticleWithoutImages.dataexport.json; sourceTree = "<group>"; };
 		BC8210D61B4F048F0010BF7B /* Barack_Obama */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Barack_Obama; sourceTree = "<group>"; };
+		BC8B4F1B1C77A30C009B06F7 /* WMFBaseExploreSectionControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFBaseExploreSectionControllerTests.m; sourceTree = "<group>"; };
+		BC8B4F1D1C77B29A009B06F7 /* LSNocilla+AnyRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "LSNocilla+AnyRequest.h"; path = "WikipediaUnitTests/Code/LSNocilla+AnyRequest.h"; sourceTree = SOURCE_ROOT; };
 		BC8E58561BF69C3F00F55225 /* NoSearchResultsWithSuggestion.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = NoSearchResultsWithSuggestion.json; sourceTree = "<group>"; };
 		BC90DE781C57C5AD007E0E81 /* WMFWelcomeLanguageViewControllerVisualTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFWelcomeLanguageViewControllerVisualTests.m; sourceTree = "<group>"; };
 		BC90DE7A1C57D142007E0E81 /* WMFWelcomeLanguageViewController_Testing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFWelcomeLanguageViewController_Testing.h; path = Wikipedia/Code/WMFWelcomeLanguageViewController_Testing.h; sourceTree = SOURCE_ROOT; };
@@ -4244,6 +4247,7 @@
 				BC45FF4C1C1B2DDB00BAE501 /* QueuesSingleton+AllManagers.h */,
 				BC45FF4D1C1B2DDB00BAE501 /* QueuesSingleton+AllManagers.m */,
 				BCFEEA461C286DD600CA2986 /* LSNocilla+Quick.h */,
+				BC8B4F1D1C77B29A009B06F7 /* LSNocilla+AnyRequest.h */,
 				BCD557B91C45B1600060A51A /* UIApplication+VisualTestUtils.h */,
 				BCD557BA1C45B1600060A51A /* UIApplication+VisualTestUtils.m */,
 				BC62AE601C58FC810064C589 /* NSProcessInfo+WMFTestEnvironment.h */,
@@ -4590,6 +4594,7 @@
 				08A3C7B51C5FCC8500682DC0 /* WMFArticlePreviewCellVisualTests.m */,
 				BCD320071C6EC44300317D08 /* Time Zone Tests */,
 				B0C0B07C1C6D988800859AD5 /* WMFSettingsCellVisualTests.m */,
+				BC8B4F1B1C77A30C009B06F7 /* WMFBaseExploreSectionControllerTests.m */,
 			);
 			name = Tests;
 			path = WikipediaUnitTests/Code;
@@ -5376,6 +5381,7 @@
 				BCD557BB1C45B1600060A51A /* UIApplication+VisualTestUtils.m in Sources */,
 				B0E809191C0D19340065EBC0 /* LegacyCoreDataMigratorTests.m in Sources */,
 				B0C0B07E1C6D989000859AD5 /* WMFSettingsCellVisualTests.m in Sources */,
+				BC8B4F1C1C77A30C009B06F7 /* WMFBaseExploreSectionControllerTests.m in Sources */,
 				B0E8091F1C0D19700065EBC0 /* NSIndexSet+BKReduceTests.m in Sources */,
 				B0E809621C0D1BAD0065EBC0 /* WMFSearchResultsMergeTests.m in Sources */,
 				B0E808F71C0D18410065EBC0 /* MWKTestCase.m in Sources */,

--- a/Wikipedia/Code/WMFArticlePlaceholderTableViewCell.xib
+++ b/Wikipedia/Code/WMFArticlePlaceholderTableViewCell.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -26,9 +27,9 @@
                         </variation>
                     </imageView>
                     <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pC6-LC-20b" userLabel="Save Button" customClass="WMFTitleInsetRespectingButton">
-                        <rect key="frame" x="18" y="375" width="119" height="25"/>
+                        <rect key="frame" x="13" y="372" width="341" height="40"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="999" constant="25" id="AEV-vl-3YX"/>
+                            <constraint firstAttribute="height" priority="999" constant="40" id="AEV-vl-3YX"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="25" id="nQE-Ht-SAz"/>
                         </constraints>
                         <color key="tintColor" red="0.96862745098039216" green="0.96862745098039216" blue="0.96862745098039216" alpha="1" colorSpace="calibratedRGB"/>
@@ -45,12 +46,13 @@
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="pC6-LC-20b" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="18" id="1vd-Gr-Mmq"/>
+                    <constraint firstItem="pC6-LC-20b" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="13" id="1vd-Gr-Mmq"/>
                     <constraint firstItem="RoZ-Ue-BfV" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="8hK-JT-Orq"/>
                     <constraint firstAttribute="trailing" secondItem="RoZ-Ue-BfV" secondAttribute="trailing" id="FFH-2w-PSs"/>
                     <constraint firstItem="RoZ-Ue-BfV" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="FbC-nC-GOz"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="pC6-LC-20b" secondAttribute="trailing" constant="13" id="dM5-an-jcD"/>
                     <constraint firstAttribute="bottom" secondItem="RoZ-Ue-BfV" secondAttribute="bottom" id="sCD-Go-kVG"/>
-                    <constraint firstAttribute="bottom" secondItem="pC6-LC-20b" secondAttribute="bottom" constant="20" id="v65-6H-bIH"/>
+                    <constraint firstAttribute="bottom" secondItem="pC6-LC-20b" secondAttribute="bottom" constant="8" id="v65-6H-bIH"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
@@ -61,7 +63,7 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="article-card-placeholder" width="375" height="420"/>
+        <image name="article-card-placeholder" width="375" height="416"/>
         <image name="save-mini" width="12" height="17"/>
     </resources>
 </document>

--- a/Wikipedia/Code/WMFArticlePreviewTableViewCell.m
+++ b/Wikipedia/Code/WMFArticlePreviewTableViewCell.m
@@ -189,7 +189,7 @@
 #pragma mark - Height Estimation
 
 + (CGFloat)estimatedRowHeight {
-    return 345.f;
+    return 420.f;
 }
 
 @end

--- a/Wikipedia/Code/WMFBaseExploreSectionController.h
+++ b/Wikipedia/Code/WMFBaseExploreSectionController.h
@@ -74,6 +74,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable UINib*)placeholderCellNib;
 
+- (BOOL)containsPlaceholders;
+
 @end
 
 /**

--- a/Wikipedia/Code/WMFBaseExploreSectionController.m
+++ b/Wikipedia/Code/WMFBaseExploreSectionController.m
@@ -67,13 +67,13 @@ static NSString* const WMFExploreSectionControllerException = @"WMFExploreSectio
              NSStringFromProtocol(@protocol(WMFExploreSectionController)),
              [self class]);
     return [NSString stringWithFormat:@"%@ identifier = %@",
-            [super description], [(id<WMFExploreSectionController>)self sectionIdentifier]];
+            [super description], [(id < WMFExploreSectionController >)self sectionIdentifier]];
 }
 
 #pragma mark - WMFBaseExploreSectionController
 
 - (BOOL)containsPlaceholders {
-    return [self.items bk_all:^BOOL(id obj) {
+    return [self.items bk_all:^BOOL (id obj) {
         return [obj isKindOfClass:[NSNumber class]];
     }];
 }

--- a/Wikipedia/Code/WMFBaseExploreSectionController.m
+++ b/Wikipedia/Code/WMFBaseExploreSectionController.m
@@ -72,6 +72,12 @@ static NSString* const WMFExploreSectionControllerException = @"WMFExploreSectio
 
 #pragma mark - WMFBaseExploreSectionController
 
+- (BOOL)containsPlaceholders {
+    return [self.items bk_all:^BOOL(id obj) {
+        return [obj isKindOfClass:[NSNumber class]];
+    }];
+}
+
 - (MWKSavedPageList*)savedPageList {
     return self.dataStore.userDataStore.savedPageList;
 }

--- a/Wikipedia/Code/WMFBaseExploreSectionController.m
+++ b/Wikipedia/Code/WMFBaseExploreSectionController.m
@@ -60,6 +60,16 @@ static NSString* const WMFExploreSectionControllerException = @"WMFExploreSectio
     return self;
 }
 
+- (NSString*)description {
+    NSAssert([self conformsToProtocol:@protocol(WMFExploreSectionController)],
+             @"Expected subclass of %@ to conform to %@, but %@ does not.",
+             [WMFBaseExploreSectionController class],
+             NSStringFromProtocol(@protocol(WMFExploreSectionController)),
+             [self class]);
+    return [NSString stringWithFormat:@"%@ identifier = %@",
+            [super description], [(id<WMFExploreSectionController>)self sectionIdentifier]];
+}
+
 #pragma mark - WMFBaseExploreSectionController
 
 - (MWKSavedPageList*)savedPageList {

--- a/Wikipedia/Code/WMFExploreSection.m
+++ b/Wikipedia/Code/WMFExploreSection.m
@@ -178,7 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
     return item;
 }
 
-+ (NSUInteger)maxNumberOfSectionsForType:(WMFExploreSectionType)type{
++ (NSUInteger)maxNumberOfSectionsForType:(WMFExploreSectionType)type {
     switch (type) {
         case WMFExploreSectionTypeHistory:
         case WMFExploreSectionTypeSaved:
@@ -196,18 +196,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-+ (NSUInteger)totalMaxNumberOfSections{
++ (NSUInteger)totalMaxNumberOfSections {
     return [self maxNumberOfSectionsForType:WMFExploreSectionTypeHistory] +
-    [self maxNumberOfSectionsForType:WMFExploreSectionTypeSaved] +
-    [self maxNumberOfSectionsForType:WMFExploreSectionTypeFeaturedArticle] +
-    [self maxNumberOfSectionsForType:WMFExploreSectionTypePictureOfTheDay] +
-    [self maxNumberOfSectionsForType:WMFExploreSectionTypeMostRead] +
-    [self maxNumberOfSectionsForType:WMFExploreSectionTypeNearby] +
-    [self maxNumberOfSectionsForType:WMFExploreSectionTypeContinueReading] +
-    [self maxNumberOfSectionsForType:WMFExploreSectionTypeRandom] +
-    [self maxNumberOfSectionsForType:WMFExploreSectionTypeMainPage];
+           [self maxNumberOfSectionsForType:WMFExploreSectionTypeSaved] +
+           [self maxNumberOfSectionsForType:WMFExploreSectionTypeFeaturedArticle] +
+           [self maxNumberOfSectionsForType:WMFExploreSectionTypePictureOfTheDay] +
+           [self maxNumberOfSectionsForType:WMFExploreSectionTypeMostRead] +
+           [self maxNumberOfSectionsForType:WMFExploreSectionTypeNearby] +
+           [self maxNumberOfSectionsForType:WMFExploreSectionTypeContinueReading] +
+           [self maxNumberOfSectionsForType:WMFExploreSectionTypeRandom] +
+           [self maxNumberOfSectionsForType:WMFExploreSectionTypeMainPage];
 }
-
 
 @end
 

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -664,30 +664,6 @@ NS_ASSUME_NONNULL_BEGIN
         }
 
         [observer.tableView reloadData];
-        return;
-
-        //TODO: enable animated updates. Currently causes more jitters
-
-        NSIndexSet* indices = [change objectForKey:NSKeyValueChangeIndexesKey];
-        if (indices == nil) {
-            return;
-        }
-        NSMutableArray* indexPathArray = [NSMutableArray array];
-        [indices enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL* _Nonnull stop) {
-            NSIndexPath* newPath = [NSIndexPath indexPathForRow:idx inSection:sectionIndex];
-            [indexPathArray addObject:newPath];
-        }];
-
-        [observer.tableView wmf_performUpdates:^{
-            NSNumber* kind = [change objectForKey:NSKeyValueChangeKindKey];
-            if ([kind integerValue] == NSKeyValueChangeInsertion) { // Rows were added
-                [observer.tableView insertRowsAtIndexPaths:indexPathArray withRowAnimation:UITableViewRowAnimationAutomatic];
-            } else if ([kind integerValue] == NSKeyValueChangeRemoval) { // Rows were removed
-                [observer.tableView deleteRowsAtIndexPaths:indexPathArray withRowAnimation:UITableViewRowAnimationAutomatic];
-            } else { // Rows were Replaced
-                [observer.tableView reloadRowsAtIndexPaths:indexPathArray withRowAnimation:UITableViewRowAnimationAutomatic];
-            }
-        } withoutMovingCellAtIndexPath:[[self.tableView indexPathsForVisibleRows] firstObject]];
     }];
 }
 

--- a/Wikipedia/Code/WMFMostReadSectionController.m
+++ b/Wikipedia/Code/WMFMostReadSectionController.m
@@ -119,7 +119,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Meta
 
 - (NSString*)sectionIdentifier {
-    return [NSString stringWithFormat:@"%@_%@", self.site, [self englishUTCDateString]];
+    return [NSString stringWithFormat:@"%@_%@", self.site.URL.host, [self englishUTCDateString]];
 }
 
 - (CGFloat)estimatedRowHeight {

--- a/Wikipedia/Code/WMFRandomSectionController.m
+++ b/Wikipedia/Code/WMFRandomSectionController.m
@@ -25,7 +25,7 @@ NSString* const WMFRandomSectionIdentifier = @"WMFRandomSectionIdentifier";
 
 @property (nonatomic, strong, nullable) MWKSearchResult* result;
 
-@property (nonatomic, weak) WMFArticlePreviewTableViewCell* cell;
+@property (nonatomic, weak, nullable) WMFArticlePreviewTableViewCell* cell;
 
 @end
 
@@ -99,6 +99,7 @@ NSString* const WMFRandomSectionIdentifier = @"WMFRandomSectionIdentifier";
     [cell wmf_layoutIfNeededIfOperatingSystemVersionLessThan9_0_0];
     cell.saveButtonController.analyticsContext     = self;
     cell.saveButtonController.analyticsContentType = self;
+    self.cell                                      = cell;
 }
 
 - (CGFloat)estimatedRowHeight {

--- a/WikipediaUnitTests/Code/LSNocilla+AnyRequest.h
+++ b/WikipediaUnitTests/Code/LSNocilla+AnyRequest.h
@@ -16,3 +16,4 @@ static inline LSStubRequestDSL* stubAnyRequest() {
     NSCParameterAssert(!regexError);
     return stubRequest(@"GET", anyRequestRegex);
 }
+

--- a/WikipediaUnitTests/Code/LSNocilla+AnyRequest.h
+++ b/WikipediaUnitTests/Code/LSNocilla+AnyRequest.h
@@ -1,0 +1,18 @@
+//
+//  LSNocilla+AnyRequest.h
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 2/19/16.
+//  Copyright © 2016 Wikimedia Foundation. All rights reserved.
+//
+
+#import <Nocilla/Nocilla.h>
+#import <Foundation/Foundation.h>
+
+static inline LSStubRequestDSL* stubAnyRequest() {
+    NSError* regexError;
+    NSRegularExpression* anyRequestRegex =
+        [NSRegularExpression regularExpressionWithPattern:@".*" options:0 error:&regexError];
+    NSCParameterAssert(!regexError);
+    return stubRequest(@"GET", anyRequestRegex);
+}

--- a/WikipediaUnitTests/Code/WMFBaseExploreSectionControllerTests.m
+++ b/WikipediaUnitTests/Code/WMFBaseExploreSectionControllerTests.m
@@ -168,12 +168,14 @@ QuickConfigurationBegin(WMFSharedSectionControllerTests)
             });
         });
 
-        context(@"has items", ^{
+        // pending...
+
+        xcontext(@"has items", ^{
             it(@"should only fetch if the user initiated it.", ^{
             });
         });
 
-        context(@"is fetching", ^{
+        xcontext(@"is fetching", ^{
             it(@"should not perform other fetches", ^{
             });
         });

--- a/WikipediaUnitTests/Code/WMFBaseExploreSectionControllerTests.m
+++ b/WikipediaUnitTests/Code/WMFBaseExploreSectionControllerTests.m
@@ -42,7 +42,7 @@
 
 - (AnyPromise*)fetchData {
     return [NSURLConnection GET:@"https://test.io/foo"]
-    .then(^(id _) {
+           .then(^(id _) {
         return [WMFDummyExploreSectionController dummyItems];
     });
 }
@@ -55,7 +55,7 @@
 
 QuickConfigurationBegin(WMFSharedSectionControllerTests)
 
-+ (void)configure:(Configuration *)configuration {
++ (void)configure : (Configuration*)configuration {
     sharedExamples(@"a fetching section controller", ^(QCKDSLSharedExampleContext getContext) {
         __block FBKVOController* kvoController;
         __block NSMutableArray* itemsPerKVONotification;
@@ -77,7 +77,7 @@ QuickConfigurationBegin(WMFSharedSectionControllerTests)
             [kvoController observe:sectionController
                            keyPath:WMF_SAFE_KEYPATH(sectionController, items)
                            options:0
-                             block:^(id observer, WMFBaseExploreSectionController* controller, NSDictionary *change) {
+                             block:^(id observer, WMFBaseExploreSectionController* controller, NSDictionary* change) {
                 [itemsPerKVONotification addObject:[controller items]];
             }];
         });
@@ -88,13 +88,13 @@ QuickConfigurationBegin(WMFSharedSectionControllerTests)
 
         /*
             `expect()` takes a block—implicitly—which is repeatedly invoked to get the value of the given expression.
-            therefore, we need to be smart about `expect`-ing the value of a promise returned by a function to prevent 
+            therefore, we need to be smart about `expect`-ing the value of a promise returned by a function to prevent
             the function from being repeatedly invoked.
-        */
-        #define expectValueOfPromiseReturnedBySectionControllerCall(fetchMethod) ^{ \
-            AnyPromise* fetch = [sectionController fetchMethod]; \
-            return expect(fetch.value); \
-        }()
+         */
+        #define expectValueOfPromiseReturnedBySectionControllerCall(fetchMethod) ^ { \
+    AnyPromise* fetch = [sectionController fetchMethod]; \
+    return expect(fetch.value); \
+} ()
 
         context(@"initial state", ^{
             it(@"should be filled with placeholders, if it supports placeholders", ^{
@@ -102,7 +102,7 @@ QuickConfigurationBegin(WMFSharedSectionControllerTests)
                 if (numberOfPlaceholders > 0
                     && [sectionController placeholderCellNib]
                     && [sectionController placeholderCellIdentifier]) {
-                    expect(@([sectionController.items bk_all:^BOOL(id obj) {
+                    expect(@([sectionController.items bk_all:^BOOL (id obj) {
                         return [obj isKindOfClass:[NSNumber class]];
                     }])).to(beTrue());
                     expect(@([sectionController containsPlaceholders])).to(beTrue());

--- a/WikipediaUnitTests/Code/WMFBaseExploreSectionControllerTests.m
+++ b/WikipediaUnitTests/Code/WMFBaseExploreSectionControllerTests.m
@@ -1,0 +1,177 @@
+//
+//  WMFBaseExploreSectionControllerTests.m
+//  Wikipedia
+//
+//  Created by Brian Gerstle on 2/19/16.
+//  Copyright © 2016 Wikimedia Foundation. All rights reserved.
+//
+
+@import Quick;
+@import Nimble;
+
+#import "LSNocilla+Quick.h"
+#import "LSNocilla+AnyRequest.h"
+#import "MWKDataStore+TempDataStoreForEach.h"
+#import "XCTestCase+PromiseKit.h"
+#import <PromiseKit/NSURLConnection+AnyPromise.h>
+
+#import "WMFBaseExploreSectionController.h"
+#import "WMFArticlePlaceholderTableViewCell.h"
+#import "WMFArticlePreviewTableViewCell.h"
+#import "UIView+WMFDefaultNib.h"
+
+// Subclass for testing basic functionality
+@interface WMFDummyExploreSectionController : WMFBaseExploreSectionController
+
+@end
+
+@implementation WMFDummyExploreSectionController
+
+- (NSString*)description {
+    // override description to prevent base explore section impl, which assumes conformance to WMFExploreSectionController
+    return [NSString stringWithFormat:@"<%@ %p>", [self class], self];
+}
+
+- (NSString*)placeholderCellIdentifier {
+    return [WMFArticlePlaceholderTableViewCell identifier];
+}
+
+- (UINib*)placeholderCellNib {
+    return [WMFArticlePlaceholderTableViewCell wmf_classNib];
+}
+
+- (AnyPromise*)fetchData {
+    return [NSURLConnection GET:@"https://test.io/foo"]
+    .then(^(id _) {
+        return [WMFDummyExploreSectionController dummyItems];
+    });
+}
+
++ (NSArray*)dummyItems {
+    return @[@"foo", @"bar", @"baz"];
+}
+
+@end
+
+QuickConfigurationBegin(WMFSharedSectionControllerTests)
+
++ (void)configure:(Configuration *)configuration {
+    sharedExamples(@"a fetching section controller", ^(QCKDSLSharedExampleContext getContext) {
+        static FBKVOController* kvoController;
+        static NSMutableArray* itemsPerChange;
+        static WMFBaseExploreSectionController* sectionController;
+        static NSArray* expectedSuccessItems;
+
+        beforeEach(^{
+            kvoController = [[FBKVOController alloc] initWithObserver:self retainObserved:NO];
+            itemsPerChange = [NSMutableArray new];
+        });
+
+        startAndStopStubbingBetweenEach();
+
+        configureTempDataStoreForEach(tempDataStore, ^{
+            NSDictionary* context = getContext();
+            Class SectionControllerClass = context[@"controllerClass"];
+            sectionController = [[SectionControllerClass alloc] initWithDataStore:tempDataStore];
+            expectedSuccessItems = context[@"expectedSuccessItems"];
+        });
+
+        /*
+            `expect()` takes a block—implicitly—which is repeatedly invoked to get the value of the given expression.
+            therefore, we need to be smart about `expect`-ing the value of a promise returned by a function to prevent 
+            the function from being repeatedly invoked.
+        */
+        #define expectValueOfPromiseReturnedBySectionControllerCall(fetchMethod) \
+        ^{ AnyPromise* fetch = [sectionController fetchMethod]; return expect(fetch.value); }()
+
+        context(@"initial state", ^{
+            it(@"should be filled with placeholders, if it supports placeholders", ^{
+                NSUInteger numberOfPlaceholders = [sectionController numberOfPlaceholderCells];
+                if (numberOfPlaceholders > 0
+                    && [sectionController placeholderCellNib]
+                    && [sectionController placeholderCellIdentifier]) {
+                    expect(@([sectionController.items bk_all:^BOOL(id obj) {
+                        return [obj isKindOfClass:[NSNumber class]];
+                    }])).to(beTrue());
+                    expect(@([sectionController containsPlaceholders])).to(beTrue());
+                    expect(sectionController.items).to(haveCount(@(numberOfPlaceholders)));
+                } else {
+                    expect(sectionController.items).to(beEmpty());
+                }
+            });
+        });
+
+        context(@"previous request failed", ^{
+            static NSError* initialError;
+
+            beforeEach(^{
+                stubAnyRequest().andReturn(500);
+
+                expectValueOfPromiseReturnedBySectionControllerCall(fetchDataIfNeeded)
+                .withTimeout(10)
+                .toEventually(beAKindOf([NSError class]));
+
+                initialError = [[sectionController items] firstObject];
+
+                expect(initialError).to(beAKindOf([NSError class]));
+
+                // restart nocilla stubbing to remove failure stub & fail on any unexpected requests
+                [[LSNocilla sharedInstance] stop];
+                [[LSNocilla sharedInstance] start];
+            });
+
+            it(@"should immediately yield an error when asked to fetch if needed", ^{
+                expectValueOfPromiseReturnedBySectionControllerCall(fetchDataIfNeeded)
+                .withTimeout(5)
+                .toEventually(beIdenticalTo(initialError));
+            });
+
+            it(@"should retry when asked to fetch by user", ^{
+                stubAnyRequest().andReturn(200);
+
+                expectValueOfPromiseReturnedBySectionControllerCall(fetchDataUserInitiated)
+                .withTimeout(5)
+                .toEventually(equal(expectedSuccessItems));
+
+                expect(@([sectionController containsPlaceholders]))
+                .toWithDescription(beFalse(), @"it should have fetched real items.");
+
+                expect(sectionController.items).to(equal(expectedSuccessItems));
+            });
+
+            it(@"should retry when asked to fetch and ignore current error", ^{
+                stubAnyRequest().andReturn(200);
+
+                expectValueOfPromiseReturnedBySectionControllerCall(fetchDataIfError)
+                .withTimeout(5)
+                .toEventually(beAKindOf([NSArray class]));
+
+                expect(@([sectionController containsPlaceholders]))
+                .toWithDescription(beFalse(), @"it should have fetched real items.");
+
+                expect(sectionController.items).to(equal(expectedSuccessItems));
+            });
+        });
+
+        context(@"has items", ^{
+            it(@"should only fetch if the user initiated it.", ^{
+            });
+        });
+
+        context(@"is fetching", ^{
+            it(@"should not perform other fetches", ^{
+            });
+        });
+    });
+}
+
+QuickConfigurationEnd
+
+QuickSpecBegin(WMFBaseExploreSectionControllerTests)
+
+itBehavesLike(@"a fetching section controller", ^{
+    return @{@"controllerClass": [WMFDummyExploreSectionController class],
+             @"expectedSuccessItems": [WMFDummyExploreSectionController dummyItems]};
+});
+
+QuickSpecEnd

--- a/WikipediaUnitTests/Code/WMFBaseExploreSectionControllerTests.m
+++ b/WikipediaUnitTests/Code/WMFBaseExploreSectionControllerTests.m
@@ -91,10 +91,11 @@ QuickConfigurationBegin(WMFSharedSectionControllerTests)
             therefore, we need to be smart about `expect`-ing the value of a promise returned by a function to prevent
             the function from being repeatedly invoked.
          */
-        #define expectValueOfPromiseReturnedBySectionControllerCall(fetchMethod) ^ { \
-    AnyPromise* fetch = [sectionController fetchMethod]; \
-    return expect(fetch.value); \
-} ()
+                #define expectValueOfPromiseReturnedBySectionControllerCall(fetchMethod) \
+    ^ { \
+        AnyPromise* fetch = [sectionController fetchMethod]; \
+        return expect(fetch.value); \
+    } ()
 
         context(@"initial state", ^{
             it(@"should be filled with placeholders, if it supports placeholders", ^{

--- a/WikipediaUnitTests/Code/XCTestCase+PromiseKit.h
+++ b/WikipediaUnitTests/Code/XCTestCase+PromiseKit.h
@@ -20,6 +20,14 @@
 #define expectResolutionWithTimeout(timeoutSecs, promiseBlock) \
     [self expectAnyPromiseToResolve : (promiseBlock)timeout : (timeoutSecs)WMFExpectFromHere]
 
+/// Shorthand macro to expect a promise to catch with an error within the given timeout.
+#define expectCaughtErrorForPolicyWithTimeout(policy, aTimeout, promiseBlock) \
+    [self expectAnyPromiseToCatch:(promiseBlock) withPolicy:(policy) timeout:(aTimeout) WMFExpectFromHere]
+
+/// Shorthand macro to expect a promise to catch with an error within the given timeout, using default policy (except cancellation).
+#define expectCaughtErrorWithTimeout(timeout, promiseBlock) \
+    expectCaughtErrorForPolicyWithTimeout(PMKCatchPolicyAllErrorsExceptCancellation, timeout, promiseBlock)
+
 /**
  * Utility for testing promises in ObjC.
  *

--- a/WikipediaUnitTests/Code/XCTestCase+PromiseKit.h
+++ b/WikipediaUnitTests/Code/XCTestCase+PromiseKit.h
@@ -22,7 +22,7 @@
 
 /// Shorthand macro to expect a promise to catch with an error within the given timeout.
 #define expectCaughtErrorForPolicyWithTimeout(policy, aTimeout, promiseBlock) \
-    [self expectAnyPromiseToCatch:(promiseBlock) withPolicy:(policy) timeout:(aTimeout) WMFExpectFromHere]
+    [self expectAnyPromiseToCatch : (promiseBlock)withPolicy : (policy)timeout : (aTimeout)WMFExpectFromHere]
 
 /// Shorthand macro to expect a promise to catch with an error within the given timeout, using default policy (except cancellation).
 #define expectCaughtErrorWithTimeout(timeout, promiseBlock) \


### PR DESCRIPTION
Phab: [T120474](https://phabricator.wikimedia.org/T120474)

---

Current scroll behavior on master when scrolling doing as sections are added: https://vid.me/MVlM
New behavior: https://vid.me/h1Om

The issue was due to a couple things:

- We updated the placeholder image & nib, but not the actual `estimatedRowHeight` value
- The way we were setting items in section controllers was causing extra KVO callbacks, which caused the table to reload each. time. a. cell. was. added.  by the end, our table be all like :rage4: 

So, we just call `self.fetchError = oops` and `self.fetchedItems = yayNewStuff`, and the setters handle the internal state transitions.

Plus, now we have some tests to verify expected KVO notifications! (Hopefully they pass in Travis :pray:, if not, I'll make them Jenkins-only).

