### PR TITLE
add weakify/strongify for article image protocol repsonse handling

### DIFF
--- a/Wikipedia/Code/WMFArticleImageProtocol.m
+++ b/Wikipedia/Code/WMFArticleImageProtocol.m
@@ -53,11 +53,14 @@ static NSString* const WMFArticleImageProtocolHost               = @"upload.wiki
 
 - (void)startLoading {
     DDLogVerbose(@"Fetching image %@", self.request.URL);
+    @weakify(self);
     [[WMFImageController sharedInstance] fetchImageWithURL:self.request.URL]
     .thenInBackground(^(WMFImageDownload* download) {
+        @strongify(self);
         [self respondWithDataFromDownload:download];
     })
     .catch(^(NSError* err) {
+        @strongify(self);
         [self respondWithError:err];
     });
 }


### PR DESCRIPTION
was implicitly being captured by promise callbacks. may resolve:

https://rink.hockeyapp.net/manage/apps/152725/crash_reasons/112342652/multiple