### PR TITLE
always request EN POTD

### DIFF
--- a/Wikipedia/Code/NSDate+WMFPOTDTitle.h
+++ b/Wikipedia/Code/NSDate+WMFPOTDTitle.h
@@ -14,6 +14,14 @@ extern NSString* const WMFPOTDTitlePrefix;
 
 @interface NSDate (WMFPOTDTitle)
 
+/**
+ *  Retrieve the URL path of the commons POTD for the date represented by the receiver.
+ *
+ *  @note Internally, this fetches the "en" localization of this page, as that's most likely to be available, and
+ *        the template doesn't automatically fallback if the chosen language isn't available.
+ *
+ *  @return A string in the format "/YYYY-MM-DD_(en)"
+ */
 - (NSString*)wmf_picOfTheDayPageTitle;
 
 @end

--- a/Wikipedia/Code/NSDate+WMFPOTDTitle.m
+++ b/Wikipedia/Code/NSDate+WMFPOTDTitle.m
@@ -16,9 +16,13 @@ NSString* const WMFPOTDTitlePrefix = @"Template:Potd";
 @implementation NSDate (WMFPOTDTitle)
 
 - (NSString*)wmf_picOfTheDayPageTitle {
+    return [self wmf_picOfTheDayPageTitleForLanguage:@"en"];
+}
+
+- (NSString*)wmf_picOfTheDayPageTitleForLanguage:(NSString*)language {
     NSString* potdTitleDateComponent = [[NSDateFormatter wmf_englishHyphenatedYearMonthDayFormatter] stringFromDate:self];
     NSParameterAssert(potdTitleDateComponent);
-    return [WMFPOTDTitlePrefix stringByAppendingFormat:@"/%@", potdTitleDateComponent];
+    return [WMFPOTDTitlePrefix stringByAppendingFormat:@"/%@_(%@)", potdTitleDateComponent, language];
 }
 
 @end

--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -92,7 +92,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 
 @implementation WMFSearchViewController
 
-+ (instancetype)searchViewControllerWithDataStore:(MWKDataStore*)dataStore{
++ (instancetype)searchViewControllerWithDataStore:(MWKDataStore*)dataStore {
     NSParameterAssert(dataStore);
     WMFSearchViewController* searchVC = [self wmf_initialViewControllerFromClassStoryboard];
     searchVC.dataStore              = dataStore;
@@ -110,7 +110,6 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 - (MWKSite*)currentResultsSearchSite {
     return [self.resultsListController.dataSource searchSite];
 }
-
 
 - (NSString*)searchSuggestion {
     return [[self.resultsListController.dataSource searchResults] searchSuggestion];
@@ -391,29 +390,25 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 
 #pragma mark - Search
 
-- (MWKSite*)currentlySelectedSearchSite{
-    if([[NSUserDefaults standardUserDefaults] wmf_showSearchLanguageBar]){
-        
-        NSUInteger index = [self.languageButtons indexOfObjectPassingTest:^BOOL(UIButton*  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-            if(obj.selected){
+- (MWKSite*)currentlySelectedSearchSite {
+    if ([[NSUserDefaults standardUserDefaults] wmf_showSearchLanguageBar]) {
+        NSUInteger index = [self.languageButtons indexOfObjectPassingTest:^BOOL (UIButton* _Nonnull obj, NSUInteger idx, BOOL* _Nonnull stop) {
+            if (obj.selected) {
                 *stop = YES;
                 return YES;
             }
             return NO;
         }];
-        
-        if(index == NSNotFound){
+
+        if (index == NSNotFound) {
             index = 0;
         }
-        
+
         MWKLanguageLink* lang = self.searchLanguages[index];
         return [lang site];
-        
-    }else{
+    } else {
         return [[NSUserDefaults standardUserDefaults] wmf_appSite];
     }
-    
-   
 }
 
 - (void)didCancelSearch {

--- a/WikipediaUnitTests/Code/NSDate+WMFPOTDTitleTests.m
+++ b/WikipediaUnitTests/Code/NSDate+WMFPOTDTitleTests.m
@@ -13,7 +13,7 @@
 #import "NSDate+Utilities.h"
 
 static inline NSString* expectedPOTDTitleStringForYearMonthDay(NSInteger year, NSInteger month, NSInteger day) {
-    return [NSString stringWithFormat:@"%@/%ld-%02ld-%02ld", WMFPOTDTitlePrefix, year, month, day];
+    return [NSString stringWithFormat:@"%@/%ld-%02ld-%02ld_(en)", WMFPOTDTitlePrefix, year, month, day];
 }
 
 QuickSpecBegin(NSDate_WMFPOTDTitleTests)


### PR DESCRIPTION
not specifying the language can end up returning a page consisting only of a filename, which causes our "image info generator" approach to fail.

See https://commons.wikimedia.org/wiki/Template:Potd/2016-02-22 vs. https://commons.wikimedia.org/wiki/Template:Potd/2016-02-22_(en)

![image](https://cloud.githubusercontent.com/assets/444217/13229549/95055b7a-d96f-11e5-9eb8-3ef2e58d83c2.png)
