### PR TITLE
Fix set article crash

### DIFF
--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -127,9 +127,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     self = [super init];
     if (self) {
-        self.articleTitle = title;
-        self.dataStore    = dataStore;
-        [self observeArticleUpdates];
+        self.articleTitle             = title;
+        self.dataStore                = dataStore;
         self.hidesBottomBarWhenPushed = YES;
     }
     return self;
@@ -173,6 +172,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self createTableOfContentsViewControllerIfNeeded];
     [self fetchReadMoreIfNeeded];
     [self updateWebviewFootersIfNeeded];
+    [self observeArticleUpdates];
 }
 
 - (MWKHistoryList*)recentPages {
@@ -695,7 +695,6 @@ NS_ASSUME_NONNULL_BEGIN
     }).finally(^{
         @strongify(self);
         self.articleFetcherPromise = nil;
-        [self observeArticleUpdates];
     });
 }
 


### PR DESCRIPTION
Was tripping an assertion - this makes sense we were observing the article on init, so of course there is the possibility of getting an update before the view is on screen.

Now we only observe article after the article is set, nice and neat.