### PR TITLE
only ever show gallery after article data has arrived

### DIFF
--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -837,26 +837,12 @@ NS_ASSUME_NONNULL_BEGIN
      didSelectImageAtIndex:(NSUInteger)index {
     WMFModalImageGalleryViewController* fullscreenGallery;
 
-    if (self.article.isCached) {
-        fullscreenGallery = [[WMFModalImageGalleryViewController alloc] initWithImagesInArticle:self.article
-                                                                                   currentImage:nil];
-        fullscreenGallery.currentPage = gallery.currentPage;
-    } else {
-        /*
-           In case the user taps on the lead image before the article is loaded, present the gallery w/ the lead image
-           as a placeholder, then populate it in-place once the article is fetched.
-         */
-        NSAssert(index == 0, @"Unexpected selected index for uncached article. Only expecting lead image tap.");
-        if (!self.articleFetcherPromise) {
-            // Fetch the article if it hasn't been fetched already
-            DDLogInfo(@"User tapped lead image before article fetch started, fetching before showing gallery.");
-            [self fetchArticleIfNeeded];
-        }
-        fullscreenGallery =
-            [[WMFModalImageGalleryViewController alloc] initWithImagesInFutureArticle:self.articleFetcherPromise
-                                                                          placeholder:self.article];
+    NSAssert(self.article.isCached, @"Expected article data to already be downloaded.");
+    if (!self.article.isCached) {
+        return;
     }
-
+    fullscreenGallery = [[WMFModalImageGalleryViewController alloc] initWithImagesInArticle:self.article currentImage:nil];
+    fullscreenGallery.currentPage = gallery.currentPage;
     // set delegate to ensure the header gallery is updated when the fullscreen gallery is dismissed
     fullscreenGallery.delegate = self;
 

--- a/Wikipedia/Code/WMFModalImageGalleryViewController.h
+++ b/Wikipedia/Code/WMFModalImageGalleryViewController.h
@@ -72,18 +72,6 @@ NS_ASSUME_NONNULL_BEGIN
                            currentImage:(nullable MWKImage*)currentImage;
 
 /**
- *  Initialize a modal gallery with images in an article that hasn't been downloaded yet.
- *
- *  @param articlePromise       Promise which should resolve to an @c MWKArticle.
- *  @param placeholderArticle   Article object with partial data, such as @c image or @c thumbnailImage, which will be
- *                              displayed while the article and its images' info are downloaded.
- *
- *  @return A new modal image gallery which will eventually display the images in the resolved article.
- */
-- (instancetype)initWithImagesInFutureArticle:(AnyPromise*)articlePromise
-                                  placeholder:(nullable MWKArticle*)placeholderArticle;
-
-/**
  *  Initialize a modal gallery which will display the last several pictures of the day, including the given date.
  *
  *  @param info The info which was already downloaded to display picture of the day in the Home view.

--- a/Wikipedia/Code/WMFModalImageGalleryViewController.m
+++ b/Wikipedia/Code/WMFModalImageGalleryViewController.m
@@ -115,12 +115,7 @@ static NSString* const WMFImageGalleryCollectionViewCellReuseId = @"WMFImageGall
 - (instancetype)initWithImagesInArticle:(MWKArticle*)article currentImage:(nullable MWKImage*)currentImage {
     self = [self init];
     if (self) {
-        NSAssert(article.isCached, @"Unexpected initialization with uncached instance of %@ in %@, use %@ instead.",
-                 article.title,
-                 NSStringFromSelector(_cmd),
-                 NSStringFromSelector(@selector(initWithImagesInFutureArticle:placeholder:)));
-        WMFModalArticleImageGalleryDataSource* articleGalleryDataSource =
-            [[WMFModalArticleImageGalleryDataSource alloc] initWithArticle:article];
+        WMFModalArticleImageGalleryDataSource* articleGalleryDataSource = [[WMFModalArticleImageGalleryDataSource alloc] initWithArticle:article];
         self.dataSource = articleGalleryDataSource;
         if (currentImage) {
             NSInteger selectedImageIndex = [articleGalleryDataSource.allItems
@@ -138,26 +133,6 @@ static NSString* const WMFImageGalleryCollectionViewCellReuseId = @"WMFImageGall
             }
             self.currentPage = selectedImageIndex;
         }
-    }
-    return self;
-}
-
-- (instancetype)initWithImagesInFutureArticle:(AnyPromise*)articlePromise
-                                  placeholder:(nullable MWKArticle*)placeholderArticle {
-    self = [self init];
-    if (self) {
-        if (placeholderArticle) {
-            self.dataSource = [[WMFModalArticleImageGalleryDataSource alloc] initWithArticle:placeholderArticle];
-        }
-        @weakify(self);
-        articlePromise.then(^(MWKArticle* article) {
-            @strongify(self);
-            self.dataSource = [[WMFModalArticleImageGalleryDataSource alloc] initWithArticle:article];
-        })
-        // NOTE: article load error is caught in article view, which will also show a banner
-        .finally(^{
-            [self.loadingIndicator stopAnimating];
-        });
     }
     return self;
 }


### PR DESCRIPTION
we don't create "partial" articles anymore, so there's no need for this API. not sure how

https://rink.hockeyapp.net/manage/apps/152731/app_versions/35/crash_reasons/113161167

was happening (since article should've always been "cached")