### PR TITLE
Updates to "About the app" license copy

### DIFF
--- a/Wikipedia/Code/AboutViewController.m
+++ b/Wikipedia/Code/AboutViewController.m
@@ -156,10 +156,13 @@ static NSString* const kWMFContributorsKey = @"contributors";
     setDivHTML(@"translators_title", MWLocalizedString(@"about-translators", nil));
     setDivHTML(@"testers_title", MWLocalizedString(@"about-testers", nil));
     setDivHTML(@"libraries_title", MWLocalizedString(@"about-libraries", nil));
-    setDivHTML(@"libraries_body", [[self class] linkHTMLForURLString:@"wmflicense://licenses" title:MWLocalizedString(@"about-libraries-licenses", nil)]);
+    setDivHTML(@"libraries_body", [[self class] linkHTMLForURLString:@"wmflicense://licenses" title:MWLocalizedString(@"about-libraries-complete-list", nil)]);
     setDivHTML(@"repositories_title", MWLocalizedString(@"about-repositories", nil));
     setDivHTML(@"repositories_body", self.repositoryLinks);
+    setDivHTML(@"repositories_subtitle", MWLocalizedString(@"about-repositories-app-source-license", nil));
     setDivHTML(@"feedback_body", [[self class] linkHTMLForURLString:self.feedbackURL title:MWLocalizedString(@"about-send-feedback", nil)]);
+    setDivHTML(@"license_title", MWLocalizedString(@"about-content-license", nil));
+    setDivHTML(@"license_body", MWLocalizedString(@"about-content-license-details", nil));
 
     NSString* twnUrl            = self.urls[kWMFURLsTranslateWikiKey];
     NSString* translatorsLink   = [[self class] linkHTMLForURLString:twnUrl title:[twnUrl substringFromIndex:7]];

--- a/Wikipedia/Code/AboutViewController.m
+++ b/Wikipedia/Code/AboutViewController.m
@@ -26,6 +26,9 @@ static NSString* const kWMFURLsFeedbackKey        = @"feedback";
 static NSString* const kWMFURLsTranslateWikiKey   = @"twn";
 static NSString* const kWMFURLsWikimediaKey       = @"wmf";
 static NSString* const kWMFURLsSpecialistGuildKey = @"tsg";
+static NSString* const kWMFURLsMITKey             = @"mit";
+static NSString* const kWMFURLsShareAlikeKey      = @"sharealike";
+
 
 static NSString* const kWMFRepositoriesKey = @"repositories";
 
@@ -159,31 +162,19 @@ static NSString* const kWMFContributorsKey = @"contributors";
     setDivHTML(@"libraries_body", [[self class] linkHTMLForURLString:@"wmflicense://licenses" title:MWLocalizedString(@"about-libraries-complete-list", nil)]);
     setDivHTML(@"repositories_title", MWLocalizedString(@"about-repositories", nil));
     setDivHTML(@"repositories_body", self.repositoryLinks);
-    setDivHTML(@"repositories_subtitle", MWLocalizedString(@"about-repositories-app-source-license", nil));
+
+    setDivHTML(@"repositories_subtitle", [self stringFromLocalizationKey:@"about-repositories-app-source-license" urlKey:kWMFURLsMITKey urlLocalizationKey:@"about-repositories-app-source-license-mit"]);
+
     setDivHTML(@"feedback_body", [[self class] linkHTMLForURLString:self.feedbackURL title:MWLocalizedString(@"about-send-feedback", nil)]);
     setDivHTML(@"license_title", MWLocalizedString(@"about-content-license", nil));
-    setDivHTML(@"license_body", MWLocalizedString(@"about-content-license-details", nil));
 
-    NSString* twnUrl            = self.urls[kWMFURLsTranslateWikiKey];
-    NSString* translatorsLink   = [[self class] linkHTMLForURLString:twnUrl title:[twnUrl substringFromIndex:7]];
-    NSString* translatorDetails =
-        [MWLocalizedString(@"about-translators-details", nil) stringByReplacingOccurrencesOfString:@"$1"
-                                                                                        withString:translatorsLink];
-    setDivHTML(@"translators_body", translatorDetails);
 
