### PR TITLE
Fix auto-layout crash from alert dismissal

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -156,7 +156,7 @@ CHECKOUT OPTIONS:
     :commit: bb49df83e72f2231a191e9477a85f0effe13430a
     :git: https://github.com/wikimedia/SDWebImage.git
   TSMessages:
-    :commit: d86e3fb47ee80175d8fa8d26d17b56e42a0d60d2
+    :commit: ec0aa9be29ab79083e4957ac500f3af2f622605d
     :git: https://github.com/wikimedia/TSMessages.git
 
 SPEC CHECKSUMS:

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -156,7 +156,7 @@ CHECKOUT OPTIONS:
     :commit: bb49df83e72f2231a191e9477a85f0effe13430a
     :git: https://github.com/wikimedia/SDWebImage.git
   TSMessages:
-    :commit: d86e3fb47ee80175d8fa8d26d17b56e42a0d60d2
+    :commit: ec0aa9be29ab79083e4957ac500f3af2f622605d
     :git: https://github.com/wikimedia/TSMessages.git
 
 SPEC CHECKSUMS:


### PR DESCRIPTION
See the new [commit in our TSMessages fork](https://github.com/wikimedia/TSMessages/commit/ec0aa9be29ab79083e4957ac500f3af2f622605d), but TL;DR; don't try to constrain a view to a superview which doesn't exist.  
![login spam demo mov](https://cloud.githubusercontent.com/assets/444217/13445434/127a0cc0-dfda-11e5-83f1-c6886e228149.gif)
