### PR TITLE
Fix account creation crash.

### DIFF
--- a/Wikipedia/Code/AccountCreationViewController.m
+++ b/Wikipedia/Code/AccountCreationViewController.m
@@ -258,8 +258,6 @@
 - (void)viewWillDisappear:(BOOL)animated {
     [self enableProgressiveButton:NO];
 
-    [[WMFAlertManager sharedInstance] dismissAlert];
-
     [[NSNotificationCenter defaultCenter] removeObserver:self
                                                     name:@"UITextFieldTextDidChangeNotification"
                                                   object:self.captchaViewController.captchaTextBox];


### PR DESCRIPTION
https://phabricator.wikimedia.org/T128412

Was crashing on a masonry constraint assert from the alert pod when fading out the alert. The alert is still being hidden without this line. 

Hmm... since this was an assert not sure if what I fixed was the cause...