-    NSString* tsgUrl     = self.urls[kWMFURLsSpecialistGuildKey];
-    NSString* tsgLink    = [[self class] linkHTMLForURLString:tsgUrl title:[tsgUrl substringFromIndex:7]];
-    NSString* tsgDetails =
-        [MWLocalizedString(@"about-testers-details", nil) stringByReplacingOccurrencesOfString:@"$1"
-                                                                                    withString:tsgLink];
-    setDivHTML(@"testers_body", tsgDetails);
+    setDivHTML(@"license_body", [self stringFromLocalizationKey:@"about-content-license-details" urlKey:kWMFURLsShareAlikeKey urlLocalizationKey:@"about-content-license-details-share-alike-license"]);
 
-    NSString* wmfUrl     = self.urls[kWMFURLsWikimediaKey];
-    NSString* foundation = [[self class] linkHTMLForURLString:wmfUrl title:MWLocalizedString(@"about-wikimedia-foundation", nil)];
-    NSString* footer     =
-        [MWLocalizedString(@"about-product-of", nil) stringByReplacingOccurrencesOfString:@"$1"
-                                                                               withString:foundation];
-    setDivHTML(@"footer", footer);
+    setDivHTML(@"translators_body", [self stringFromLocalizationKey:@"about-translators-details" urlKey:kWMFURLsTranslateWikiKey]);
+    setDivHTML(@"testers_body", [self stringFromLocalizationKey:@"about-testers-details" urlKey:kWMFURLsSpecialistGuildKey]);
+
+    setDivHTML(@"footer", [self stringFromLocalizationKey:@"about-product-of" urlKey:kWMFURLsWikimediaKey urlLocalizationKey:@"about-wikimedia-foundation"]);
 
     NSString* textDirection   = ([[UIApplication sharedApplication] wmf_isRTL] ? @"rtl" : @"ltr");
     NSString* textDirectionJS = [NSString stringWithFormat:@"document.body.style.direction = '%@'", textDirection];
@@ -191,6 +182,19 @@ static NSString* const kWMFContributorsKey = @"contributors";
 
     NSString* fontSizeJS = [NSString stringWithFormat:@"document.body.style.fontSize = '%f%%'", (MENUS_SCALE_MULTIPLIER * 100.0f)];
     [webView stringByEvaluatingJavaScriptFromString:fontSizeJS];
+}
+
+- (NSString*)stringFromLocalizationKey:(NSString*)localizationKey
+                                urlKey:(NSString*)urlKey
+                    urlLocalizationKey:(NSString*)urlLocalizationKey {
+    return [MWLocalizedString(localizationKey, nil) stringByReplacingOccurrencesOfString:@"$1"
+                                                                              withString:[[self class] linkHTMLForURLString:self.urls[urlKey] title:MWLocalizedString(urlLocalizationKey, nil)]];
+}
+
+- (NSString*)stringFromLocalizationKey:(NSString*)localizationKey
+                                urlKey:(NSString*)urlKey {
+    return [MWLocalizedString(localizationKey, nil) stringByReplacingOccurrencesOfString:@"$1"
+                                                                              withString:[[self class] linkHTMLForURLString:self.urls[urlKey] title:[self.urls[urlKey] substringFromIndex:7]]];
 }
 
 #pragma mark - Introspection
