### PR TITLE
Fix deadlocks in SDWebImage

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -18,7 +18,7 @@ pod 'AFNetworking/NSURLConnection', '~> 2.6.0'
 pod 'Mantle', '~> 2.0.0'
 
 # Images
-pod 'SDWebImage', :git => 'https://github.com/wikimedia/SDWebImage.git', :commit => 'f4529eeac3da5bc5a5f43ec51ea142eba6c86999'
+pod 'SDWebImage', :git => 'https://github.com/wikimedia/SDWebImage.git', :commit => '5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f'
 pod 'AnimatedGIFImageSerialization'
 
 # Utilities

--- a/Podfile
+++ b/Podfile
@@ -18,7 +18,7 @@ pod 'AFNetworking/NSURLConnection', '~> 2.6.0'
 pod 'Mantle', '~> 2.0.0'
 
 # Images
-pod 'SDWebImage', :git => 'https://github.com/wikimedia/SDWebImage.git', :commit => '5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f'
+pod 'SDWebImage', :git => 'https://github.com/wikimedia/SDWebImage.git', :commit => 'bb49df83e72f2231a191e9477a85f0effe13430a'
 pod 'AnimatedGIFImageSerialization'
 
 # Utilities

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -105,7 +105,7 @@ DEPENDENCIES:
   - PromiseKit/SystemConfiguration (from `https://github.com/mxcl/PromiseKit.git`,
     branch `swift-2.0-beta5`)
   - Quick (~> 0.8.0)
-  - SDWebImage (from `https://github.com/wikimedia/SDWebImage.git`, commit `5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f`)
+  - SDWebImage (from `https://github.com/wikimedia/SDWebImage.git`, commit `bb49df83e72f2231a191e9477a85f0effe13430a`)
   - SSDataSources (~> 0.8.0)
   - SVWebViewController (~> 1.0)
   - TSMessages (from `https://github.com/wikimedia/TSMessages.git`)
@@ -123,7 +123,7 @@ EXTERNAL SOURCES:
     :branch: swift-2.0-beta5
     :git: https://github.com/mxcl/PromiseKit.git
   SDWebImage:
-    :commit: 5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f
+    :commit: bb49df83e72f2231a191e9477a85f0effe13430a
     :git: https://github.com/wikimedia/SDWebImage.git
   TSMessages:
     :git: https://github.com/wikimedia/TSMessages.git
@@ -142,7 +142,7 @@ CHECKOUT OPTIONS:
     :commit: c90cfc1c578ed09b5d3d21e0ac71aa5020be0899
     :git: https://github.com/mxcl/PromiseKit.git
   SDWebImage:
-    :commit: 5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f
+    :commit: bb49df83e72f2231a191e9477a85f0effe13430a
     :git: https://github.com/wikimedia/SDWebImage.git
   TSMessages:
     :commit: d86e3fb47ee80175d8fa8d26d17b56e42a0d60d2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -105,7 +105,7 @@ DEPENDENCIES:
   - PromiseKit/SystemConfiguration (from `https://github.com/mxcl/PromiseKit.git`,
     branch `swift-2.0-beta5`)
   - Quick (~> 0.8.0)
-  - SDWebImage (from `https://github.com/wikimedia/SDWebImage.git`, commit `f4529eeac3da5bc5a5f43ec51ea142eba6c86999`)
+  - SDWebImage (from `https://github.com/wikimedia/SDWebImage.git`, commit `5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f`)
   - SSDataSources (~> 0.8.0)
   - SVWebViewController (~> 1.0)
   - TSMessages (from `https://github.com/wikimedia/TSMessages.git`)
@@ -123,7 +123,7 @@ EXTERNAL SOURCES:
     :branch: swift-2.0-beta5
     :git: https://github.com/mxcl/PromiseKit.git
   SDWebImage:
-    :commit: f4529eeac3da5bc5a5f43ec51ea142eba6c86999
+    :commit: 5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f
     :git: https://github.com/wikimedia/SDWebImage.git
   TSMessages:
     :git: https://github.com/wikimedia/TSMessages.git
@@ -142,7 +142,7 @@ CHECKOUT OPTIONS:
     :commit: c90cfc1c578ed09b5d3d21e0ac71aa5020be0899
     :git: https://github.com/mxcl/PromiseKit.git
   SDWebImage:
-    :commit: f4529eeac3da5bc5a5f43ec51ea142eba6c86999
+    :commit: 5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f
     :git: https://github.com/wikimedia/SDWebImage.git
   TSMessages:
     :commit: d86e3fb47ee80175d8fa8d26d17b56e42a0d60d2

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -105,7 +105,7 @@ DEPENDENCIES:
   - PromiseKit/SystemConfiguration (from `https://github.com/mxcl/PromiseKit.git`,
     branch `swift-2.0-beta5`)
   - Quick (~> 0.8.0)
