### PR TITLE
Update string and string key from "project" to "language".

### DIFF
--- a/Wikipedia/Code/WMFSettingsMenuItem.m
+++ b/Wikipedia/Code/WMFSettingsMenuItem.m
@@ -51,7 +51,7 @@
         case WMFSettingsMenuItemType_SearchLanguage: {
             return
                 [[WMFSettingsMenuItem alloc] initWithType:type
-                                                    title:MWLocalizedString(@"settings-project", nil)
+                                                    title:MWLocalizedString(@"settings-language", nil)
                                                  iconName:@"settings-project"
                                                 iconColor:[UIColor wmf_colorWithHex:0x1F95DE alpha:1.0]
                                            disclosureType:WMFSettingsMenuItemDisclosureType_ViewControllerWithDisclosureText

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -112,7 +112,7 @@
 "search-result-redirected-from" = "Redirected from: $1";
 
 "settings-title" = "Settings";
-"settings-project" = "Wikipedia project";
+"settings-language" = "Wikipedia language";
 "settings-support" = "Support Wikipedia";
 "settings-language-bar" = "Show languages on search";
 

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -111,7 +111,7 @@
 "search-recent-clear-delete-all" = "Button text for confirming delete all action\n{{Identical|Delete all}}";
 "search-result-redirected-from" = "Text for search result letting user know if a result is a redirect from another article. Parameters:\n* $1 - article title the current search result redirected from";
 "settings-title" = "Title of the view where app settings are displayed.\n{{Identical|Settings}}";
-"settings-project" = "Title for button letting user choose primary language Wikipedia for the app.";
+"settings-language" = "Title for button letting user choose primary language Wikipedia for the app.";
 "settings-support" = "Title for button letting user make a donation.";
 "settings-language-bar" = "Title in Settings for toggling the display the language bar in the search view";
 "main-menu-title" = "Title for menu of secondary items.\n{{Identical|More}}";


### PR DESCRIPTION
https://phabricator.wikimedia.org/T128252

Was confusing, reported by TWN, because project refers to things
like Wiktionary.