@@ -213,7 +217,7 @@ static NSString* const kWMFContributorsKey = @"contributors";
     if ([[self class] isLicenseURL:requestURL]) {
         VTAcknowledgementsViewController* vc = [VTAcknowledgementsViewController acknowledgementsViewController];
         vc.headerText = [MWLocalizedString(@"about-libraries-licenses-title", nil) stringByReplacingOccurrencesOfString:@"$1" withString:@"💖"];
-        
+
         UINavigationController* nc = [[UINavigationController alloc] initWithRootViewController:vc];
         [self presentViewController:nc animated:YES completion:nil];
 

--- a/Wikipedia/Code/AboutViewController.plist
+++ b/Wikipedia/Code/AboutViewController.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>urls</key>
 	<dict>
+		<key>sharealike</key>
+		<string>https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License</string>
+		<key>mit</key>
+		<string>https://raw.githubusercontent.com/wikimedia/wikipedia-ios/master/LICENSE.txt</string>
 		<key>tsg</key>
 		<string>http://specialistsguild.org</string>
 		<key>feedback</key>

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -208,16 +208,20 @@
 
 "about-title" = "About";
 "about-wikipedia" = "Wikipedia";
-"about-contributors" = "contributors";
-"about-testers" = "testers";
+"about-contributors" = "Contributors";
+"about-testers" = "Testers";
 "about-testers-details" = "QA tested by $1";
-"about-translators" = "translators";
+"about-translators" = "Translators";
 "about-translators-details" = "Translated by volunteers at $1";
-"about-libraries" = "libraries used";
+"about-libraries" = "Libraries used";
 "about-libraries-license" = "License";
 "about-libraries-licenses" = "Licenses";
+"about-content-license" = "Content license";
+"about-content-license-details" = "Unless otherwise specified, content is available under a Creative Commons Attribution-ShareAlike License.";
 "about-libraries-licenses-title" = "We love open source software $1";
-"about-repositories" = "repositories";
+"about-libraries-complete-list" = "Complete list";
+"about-repositories" = "Repositories";
+"about-repositories-app-source-license" = "Source code available under the MIT License.";
 "about-send-feedback" = "Send app feedback";
 "about-product-of" = "A product of the $1";
 "about-wikimedia-foundation" = "Wikimedia Foundation";

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -217,11 +217,13 @@
 "about-libraries-license" = "License";
 "about-libraries-licenses" = "Licenses";
 "about-content-license" = "Content license";
-"about-content-license-details" = "Unless otherwise specified, content is available under a Creative Commons Attribution-ShareAlike License.";
+"about-content-license-details" = "Unless otherwise specified, content is available under a $1.";
+"about-content-license-details-share-alike-license" = "Creative Commons Attribution-ShareAlike License";
 "about-libraries-licenses-title" = "We love open source software $1";
 "about-libraries-complete-list" = "Complete list";
 "about-repositories" = "Repositories";
-"about-repositories-app-source-license" = "Source code available under the MIT License.";
+"about-repositories-app-source-license" = "Source code available under the $1.";
+"about-repositories-app-source-license-mit" = "MIT License";
 "about-send-feedback" = "Send app feedback";
 "about-product-of" = "A product of the $1";
 "about-wikimedia-foundation" = "Wikimedia Foundation";

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -202,9 +202,13 @@
 "about-libraries" = "Header text for libraries section (as in a collection of subprograms used to develop software) of the about page. Is not capitalised for aesthetic reasons, but could be capitalised in translations.";
 "about-libraries-license" = "About page link title that will display a license for a library used in the app\n{{Identical|License}}";
 "about-repositories" = "Header text for repositories section of the about page. Is not capitalised for aesthetic reasons, but could be capitalised in translations. \n{{Identical|Repository}}";
+"about-repositories-app-source-license" = "Text explaining the app source licensing";
 "about-libraries-licenses" = "About page link title that will display all licenses for libraries used in the app";
+"about-content-license" = "Header text for content license section";
+"about-content-license-details" = "Text explaining license of app content";
 "about-libraries-licenses-title" = "Title for list of library licenses. $1 will be replaced with an emoji expressing our love for open source software";
 
+"about-libraries-complete-list" = "Title for link to complete list of libraries use by the app";
 "about-send-feedback" = "Link text for sending app feedback";
 "about-product-of" = "Description of who produced the app. $1 is the message {{msg-wikimedia|wikipedia-ios-about-wikimedia-foundation}}.";
 "about-wikimedia-foundation" = "Name of the Wikimedia Foundation. Used by the message {{Msg-wikimedia|wikipedia-ios-about-product-of}}.";

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -202,10 +202,12 @@
 "about-libraries" = "Header text for libraries section (as in a collection of subprograms used to develop software) of the about page. Is not capitalised for aesthetic reasons, but could be capitalised in translations.";
 "about-libraries-license" = "About page link title that will display a license for a library used in the app\n{{Identical|License}}";
 "about-repositories" = "Header text for repositories section of the about page. Is not capitalised for aesthetic reasons, but could be capitalised in translations. \n{{Identical|Repository}}";
-"about-repositories-app-source-license" = "Text explaining the app source licensing";
+"about-repositories-app-source-license" = "Text explaining the app source licensing. $1 is the message {{msg-wikimedia|about-repositories-app-source-license-mit}}.";
+"about-repositories-app-source-license-mit" = "Name of the \"MIT\" license";
 "about-libraries-licenses" = "About page link title that will display all licenses for libraries used in the app";
 "about-content-license" = "Header text for content license section";
-"about-content-license-details" = "Text explaining license of app content";
+"about-content-license-details" = "Text explaining license of app content. $1 is the message {{msg-wikimedia|about-content-license-details-share-alike-license}}.";
+"about-content-license-details-share-alike-license" = "Name of the \"Creative Commons Attribution-ShareAlike\" license";
 "about-libraries-licenses-title" = "Title for list of library licenses. $1 will be replaced with an emoji expressing our love for open source software";
 
 "about-libraries-complete-list" = "Title for link to complete list of libraries use by the app";

--- a/Wikipedia/assets/about.html
+++ b/Wikipedia/assets/about.html
@@ -2,95 +2,105 @@
 <html>
     <head>
         <meta name="viewport" id="viewport" content="width=device-width, user-scalable=no">
-
-        <style type="text/css">
-
-            body{
-                font-size:100%;
-                margin:1.45em;
-                font-family: Helvetica;
-                color:#444444;
-                border-style:none;
-                -webkit-text-size-adjust: none;
-                direction:ltr;
-            }
-
+            
+            <style type="text/css">
+                
+                body{
+                    font-size:100%;
+                    margin:1.45em;
+                    font-family: Helvetica;
+                    color:#444444;
+                    border-style:none;
+                    -webkit-text-size-adjust: none;
+                    direction:ltr;
+                }
+            
             div body{
                 margin-top:0.5em;
                 margin-bottom:0.5em;
             }
-
+            
             .heading{
                 font-weight:bold;
                 color:#000000;
             }
-
+            
             #version{
                 font-size:1.5em;
             }
