### PR TITLE
Support multiple nearby sections in the feed

### DIFF
--- a/Wikipedia/Code/WMFExploreSection.m
+++ b/Wikipedia/Code/WMFExploreSection.m
@@ -188,10 +188,10 @@ NS_ASSUME_NONNULL_BEGIN
         case WMFExploreSectionTypeSaved:
         case WMFExploreSectionTypeFeaturedArticle:
         case WMFExploreSectionTypeMostRead:
+        case WMFExploreSectionTypeNearby:
             return 10;
             break;
         case WMFExploreSectionTypePictureOfTheDay:
-        case WMFExploreSectionTypeNearby:
         case WMFExploreSectionTypeContinueReading:
         case WMFExploreSectionTypeRandom:
         case WMFExploreSectionTypeMainPage:


### PR DESCRIPTION
Part of this ticket:

https://phabricator.wikimedia.org/T124692

Note: this follows the same update behavior as previously, it just doesn't remove the old nearby section.

We need to decide if we want to have more than one nearby section per day, but hopefully the should address the un-intuitiveness of it all.