### PR TITLE
Fix crash when removing nearby

### DIFF
--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -611,7 +611,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable id<WMFExploreSectionController>)sectionControllerForSectionAtIndex:(NSInteger)index {
-    if (index >= self.schemaManager.sections.count) {
+    if(index >= self.schemaManager.sections.count){
         return nil;
     }
     WMFExploreSection* section = self.schemaManager.sections[index];

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -611,6 +611,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable id<WMFExploreSectionController>)sectionControllerForSectionAtIndex:(NSInteger)index {
+    if (index >= self.schemaManager.sections.count) {
+        return nil;
+    }
     WMFExploreSection* section = self.schemaManager.sections[index];
     return [self sectionControllerForSection:section];
 }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T128229

When the nearby section is removed, but before the table is updated, we can be in a state where the table delegate methods are still requesting cells/sections/etc… with the old section indexes
This makes sure we don't try to access a section that is beyond the bounds of the section array.

To be more specific - this method:

```
- (void)tableView:(UITableView*)tableView didEndDisplayingCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath
```

…fires when we reload the table. And if we are scrolled down to the end of the table, then the last section will now be out of bounds if we removed a section. 

So this really is only a situation that exists during the reload process, and only because we try to make a call to a section that is going away in that delegate method.