-
+            
             #wikipedia{
                 font-size:2.0em;
             }
-
+            
             .title{
                 color:#888888;
                 margin-bottom:0.5em;
             }
-
+            
+            .subtitle{
+                margin-top:0.5em;
+            }
+            
             A{
                 color:#4F76eB;
             }
-
+            
             .feedback{
                 text-align:center;
             }
-
+            
             .title, .feedback{
                 margin-top:1.5em;
             }
-
+            
             .footer-table{
                 margin-top:1.0em;
                 width:100%;
             }
-
+            
             .footer{
                 width:100%;
             }
-
+            
             .wmf-logo{
                 padding-right:0.5em;
                 width:60px;
             }
-
-        </style>
-    </head>
+            
+                </style>
+            </head>
     <body>
-
+        
         <div id="wikipedia" class="heading">wikipedia</div>
-
+        
         <div id="version" class="heading">version</div>
-
+        
         <div id="contributors_title" class="title">contributors_title</div>
-
+        
         <div id="contributors_body">contributors_body</div>
-
+        
         <div id="translators_title" class="title">translators_title</div>
-
+        
         <div id="translators_body">translators_body</div>
-
+        
         <div id="testers_title" class="title">testers_title</div>
-
+        
         <div id="testers_body">testers_body</div>
-
+        
         <div id="libraries_title" class="title">libraries_title</div>
-
+        
         <div id="libraries_body">libraries_body</div>
-
+        
         <div id="repositories_title" class="title">repositories_title</div>
-
+        
         <div id="repositories_body">repositories_body</div>
