### PR TITLE
Fix frozen compasses

### DIFF
--- a/Wikipedia/Code/CLLocation+WMFBearing.m
+++ b/Wikipedia/Code/CLLocation+WMFBearing.m
@@ -25,7 +25,14 @@
 
 - (CLLocationDegrees)wmf_bearingToLocation:(CLLocation*)location
                          forCurrentHeading:(CLHeading*)currentHeading {
-    return [self wmf_bearingToLocation:location] - currentHeading.trueHeading;
+    CLLocationDegrees bearing = [self wmf_bearingToLocation:location];
+
+    // use true heading if available, otherwise fall back to magnetic heading
+    if (currentHeading.trueHeading >= 0) {
+        return bearing - currentHeading.trueHeading;
+    } else {
+        return bearing - currentHeading.magneticHeading;
+    }
 }
 
 @end

--- a/Wikipedia/Code/WMFLocationManager.m
+++ b/Wikipedia/Code/WMFLocationManager.m
@@ -218,11 +218,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)locationManager:(CLLocationManager*)manager didUpdateLocations:(NSArray*)locations {
-    if (self.locationUpdatesStopped) {
-        return;
-    }
-    if (!manager.location) {
-        // ignore nil values to keep last known heading on the screen
+    // ignore nil values to keep last known heading on the screen
+    if (self.locationUpdatesStopped || !manager.location) {
         return;
     }
     self.lastLocation = manager.location;
@@ -231,11 +228,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)locationManager:(CLLocationManager*)manager didUpdateHeading:(CLHeading*)newHeading {
-    if (self.locationUpdatesStopped) {
-        return;
-    }
-    if (!newHeading) {
-        // ignore nil values to keep last known heading on the screen
+    // ignore nil or innaccurate values values to keep last known heading on the screen
+    if (self.locationUpdatesStopped
+        || !newHeading
+        || newHeading.headingAccuracy <= 0) {
         return;
     }
     self.lastHeading = newHeading;


### PR DESCRIPTION
Use magnetic heading if true heading isn't available.  Also, only report "accurate" heading values.  This is all per [Apple's recommendations](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/LocationAwarenessPG/GettingHeadings/GettingHeadings.html#//apple_ref/doc/uid/TP40009497-CH5-SW56) for handling heading updates.