-  - SDWebImage (from `https://github.com/wikimedia/SDWebImage.git`, commit `5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f`)
+  - SDWebImage (from `https://github.com/wikimedia/SDWebImage.git`, commit `bb49df83e72f2231a191e9477a85f0effe13430a`)
   - SSDataSources (~> 0.8.0)
   - SVWebViewController (~> 1.0)
   - TSMessages (from `https://github.com/wikimedia/TSMessages.git`)
@@ -123,7 +123,7 @@ EXTERNAL SOURCES:
     :branch: swift-2.0-beta5
     :git: https://github.com/mxcl/PromiseKit.git
   SDWebImage:
-    :commit: 5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f
+    :commit: bb49df83e72f2231a191e9477a85f0effe13430a
     :git: https://github.com/wikimedia/SDWebImage.git
   TSMessages:
     :git: https://github.com/wikimedia/TSMessages.git
@@ -142,7 +142,7 @@ CHECKOUT OPTIONS:
     :commit: c90cfc1c578ed09b5d3d21e0ac71aa5020be0899
     :git: https://github.com/mxcl/PromiseKit.git
   SDWebImage:
-    :commit: 5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f
+    :commit: bb49df83e72f2231a191e9477a85f0effe13430a
     :git: https://github.com/wikimedia/SDWebImage.git
   TSMessages:
     :commit: d86e3fb47ee80175d8fa8d26d17b56e42a0d60d2

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -105,7 +105,7 @@ DEPENDENCIES:
   - PromiseKit/SystemConfiguration (from `https://github.com/mxcl/PromiseKit.git`,
     branch `swift-2.0-beta5`)
   - Quick (~> 0.8.0)
-  - SDWebImage (from `https://github.com/wikimedia/SDWebImage.git`, commit `f4529eeac3da5bc5a5f43ec51ea142eba6c86999`)
+  - SDWebImage (from `https://github.com/wikimedia/SDWebImage.git`, commit `5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f`)
   - SSDataSources (~> 0.8.0)
   - SVWebViewController (~> 1.0)
   - TSMessages (from `https://github.com/wikimedia/TSMessages.git`)
@@ -123,7 +123,7 @@ EXTERNAL SOURCES:
     :branch: swift-2.0-beta5
     :git: https://github.com/mxcl/PromiseKit.git
   SDWebImage:
-    :commit: f4529eeac3da5bc5a5f43ec51ea142eba6c86999
+    :commit: 5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f
     :git: https://github.com/wikimedia/SDWebImage.git
   TSMessages:
     :git: https://github.com/wikimedia/TSMessages.git
@@ -142,7 +142,7 @@ CHECKOUT OPTIONS:
     :commit: c90cfc1c578ed09b5d3d21e0ac71aa5020be0899
     :git: https://github.com/mxcl/PromiseKit.git
   SDWebImage:
-    :commit: f4529eeac3da5bc5a5f43ec51ea142eba6c86999
+    :commit: 5c85e9042226df2ab8fc5f7c3d5370dc4f2a035f
     :git: https://github.com/wikimedia/SDWebImage.git
   TSMessages:
     :commit: d86e3fb47ee80175d8fa8d26d17b56e42a0d60d2

--- a/Pods/SDWebImage/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/Pods/SDWebImage/SDWebImage/SDWebImageDownloaderOperation.m
@@ -144,8 +144,7 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
 - (void)cancel {
     @synchronized (self) {
         if (self.thread) {
-            NSParameterAssert(![[NSThread currentThread] isEqual:self.thread]);
-            [self performSelector:@selector(cancelInternalAndStop) onThread:self.thread withObject:nil waitUntilDone:YES];
+            [self performSelector:@selector(cancelInternalAndStop) onThread:self.thread withObject:nil waitUntilDone:NO];
         }
         else {
             [self cancelInternal];

--- a/Pods/Tweaks/README.md
+++ b/Pods/Tweaks/README.md
@@ -172,7 +172,7 @@ In release builds, the macros just expand to the default value. Nothing extra is
 ## Installation
 There are two options:
 
- 1. Tweaks is available as `Tweaks` in [Cocoapods](http://cocoapods.org). (If you have issues with custom Xcode configurations, [this comment](https://github.com/facebook/Tweaks/issues/4#issuecomment-40629741) might help.)
+ 1. Tweaks is available as `Tweaks` in [CocoaPods](http://cocoapods.org). (If you have issues with custom Xcode configurations, [this comment](https://github.com/facebook/Tweaks/issues/4#issuecomment-40629741) might help.)
  2. Manually add the files from `FBTweak/` into your Xcode project. Slightly simpler, but updates are also manual.
 
 Tweaks requires iOS 6 or later.


### PR DESCRIPTION
Deadlock was due to unnecessarily performing cancellation logic on internal thread, which was deadlocked due to the `cancel` method having already required the lock it needs to do its work.

See example of reproducing the deadlock by [scrolling in search on master](https://vid.me/GRzC) vs. [scrolling in search with these fixes](https://vid.me/pfJe).