### PR TITLE
Always monitor location when nearby cell appears

### DIFF
--- a/Wikipedia/Code/WMFExploreSectionController.h
+++ b/Wikipedia/Code/WMFExploreSectionController.h
@@ -140,6 +140,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  Called when a section is about to be displayed.
+ *
+ *  This can happen when one of a section's cells scrolls on screen, or the entire table view appears and the receiver's section is visible. Note that
+ *  cells can also rapidly appear & disappear as the result of table reloads.
+ *
+ *  @warning
+ *  This method must be idempotent, as it will be called multiple times for each cell appearance.
  */
 - (void)willDisplaySection;
 
@@ -147,7 +153,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Called when the receiver's section in the table is no longer visible.
  *
  *  This can happen when either the cells are scolled offscreen (invoked after last cell scolls away) or when the entire
- *  table view disappears (e.g. switching tabs).
+ *  table view disappears (e.g. switching tabs). Note that cells can also rapidly appear & disappear as the result of table reloads.
  */
 - (void)didEndDisplayingSection;
 

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -513,12 +513,8 @@ NS_ASSUME_NONNULL_BEGIN
     id<WMFExploreSectionController> controller = [self sectionControllerForSectionAtIndex:indexPath.section];
 
     if ([controller respondsToSelector:@selector(willDisplaySection)]) {
-        if ([self isVisibilityTransitioningForRowIndexPath:indexPath]) {
-            DDLogVerbose(@"Sending willDisplaySection for contorller %@ at indexPath %@", controller, indexPath);
-            [controller willDisplaySection];
-        } else {
-            DDLogVerbose(@"Skipping willDisplaySection for controller %@ at indexPath %@", controller, indexPath);
-        }
+        DDLogDebug(@"Sending willDisplaySection for controller %@ at indexPath %@", controller, indexPath);
+        [controller willDisplaySection];
     }
 
     [self performSelector:@selector(fetchSectionIfShowing:) withObject:controller afterDelay:0.25 inModes:@[NSRunLoopCommonModes]];

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -297,6 +297,7 @@ NS_ASSUME_NONNULL_BEGIN
     // stop location manager from updating.
     [[self visibleSectionControllers] bk_each:^(id<WMFExploreSectionController> _Nonnull obj) {
         if ([obj respondsToSelector:@selector(didEndDisplayingSection)]) {
+            DDLogDebug(@"Sending didEndDisplayingSection to controller %@ on view disappearance", obj);
             [obj didEndDisplayingSection];
         }
     }];
@@ -534,9 +535,10 @@ NS_ASSUME_NONNULL_BEGIN
 
     if ([controller respondsToSelector:@selector(didEndDisplayingSection)]) {
         if ([self isVisibilityTransitioningForRowIndexPath:indexPath]) {
+            DDLogDebug(@"Sending didEndDisplayingSection for controller %@ at indexPath %@", controller, indexPath);
             [controller didEndDisplayingSection];
         } else {
-            DDLogVerbose(@"Skipping calling didEndDisplaySection for controller %@ indexPath %@", controller, indexPath);
+            DDLogDebug(@"Skipping calling didEndDisplaySection for controller %@ indexPath %@", controller, indexPath);
         }
     }
 
@@ -550,7 +552,7 @@ NS_ASSUME_NONNULL_BEGIN
     }];
 
     if (visibleIndexPathsInSection.count == 0) {
-        DDLogVerbose(@"Cancelling fetch for scrolled-away section: %@", controller);
+        DDLogInfo(@"Cancelling fetch for scrolled-away section: %@", controller);
         [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(fetchSectionIfShowing:) object:controller];
     }
 }
@@ -667,7 +669,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)fetchSectionIfShowing:(id<WMFExploreSectionController>)controller {
     if ([self isDisplayingCellsForSectionController:controller]) {
-        DDLogVerbose(@"Fetching section after delay: %@", controller);
+        DDLogDebug(@"Fetching section after delay: %@", controller);
         @weakify(self);
         [controller fetchDataIfNeeded].catch(^(NSError* error){
             @strongify(self);
@@ -730,7 +732,7 @@ NS_ASSUME_NONNULL_BEGIN
                                               NSDictionary* _) {
         NSUInteger sectionIndex = [observer indexForSectionController:observedController];
         if (sectionIndex != NSNotFound && [observer isDisplayingCellsForSection:sectionIndex]) {
-            DDLogVerbose(@"Reloading table to display results in controller %@", observedController);
+            DDLogDebug(@"Reloading table to display results in controller %@", observedController);
             [observer.tableView reloadData];
         }
     }];

--- a/Wikipedia/Code/WMFLogFormatter.m
+++ b/Wikipedia/Code/WMFLogFormatter.m
@@ -22,25 +22,25 @@ static NSString* cachedApplicationName;
 - (NSString*)formatLogMessage:(DDLogMessage*)logMessage {
     NSString* level = @"";
     switch (logMessage->_flag) {
-        case DDLogFlagDebug:
-            level = @"DEBUG";
-            break;
         case DDLogFlagVerbose:
-            level = @"VERBOSE";
+            level = @"V";
+            break;
+        case DDLogFlagDebug:
+            level = @"D";
             break;
         case DDLogFlagInfo:
-            level = @"INFO";
+            level = @"I";
             break;
         case DDLogFlagWarning:
-            level = @"WARN";
+            level = @"W";
             break;
         case DDLogFlagError:
-            level = @"ERROR";
+            level = @"E";
             break;
         default:
             break;
     }
-    return [NSString stringWithFormat:@"%@ %@[%@] %@#L%lu %@:\n%@",
+    return [NSString stringWithFormat:@"%@ %@[%@] %@#L%lu %@: %@",
             [self stringFromDate:logMessage->_timestamp],
             cachedApplicationName,
             [self queueThreadLabelForLogMessage:logMessage],


### PR DESCRIPTION
Phab: [T128608](https://phabricator.wikimedia.org/T128608)

See testing notes in Phab ticket :point_up:

---

This was originally part of the original fix (#530), but I removed it when I couldn't reproduce the issue.  I've now found additional conditions which make the issue more reproducible, but still not perfectly consistent.  With this change, I can't get compasses to freeze after several tries.

@coreyfloyd we had discussed issues w/ sections "never" fetching to do cancellation of fetches when the last cell is ends displaying, but I can't reproduce the issue and don't have concrete evidence that it's actually a problem. I'll continue trying and if I run into again and I have logs to show the sections never would've been fetched, I'll file an issue.