### PR TITLE
prevent nil obj in placeholder array crash, add lang/site fallbacks

### DIFF
--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -111,10 +111,7 @@ static id _sharedInstance;
 
 - (nullable MWKLanguageLink*)languageForSite:(MWKSite*)site {
     return [self.allLanguages bk_match:^BOOL (MWKLanguageLink* obj) {
-        if ([obj.site isEqualToSite:site]) {
-            return YES;
-        }
-        return NO;
+        return [obj.site isEqualToSite:site];
     }];
 }
 

--- a/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
+++ b/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
@@ -104,11 +104,15 @@ extension NSUserDefaults {
     }
     
     public func wmf_appSite() -> MWKSite? {
-        if let data = self.objectForKey(WMFAppSiteKey) as? String{
-            return MWKSite.init(domain: WMFDefaultSiteDomain, language: data)
-        }else{
-            return nil
+        guard let data = self.objectForKey(WMFAppSiteKey) as? String else {
+            DDLogError("Site preference was empty! Falling back to device language")
+            let fallbackSite = MWKSite.siteWithCurrentLocale()
+            // NOTE: need to set defaults directly, otherwise we'd get into inf. loop
+            self.setObject(fallbackSite.language, forKey: WMFAppSiteKey)
+            self.synchronize()
+            return fallbackSite
         }
+        return MWKSite.init(domain: WMFDefaultSiteDomain, language: data)
     }
     
     public func wmf_setAppSite(site: MWKSite) {

--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -1,5 +1,6 @@
 #import "WMFSearchViewController.h"
 #import "PiwikTracker+WMFExtensions.h"
+#import "NSMutableArray+WMFSafeAdd.h"
 
 #import "RecentSearchesViewController.h"
 #import "WMFSearchResultsTableViewController.h"
@@ -547,14 +548,19 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 }
 
 - (NSArray<MWKLanguageLink*>*)languages {
-    NSMutableArray* l = [NSMutableArray arrayWithObject:[self appLanguage]];
-    [l addObjectsFromArray:self.preferredLanguages];
-    return l;
+    NSMutableArray* languages = [NSMutableArray new];
+    [languages wmf_safeAddObject:[self appLanguage]];
+    [languages addObjectsFromArray:self.preferredLanguages];
+    return languages;
 }
 
-- (MWKLanguageLink*)appLanguage {
+- (nullable MWKLanguageLink*)appLanguage {
     MWKSite* site             = [[NSUserDefaults standardUserDefaults] wmf_appSite];
     MWKLanguageLink* language = [[MWKLanguageLinkController sharedInstance] languageForSite:site];
+    NSAssert(language, @"No language data found for site %@", site);
+    if (!language) {
+        DDLogError(@"No language data found for site %@", site);
+    }
     return language;
 }
 
@@ -562,10 +568,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
     NSArray* languages           = [[MWKLanguageLinkController sharedInstance].preferredLanguages wmf_arrayByTrimmingToLength:3];
     MWKLanguageLink* appLanguage = [self appLanguage];
     languages = [languages bk_reject:^BOOL (MWKLanguageLink* obj) {
-        if ([obj isEqualToLanguageLink:appLanguage]) {
-            return YES;
-        }
-        return NO;
+        return [obj isEqualToLanguageLink:appLanguage];
     }];
     self.preferredLanguages = [languages wmf_arrayByTrimmingToLength:2];
 }


### PR DESCRIPTION
not sure how site was nil or not contained in language links, but we should at least prevent crashes in production

see: https://rink.hockeyapp.net/manage/apps/152731/app_versions/35/crash_reasons/113233708