### PR TITLE
Fix scrolls to top in non-browser mode

### DIFF
--- a/Wikipedia/Code/UIScrollView+WMFScrollsToTop.h
+++ b/Wikipedia/Code/UIScrollView+WMFScrollsToTop.h
@@ -14,3 +14,14 @@
 - (void)wmf_shouldScrollToTopOnStatusBarTap:(BOOL)shouldScrollOnTap;
 
 @end
+
+@interface UIView (WMFScrollsToTop)
+
+/**
+ *  Disable scrolls to top on any sroll views in the hirarchy of the given view
+ *
+ */
+- (void)wmf_recursivelyDisableScrollsToTop;
+
+@end
+

--- a/Wikipedia/Code/UIScrollView+WMFScrollsToTop.m
+++ b/Wikipedia/Code/UIScrollView+WMFScrollsToTop.m
@@ -9,20 +9,23 @@
     if (shouldScrollOnTap) {
         UIViewController* rootViewController =
             (UIViewController*)[[[UIApplication sharedApplication] delegate] window].rootViewController;
-        [self recursivelyDisableScrollsToTop:rootViewController.view];
+        [rootViewController.view.window wmf_recursivelyDisableScrollsToTop];
     }
     self.scrollsToTop = shouldScrollOnTap;
 }
 
-- (void)recursivelyDisableScrollsToTop:(UIView*)view {
-    for (UIView* subview in [view subviews]) {
+@end
+
+
+@implementation UIView (WMFScrollsToTop)
+
+- (void)wmf_recursivelyDisableScrollsToTop {
+    for (UIView* subview in [self subviews]) {
         if ([subview isKindOfClass:[UIScrollView class]]) {
             UIScrollView* scrollView = (UIScrollView*)subview;
-            if ([scrollView scrollsToTop]) {
-                scrollView.scrollsToTop = NO;
-            }
+            scrollView.scrollsToTop = NO;
         }
-        [self recursivelyDisableScrollsToTop:subview];
+        [subview wmf_recursivelyDisableScrollsToTop];
     }
 }
 

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -259,6 +259,7 @@ NSString* const WMFLicenseTitleOnENWiki =
     self.footerViewHeadersByIndex = [NSMutableDictionary dictionary];
     [self addFooterContainerView];
     [self addFooterContentViews];
+    [self.footerContainerView wmf_recursivelyDisableScrollsToTop];
 }
 
 - (void)addFooterContainerView {
@@ -324,6 +325,7 @@ NSString* const WMFLicenseTitleOnENWiki =
         [self addChildViewController:childVC];
         // didMoveToParent is called when they are added to the view
     }];
+    
     [self addFooterView];
 }
 


### PR DESCRIPTION
Needed to disable the scrolls to top of the subviews of the web view (we have a scroll view in the footer now)


The browser mode is another animal… view containment + navigation bar unassociated with a navigation controller seems to be making this not work.