+        
+        <div id="repositories_subtitle" class="subtitle">repositories_subtitle</div>
+        
+        <div id="license_title" class="title">license_title</div>
+        
+        <div id="license_body">license_body</div>
 
         <div id="feedback_body" class="feedback">feedback_body</div>
 
@@ -98,12 +108,12 @@
             <tr>
                 <td>
                     <img class="wmf-logo" src="wmf://bundledImage/WMFLogo_60">
-                </td>
+                        </td>
                 <td id="footer" class="footer">
                     footer
                 </td>
             </tr>
         </table>
-
+        
     </body>
 </html>

--- a/www/about.html
+++ b/www/about.html
@@ -2,95 +2,105 @@
 <html>
     <head>
         <meta name="viewport" id="viewport" content="width=device-width, user-scalable=no">
-
-        <style type="text/css">
-
-            body{
-                font-size:100%;
-                margin:1.45em;
-                font-family: Helvetica;
-                color:#444444;
-                border-style:none;
-                -webkit-text-size-adjust: none;
-                direction:ltr;
-            }
-
+            
+            <style type="text/css">
+                
+                body{
+                    font-size:100%;
+                    margin:1.45em;
+                    font-family: Helvetica;
+                    color:#444444;
+                    border-style:none;
+                    -webkit-text-size-adjust: none;
+                    direction:ltr;
+                }
+            
             div body{
                 margin-top:0.5em;
                 margin-bottom:0.5em;
             }
-
+            
             .heading{
                 font-weight:bold;
                 color:#000000;
             }
-
+            
             #version{
                 font-size:1.5em;
             }
-
+            
             #wikipedia{
                 font-size:2.0em;
             }
-
+            
             .title{
                 color:#888888;
                 margin-bottom:0.5em;
             }
-
+            
+            .subtitle{
+                margin-top:0.5em;
+            }
+            
             A{
                 color:#4F76eB;
             }
-
+            
             .feedback{
                 text-align:center;
             }
-
+            
             .title, .feedback{
                 margin-top:1.5em;
             }
-
+            
             .footer-table{
                 margin-top:1.0em;
                 width:100%;
             }
-
+            
             .footer{
                 width:100%;
             }
-
+            
             .wmf-logo{
                 padding-right:0.5em;
                 width:60px;
             }
-
-        </style>
-    </head>
+            
+                </style>
+            </head>
     <body>
-
+        
         <div id="wikipedia" class="heading">wikipedia</div>
-
+        
         <div id="version" class="heading">version</div>
-
+        
         <div id="contributors_title" class="title">contributors_title</div>
-
+        
         <div id="contributors_body">contributors_body</div>
-
+        
         <div id="translators_title" class="title">translators_title</div>
-
+        
         <div id="translators_body">translators_body</div>
-
+        
         <div id="testers_title" class="title">testers_title</div>
-
+        
         <div id="testers_body">testers_body</div>
-
+        
         <div id="libraries_title" class="title">libraries_title</div>
-
+        
         <div id="libraries_body">libraries_body</div>
-
+        
         <div id="repositories_title" class="title">repositories_title</div>
-
+        
         <div id="repositories_body">repositories_body</div>
+        
+        <div id="repositories_subtitle" class="subtitle">repositories_subtitle</div>
+        
+        <div id="license_title" class="title">license_title</div>
+        
+        <div id="license_body">license_body</div>
 
         <div id="feedback_body" class="feedback">feedback_body</div>
 
@@ -98,12 +108,12 @@
             <tr>
                 <td>
                     <img class="wmf-logo" src="wmf://bundledImage/WMFLogo_60">
-                </td>
+                        </td>
                 <td id="footer" class="footer">
                     footer
                 </td>
             </tr>
         </table>
-
+        
     </body>
 </html>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T127229

Updates to the about screen adding license links and some small tweaks (per Josh):

<img width="487" alt="screen shot 2016-02-26 at 4 04 39 pm" src="https://cloud.githubusercontent.com/assets/3143487/13369293/dbcd3ba0-dca7-11e5-9665-850ff660b12b.png">