### PR TITLE
Fix (silent) errors when Explore schema saves fail & save copies async

### DIFF
--- a/Wikipedia/Code/WMFExploreSectionSchema.m
+++ b/Wikipedia/Code/WMFExploreSectionSchema.m
@@ -665,8 +665,8 @@ static CLLocationDistance const WMFMinimumDistanceBeforeUpdatingNearby = 500.0;
 
 - (void)save {
     /*
-     NOTE: until this class is made immutable, it cannot safely be passed between threads.
-    */
+       NOTE: until this class is made immutable, it cannot safely be passed between threads.
+     */
     WMFExploreSectionSchema* backgroundCopy = [self copy];
     dispatch_async(self.saveQueue, ^{
         NSError* error;
@@ -709,11 +709,11 @@ static CLLocationDistance const WMFMinimumDistanceBeforeUpdatingNearby = 500.0;
     [NSKeyedUnarchiver setClass:[WMFExploreSection class] forClassName:@"WMFHomeSection"];
     NSError* error;
     NSURL* fileURL = [NSURL fileURLWithPath:filePath isDirectory:NO];
-    NSData* data = [[NSData alloc] initWithContentsOfURL:fileURL options:0 error:&error];
+    NSData* data   = [[NSData alloc] initWithContentsOfURL:fileURL options:0 error:&error];
     if (!data) {
-       NSAssert([error.domain isEqualToString:NSCocoaErrorDomain] && error.code == NSFileReadNoSuchFileError,
-                @"Unexpected error reading schema data: %@", error);
-       return nil;
+        NSAssert([error.domain isEqualToString:NSCocoaErrorDomain] && error.code == NSFileReadNoSuchFileError,
+                 @"Unexpected error reading schema data: %@", error);
+        return nil;
     }
     WMFExploreSectionSchema* schema = [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:data error:&error];
     NSAssert(schema, @"Failed to unarchive schema: %@", error);


### PR DESCRIPTION
And make them LOUD again! 💣

TL;DR; the way we were creating file URL's was confusing Foundation, and we kept getting "No such 'file'" errors, because it thought the URL we were saving to was a directory.  Now fixed via super explicitness.

As an add'l boyscout, I changed the asynchronous save implementation to save **copy** instead of the original.  See the commit message for extra details about why the change was made, but suffice it to say that passing **mutable** objects between threads is bad m'kay.