### PR TITLE
Fix crash in sharing on iPad

### DIFF
--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -726,18 +726,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Share
 
-- (void)shareAFactWithTextSnippet : (nullable NSString*)text fromButton:(nullable UIBarButtonItem*)button {
+- (void)shareAFactWithTextSnippet : (nullable NSString*)text{
     if (self.shareOptionsController.isActive) {
         return;
     }
-    [self.shareOptionsController presentShareOptionsWithSnippet:text inViewController:self fromBarButtonItem:button];
+    [self.shareOptionsController presentShareOptionsWithSnippet:text inViewController:self fromBarButtonItem:self.shareToolbarItem];
 }
 
 - (void)shareArticleFromButton:(nullable UIBarButtonItem*)button {
     [self shareArticleWithTextSnippet:nil fromButton:button];
 }
 
-- (void)shareArticleWithTextSnippet:(nullable NSString*)text fromButton:(nullable UIBarButtonItem*)button {
+- (void)shareArticleWithTextSnippet:(nullable NSString*)text fromButton:(UIBarButtonItem*)button {
     [self.shareFunnel logShareButtonTappedResultingInSelection:text];
 
     NSMutableArray* items = [NSMutableArray array];
@@ -753,6 +753,8 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     UIActivityViewController* vc = [[UIActivityViewController alloc] initWithActivityItems:items applicationActivities:@[[[TUSafariActivity alloc] init]]];
+    UIPopoverPresentationController* presenter = [vc popoverPresentationController];
+    presenter.barButtonItem = button;
 
     [self presentViewController:vc animated:YES completion:NULL];
 }
@@ -814,7 +816,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)webViewController:(WebViewController*)controller didTapShareWithSelectedText:(NSString*)text {
-    [self shareAFactWithTextSnippet:text fromButton:nil];
+    [self shareAFactWithTextSnippet:text];
 }
 
 - (nullable NSString*)webViewController:(WebViewController*)controller titleForFooterViewController:(UIViewController*)footerViewController {

--- a/Wikipedia/Code/WMFShareOptionsController.h
+++ b/Wikipedia/Code/WMFShareOptionsController.h
@@ -36,12 +36,12 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @note Truncating `snippet` is not necessary, as it's done internally by the share view's `UILabel`.
  */
-- (void)presentShareOptionsWithSnippet:(NSString*)snippet inViewController:(UIViewController*)viewController fromBarButtonItem:(nullable UIBarButtonItem*)item;
+- (void)presentShareOptionsWithSnippet:(NSString*)snippet inViewController:(UIViewController*)viewController fromBarButtonItem:(UIBarButtonItem*)item;
 
 /**
  * Same as above, but presented from a view instead of a bar button item
  */
-- (void)presentShareOptionsWithSnippet:(NSString*)snippet inViewController:(UIViewController*)viewController fromView:(nullable UIView*)view;
+- (void)presentShareOptionsWithSnippet:(NSString*)snippet inViewController:(UIViewController*)viewController fromView:(UIView*)view;
 
 @end
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T128430

in iOS 8 and above you need to configure the popover presentation controller

Additionally, removed some nullable attributes that were not needed.