### PR TITLE
Localisation updates from https://translatewiki.net.

### DIFF
--- a/Wikipedia/Localizations/ar.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/ar.lproj/Localizable.strings
@@ -93,6 +93,7 @@
 "search-recent-clear-delete-all" = "حذف الكل";
 "search-result-redirected-from" = "بالتحويل من: $1";
 "settings-title" = "إعدادات";
+"settings-language" = "لغة ويكيبيديا";
 "settings-language-bar" = "إظهار اللغات في البحث";
 "main-menu-title" = "المزيد";
 "main-menu-heading-about" = "حول";
@@ -239,6 +240,7 @@
 "welcome-volunteer-send-usage-reports" = "إرسال تقارير الاستخدام";
 "welcome-volunteer-continue-button" = "استمرار";
 "welcome-volunteer-thanks" = "شكرا لك!$1";
+"empty-no-feed-action-message" = "ما زال بالإمكان قراءة الصفحات المحفوظة";
 "empty-no-search-results-message" = "لا توجد نتائج";
 "alert-no-internet" = "لا يوجد اتصال بالإنترنت";
 "icon-shortcut-search-title" = "البحث في ويكيبيديا";

--- a/Wikipedia/Localizations/bn.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/bn.lproj/Localizable.strings
@@ -2,6 +2,7 @@
 // Exported from translatewiki.net
 // Author: Aftab1995
 // Author: Aftabuzzaman
+// Author: Bodhisattwa
 // Author: Kayser Ahmad
 // Author: Sayma Jahan
 // Author: Tauhid16
@@ -10,8 +11,7 @@
 "article-languages-label" = "ভাষা নির্বাচন করুন";
 "article-languages-cancel" = "বাতিল";
 "article-languages-downloading" = "নিবন্ধের ভাষাসমূহ লোড হচ্ছে...";
-// Fuzzy
-"article-languages-filter-placeholder" = "ভাষা ছাকনী";
+"article-languages-filter-placeholder" = "ভাষা খুঁজুন";
 "article-read-more-title" = "আরো পড়ুন";
 "article-about-title" = "এই নিবন্ধ সম্পর্কে";
 "article-unable-to-load-section" = "এই অনুচ্ছেদ পূরণ করতে অসমর্থ। যদি এই সমস্যা সমাধান হয়ে থাকে তাহলে নিবন্ধটি দেখার জন্য পুনরায় সতেজ করুন।";
@@ -20,8 +20,8 @@
 "info-box-title" = "দ্রুত কার্য";
 "info-box-close-text" = "বন্ধ";
 "table-title-other" = "আরও তথ্য";
-"saved-clear-all" = "পরিষ্কার";
-"history-clear-all" = "পরিষ্কার";
+"saved-clear-all" = "পরিষ্কার করুন";
+"history-clear-all" = "পরিষ্কার করুন";
 "history-label" = "সাম্প্রতিক";
 "history-section-today" = "আজ";
 "history-section-yesterday" = "গতকাল";
@@ -30,7 +30,7 @@
 "history-clear-confirmation-heading" = "সাম্প্রতিক সব আইটেম মুছে ফেলবেন?";
 "history-clear-confirmation-sub-heading" = "এই ক্রিয়াটি পূর্বাবস্থায় ফেরানো যাবে না!";
 "history-clear-cancel" = "বাতিল";
-"history-clear-delete-all" = "হ্যা, সব মুছে ফেলুন";
+"history-clear-delete-all" = "হ্যাঁ, সব মুছে ফেলুন";
 "history-description" = "আপনি সম্ভবত সবকিছু মুছে ফেলেছেন। পরবর্তী সময়ে আপনি একটি পাতায় গেলে আপনি এখানে থেকে তা ফিরে পেতে পারেন।";
 "history-none" = "এখানে কোন সাম্প্রতিক পাতা নেই।";
 "zero-free-verbiage" = "মোবাইল অপারেটরদের সৌজন্যে বিনামূল্যে উইকিপিডয়া (ডাটা চার্জ প্রযোজ্য নয়)";
@@ -105,8 +105,9 @@
 "search-recent-clear-delete-all" = "সব মুছে ফেলুন";
 "search-result-redirected-from" = "$1 থেকে পুনর্নির্দেশিত";
 "settings-title" = "সেটিংস";
-"settings-support" = "উইকিমিডিয়াকে সাহায্য করুন";
-"settings-language-bar" = "অনুসন্ধানের উপর ভাষা দেখাও";
+"settings-language" = "উইকিপিডিয়া ভাষা";
+"settings-support" = "উইকিপিডিয়াকে সাহায্য করুন";
+"settings-language-bar" = "অনুসন্ধানের সময় ভাষাগুলিকে দেখাও";
 "main-menu-title" = "আরও";
 "main-menu-heading-about" = "পরিচিতি";
 "main-menu-language-title" = "$1 ভাষার উইকিতে অনুসন্ধান";
@@ -118,7 +119,7 @@
 "main-menu-account-title-logged-in" = "$1 হিসাবে প্রবেশ";
 "main-menu-account-login" = "প্রবেশ করুন";
 "main-menu-account-logout" = "প্রস্থান";
-"main-menu-account-logout-are-you-sure" = "আপনি কি নিশ্চিত প্রস্থান করতে চান?";
+"main-menu-account-logout-are-you-sure" = "আপনি কি নিশ্চিত যে আপনি প্রস্থান করতে চান?";
 "main-menu-account-logout-cancel" = "বাতিল";
 "main-menu-show-title" = "আমাকে দেখাও...";
 "main-menu-show-history" = "সাম্প্রতিক";
@@ -141,17 +142,19 @@
 "main-menu-more" = "আরও...";
 "main-menu-heading-debug" = "ডিবাগ";
 "main-menu-debug-crash" = "ক্র্যাশ";
+"main-menu-debug-tweaks" = "বিকাশকারীর সেটিংস";
 "saved-title" = "সংরক্ষিত";
 "saved-pages-title" = "সংরক্ষিত পাতা";
 "saved-pages-clear-confirmation-heading" = "সংরক্ষিত সব আইটেম অপসারণ করবেন?";
 "saved-pages-clear-confirmation-sub-heading" = "এই ক্রিয়াটি পূর্বাবস্থায় ফেরানো যাবে না!";
 "saved-pages-clear-cancel" = "বাতিল";
-"saved-pages-clear-delete-all" = "হ্যা, সব মুছে ফেলুন";
+"saved-pages-clear-delete-all" = "হ্যাঁ, সব মুছে ফেলুন";
 "saved-pages-refresh-cancel-alert-title" = "আপলোড বাতিল হয়েছে";
 "saved-pages-refresh-cancel-alert-message" = "উইকিপিডিয়া নিবন্ধ সব সময় হালনাগাদ করা হয়। সব নিবন্ধের সর্বশেষ সংস্করণ পেতে পুনঃসতেজ বোতামে টোকা দিন";
 "saved-pages-refresh-cancel-alert-button" = "বুঝেছি";
 "saved-pages-description" = "সংরক্ষিত পাতা বেশ ভালো। তাদের বুকমার্ক হিসাবে চিন্তা করুন যা এমনকি আপনি অফলাইনে থাকাকালীন আপনি পড়তে পারেন।";
 "saved-pages-none" = "এখনো কোন পাতা সংরক্ষিত হয়নি।";
+"saved-pages-image-download-error" = "এই সংরক্ষিত পাতার জন্য চিত্র ডাউনলোড করা ব্যর্থ হয়েছে।";
 "history-title" = "ইতিহাস";
 "page-history-title" = "নিবন্ধের ইতিহাস";
 "page-history-downloading" = "নিবন্ধের ইতিহাস লোড হচ্ছে...";
@@ -197,9 +200,12 @@
 "about-libraries-license" = "লাইসেন্স";
 "about-libraries-licenses" = "লাইসেন্স";
 "about-content-license" = "বিষয়বস্তুর লাইসেন্স";
+"about-content-license-details" = "অন্যথায় নির্দিষ্ট করা না থাকলে, বিষয়বস্তু $1-এর অধীনে উপলব্ধ।";
 "about-content-license-details-share-alike-license" = "ক্রিয়েটিভ কমন্স অ্যাট্রিবিউশন শেয়ার অ্যালাইক";
+"about-libraries-licenses-title" = "আমরা মুক্ত উৎসের সফটওয়্যার ভালোবাসি $1";
 "about-libraries-complete-list" = "সম্পূর্ণ তালিকা";
 "about-repositories" = "সংগ্রহস্থল";
+"about-repositories-app-source-license" = "উৎস কোড $1-এর অধীনে উপলব্ধ।";
 "about-repositories-app-source-license-mit" = "এমআইটি লাইসেন্স";
 "about-send-feedback" = "অ্যাপ সম্পর্কে প্রতিক্রিয়া জানান";
 "about-product-of" = "$1-এর একটি পণ্য";
@@ -245,7 +251,7 @@
 "table-of-contents-heading" = "পরিচ্ছেদসমূহ";
 "table-of-contents-button-label" = "সূচিপত্র";
 "table-of-contents-close-accessibility-label" = "বিষয়বস্তুর সূচিপত্র বন্ধ করুন";
-"table-of-contents-close-accessibility-hint" = "বন্ধ";
+"table-of-contents-close-accessibility-hint" = "বন্ধ করুন";
 "abuse-filter-warning-heading" = "এটি অ-গঠনমূলক সম্পাদনা বলে মনে হচ্ছে, আপনি কি নিশ্চিতভাবে এটি সংরক্ষণ করতে চান?";
 "abuse-filter-warning-subheading" = "আপনার সম্পাদনায় নিম্নলিখিতগুলি এক বা একাধিক থাকতে পারে:";
 "abuse-filter-warning-caps" = "সব বড় হাতের অক্ষরে লেখা";
@@ -301,24 +307,35 @@
 "home-empty-section" = "কোন ফলাফল নেই";
 "home-empty-section-check-again" = "আবার চেষ্টা করুন";
 "home-continue-reading-heading" = "পড়া অব্যাহত রাখুন";
-"home-nearby-location-footer" = "কাছে আরও $১";
+"home-nearby-location-footer" = "$1-এর আরো কাছাকাছি";
+"home-main-page-heading" = "আজ উইকিপিডিয়ায়";
 "home-last-update-label" = "সর্বশেষ হালনাগাদ: $1";
 "home-hide-suggestion-cancel" = "বাতিল";
-"welcome-explore-title" = "অন্বেষণ";
+"welcome-explore-title" = "অন্বেষণ করুন";
 "welcome-explore-tell-me-more" = "আমাকে আরও বলুন";
-"welcome-explore-tell-me-more-about-explore" = "সম্পর্কে আর অন্বেষণ করুন";
+"welcome-explore-tell-me-more-about-explore" = "অন্বেষণ সম্পর্কে আরো";
 "welcome-explore-tell-me-more-done-button" = "বুঝেছি";
 "welcome-explore-continue-button" = "শুরু করুন";
-"welcome-languages-title" = "ভাষা";
-"welcome-languages-add-button" = "অপর একটি যোগ করুন";
+"welcome-languages-title" = "ভাষাসমূহ";
+"welcome-languages-add-button" = "+ আরেকটি যোগ করুন";
+"welcome-languages-continue-button" = "অব্যাহত";
 "welcome-volunteer-title" = "স্বেচ্ছাসেবক";
 "welcome-volunteer-send-usage-reports" = "ব্যবহারের রিপোর্ট পাঠান";
-"welcome-volunteer-continue-button" = "অব্যাহত";
+"welcome-volunteer-continue-button" = "অব্যাহত রাখুন";
 "welcome-volunteer-thanks" = "$1 আপনাকে ধন্যবাদ!";
 "empty-no-feed-title" = "কোন ইন্টারনেট সংযোগ নেই";
-"empty-no-search-results-message" = "কোনো ফলাফল পাওয়া যায়নি";
+"empty-no-feed-action-message" = "আপনি এখনো সংরক্ষিত পাতা পাঠ করতে পারেন।";
+"empty-no-search-results-message" = "কোন ফলাফল পাওয়া যায়নি";
+"alert-no-internet" = "ইন্টারনেট সংযোগ নেই";
+"icon-shortcut-search-title" = "উইকিপিডিয়া অনুসন্ধান";
+"icon-shortcut-continue-reading-title" = "পড়া অব্যাহত রাখুন";
+"icon-shortcut-nearby-title" = "কাছাকাছি নিবন্ধ";
 "close-button-accessibility-label" = "বন্ধ";
 "back-button-accessibility-label" = "পিছনে";
-"explore-most-read-footer" = "সব শীর্ষ পঠিত নিবন্ধ";
-// Fuzzy
-"explore-most-read-more-list-title" = "বেশি পঠিত নিবন্ধ";
+"explore-featured-article-heading" = "নির্বাচিত নিবন্ধ";
+"explore-nearby-heading" = "নিকটবর্তী স্থানগুলি";
+"explore-main-page-heading" = "আজ উইকিপিডিয়ায়";
+"explore-random-article-heading" = "অজানা যে-কোনো নিবন্ধ";
+"explore-random-article-sub-heading" = "ইংরেজি উইকিপিডিয়া";
+"explore-most-read-footer" = "সর্বাধিক পঠিত নিবন্ধগুলি";
+"explore-most-read-more-list-title" = "শীর্ষ নিবন্ধ";

--- a/Wikipedia/Localizations/de.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/de.lproj/Localizable.strings
@@ -7,8 +7,7 @@
 "article-languages-label" = "Sprache auswählen";
 "article-languages-cancel" = "Abbrechen";
 "article-languages-downloading" = "Lade Artikelsprachen …";
-// Fuzzy
-"article-languages-filter-placeholder" = "Sprachfilter";
+"article-languages-filter-placeholder" = "Sprache finden";
 "article-read-more-title" = "Mehr lesen";
 "article-about-title" = "Über diesen Artikel";
 "article-unable-to-load-section" = "Dieser Abschnitt konnte nicht geladen werden. Versuche, den Artikel neu zu laden, um zu sehen, ob dies das Problem behebt.";
@@ -102,6 +101,7 @@
 "search-recent-clear-delete-all" = "Alle löschen";
 "search-result-redirected-from" = "Weitergeleitet von: $1";
 "settings-title" = "Einstellungen";
+"settings-language" = "Wikipedia-Sprache";
 "settings-support" = "Wikipedia unterstützen";
 "settings-language-bar" = "Sprachen in der Suche anzeigen";
 "main-menu-title" = "Weitere";
@@ -340,8 +340,9 @@
 "welcome-explore-sub-title" = "Ein neuer Weg, um täglich interessante Artikel zu entdecken.";
 "welcome-explore-tell-me-more" = "Mehr erfahren";
 "welcome-explore-tell-me-more-about-explore" = "Mehr über Entdecken";
-// Fuzzy
-"welcome-explore-tell-me-more-details" = "Wenn du einen Artikel besuchst, werden verwandte Artikel automatisch deinem Entdecken-Feed hinzugefügt. Dies ändert nichts daran, wie wir deine Informationen sammeln, sodass dein Leseverlauf privat bleibt.";
+"welcome-explore-tell-me-more-details" = "Wenn du einen Artikel liest, werden verwandte Artikel automatisch deinem Entdecken-Feed hinzugefügt. Dies ändert nichts daran, wie wir deine Informationen sammeln, sodass dein Leseverlauf privat bleibt.";
+"welcome-explore-tell-me-more-related" = "Das Entdecken-Feed zeigt dir ähnliche Artikel zu Artikeln, die du gelesen hast.";
+"welcome-explore-tell-me-more-privacy" = "Auf unseren Servern ist keine Leseliste oder kein Profil gespeichert.";
 "welcome-explore-tell-me-more-done-button" = "Verstanden";
 "welcome-explore-continue-button" = "Anfangen";
 "welcome-languages-title" = "Sprachen";
@@ -355,8 +356,7 @@
 "welcome-volunteer-thanks" = "$1 Vielen Dank!";
 "empty-no-feed-title" = "Keine Internetverbindung";
 "empty-no-feed-message" = "Du kannst deine empfohlenen Artikel ansehen, wenn du Internet hast.";
-// Fuzzy
-"empty-no-feed-action-message" = "Du kannst in der Zwischenzeit gespeicherte Seiten lesen";
+"empty-no-feed-action-message" = "Du kannst trotzdem gespeicherte Seiten lesen";
 "empty-no-article-message" = "Leider konnte der Artikel nicht geladen werden";
 "empty-no-search-results-message" = "Keine Ergebnisse gefunden";
 "empty-no-saved-pages-title" = "Noch keine gespeicherten Seiten";
@@ -373,8 +373,7 @@
 "compass-direction" = "nach $1 Uhr";
 "explore-featured-article-heading" = "Vorgestellter Artikel";
 "explore-continue-reading-heading" = "Mit dem Lesen fortfahren";
-// Fuzzy
-"explore-nearby-heading" = "Orte in der Nähe";
+"explore-nearby-heading" = "Orte in der Nähe von";
 "explore-continue-related-heading" = "Weil du liest";
 "explore-main-page-heading" = "Heute auf Wikipedia";
 "explore-random-article-heading" = "Zufälliger Artikel";
@@ -382,5 +381,4 @@
 "explore-potd-heading" = "Bild des Tages";
 "explore-most-read-heading" = "Meistgelesen in der Wikipedia auf $1";
 "explore-most-read-footer" = "Alle beliebtesten Artikel";
-// Fuzzy
 "explore-most-read-more-list-title" = "Beliebteste Artikel";

--- a/Wikipedia/Localizations/es.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/es.lproj/Localizable.strings
@@ -16,8 +16,7 @@
 "article-languages-label" = "Elige un idioma";
 "article-languages-cancel" = "Cancelar";
 "article-languages-downloading" = "Cargando idiomas del artículo…";
-// Fuzzy
-"article-languages-filter-placeholder" = "Filtro de idiomas";
+"article-languages-filter-placeholder" = "Seleccionar idioma";
 "article-read-more-title" = "Leer más";
 "article-about-title" = "Acerca de este artículo";
 "article-unable-to-load-section" = "No se pudo cargar esta sección. Prueba recargar el artículo para ver si se soluciona el problema.";
@@ -111,6 +110,7 @@
 "search-recent-clear-delete-all" = "Borrar todas";
 "search-result-redirected-from" = "Redirigido desde: $1";
 "settings-title" = "Configuración";
+"settings-language" = "Idioma de Wikipedia";
 "settings-support" = "Apoya a Wikipedia";
 "settings-language-bar" = "Mostrar los idiomas al buscar";
 "main-menu-title" = "Más";
@@ -349,8 +349,9 @@
 "welcome-explore-sub-title" = "Una forma nueva de descubrir artículos interesantes todos los días";
 "welcome-explore-tell-me-more" = "Más información";
 "welcome-explore-tell-me-more-about-explore" = "Más acerca de Explorar";
-// Fuzzy
-"welcome-explore-tell-me-more-details" = "Cuando visitas un artículo, los artículos relacionados se agregan automáticamente a tu canal de Explorar. Esto no cambia la manera en que recopilamos tu información, y tu historial de lectura sigue siendo privado.";
+"welcome-explore-tell-me-more-details" = "Cuando lees un artículo, los artículos relacionados se agregan automáticamente a tu canal de Explorar. Esto no cambia la manera en que recopilamos tu información, y tu historial de lectura sigue siendo privado.";
+"welcome-explore-tell-me-more-related" = "El canal Explorar muestra artículos relacionados con los artículos que hayas leído.";
+"welcome-explore-tell-me-more-privacy" = "En nuestros servidores no se guardan ni perfiles ni listas de lectura.";
 "welcome-explore-tell-me-more-done-button" = "Entendido";
 "welcome-explore-continue-button" = "Empezar";
 "welcome-languages-title" = "Idiomas";
@@ -364,8 +365,7 @@
 "welcome-volunteer-thanks" = "$1 ¡Gracias!";
 "empty-no-feed-title" = "No hay conexión a Internet";
 "empty-no-feed-message" = "Puedes ver tus artículos recomendados cuando tengas Internet";
-// Fuzzy
-"empty-no-feed-action-message" = "Puedes leer páginas guardadas mientras tanto";
+"empty-no-feed-action-message" = "Aún puedes leer las páginas guardadas";
 "empty-no-article-message" = "Lo sentimos, no se pudo cargar el artículo";
 "empty-no-search-results-message" = "No se encontraron resultados";
 "empty-no-saved-pages-title" = "Todavía no hay páginas guardadas";
@@ -382,8 +382,7 @@
 "compass-direction" = "a las $1 en punto";
 "explore-featured-article-heading" = "Artículo destacado";
 "explore-continue-reading-heading" = "Continuar leyendo";
-// Fuzzy
-"explore-nearby-heading" = "Lugares cercanos";
+"explore-nearby-heading" = "Lugares cercanos a";
 "explore-continue-related-heading" = "Porque leíste";
 "explore-main-page-heading" = "Hoy en Wikipedia";
 "explore-random-article-heading" = "Artículo aleatorio";
@@ -391,5 +390,4 @@
 "explore-potd-heading" = "Imagen del día";
 "explore-most-read-heading" = "Los más leídos en Wikipedia en $1";
 "explore-most-read-footer" = "Todos los artículos más leídos";
-// Fuzzy
 "explore-most-read-more-list-title" = "Los artículos más leídos";

--- a/Wikipedia/Localizations/fa.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/fa.lproj/Localizable.strings
@@ -19,8 +19,7 @@
 "article-languages-label" = "انتخاب زبان";
 "article-languages-cancel" = "لغو";
 "article-languages-downloading" = "در حال بارگیری زبان‌های مقاله...";
-// Fuzzy
-"article-languages-filter-placeholder" = "پالایه زبان";
+"article-languages-filter-placeholder" = "یافتن زبان";
 "article-read-more-title" = "بیشتر بخوانید";
 "article-about-title" = "دربارهٔ این مقاله";
 "article-unable-to-load-section" = "امکان بارگیری این بخش وجود ندارد. برای رفع مشکل صفحه را تازه کنید.";
@@ -114,6 +113,7 @@
 "search-recent-clear-delete-all" = "حذف همه";
 "search-result-redirected-from" = "تغییرمسیر از: $1";
 "settings-title" = "تنظیمات";
+"settings-language" = "زبان ویکی‌پدیا";
 "settings-support" = "حمایت از ویکی‌پدیا";
 "settings-language-bar" = "نمایش زبان در جستجو";
 "main-menu-title" = "بیشتر";
@@ -352,8 +352,9 @@
 "welcome-explore-sub-title" = "روش جدید برای پیدا کردن روزانهٔ مقالات جذاب";
 "welcome-explore-tell-me-more" = "به من بیشتر بگو";
 "welcome-explore-tell-me-more-about-explore" = "بیشتر در مورد کاوش";
-// Fuzzy
-"welcome-explore-tell-me-more-details" = "زمانی که شما یک مقاله را مشاهده می‌کنید مقاله به صورت خودکار به فهرست کاوش شما افزوده می‌شود. این مورد به روش جمع‌آوری اطلاعات شما توسط ما کاری ندارد و تاریخچهٔ مشاهدات شما به صورت خصوصی باقی می‌ماند.";
+"welcome-explore-tell-me-more-details" = "زمانی که شما یک مقاله را مطالعه می‌کنید مقاله به صورت خودکار به فهرست کاوش شما افزوده می‌شود. این مورد به روش جمع‌آوری اطلاعات شما توسط ما کاری ندارد و تاریخچهٔ مشاهدات شما به صورت خصوصی باقی می‌ماند.";
+"welcome-explore-tell-me-more-related" = "فیدهای کاوش مقالات مرتبط با مقاله‌ای که مطالعه کرده‌اید را به شما نمایش می‌دهد.";
+"welcome-explore-tell-me-more-privacy" = "هیچ فهرست یا داده‌ای از مطالعات و اطلاعات شما بر روی سرورهای ما ذخیره نمی‌شود.";
 "welcome-explore-tell-me-more-done-button" = "گرفتم";
 "welcome-explore-continue-button" = "شروع شد";
 "welcome-languages-title" = "زبان‌ها";
@@ -367,8 +368,7 @@
 "welcome-volunteer-thanks" = "$1 متشکریم!";
 "empty-no-feed-title" = "عدم اتصال به اینترنت";
 "empty-no-feed-message" = "زمانی که به اینترنت متصل باشید می‌توانید مقالات پیشنهادی را مشاهده کنید.";
-// Fuzzy
-"empty-no-feed-action-message" = "فعلا می توانید صفحه‌های ذخیره شده را مطالعه کنید";
+"empty-no-feed-action-message" = "فعلاً می توانید صفحه‌های ذخیره شده را مطالعه کنید";
 "empty-no-article-message" = "متاسفانه امکان بارگیری مقاله نیست";
 "empty-no-search-results-message" = "نتیجه‌ای یافت نشد";
 "empty-no-saved-pages-title" = "هنوز صفحه‌ای ذخیره نشده‌است";
@@ -385,8 +385,7 @@
 "compass-direction" = "در ساعت $1";
 "explore-featured-article-heading" = "مقالهٔ برگزیده";
 "explore-continue-reading-heading" = "ادامه دادن به خواندن";
-// Fuzzy
-"explore-nearby-heading" = "مکان های نزدیک";
+"explore-nearby-heading" = "مکان‌های نزدیک";
 "explore-continue-related-heading" = "چون شما مطالعه می‌کنید";
 "explore-main-page-heading" = "امروز در ویکی‌پدیا";
 "explore-random-article-heading" = "مقاله تصادفی";
@@ -394,5 +393,4 @@
 "explore-potd-heading" = "نگارهٔ برگزیدهٔ روز";
 "explore-most-read-heading" = "برای مطالعه در ویکی‌پدیای $1";
 "explore-most-read-footer" = "همهٔ مقالاتی که بیشترین بازدید را داشتند";
-// Fuzzy
-"explore-most-read-more-list-title" = "مقالات بیشتر خوانده شده";
+"explore-most-read-more-list-title" = "بالاترین مقالات";

--- a/Wikipedia/Localizations/fi.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/fi.lproj/Localizable.strings
@@ -14,8 +14,7 @@
 "article-languages-label" = "Valitse kieli";
 "article-languages-cancel" = "Peruuta";
 "article-languages-downloading" = "Ladataan artikkelin kieliä...";
-// Fuzzy
-"article-languages-filter-placeholder" = "Kielisuodatin";
+"article-languages-filter-placeholder" = "Löydä kieli";
 "article-read-more-title" = "Lue lisää";
 "article-about-title" = "Tietoja tästä artikkelista";
 "article-unable-to-load-section" = "Tämän osion lataaminen ei onnistu. Yritä päivittää artikkeli nähdäksesi josko se korjaa ongelman.";
@@ -109,6 +108,7 @@
 "search-recent-clear-delete-all" = "Poista kaikki";
 "search-result-redirected-from" = "Ohjattu sivulta: $1";
 "settings-title" = "Asetukset";
+"settings-language" = "Wikipedian kieli";
 "settings-support" = "Tue Wikipediaa";
 "main-menu-title" = "Lisää";
 "main-menu-heading-about" = "Tietoja";
@@ -215,6 +215,7 @@
 "share-menu-page-saved-access" = "Vihje: Päästäksesi tallentamillesi sivuille näpäytä kuvaketta $1 tai paina pitkään kuvaketta $2.";
 "share-custom-menu-item" = "Jaa";
 "share-a-fact-share-menu-item" = "Jaa fakta";
+"share-on-twitter-sign-off" = "@Wikipedia'n kautta";
 "share-article-name-on-wikipedia" = "\"$1\" @Wikipedia'ssa:";
 "share-article-name-on-wikipedia-with-selected-text" = "\"$1\" @Wikipedia'ssa: \"$2\"";
 "share-as-image" = "Jaa kuvana";
@@ -338,8 +339,7 @@
 "welcome-volunteer-thanks" = "$1 Kiitos!";
 "empty-no-feed-title" = "Ei Internet-yhteyttä";
 "empty-no-feed-message" = "Näet suositellut artikkelisi kun sinulla on Internet-yhteys";
-// Fuzzy
-"empty-no-feed-action-message" = "Voit lukea tallennettuja sivuja sillä välin";
+"empty-no-feed-action-message" = "Voit silti lukea tallennettuja sivuja";
 "empty-no-article-message" = "Pahoittelut, artikkelia ei voitu ladata";
 "empty-no-search-results-message" = "Tuloksia ei löytynyt";
 "empty-no-saved-pages-title" = "Ei tallennettuja sivua vielä";
@@ -357,3 +357,4 @@
 "explore-random-article-heading" = "Satunnainen artikkeli";
 "explore-random-article-sub-heading" = "Englanninkielinen Wikipedia";
 "explore-potd-heading" = "Päivän kuva";
+"explore-most-read-more-list-title" = "Huippuartikkelit";

--- a/Wikipedia/Localizations/fr.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/fr.lproj/Localizable.strings
@@ -16,8 +16,7 @@
 "article-languages-label" = "Choisir langue";
 "article-languages-cancel" = "Annuler";
 "article-languages-downloading" = "Chargement des langues de l’article en cours…";
-// Fuzzy
-"article-languages-filter-placeholder" = "Filtre de langue";
+"article-languages-filter-placeholder" = "Trouver la langue";
 "article-read-more-title" = "En savoir plus";
 "article-about-title" = "À propos de cet article";
 "article-unable-to-load-section" = "Impossible de charger cette section. Essayez de rafraîchir l’article pour voir si cela corrige le problème.";
@@ -111,6 +110,7 @@
 "search-recent-clear-delete-all" = "Supprimer tout";
 "search-result-redirected-from" = "(Redirigé depuis $1)";
 "settings-title" = "Paramètres";
+"settings-language" = "Langue de Wikipédia";
 "settings-support" = "Soutenir Wikipédia";
 "settings-language-bar" = "Afficher les langues dans la recherche";
 "main-menu-title" = "Plus";
@@ -349,8 +349,9 @@
 "welcome-explore-sub-title" = "Une nouvelle manière de découvrir des articles intéressants chaque jour";
 "welcome-explore-tell-me-more" = "M’en dire plus";
 "welcome-explore-tell-me-more-about-explore" = "Davantage au sujet de Explore";
-// Fuzzy
-"welcome-explore-tell-me-more-details" = "Quand vous visitez un article, les articles connexes sont automatiquement ajoutés à votre fil Explore. Cela ne change rien à la manière dont nous collectons vos informations, et votre historique de lecture reste privé.";
+"welcome-explore-tell-me-more-details" = "Quand vous lisez un article, les articles connexes sont automatiquement ajoutés à votre fil Explore. Cela ne change rien à la manière dont nous collectons vos informations, et votre historique de lecture reste privé.";
+"welcome-explore-tell-me-more-related" = "Le fil Explore vous montre les articles liés aux articles que vous avez lus.";
+"welcome-explore-tell-me-more-privacy" = "Aucune liste ni profil de lecture ne sont stockés sur nos serveurs.";
 "welcome-explore-tell-me-more-done-button" = "Opter pour";
 "welcome-explore-continue-button" = "Commencer";
 "welcome-languages-title" = "Langues";
@@ -364,8 +365,7 @@
 "welcome-volunteer-thanks" = "$1 Merci !";
 "empty-no-feed-title" = "Pas de connexion à Internet";
 "empty-no-feed-message" = "Vous pouvez voir vos articles recommandés quand vous avez Internet";
-// Fuzzy
-"empty-no-feed-action-message" = "Vous pouvez lire les pages enregistrées entre temps";
+"empty-no-feed-action-message" = "Vous pouvez toujours lire les pages enregistrées";
 "empty-no-article-message" = "Désolé, l'article n'a pas pu être chargé";
 "empty-no-search-results-message" = "Aucun résultat trouvé";
 "empty-no-saved-pages-title" = "Encore aucune page enregistrée";
@@ -382,8 +382,7 @@
 "compass-direction" = "à $1 heures";
 "explore-featured-article-heading" = "Article vedette";
 "explore-continue-reading-heading" = "Continuer à lire";
-// Fuzzy
-"explore-nearby-heading" = "Endroits voisins";
+"explore-nearby-heading" = "Endroits proches";
 "explore-continue-related-heading" = "Parce que vous avez lu";
 "explore-main-page-heading" = "Aujourd’hui sur Wikipédia";
 "explore-random-article-heading" = "Article au hasard";
@@ -391,5 +390,4 @@
 "explore-potd-heading" = "Image du jour";
 "explore-most-read-heading" = "Meilleures lectures sur Wikipédia en $1";
 "explore-most-read-footer" = "Tous les articles les plus lus";
-// Fuzzy
-"explore-most-read-more-list-title" = "Articles les plus lus";
+"explore-most-read-more-list-title" = "Meilleurs articles";

--- a/Wikipedia/Localizations/gl.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/gl.lproj/Localizable.strings
@@ -10,8 +10,7 @@
 "article-languages-label" = "Escolla unha lingua";
 "article-languages-cancel" = "Cancelar";
 "article-languages-downloading" = "Cargando as linguas do artigo...";
-// Fuzzy
-"article-languages-filter-placeholder" = "Filtro de linguas";
+"article-languages-filter-placeholder" = "Atopar lingua";
 "article-read-more-title" = "Ler máis";
 "article-about-title" = "Acerca deste artigo";
 "article-unable-to-load-section" = "Non foi posible cargar esta sección. Probe a refrescar o artigo para intentar amañar o problema.";
@@ -105,6 +104,7 @@
 "search-recent-clear-delete-all" = "Borrar todo";
 "search-result-redirected-from" = "Redirixido de: $1";
 "settings-title" = "Configuración";
+"settings-language" = "Lingua de Wikipedia";
 "settings-support" = "Apoie a Wikipedia";
 "settings-language-bar" = "Amosar as linguas ó buscar";
 "main-menu-title" = "Máis";
@@ -343,8 +343,9 @@
 "welcome-explore-sub-title" = "Unha forma nova de descubrir artigos interesantes todos os días";
 "welcome-explore-tell-me-more" = "Contarme máis";
 "welcome-explore-tell-me-more-about-explore" = "Máis sobre Explorar";
-// Fuzzy
-"welcome-explore-tell-me-more-details" = "Cando visita un artigo, os artigos relacionados agréganse automaticamente á súa canle de Explorar. Isto non cambia a maneira en que recompilamos a súa información, e o seu historial de lectura segue sendo privado.";
+"welcome-explore-tell-me-more-details" = "Cando le un artigo, os artigos relacionados agréganse automaticamente á súa canle de Explorar. Isto non cambia a maneira en que recompilamos a súa información, e o seu historial de lectura segue sendo privado.";
+"welcome-explore-tell-me-more-related" = "A canle Explorar mostra artigos relacionados cos artigos que xa leu.";
+"welcome-explore-tell-me-more-privacy" = "Nos nosos servidores non se gardan nin perfís nin listas de lectura.";
 "welcome-explore-tell-me-more-done-button" = "Entendido";
 "welcome-explore-continue-button" = "Comezar";
 "welcome-languages-title" = "Linguas";
@@ -358,8 +359,7 @@
 "welcome-volunteer-thanks" = "$1 Grazas!";
 "empty-no-feed-title" = "Sen conexión a Internet";
 "empty-no-feed-message" = "Pode ver os seus artigos recomendados cando teña conexión a Internet";
-// Fuzzy
-"empty-no-feed-action-message" = "Mentras tanto, pode ler a páxinas gardadas";
+"empty-no-feed-action-message" = "Aínda pode ler as páxinas gardadas";
 "empty-no-article-message" = "Sentímolo, non foi posible cargar o artigo";
 "empty-no-search-results-message" = "No se atoparon resultados";
 "empty-no-saved-pages-title" = "Aínda non hai páxinas gardadas";
@@ -376,7 +376,6 @@
 "compass-direction" = "ás $1";
 "explore-featured-article-heading" = "Artigo destacado";
 "explore-continue-reading-heading" = "Continuar lendo";
-// Fuzzy
 "explore-nearby-heading" = "Lugares próximos";
 "explore-continue-related-heading" = "Porque leu";
 "explore-main-page-heading" = "Hoxe en Wikipedia";
@@ -385,5 +384,4 @@
 "explore-potd-heading" = "Imaxe do día";
 "explore-most-read-heading" = "Os máis lidos en Wikipedia en $1";
 "explore-most-read-footer" = "Todos os artigos máis lidos";
-// Fuzzy
-"explore-most-read-more-list-title" = "Os artigos máis lidos";
+"explore-most-read-more-list-title" = "Os mellores artigos";

--- a/Wikipedia/Localizations/he.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/he.lproj/Localizable.strings
@@ -11,8 +11,7 @@
 "article-languages-label" = "בחירת שפה";
 "article-languages-cancel" = "ביטול";
 "article-languages-downloading" = "טעינת שפות הערך...";
-// Fuzzy
-"article-languages-filter-placeholder" = "סינון שפה";
+"article-languages-filter-placeholder" = "מציאת שפה";
 "article-read-more-title" = "לקרוא עוד";
 "article-about-title" = "מידע על הערך הזה";
 "article-unable-to-load-section" = "לא ניתן לטעון את הפסקה הזאת. נא לנסות לרענן את הערך כדי לראות אם זה מתקן את הבעיה.";
@@ -106,6 +105,7 @@
 "search-recent-clear-delete-all" = "למחוק הכול";
 "search-result-redirected-from" = "הופנה מהדף: $1";
 "settings-title" = "הגדרות";
+"settings-language" = "שפת הוויקיפדיה";
 "settings-support" = "תמיכה בוויקיפדיה";
 "settings-language-bar" = "הצגת שפות בחיפוש";
 "main-menu-title" = "עוד";
@@ -344,8 +344,9 @@
 "welcome-explore-sub-title" = "דרך חדשה לגלות ערכים מעניינים מדי יום";
 "welcome-explore-tell-me-more" = "ספרו לי עוד";
 "welcome-explore-tell-me-more-about-explore" = "עוד על האפשרות לחקור";
-// Fuzzy
 "welcome-explore-tell-me-more-details" = "בזמן קריאת ערך, ערכים קשורים נוספים באופן אוטומטי להזנת ה\"לחקור\" שלך. זה לא משנה את הצורה שבה אנחנו אוספים את המידע שלך, והיסטוריית הגלישה שלך עדיין פרטית.";
+"welcome-explore-tell-me-more-related" = "הזנת ה\"לחקור\" מציכה לך ערכים שקשורים לערכים שכבר קראת.";
+"welcome-explore-tell-me-more-privacy" = "איננו שומרים שום רשימת קריאה או פרופיל בשרתים שלנו.";
 "welcome-explore-tell-me-more-done-button" = "הבנתי";
 "welcome-explore-continue-button" = "להתחיל";
 "welcome-languages-title" = "שפות";
@@ -359,8 +360,7 @@
 "welcome-volunteer-thanks" = "$1 תודה!";
 "empty-no-feed-title" = "אין חיבור אינטרנט";
 "empty-no-feed-message" = "אפשר לראות הצעות לערכים כשיהיה לך אינטרנט";
-// Fuzzy
-"empty-no-feed-action-message" = "בינתיים אפשר לקרוא דפים שמורים";
+"empty-no-feed-action-message" = "עדיין אפשר לקרוא דפים שמורים";
 "empty-no-article-message" = "סליחה, לא ניתן לטעון ערך";
 "empty-no-search-results-message" = "לא נמצאו תוצאות";
 "empty-no-saved-pages-title" = "אין עדיין דפים שמורים";
@@ -377,7 +377,6 @@
 "compass-direction" = "בשעה $1";
 "explore-featured-article-heading" = "ערך מומלץ";
 "explore-continue-reading-heading" = "המשך קריאה";
-// Fuzzy
 "explore-nearby-heading" = "מקומות בסביבה";
 "explore-continue-related-heading" = "כי קראת את";
 "explore-main-page-heading" = "היום בוויקיפדיה";
@@ -386,5 +385,4 @@
 "explore-potd-heading" = "תמונת היום";
 "explore-most-read-heading" = "הכי נקרא בוויקיפדיה ה$1";
 "explore-most-read-footer" = "כל הערכים שנקראו הכי הרבה";
-// Fuzzy
-"explore-most-read-more-list-title" = "ערכים שנקראו הכי הרבה";
+"explore-most-read-more-list-title" = "ערכים מובילים";

--- a/Wikipedia/Localizations/id.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/id.lproj/Localizable.strings
@@ -17,8 +17,7 @@
 "article-languages-label" = "Pilih bahasa";
 "article-languages-cancel" = "Batal";
 "article-languages-downloading" = "Memuat bahasa artikel...";
-// Fuzzy
-"article-languages-filter-placeholder" = "Saring Bahasa";
+"article-languages-filter-placeholder" = "Cari Bahasa";
 "article-read-more-title" = "Baca lebih lanjut";
 "article-about-title" = "Mengenai berkas ini";
 "article-unable-to-load-section" = "Tidak dapat memuat bagian ini. Coba menyegarkan artikel untuk melihat apakah itu bisa memperbaiki masalah.";
@@ -112,6 +111,7 @@
 "search-recent-clear-delete-all" = "Hapus Semua";
 "search-result-redirected-from" = "Dialihkan dari: $1";
 "settings-title" = "Pengaturan";
+"settings-language" = "Bahasa Wikipedia";
 "settings-support" = "Dukung Wikipedia";
 "settings-language-bar" = "Tampilkan bahasa di pencarian";
 "main-menu-title" = "Lainnya";
@@ -350,8 +350,9 @@
 "welcome-explore-sub-title" = "Cara baru untuk menemukan artikel yang menarik setiap hari";
 "welcome-explore-tell-me-more" = "Beritahu saya lebih lanjut";
 "welcome-explore-tell-me-more-about-explore" = "Lebih lanjut mengenai Jelajah";
-// Fuzzy
-"welcome-explore-tell-me-more-details" = "Ketika Anda mengunjungi artikel, artikel yang terkait ditambahkan ke umpan Jelajah Anda. Hal ini tidak mengubah bagaimana mengumpulkan informasi Anda, dan riwayat bacaan Anda selalu tetap rahasia.";
+"welcome-explore-tell-me-more-details" = "Ketika Anda membaca artikel, artikel yang terkait ditambahkan ke umpan Jelajah Anda. Hal ini tidak mengubah bagaimana mengumpulkan informasi Anda, dan riwayat bacaan Anda selalu tetap rahasia.";
+"welcome-explore-tell-me-more-related" = "Umpan Jelajah menampilkan Anda artikel yang berhubungan dengan artikel yang Anda sudah baca.";
+"welcome-explore-tell-me-more-privacy" = "Tidak ada daftar bacaan ataupun profil yang disimpan di server kami.";
 "welcome-explore-tell-me-more-done-button" = "Mengerti";
 "welcome-explore-continue-button" = "Memulai";
 "welcome-languages-title" = "Bahasa";
@@ -365,8 +366,7 @@
 "welcome-volunteer-thanks" = "Terima kasih! $1";
 "empty-no-feed-title" = "Tidak ada sambungan internet";
 "empty-no-feed-message" = "Anda bisa melihat artikel yang disarankan untuk Anda saat Anda mempunyai sambungan intenet";
-// Fuzzy
-"empty-no-feed-action-message" = "Anda masih bisa membaca laman tersimpan";
+"empty-no-feed-action-message" = "Anda masih dapat membaca laman tersimpan";
 "empty-no-article-message" = "Maaf, artikel tidak bisa dimuat";
 "empty-no-search-results-message" = "Tidak ada hasil yang ditemukan";
 "empty-no-saved-pages-title" = "Tidak ada halaman yang disimpan.";
@@ -383,8 +383,7 @@
 "compass-direction" = "pada pukul $1 tepat";
 "explore-featured-article-heading" = "Artikel pilihan";
 "explore-continue-reading-heading" = "Lanjutkan membaca";
-// Fuzzy
-"explore-nearby-heading" = "Tempat sekitar";
+"explore-nearby-heading" = "Tempat dekat";
 "explore-continue-related-heading" = "Karena Anda membaca";
 "explore-main-page-heading" = "Hari ini di Wikipedia";
 "explore-random-article-heading" = "Artikel acak";
@@ -392,5 +391,4 @@
 "explore-potd-heading" = "Gambar pilihan";
 "explore-most-read-heading" = "Bacaan teratas di Wikipedia Bahasa $1";
 "explore-most-read-footer" = "Semua artikel bacaan teratas";
-// Fuzzy
-"explore-most-read-more-list-title" = "Artikel bacaan teratas";
+"explore-most-read-more-list-title" = "Artikel teratas";

--- a/Wikipedia/Localizations/is.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/is.lproj/Localizable.strings
@@ -9,26 +9,27 @@
 "article-languages-label" = "Velja tungumál";
 "article-languages-cancel" = "Hætta við";
 "article-languages-downloading" = "Hleður greinartungumál...";
-// Fuzzy
-"article-languages-filter-placeholder" = "Tungumálasía";
+"article-languages-filter-placeholder" = "Finna tungumál";
 "article-read-more-title" = "Lesa meira";
 "article-about-title" = "Um þessa grein";
+"article-unable-to-load-section" = "Gat ekki hlaðið þessum hluta inn. Reyndu að endurhlaða inn greininni til að sjá hvort það lagi vandamálið.";
 "article-unable-to-load-article" = "Gat ekki hlaðið inn grein!";
 "article-related-articles-title" = "Tengdar greinar";
 "info-box-title" = "Staðreyndir í einum hvelli";
 "info-box-close-text" = "Loka";
 "table-title-other" = "Nánari upplýsingar";
+"saved-clear-all" = "Hreinsa";
+"history-clear-all" = "Hreinsa";
 "history-label" = "Nýlegt";
 "history-section-today" = "Í dag";
 "history-section-yesterday" = "Í gær";
 "history-section-lastweek" = "Síðustu viku";
 "history-section-lastmonth" = "Síðasta mánuð";
-// Fuzzy
-"history-clear-confirmation-heading" = "Á að eyða öllum nýlegum atriðum?";
+"history-clear-confirmation-heading" = "Ertu viss um að þú viljir eyða öllum nýlegum atriðum?";
 "history-clear-confirmation-sub-heading" = "Þessa aðgerð er ekki hægt að afturkalla!";
 "history-clear-cancel" = "Hætta við";
-// Fuzzy
-"history-clear-delete-all" = "Eyða öllu";
+"history-clear-delete-all" = "Já, eyða öllu";
+"history-description" = "Líklega eyddirðu þeim öllum. Næst þegar þú ferð á síðu, geturðu komist til baka á hana hér.";
 "history-none" = "Engar nýlegar síður hér.";
 "zero-free-verbiage" = "Ókeyps aðgangur að Wikipedia á vegum símafyrirtækis þíns (enginn gagnakostnaður)";
 "zero-charged-verbiage" = "Slökkt er á Wikipedia Zero";
@@ -42,7 +43,6 @@
 "zero-learn-more-learn-more" = "Lesa meira";
 "zero-learn-more-no-thanks" = "Loka";
 "zero-wikipedia-zero-heading" = "Wikipedia Zero";
-// Fuzzy
 "zero-warn-when-leaving" = "Áminna mig ef ég fer burt af Wikipedia Zero";
 "zero-settings-devmode" = "Zero forritarastaða";
 "account-creation-captcha-required" = "Staðfesting með CAPTCHA krefst.";
@@ -103,38 +103,36 @@
 "search-recent-clear-delete-all" = "Eyða öllu";
 "search-result-redirected-from" = "Endurbeint frá: $1";
 "settings-title" = "Stillingar";
+"settings-language" = "Tungumál Wikipediu";
+"settings-support" = "Styðja Wikipedia";
+"settings-language-bar" = "Sýna tungumál við leit";
 "main-menu-title" = "Fleira";
 "main-menu-heading-about" = "Um hugbúnaðinn";
 "main-menu-language-title" = "Leita að $1 á Wikipedia";
-// Fuzzy
 "main-menu-faq" = "FAQ / Algengar spurningar";
 "main-menu-language-toggle-show" = "Sýna tungumál";
 "main-menu-language-toggle-hide" = "Fela tungumál";
 "main-menu-language-selection-saved" = "Tungumálastilling vistuð";
 "main-menu-account-title-logged-out" = "Aðgangur";
-// Fuzzy
-"main-menu-account-title-logged-in" = "Innskráð(ur) sem: $1";
-// Fuzzy
-"main-menu-account-login" = "Skrá inn á Wikipedia";
-"main-menu-account-logout" = "Útskrá";
+"main-menu-account-title-logged-in" = "Skráð(ur) inn sem: $1";
+"main-menu-account-login" = "Skrá inn";
+"main-menu-account-logout" = "Skrá út";
+"main-menu-account-logout-are-you-sure" = "Ertu viss að þú viljir skrá þig út?";
+"main-menu-account-logout-cancel" = "Hætta við";
 "main-menu-show-title" = "Sýna mér...";
 "main-menu-show-history" = "Nýlegt";
 "main-menu-show-saved" = "Vista greinar";
 "main-menu-current-article-save" = "Vista $1 fyrir tengingarlausan lestur";
 "main-menu-random" = "Handahófsvalið";
 "main-menu-feedback-heading" = "Ábendingar";
-// Fuzzy
-"main-menu-send-feedback" = "Senda ábendingar um appið";
+"main-menu-send-feedback" = "Skrifaðu okkur";
 "main-menu-show-page-history" = "Breytingaskrá um $1";
 "main-menu-credits" = "Viðurkenningar";
-// Fuzzy
 "main-menu-about" = "Um Wikipedia-appið";
 "main-menu-zero-faq" = "Algengar spurningar um Wikipedia Zero";
 "main-menu-privacy-policy" = "Persónuvernd";
-// Fuzzy
 "main-menu-terms-of-use" = "Notkunarskilmálar";
-// Fuzzy
-"main-menu-rate-app" = "Meta appið";
+"main-menu-rate-app" = "Gefa appinu einkunn";
 "main-menu-heading-zero" = "Wikipedia Zero";
 "main-menu-heading-legal" = "Gagnaleynd og skilmálar";
 "main-menu-show-today" = "Í dag";
@@ -145,14 +143,14 @@
 "main-menu-debug-tweaks" = "Stillingar fyrir forritara";
 "saved-title" = "Vistað";
 "saved-pages-title" = "Vistaðar síður";
-// Fuzzy
-"saved-pages-clear-confirmation-heading" = "Á að eyða öllum nýlegum atriðum?";
+"saved-pages-clear-confirmation-heading" = "Ertu viss um að þú viljir eyða öllum vistuðum síðum?";
 "saved-pages-clear-confirmation-sub-heading" = "Þessa aðgerð er ekki hægt að afturkalla!";
 "saved-pages-clear-cancel" = "Hætta við";
-// Fuzzy
-"saved-pages-clear-delete-all" = "Eyða öllu";
+"saved-pages-clear-delete-all" = "Já, eyða öllu";
 "saved-pages-refresh-cancel-alert-title" = "Hætt við uppfærslu";
+"saved-pages-refresh-cancel-alert-message" = "Wikipedia-greinar eru sífellt uppfærðar. Sláðu létt á endurhleðslu til að fá nýjustu útgáfu af öllum greinum.";
 "saved-pages-refresh-cancel-alert-button" = "Náði því";
+"saved-pages-description" = "Vistaðar síður eru ansi sniðugar. Ímyndaðu þér þær sem eins konar bókamerki sem þú getur lesið jafnvel þótt þú sért ekki nettengdur.";
 "saved-pages-none" = "Engar síður vistaðar ennþá.";
 "saved-pages-image-download-error" = "Tókst ekki að sækja myndir fyrir þessa vistuðu síðu.";
 "history-title" = "Ferill";
@@ -191,26 +189,27 @@
 "credits-external-libraries" = "Utanáliggjandi söfn";
 "about-title" = "Um";
 "about-wikipedia" = "Wikipedia";
-// Fuzzy
-"about-contributors" = "framleggjendur";
-// Fuzzy
-"about-testers" = "prófarar";
+"about-contributors" = "Framlög frá";
+"about-testers" = "Prófarar";
 "about-testers-details" = "Gæðaprófað af $1";
-// Fuzzy
-"about-translators" = "þýðendur";
+"about-translators" = "Þýðendur";
 "about-translators-details" = "Þýtt af sjálfboðaaðilum á $1";
-// Fuzzy
-"about-libraries" = "notuð söfn";
-"about-libraries-license" = "Leyfi";
-// Fuzzy
-"about-repositories" = "söfn";
+"about-libraries" = "Notuð aðgerðasöfn";
+"about-libraries-license" = "Notkunarleyfi";
+"about-libraries-licenses" = "Notkunarleyfi";
+"about-content-license" = "Notkunarleyfi efnis";
+"about-libraries-complete-list" = "Fullur listi";
+"about-repositories" = "Hugbúnaðarsöfn";
+"about-repositories-app-source-license" = "Upprunakóði er tiltækur með $1.";
+"about-repositories-app-source-license-mit" = "MIT notkunarleyfi";
 "about-send-feedback" = "Senda ábendingar um appið";
-"about-product-of" = "Vara frá $1";
+"about-product-of" = "Búið til af $1";
 "about-wikimedia-foundation" = "Wikimedia Foundation";
 "share-menu-save-page" = "Vista síðu";
 "share-menu-page-saved" = "Vista $1 fyrir tengingarlausan lestur";
 "share-menu-page-saved-access" = "Smáráð: til að fá aðgang að vistuðu síðunum þínum, bankaði á $1 fyrir ofan eða ýttu og haltu niðri á $2 fyrir neðan.";
 "share-custom-menu-item" = "Deila";
+"share-on-twitter-sign-off" = "með @Wikipedia";
 "share-article-name-on-wikipedia" = "„$1“ á @Wikipedia:";
 "share-article-name-on-wikipedia-with-selected-text" = "„$1“ á @Wikipedia: „$2“";
 "share-as-image" = "Deila sem mynd";
@@ -222,16 +221,15 @@
 "timestamp-days" = "Fyrir %d dögum";
 "timestamp-months" = "Fyrir %d mánuðum";
 "timestamp-years" = "Fyrir %d árum";
-// Fuzzy
-"lastmodified-by-user" = "Breytt $1 af $2";
-"lastmodified-by-anon" = "Breytt $1 af nafnlausum notanda";
+"lastmodified-by-user" = "Breytti $1 eftir $2";
+"lastmodified-by-anon" = "Breytti $1 eftir nafnlausan notanda";
 "button-next" = "Áfram";
 "button-done" = "Búið";
 "button-save" = "Vista";
 "button-save-for-later" = "Vista til síðari tíma";
 "button-saved-for-later" = "Vistað til síðari tíma brúks";
 "onboarding-create-account" = "Stofna aðgang";
-"onboarding-login" = "Innskrá";
+"onboarding-login" = "Skrá inn";
 "onboarding-already-have-account" = "Ert þú með aðgang? $1";
 "onboarding-skip" = "Sleppa";
 "onboarding-wikipedia" = "Wikipedia";
@@ -247,6 +245,8 @@
 "license-footer-name" = "CC BY-SA 3.0";
 "table-of-contents-heading" = "Efni";
 "table-of-contents-button-label" = "Efnisyfirlit";
+"table-of-contents-close-accessibility-label" = "Loka efnisyfirliti";
+"table-of-contents-close-accessibility-hint" = "Loka";
 "abuse-filter-warning-heading" = "Þetta lítur ekki út fyrir að vera uppbyggileg breyting, ert þú viss um að þú viljir vista hana?";
 "abuse-filter-warning-subheading" = "Breyting þín gæti innihaldið eitt eða fleira af eftirfarandi:";
 "abuse-filter-warning-caps" = "Textinn er í STÓRUM BÓKSTÖFUM";
@@ -290,31 +290,36 @@
 "migration-update-progress-label" = "Yfirfæri staðvær gögn";
 "migration-update-progress-count-label" = "Yfirfæri grein $1 af $2";
 "migration-prompt-title" = "Það lítur út eins og að til sé ferill!";
+"migration-prompt-message" = "Við þurfum að færa yfir vistaðar og nýlegar síður sem þú ert með. Þetta gæti tekið dálítinn tíma…";
 "migration-confirm-button-title" = "Yfirfæra dótið mitt";
 "migration-skip-button-title" = "Eyða því";
 "image-gallery-unknown-owner" = "Sendandi óþekktur.";
 "image-gallery-fetch-image-info-error-title" = "Gat ekki sótt myndir";
-"image-gallery-fetch-image-info-error-message" = "Gat ekki sótt myndir með þessari grein. Prófaðu að endurlesa inn greinina til að reyna aftur.";
+"image-gallery-fetch-image-info-error-message" = "Gat ekki sótt myndir með þessari grein. Prófaðu að endurlesa greinina inn til að reyna aftur.";
 "image-gallery-fetch-image-info-error-ok" = "Í lagi";
+"hockeyapp-alert-question" = "Viltu senda tilkynningu um hrunið til $1 þannig að Wikimedia geti skoðað hvað fór úrskeiðis?";
+"hockeyapp-alert-question-with-response-field" = "Viltu senda tilkynningu um hrunið til $1 þannig að Wikimedia geti skoðað hvað fór úrskeiðis? Endilega lýstu því sem var í gangi þegar hrunið átti sér stað:";
 "hockeyapp-alert-title" = "Því miður, appið hrundi síðast";
 "hockeyapp-alert-send-report" = "Senda villuskýrslu";
 "hockeyapp-alert-always-send" = "Alltaf senda";
 "hockeyapp-alert-do-not-send" = "Ekki senda";
-"hockeyapp-alert-privacy" = "$1 friðhelgi";
+"hockeyapp-alert-privacy" = "Friðhelgi $1";
 "page-issues" = "Vandamál varðandi síðu";
 "page-similar-titles" = "Áþekkar síður";
-// Fuzzy
-"page-read-in-other-languages" = "Lesa á $1 tungumálum";
+"page-read-in-other-languages" = "Tiltækt á $1 tungumálum";
 "page-last-edited" = "Breytt fyrir $1 dögum";
 "page-edit-history" = "Öll breytingaskráin";
 "captcha-reload" = "Sýna annað captcha";
 "captcha-prompt" = "Settu inn CAPTCHA-textann úr myndinni hér fyrir ofan";
 "mwk-empty-title-error" = "Gat ekki framkvæmt aðgerð með auðum titli.";
 "home-title" = "Skoða";
+"home-empty-section" = "Engar niðurstöður";
+"home-empty-section-check-again" = "Reyndu aftur";
 "home-continue-reading-heading" = "Halda lestri áfram";
 "home-continue-related-heading" = "Því þú last $1";
 "home-more-like-footer" = "Fleira í líkingu við $1";
 "home-nearby-footer" = "Fleira frá stöðum í nágrenninu";
+"home-nearby-location-footer" = "Fleira frá nágrenni $1";
 "home-nearby-nothing" = "Ekkert í nágrenninu";
 "home-nearby-check-again" = "Kanna aftur";
 "home-featured-article-heading" = "Grein sem er efst á baugi fyrir $1";
@@ -329,9 +334,26 @@
 "home-button-accessibility-label" = "Heimahnappur";
 "potd-empty-error-description" = "Mistókst að ná í mynd dagsins fyrir $1";
 "potd-description-prefix" = "Mynd dagsins fyrir $1";
+"welcome-explore-title" = "Skoða";
+"welcome-explore-tell-me-more" = "Segðu mér fleira";
+"welcome-explore-tell-me-more-done-button" = "Náði því";
+"welcome-explore-continue-button" = "Komast í gang";
+"welcome-languages-title" = "Tungumál sem á að leita í";
+"welcome-languages-add-button" = "+ Bæta við öðru";
+"welcome-languages-continue-button" = "Halda áfram";
+"welcome-volunteer-title" = "Bjóða sig fram";
+"welcome-volunteer-send-usage-reports" = "Senda notkunarskýrslur";
+"welcome-volunteer-continue-button" = "Halda áfram";
+"welcome-volunteer-thanks" = "Þakka þér $1 !";
 "empty-no-feed-title" = "Engin internettenging";
+"empty-no-feed-message" = "Þú getur séð þær greinar sem mælt er með fyrir þig þegar þú ert með virka nettengingu";
+"empty-no-feed-action-message" = "Þú getur lesið vistaðar síður á meðan";
+"empty-no-article-message" = "Því miður, gat ekki hlaðið greininni inn";
+"empty-no-search-results-message" = "Því miður, gat ekki hlaðið inn niðurstöðum";
 "empty-no-saved-pages-title" = "Engar síður vistaðar ennþá";
+"empty-no-saved-pages-message" = "Vista síður til að skoða þær síðar, jafnvel án nettengingar";
 "empty-no-history-title" = "Enginn ferill sem hægt er að birta";
+"empty-no-history-message" = "Haltu utan um það sem þú hefur verið að lesa hérna";
 "alert-no-internet" = "Það er engin internettenging";
 "icon-shortcut-search-title" = "Leita á Wikipedia";
 "icon-shortcut-continue-reading-title" = "Halda lestri áfram";
@@ -349,3 +371,6 @@
 "explore-random-article-heading" = "Handahófsvalin grein";
 "explore-random-article-sub-heading" = "Enska Wikipedia";
 "explore-potd-heading" = "Mynd dagsins";
+"explore-most-read-heading" = "Mest lesið á $1 Wikipedia";
+"explore-most-read-footer" = "Allar mest lesnu greinar";
+"explore-most-read-more-list-title" = "Mest lesnu greinar";

--- a/Wikipedia/Localizations/it.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/it.lproj/Localizable.strings
@@ -25,8 +25,7 @@
 "article-languages-label" = "Scegli la lingua";
 "article-languages-cancel" = "Annulla";
 "article-languages-downloading" = "Caricamento delle lingue in cui è disponibile la voce...";
-// Fuzzy
-"article-languages-filter-placeholder" = "Filtra lingua";
+"article-languages-filter-placeholder" = "Trova lingua";
 "article-read-more-title" = "Leggi altro";
 "article-about-title" = "Su questa voce";
 "article-unable-to-load-section" = "Impossibile caricare questa sezione. Prova ad aggiornare l'articolo per vedere se si risolve il problema.";
@@ -120,6 +119,7 @@
 "search-recent-clear-delete-all" = "Cancella tutto";
 "search-result-redirected-from" = "Reindirizzamento da: $1";
 "settings-title" = "Impostazioni";
+"settings-language" = "Lingua di Wikipedia";
 "settings-support" = "Sostieni Wikipedia";
 "settings-language-bar" = "Mostra lingue nella ricerca";
 "main-menu-title" = "Altro";
@@ -358,8 +358,9 @@
 "welcome-explore-sub-title" = "Un nuovo modo di scoprire voci interessanti ogni giorno";
 "welcome-explore-tell-me-more" = "Dimmi di più";
 "welcome-explore-tell-me-more-about-explore" = "Altro su Esplorare";
-// Fuzzy
-"welcome-explore-tell-me-more-details" = "Quando visiti una voce, le voci correlate sono aggiunte automaticamente al tuo feed Esplora. Questo non modificherà il modo in cui raccogliamo le tue informazioni, e la tua cronologia di lettura resterà privata.";
+"welcome-explore-tell-me-more-details" = "Quando leggi una voce, le voci correlate sono aggiunte automaticamente al tuo feed Esplora. Questo non modificherà il modo in cui raccogliamo le tue informazioni, e la tua cronologia di lettura resterà privata.";
+"welcome-explore-tell-me-more-related" = "Il feed Esplora ti mostra voci relative a voci che hai letto.";
+"welcome-explore-tell-me-more-privacy" = "Nessun elenco di lettura o profilo è memorizzato sui nostri server.";
 "welcome-explore-tell-me-more-done-button" = "Capito";
 "welcome-explore-continue-button" = "Inizia";
 "welcome-languages-title" = "Lingue";
@@ -373,8 +374,7 @@
 "welcome-volunteer-thanks" = "$1 Grazie!";
 "empty-no-feed-title" = "Nessuna connessione internet";
 "empty-no-feed-message" = "Puoi vedere le tue voci consigliate quando si dispone di internet";
-// Fuzzy
-"empty-no-feed-action-message" = "Puoi leggere le pagine salvate nel frattempo";
+"empty-no-feed-action-message" = "Puoi ancora leggere le pagine salvate";
 "empty-no-article-message" = "Spiacenti, impossibile caricare la voce";
 "empty-no-search-results-message" = "Nessun risultato trovato";
 "empty-no-saved-pages-title" = "Nessuna pagina salvata ancora";
@@ -391,8 +391,7 @@
 "compass-direction" = "a ore $1";
 "explore-featured-article-heading" = "Voce in vetrina";
 "explore-continue-reading-heading" = "Continua a leggere";
-// Fuzzy
-"explore-nearby-heading" = "Luoghi nelle vicinanze";
+"explore-nearby-heading" = "Luoghi vicino";
 "explore-continue-related-heading" = "Perché hai letto";
 "explore-main-page-heading" = "Oggi su Wikipedia";
 "explore-random-article-heading" = "Voce a caso";

--- a/Wikipedia/Localizations/ja.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/ja.lproj/Localizable.strings
@@ -112,6 +112,7 @@
 "search-recent-clear-delete-all" = "すべて削除";
 "search-result-redirected-from" = "$1 から転送されました";
 "settings-title" = "設定";
+"settings-language" = "ウィキペディアの言語";
 "settings-language-bar" = "検索結果に表示する言語";
 "main-menu-title" = "その他";
 "main-menu-heading-about" = "このアプリについて";

--- a/Wikipedia/Localizations/ko.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/ko.lproj/Localizable.strings
@@ -1,6 +1,7 @@
 // Messages for Korean (한국어)
 // Exported from translatewiki.net
 // Author: Alex00728
+// Author: HDNua
 // Author: Hwangjy9
 // Author: Idh0854
 // Author: Namoroka
@@ -113,6 +114,7 @@
 "search-recent-clear-delete-all" = "모두 삭제";
 "search-result-redirected-from" = "($1에서 넘어옴)";
 "settings-title" = "설정";
+"settings-language" = "위키백과 언어";
 "main-menu-title" = "더 보기";
 "main-menu-heading-about" = "정보";
 "main-menu-language-title" = "$1 위키백과 검색";
@@ -335,9 +337,11 @@
 "home-hide-suggestion-cancel" = "취소";
 "home-button-accessibility-label" = "홈 버튼";
 "potd-description-prefix" = "$1의 그림";
+"welcome-explore-tell-me-more-privacy" = "서버에 읽기 목록 또는 프로필이 저장되어있지 않습니다.";
 // Fuzzy
 "welcome-languages-title" = "검색할 언어";
 "empty-no-feed-title" = "인터넷 연결 없음";
+"empty-no-feed-action-message" = "여전히 저장된 페이지를 읽을 수 있습니다.";
 "empty-no-article-message" = "죄송합니다, 문서를 불러올 수 없습니다";
 // Fuzzy
 "empty-no-search-results-message" = "죄송합니다, 결과를 불러올 수 없습니다";

--- a/Wikipedia/Localizations/ksh.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/ksh.lproj/Localizable.strings
@@ -6,8 +6,7 @@
 "article-languages-label" = "Söhg en Schprohch uß";
 "article-languages-cancel" = "Ophüre!";
 "article-languages-downloading" = "Ben dä Sigg iehr Schprohche aam ahde&nbsp;{{int:ellipsis}}";
-// Fuzzy
-"article-languages-filter-placeholder" = "Schprohche ußsöhke";
+"article-languages-filter-placeholder" = "Schprohche fenge";
 "article-read-more-title" = "Mih lässe";
 "article-unable-to-load-section" = "mer kunnte dä affschnett nit lahde. Versöhg ens, dä jannze Atikel neu ze lahde, öm ze sinn, of dat hellef.";
 "article-unable-to-load-article" = "Mer künne dä Atikel nit lahde.";
@@ -81,6 +80,7 @@
 "search-recent-clear-cancel" = "Ophüre";
 "search-recent-clear-delete-all" = "Alle fottschmieße";
 "settings-title" = "Enschtällonge";
+"settings-language" = "Dä Wikkipehdija ier Schprohch";
 "settings-support" = "Ongerschtöz de Wikkipehdija!";
 "settings-language-bar" = "Schprohche beim Söhke aanzeije";
 "main-menu-title" = "Mih";
@@ -165,10 +165,12 @@
 "about-libraries" = "Jebruchte Projrammbibblijothke";
 "about-libraries-license" = "Lezänz";
 "about-libraries-licenses" = "Lėzänze";
+"about-content-license" = "De Lezänz för der Ennhalld";
 "about-libraries-licenses-title" = "Mer han Projrame med offe Quälle jähn $1";
 "about-libraries-complete-list" = "Kumplätte Leß";
-// Fuzzy
 "about-repositories" = "Repossetohreje";
+"about-repositories-app-source-license" = "De Projrmm-Quälle sin ze han onger $1.";
+"about-repositories-app-source-license-mit" = "dem <i lang=\"en\" xml:lang=\"en\" dir=\"ltr\" title=\"Massachusetts Institute of Technology\">MIT</i> sing Lezänz";
 "about-send-feedback" = "En Rökmäldong jävve";
 "about-product-of" = "Jemaht vun $1";
 "about-wikimedia-foundation" = "de Wikkimehdija Schtefftong";
@@ -263,15 +265,23 @@
 "home-empty-section" = "Nix jefonge";
 "home-empty-section-check-again" = "Norr_ens versöhke";
 "home-nearby-location-footer" = "Mih en Nöhde vun $1";
+"welcome-explore-title" = "Ußfochsche";
 "welcome-explore-tell-me-more" = "Lohß mesch mih weße";
+// Fuzzy
+"welcome-explore-tell-me-more-details" = "Wann De en Sigg liß, wähde Sigge, di dermet ze donn han, automattesch en Ding Explore feed jedonn. Dat ändert nix draan, wi mer Enfommazjuhne övver Desch sammelle, un wat De jelässe häs, blihv prevaht.";
+// Fuzzy
+"welcome-explore-tell-me-more-related" = "Da Kannahl zom Fochsche zeisch Der Sigge aan, di met Sigge em Zesammehang schtonn, di De jelässe häs.<!--  https://phabricator.wikimedia.org/maniphest/task/edit/128979/ -->";
 "welcome-explore-tell-me-more-done-button" = "Wiggermaache";
 "welcome-explore-continue-button" = "Wigger";
 "welcome-languages-title" = "Schprohche";
 "welcome-languages-add-button" = "+ Donn ein dobei";
 "welcome-languages-continue-button" = "Wiggermaache";
+"welcome-volunteer-title" = "Freiwellejer";
 "welcome-volunteer-continue-button" = "Wiggermaache";
 "welcome-volunteer-thanks" = "$1 Ene schöne Dangk och!";
+"empty-no-feed-action-message" = "Do kanns emmer noch de op Dingem Jeräht faßjehallde Sigge lässe.";
 "empty-no-search-results-message" = "Nix jefonge";
+"explore-nearby-heading" = "Pläz en der Nöhde vun";
 "explore-most-read-heading" = "<!-- FUZZY https://phabricator.wikimedia.org/T128258 --> De mihts jelässe Sigge en de Wikkipehdija op $1";
-// Fuzzy
+"explore-most-read-footer" = "All de mihts jelässe Sigge";
 "explore-most-read-more-list-title" = "De mihts jelässe Sigge";

--- a/Wikipedia/Localizations/lb.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/lb.lproj/Localizable.strings
@@ -6,8 +6,7 @@
 "article-languages-label" = "Sprooch eraussichen";
 "article-languages-cancel" = "Ofbriechen";
 "article-languages-downloading" = "Luede vun de Sprooche vum Artikel...";
-// Fuzzy
-"article-languages-filter-placeholder" = "Sproochfilter";
+"article-languages-filter-placeholder" = "Sprooch fannen";
 "article-read-more-title" = "Liest méi";
 "article-about-title" = "Iwwer dësen Artikel";
 "article-unable-to-load-section" = "Dësen Abschnitt konnt net geluede ginn. Probéiert fir den Artikel z'aktualiséieren an ze kucken ob dat de Problem léist.";

--- a/Wikipedia/Localizations/lt.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/lt.lproj/Localizable.strings
@@ -32,6 +32,7 @@
 "zero-learn-more-learn-more" = "Skaityti daugiau";
 "zero-learn-more-no-thanks" = "Atmesti";
 "zero-wikipedia-zero-heading" = "Vikipedija Zero";
+"zero-warn-when-leaving" = "Perspėti, jeigu paliekamas „Zero“";
 "account-creation-captcha-required" = "Reikia patikrinimo saugos kodu.";
 "account-creation-captcha-obtaining" = "Gaunamas naujas saugos kodas.";
 "account-creation-logging-in" = "Jungiamasi...";
@@ -75,7 +76,9 @@
 "search-recent-clear-cancel" = "Atšaukti";
 "search-recent-clear-delete-all" = "Naikinti viską";
 "settings-title" = "Nustatymai";
+"settings-language" = "Vikipedijos kalba";
 "settings-support" = "Paremti Vikipediją";
+"settings-language-bar" = "Rodyti kalbas paieškoje";
 "main-menu-title" = "Daugiau";
 "main-menu-heading-about" = "Apie";
 "main-menu-language-title" = "Paieška $1 Vikipedijoje";
@@ -156,6 +159,7 @@
 "share-menu-save-page" = "Įrašyti puslapį";
 "share-custom-menu-item" = "Dalintis";
 "share-a-fact-share-menu-item" = "Dalintis faktu";
+"share-on-twitter-sign-off" = "per @Wikipedia";
 "share-as-image" = "Dalintis kaip vaizdu";
 "share-as-text" = "Dalintis kaip tekstu";
 "timestamp-just-now" = "tik ką";
@@ -217,6 +221,8 @@
 "home-empty-section-check-again" = "Bandyti dar kartą";
 "home-nearby-location-footer" = "Daugiau netoliese $1";
 "welcome-explore-title" = "Tyrinėti";
+"welcome-explore-tell-me-more" = "Pasakykite man daugiau";
+"welcome-explore-tell-me-more-about-explore" = "Daugiau apie „Tyrinėti“";
 "welcome-explore-tell-me-more-done-button" = "Supratau";
 "welcome-explore-continue-button" = "Pradėti";
 "welcome-languages-title" = "Kalbos";
@@ -227,4 +233,6 @@
 "welcome-volunteer-continue-button" = "Tęsti";
 "welcome-volunteer-thanks" = "$1 Ačiū!";
 "empty-no-feed-title" = "Nėra interneto ryšio";
+"empty-no-search-results-message" = "Rezultatų nerasta";
 "alert-no-internet" = "Ten nėra interneto ryšio";
+"explore-most-read-more-list-title" = "Top straipsniai";

--- a/Wikipedia/Localizations/mk.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/mk.lproj/Localizable.strings
@@ -8,8 +8,7 @@
 "article-languages-label" = "Изберете јазик";
 "article-languages-cancel" = "Откажи";
 "article-languages-downloading" = "Ги вчитувам јазиците на статијата...";
-// Fuzzy
-"article-languages-filter-placeholder" = "Јазичен филтер";
+"article-languages-filter-placeholder" = "Најди јазик";
 "article-read-more-title" = "Прочитајте повеќе";
 "article-about-title" = "Уреди ја статијава";
 "article-unable-to-load-section" = "Не можам да го вчитам одделот. Видете дали ќе се реши проблемот ако ја превчитате страницата.";
@@ -103,6 +102,7 @@
 "search-recent-clear-delete-all" = "Избриши ги сите";
 "search-result-redirected-from" = "Пренасочено од: $1";
 "settings-title" = "Нагодувања";
+"settings-language" = "Јазик на Википедија";
 "settings-support" = "Поддржете ја Википедија";
 "settings-language-bar" = "Прикажувај јазици при пребарувањето";
 "main-menu-title" = "Повеќе";
@@ -188,21 +188,22 @@
 "credits-external-libraries" = "Надворешни";
 "about-title" = "За прилогот";
 "about-wikipedia" = "Википедија";
-// Fuzzy
-"about-contributors" = "учесници";
-// Fuzzy
-"about-testers" = "испробувачи";
+"about-contributors" = "Учесници";
+"about-testers" = "Испробувачи";
 "about-testers-details" = "Квалитетот е испробан од $1";
-// Fuzzy
-"about-translators" = "преведувачи";
+"about-translators" = "Преведувачи";
 "about-translators-details" = "Прилогов го преведоа доброволни преведувачи на $1";
-// Fuzzy
-"about-libraries" = "користени библиотеки";
+"about-libraries" = "Користени библиотеки";
 "about-libraries-license" = "Лиценца";
 "about-libraries-licenses" = "Лиценци";
+"about-content-license" = "Лиценца на содржината";
+"about-content-license-details" = "Ако не е поинаку укажано, содржината е достапна под $1.";
+"about-content-license-details-share-alike-license" = "лиценцата Криејтив комонс Наведи извор-Сподели под исти услови";
 "about-libraries-licenses-title" = "Обожаваме отворени програми $1";
-// Fuzzy
-"about-repositories" = "складишта";
+"about-libraries-complete-list" = "Целосен список";
+"about-repositories" = "Складишта";
+"about-repositories-app-source-license" = "Изворниот код е достапен под $1.";
+"about-repositories-app-source-license-mit" = "MIT-лиценца";
 "about-send-feedback" = "Испрати мислење за прилогот";
 "about-product-of" = "Производ на $1";
 "about-wikimedia-foundation" = "Фондацијата Викимедија";
@@ -210,6 +211,8 @@
 "share-menu-page-saved" = "Страницата е зачувана";
 "share-menu-page-saved-access" = "Совет: за да дојдете до вашите зачувани страници, допрете го $1 погоре или подржете на $2 подолу.";
 "share-custom-menu-item" = "Сподели";
+"share-a-fact-share-menu-item" = "Сподели факт";
+"share-on-twitter-sign-off" = "преку @Wikipedia";
 "share-article-name-on-wikipedia" = "„$1“ на @Wikipedia:";
 "share-article-name-on-wikipedia-with-selected-text" = "„$1“ на @Википедија: „$2“";
 "share-as-image" = "Сподели ја сликава";
@@ -338,8 +341,9 @@
 "welcome-explore-sub-title" = "Нов начин да откривате интересни статии секој ден";
 "welcome-explore-tell-me-more" = "Сакам да дознаам повеќе";
 "welcome-explore-tell-me-more-about-explore" = "Повеќе за „Истражете“";
-// Fuzzy
-"welcome-explore-tell-me-more-details" = "Кога ќе појдете на некоја статија, во текот на „Истражете“ автоматски ќе ви се појават поврзани статии. Ова не го менува прибирањето на информации. Историјата на читани статии останува приватна.";
+"welcome-explore-tell-me-more-details" = "Кога читате некоја статија, во текот на „Истражете“ автоматски ќе ви се појават поврзани статии. Ова не го менува прибирањето на информации. Историјата на читани статии останува приватна.";
+"welcome-explore-tell-me-more-related" = "Каналот „Истражи“ ви ги покажува статиите сродни на оние што ги имате прочитано.";
+"welcome-explore-tell-me-more-privacy" = "На опслужувачите не складираме список на читани страници или профили.";
 "welcome-explore-tell-me-more-done-button" = "Јасно";
 "welcome-explore-continue-button" = "Започни";
 "welcome-languages-title" = "Јазици";
@@ -353,8 +357,7 @@
 "welcome-volunteer-thanks" = "$1 Благодариме!";
 "empty-no-feed-title" = "Не сте поврзани со семрежјето";
 "empty-no-feed-message" = "Препорачаните статии ќе ги видите кога ќе се поврзете со семрежјето";
-// Fuzzy
-"empty-no-feed-action-message" = "Во меѓувреме, можете да ги читате зачуваните страници";
+"empty-no-feed-action-message" = "Но сепак, можете да ги читате зачуваните";
 "empty-no-article-message" = "За жал, не можев да ја вчитам статијата";
 "empty-no-search-results-message" = "Не пронајдов ништо";
 "empty-no-saved-pages-title" = "Засега нема зачувани страници";
@@ -371,7 +374,6 @@
 "compass-direction" = "во $1 часот";
 "explore-featured-article-heading" = "Избрани статии";
 "explore-continue-reading-heading" = "Продолжете со читање";
-// Fuzzy
 "explore-nearby-heading" = "Околни места";
 "explore-continue-related-heading" = "Бидејќи читавте";
 "explore-main-page-heading" = "Денес на Википедија";
@@ -380,5 +382,4 @@
 "explore-potd-heading" = "Слика на денот";
 "explore-most-read-heading" = "Најчистано на Википедија на $1";
 "explore-most-read-footer" = "Сите најчитани статии";
-// Fuzzy
 "explore-most-read-more-list-title" = "Најчитани статии";

--- a/Wikipedia/Localizations/nl.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/nl.lproj/Localizable.strings
@@ -16,8 +16,7 @@
 "article-languages-label" = "Taal kiezen";
 "article-languages-cancel" = "Annuleren";
 "article-languages-downloading" = "Paginatalen aan het laden...";
-// Fuzzy
-"article-languages-filter-placeholder" = "Taal filteren";
+"article-languages-filter-placeholder" = "Taal zoeken";
 "article-read-more-title" = "Meer lezen";
 "article-about-title" = "Over deze pagina";
 "article-unable-to-load-section" = "Het was niet mogelijk deze sectie te laden. Het verversen van de pagina verhelpt mogelijk dit probleem.";
@@ -26,17 +25,17 @@
 "info-box-title" = "Snelle feiten";
 "info-box-close-text" = "Sluiten";
 "table-title-other" = "Meer informatie";
+"saved-clear-all" = "Wissen";
+"history-clear-all" = "Wissen";
 "history-label" = "Recent";
 "history-section-today" = "Vandaag";
 "history-section-yesterday" = "Gisteren";
 "history-section-lastweek" = "Afgelopen week";
 "history-section-lastmonth" = "Afgelopen maand";
-// Fuzzy
-"history-clear-confirmation-heading" = "Alle recente items verwijderen?";
+"history-clear-confirmation-heading" = "Weet u zeker dat u alle recente items wilt verwijderen?";
 "history-clear-confirmation-sub-heading" = "Deze handeling kan niet ongedaan worden gemaakt!";
 "history-clear-cancel" = "Annuleren";
-// Fuzzy
-"history-clear-delete-all" = "Alles verwijderen";
+"history-clear-delete-all" = "Ja, alles verwijderen";
 "history-description" = "U heeft ze waarschijnlijk allemaal verwijderd. De volgende keer als u een pagina bezoekt, kunt u hem hier terugvinden.";
 "history-none" = "Geen recente pagina's.";
 "zero-free-verbiage" = "Gratis toegang tot Wikipedia van uw mobiele provider (geen kosten voor gegevens)";
@@ -51,8 +50,7 @@
 "zero-learn-more-learn-more" = "Meer lezen";
 "zero-learn-more-no-thanks" = "Sluiten";
 "zero-wikipedia-zero-heading" = "Wikipedia Zero";
-// Fuzzy
-"zero-warn-when-leaving" = "Waarschuwen bij verlaten Wikipedia Zero";
+"zero-warn-when-leaving" = "Waarschuwen bij verlaten Zero";
 "zero-settings-devmode" = "Zero-ontwikkelmodus";
 "account-creation-captcha-required" = "CAPTCHA-controle vereist.";
 "account-creation-captcha-obtaining" = "Nieuwe CAPTCHA aan het ophalen.";
@@ -112,37 +110,35 @@
 "search-recent-clear-delete-all" = "Alles verwijderen";
 "search-result-redirected-from" = "Doorverwezen vanaf: $1";
 "settings-title" = "Instellingen";
+"settings-language" = "Wikipedia-taal";
+"settings-support" = "Wikipedia steunen";
+"settings-language-bar" = "Talen weergeven bij zoeken";
 "main-menu-title" = "Meer";
 "main-menu-heading-about" = "Over";
 "main-menu-language-title" = "Zoeken in Wikipedia in het $1";
-// Fuzzy
 "main-menu-faq" = "Veelgestelde vragen";
 "main-menu-language-toggle-show" = "Talen bekijken";
 "main-menu-language-toggle-hide" = "Talen verbergen";
 "main-menu-language-selection-saved" = "Taalkeuze opgeslagen";
 "main-menu-account-title-logged-out" = "Account";
-// Fuzzy
-"main-menu-account-title-logged-in" = "Aangemeld als: $1";
-// Fuzzy
-"main-menu-account-login" = "Aanmelden bij Wikipedia";
+"main-menu-account-title-logged-in" = "Aangemeld als $1";
+"main-menu-account-login" = "Aanmelden";
 "main-menu-account-logout" = "Afmelden";
+"main-menu-account-logout-are-you-sure" = "Weet u zeker dat u wilt afmelden?";
+"main-menu-account-logout-cancel" = "Annuleren";
 "main-menu-show-title" = "Laat mij...";
 "main-menu-show-history" = "Recent bekeken";
 "main-menu-show-saved" = "Opgeslagen pagina's";
 "main-menu-current-article-save" = "$1 opslaan voor offline lezen";
 "main-menu-random" = "Willekeurige pagina";
 "main-menu-feedback-heading" = "Terugkoppeling";
-// Fuzzy
-"main-menu-send-feedback" = "App-terugkoppeling verzenden";
+"main-menu-send-feedback" = "Schrijf ons";
 "main-menu-show-page-history" = "Geschiedenis van wijzigingen aan $1";
 "main-menu-credits" = "Vermeldingen";
-// Fuzzy
-"main-menu-about" = "Over de Wikipedia-app";
+"main-menu-about" = "Over de app";
 "main-menu-zero-faq" = "Veelgestelde vragen over Wikipedia Zero";
 "main-menu-privacy-policy" = "Privacybeleid";
-// Fuzzy
 "main-menu-terms-of-use" = "Gebruiksvoorwaarden";
-// Fuzzy
 "main-menu-rate-app" = "App beoordelen";
 "main-menu-heading-zero" = "Wikipedia Zero";
 "main-menu-heading-legal" = "Privacy en voorwaarden";
@@ -154,12 +150,10 @@
 "main-menu-debug-tweaks" = "Ontwikkelaarsvoorkeuren";
 "saved-title" = "Opgeslagen";
 "saved-pages-title" = "Opgeslagen pagina's";
-// Fuzzy
-"saved-pages-clear-confirmation-heading" = "Alle opgeslagen items verwijderen?";
+"saved-pages-clear-confirmation-heading" = "Weet u zeker dat u alle opgeslagen pagina's wilt verwijderen?";
 "saved-pages-clear-confirmation-sub-heading" = "Deze handeling kan niet ongedaan worden gemaakt!";
 "saved-pages-clear-cancel" = "Annuleren";
-// Fuzzy
-"saved-pages-clear-delete-all" = "Alles verwijderen";
+"saved-pages-clear-delete-all" = "Ja, alles verwijderen";
 "saved-pages-refresh-cancel-alert-title" = "Bijwerken geanuleerd";
 "saved-pages-refresh-cancel-alert-message" = "Wikipediapagina's worden constant bijgewerkt. Druk op vernieuwen om de nieuwste versie van de pagina's te bekijken.";
 "saved-pages-refresh-cancel-alert-button" = "Begrepen";
@@ -202,18 +196,22 @@
 "credits-external-libraries" = "Externe bronnen";
 "about-title" = "Over";
 "about-wikipedia" = "Wikipedia";
-// Fuzzy
-"about-contributors" = "bijdragers";
-// Fuzzy
-"about-testers" = "testers";
+"about-contributors" = "Bijdragers";
+"about-testers" = "Testers";
 "about-testers-details" = "Getest door $1";
-// Fuzzy
-"about-translators" = "vertalers";
+"about-translators" = "Vertalers";
 "about-translators-details" = "Deze app is vertaald door de vrijwillige vertalers van $1";
-// Fuzzy
-"about-libraries" = "gebruikte bibliotheken";
+"about-libraries" = "Gebruikte bibliotheken";
 "about-libraries-license" = "Licentie";
+"about-libraries-licenses" = "Licenties";
+"about-content-license" = "Inhoudslicentie";
+"about-content-license-details" = "Tenzij anders vermeld, is de inhoud beschikbaar onder een $1.";
+"about-content-license-details-share-alike-license" = "Creative Commons Naamsvermelding-Gelijk delen-licentie";
+"about-libraries-licenses-title" = "Wij houden van opensourcesoftware $1";
+"about-libraries-complete-list" = "Volledige lijst";
 "about-repositories" = "Repositories";
+"about-repositories-app-source-license" = "Broncode is beschikbaar onder de $1.";
+"about-repositories-app-source-license-mit" = "MIT-licentie";
 "about-send-feedback" = "Terugkoppeling over app geven";
 "about-product-of" = "Een product van de $1";
 "about-wikimedia-foundation" = "Wikimedia Foundation";
@@ -221,6 +219,8 @@
 "share-menu-page-saved" = "Pgina opgeslagen voor offline lezen.";
 "share-menu-page-saved-access" = "Tip: om uw opgeslagen pagina's te bekijken, klikt u op $1 bovenaan of houdt u $2 lang ingedrukt.";
 "share-custom-menu-item" = "Delen";
+"share-a-fact-share-menu-item" = "Deel-een-feit";
+"share-on-twitter-sign-off" = "via @Wikipedia";
 "share-article-name-on-wikipedia" = "\"$1\" op @Wikipedia:";
 "share-article-name-on-wikipedia-with-selected-text" = "\"$1\" op @Wikipedia: \"$2\"";
 "share-as-image" = "Als bestand delen";
@@ -256,6 +256,8 @@
 "license-footer-name" = "CC BY-SA 3.0";
 "table-of-contents-heading" = "Inhoud";
 "table-of-contents-button-label" = "Inhoudsopgave";
+"table-of-contents-close-accessibility-label" = "Inhoudsopgave sluiten";
+"table-of-contents-close-accessibility-hint" = "Sluiten";
 "abuse-filter-warning-heading" = "Dit lijkt een niet-constructieve bewerking. Weet u zeker dat u die wilt opslaan?";
 "abuse-filter-warning-subheading" = "Uw bewerking kan een of meer van het volgende bevatten:";
 "abuse-filter-warning-caps" = "Tekst in HOOFDLETTERS";
@@ -315,18 +317,20 @@
 "hockeyapp-alert-privacy" = "Privacy van $1";
 "page-issues" = "Paginaproblemen";
 "page-similar-titles" = "Vergelijkbare pagina's";
-// Fuzzy
-"page-read-in-other-languages" = "Lezen in $1 talen";
+"page-read-in-other-languages" = "Beschikbaar in $1 talen";
 "page-last-edited" = "$1 dagen geleden bewerkt";
 "page-edit-history" = "Volledige bewerkingsgeschiedenis";
 "captcha-reload" = "Andere CAPTCHA weergeven";
 "captcha-prompt" = "Vul de CAPTCHA-tekst in";
 "mwk-empty-title-error" = "Het was niet mogelijk de bewerking uit de voeren zonder paginanaam.";
-"home-title" = "Ontdek";
+"home-title" = "Verkennen";
+"home-empty-section" = "Geen resultaten";
+"home-empty-section-check-again" = "Opnieuw proberen";
 "home-continue-reading-heading" = "Lees verder";
 "home-continue-related-heading" = "Omdat u $1 hebt gelezen";
 "home-more-like-footer" = "Vergelijkbaar met $1";
 "home-nearby-footer" = "Meer in de buurt van uw huidige locatie";
+"home-nearby-location-footer" = "Meer in de buurt van $1";
 "home-nearby-nothing" = "Niets in de buurt";
 "home-nearby-check-again" = "Controleer opnieuw";
 "home-featured-article-heading" = "Uitgelichte pagina voor $1";
@@ -337,19 +341,33 @@
 "home-updating-label" = "Bijwerken...";
 "home-hide-suggestion-prompt" = "Suggestie verbergen";
 "home-hide-suggestion-cancel" = "Annuleren";
-"home-accessibility-label" = "Wikipedia, ontdek";
+"home-accessibility-label" = "Wikipedia, Verkennen";
 "home-button-accessibility-label" = "Startscherm";
 "potd-empty-error-description" = "Ophalen van de afbeelding van de dag voor $1 is mislukt";
 "potd-description-prefix" = "Afbeelding van de dag voor $1";
-// Fuzzy
-"welcome-languages-title" = "Talen om in te zoeken";
+"welcome-explore-title" = "Verkennen";
+"welcome-explore-sub-title" = "Een nieuwe manier om elke dag interessante pagina's te ontdekken";
+"welcome-explore-tell-me-more" = "Vertel me meer";
+"welcome-explore-tell-me-more-about-explore" = "Meer over Verkennen";
+"welcome-explore-tell-me-more-details" = "Wanneer u een pagina leest worden er automatisch gerelateerde pagina's aan \"Verkennen\" toegevoegd. Er zijn geen wijzigingen aangebracht op de manier hoe wij informatie verzamelen, uw leesgeschiedenis blijft privé.";
+"welcome-explore-tell-me-more-related" = "Op Verkennen ziet u pagina's die gerelateerd zijn aan de pagina's die u al hebt gelezen.";
+"welcome-explore-tell-me-more-privacy" = "Er worden geen gegevens over uw leesgedrag opgeslagen op onze servers.";
+"welcome-explore-tell-me-more-done-button" = "Begrepen";
+"welcome-explore-continue-button" = "Aan de slag";
+"welcome-languages-title" = "Talen";
+"welcome-languages-sub-title" = "Kies de voorkeurstalen waarin u binnen Wikipedia wilt zoeken";
+"welcome-languages-add-button" = "+ taal toevoegen";
+"welcome-languages-continue-button" = "Doorgaan";
+"welcome-volunteer-title" = "Vrijwilliger";
+"welcome-volunteer-sub-title" = "Help met verbeteren van de Wikipedia-app door te delen hoe je deze gebruikt";
+"welcome-volunteer-send-usage-reports" = "Gebruiksrapporten verzenden";
+"welcome-volunteer-continue-button" = "Doorgaan";
+"welcome-volunteer-thanks" = "$1 Bedankt!";
 "empty-no-feed-title" = "Geen internetverbinding";
 "empty-no-feed-message" = "U kunt aanbevolen pagina's bekijken wanneer u bent verbonden met het internet";
-// Fuzzy
-"empty-no-feed-action-message" = "U kunt in de tussentijd wel uw opgeslagen pagina's lezen";
+"empty-no-feed-action-message" = "U kunt nog steeds opgeslagen pagina's lezen";
 "empty-no-article-message" = "Sorry, de pagina kon niet worden geladen";
-// Fuzzy
-"empty-no-search-results-message" = "De resultaten kunnen helaas niet worden opgehaald";
+"empty-no-search-results-message" = "Geen resultaten gevonden";
 "empty-no-saved-pages-title" = "Nog geen opgeslagen pagina's";
 "empty-no-saved-pages-message" = "Sla pagina's op om deze later te lezen, zelfs offline";
 "empty-no-history-title" = "Geen geschiedenis om te weergeven";
@@ -364,10 +382,12 @@
 "compass-direction" = "op $1 uur";
 "explore-featured-article-heading" = "Uitgelichte pagina";
 "explore-continue-reading-heading" = "Verder lezen";
-// Fuzzy
 "explore-nearby-heading" = "Plaatsen in de buurt";
 "explore-continue-related-heading" = "Omdat u hebt gelezen";
 "explore-main-page-heading" = "Vandaag op Wikipedia";
 "explore-random-article-heading" = "Willekeurig pagina";
 "explore-random-article-sub-heading" = "Engelstalige Wikipedia";
 "explore-potd-heading" = "Afbeelding van de dag";
+"explore-most-read-heading" = "Meest gelezen op Wikipedia in het $1";
+"explore-most-read-footer" = "Alle meest gelezen pagina's";
+"explore-most-read-more-list-title" = "Meest gelezen pagina's";

--- a/Wikipedia/Localizations/pl.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/pl.lproj/Localizable.strings
@@ -110,6 +110,7 @@
 "search-recent-clear-delete-all" = "Usuń wszystko";
 "search-result-redirected-from" = "Przekierowanie z: $1";
 "settings-title" = "Ustawienia";
+"settings-language" = "Język Wikipedii";
 "settings-support" = "Wspomóż Wikimedię";
 "main-menu-title" = "Więcej";
 "main-menu-heading-about" = "O aplikacji";
@@ -202,6 +203,7 @@
 "about-libraries-licenses" = "Licencje";
 "about-content-license-details" = "O ile nie zaznaczono inaczej, treść jest dostępna na licencji $1.";
 "about-content-license-details-share-alike-license" = "Licencja Creative Commons Uznanie autorstwa-Na tych samych warunkach";
+"about-libraries-complete-list" = "Pełna lista";
 "about-repositories" = "Repozytoria";
 "about-repositories-app-source-license" = "Kod źródłowy dostępny na licencji $1.";
 "about-repositories-app-source-license-mit" = "Licencja MIT";

--- a/Wikipedia/Localizations/pt.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/pt.lproj/Localizable.strings
@@ -12,8 +12,7 @@
 "article-languages-label" = "Escolher idioma";
 "article-languages-cancel" = "Cancelar";
 "article-languages-downloading" = "A carregar idiomas do artigo...";
-// Fuzzy
-"article-languages-filter-placeholder" = "Filtro de idioma";
+"article-languages-filter-placeholder" = "Encontrar um idioma";
 "article-read-more-title" = "Ler mais";
 "article-about-title" = "Sobre este artigo";
 "article-unable-to-load-section" = "Não foi possível carregar esta secção. Experimente recarregar o artigo para tentar corrigir o problema.";
@@ -107,6 +106,7 @@
 "search-recent-clear-delete-all" = "Apagar tudo";
 "search-result-redirected-from" = "Redirecionado de: $1";
 "settings-title" = "Definições";
+"settings-language" = "Idioma da Wikipédia";
 "settings-support" = "Apoie a Wikipédia";
 "settings-language-bar" = "Mostrar idiomas na pesquisa";
 "main-menu-title" = "Mais";
@@ -201,9 +201,13 @@
 "about-libraries-license" = "Licença";
 "about-libraries-licenses" = "Licenças";
 "about-content-license" = "Licença de conteúdo";
+"about-content-license-details" = "A menos que seja indicado o contrário, o conteúdo está disponível sob a $1.";
 "about-content-license-details-share-alike-license" = "Creative Commons - Atribuição - Partilha nos Mesmos Termos";
 "about-libraries-licenses-title" = "Adoramos software em código aberto $1";
+"about-libraries-complete-list" = "Lista completa";
 "about-repositories" = "Repositórios";
+"about-repositories-app-source-license" = "Código-fonte disponível sob a $1.";
+"about-repositories-app-source-license-mit" = "Licença MIT";
 "about-send-feedback" = "Enviar comentários sobre a aplicação";
 "about-product-of" = "Um produto da $1";
 "about-wikimedia-foundation" = "Wikimedia Foundation";
@@ -340,8 +344,8 @@
 "welcome-explore-sub-title" = "Uma nova forma de descobrir artigos interessantes todos os dias";
 "welcome-explore-tell-me-more" = "Conte-me mais";
 "welcome-explore-tell-me-more-about-explore" = "Mais sobre Explorar";
-// Fuzzy
-"welcome-explore-tell-me-more-details" = "Quando visitar um artigo, os relacionados são automaticamente adicionados ao seu <em>feed</em> Explorar. Isto não muda a forma como recolhemos a sua informação, e o seu histórico de leitura permanece privado.";
+"welcome-explore-tell-me-more-details" = "Quando ler um artigo, os relacionados são automaticamente adicionados ao seu <em>feed</em> Explorar. Isto não muda a forma como recolhemos a sua informação, e o seu histórico de leitura permanece privado.";
+"welcome-explore-tell-me-more-related" = "O feed Explorar mostra-lhe artigos relacionados com os que já leu.";
 "welcome-explore-tell-me-more-done-button" = "Entendi";
 "welcome-explore-continue-button" = "Começar";
 "welcome-languages-title" = "Idiomas";
@@ -355,8 +359,7 @@
 "welcome-volunteer-thanks" = "$1 Obrigado(a)!";
 "empty-no-feed-title" = "Sem ligação à Internet";
 "empty-no-feed-message" = "Pode ver os seus artigos recomendados quando tiver acesso à Internet";
-// Fuzzy
-"empty-no-feed-action-message" = "Entretanto, pode ler páginas que tenha guardadas";
+"empty-no-feed-action-message" = "Pode ler páginas que tenha guardadas";
 "empty-no-article-message" = "Desculpe, não foi possível carregar o artigo";
 "empty-no-search-results-message" = "Não foram encontrados resultados";
 "empty-no-saved-pages-title" = "Sem páginas guardadas ainda";
@@ -373,7 +376,6 @@
 "compass-direction" = "às $1 horas";
 "explore-featured-article-heading" = "Artigo destacado";
 "explore-continue-reading-heading" = "Continuar a ler";
-// Fuzzy
 "explore-nearby-heading" = "Lugares próximos";
 "explore-continue-related-heading" = "Porque leu";
 "explore-main-page-heading" = "Hoje na Wikipédia";
@@ -382,5 +384,4 @@
 "explore-potd-heading" = "Imagem do dia";
 "explore-most-read-heading" = "Os mais lidos na Wikipédia em $1";
 "explore-most-read-footer" = "Todos os artigos mais lidos";
-// Fuzzy
 "explore-most-read-more-list-title" = "Artigos mais lidos";

--- a/Wikipedia/Localizations/ru.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/ru.lproj/Localizable.strings
@@ -6,6 +6,7 @@
 // Author: Dicto23456
 // Author: Dyaydyasasha2015
 // Author: JackLantern
+// Author: Jackie
 // Author: Kopcap94
 // Author: Macofe
 // Author: Mariya
@@ -18,7 +19,6 @@
 "article-languages-label" = "Выберите язык";
 "article-languages-cancel" = "Отмена";
 "article-languages-downloading" = "Загрузка языков статьи…";
-// Fuzzy
 "article-languages-filter-placeholder" = "Языковой фильтр";
 "article-read-more-title" = "Читать подробнее";
 "article-about-title" = "Об этой статье";
@@ -113,6 +113,7 @@
 "search-recent-clear-delete-all" = "Удалить всё";
 "search-result-redirected-from" = "Перенаправлено с: $1";
 "settings-title" = "Настройки";
+"settings-language" = "Язык Википедии";
 "settings-support" = "Поддержать Википедию";
 "settings-language-bar" = "Показывать языки при поиске";
 "main-menu-title" = "Ещё";
@@ -332,6 +333,7 @@
 "home-continue-related-heading" = "Потому что вы читали статью $1";
 "home-more-like-footer" = "Ещё похожее на $1";
 "home-nearby-footer" = "Ещё про то, что находится поблизости от вас";
+"home-nearby-location-footer" = "Ещё поблизости от $1";
 "home-nearby-nothing" = "Поблизости ничего нет";
 "home-nearby-check-again" = "Проверить ещё раз";
 "home-featured-article-heading" = "Избранная статья за $1";
@@ -350,20 +352,22 @@
 "welcome-explore-sub-title" = "Новый способ открывать для себя интересные статьи каждый день";
 "welcome-explore-tell-me-more" = "Расскажите об этом подробнее";
 "welcome-explore-tell-me-more-about-explore" = "Подробнее об Исследовании";
-// Fuzzy
 "welcome-explore-tell-me-more-details" = "Когда вы посещаете статьи, связанные с ними статьи автоматически добавляются в вашу ленту «Исследуйте». Это не изменяет того, как мы собираем вашу информацию, так что ваша история чтения по-прежнему непублична.";
+"welcome-explore-tell-me-more-related" = "Лента «Исследуйте» показывает вам статьи, имеющие отношение к статьям, которые вы прочитали.";
+"welcome-explore-tell-me-more-privacy" = "Список прочитываемого или профиль не хранится на наших серверах.";
 "welcome-explore-tell-me-more-done-button" = "Понятно";
 "welcome-explore-continue-button" = "Начать";
 "welcome-languages-title" = "Языки";
 "welcome-languages-sub-title" = "Выберите языки, на которых вы хотели бы осуществлять поиск в Википедии";
 "welcome-languages-add-button" = "+ Добавить ещё один";
 "welcome-languages-continue-button" = "Продолжить";
+"welcome-volunteer-title" = "Доброволец";
+"welcome-volunteer-sub-title" = "Помогите улучшить приложение Википедии, рассказав, как вы его используете";
 "welcome-volunteer-send-usage-reports" = "Отправлять отчёты об использовании";
 "welcome-volunteer-continue-button" = "Продолжить";
 "welcome-volunteer-thanks" = "$1 Спасибо!";
 "empty-no-feed-title" = "Нет подключения к интернету";
 "empty-no-feed-message" = "Вы можете увидеть рекомендованные статьи, когда у вас есть доступ в интернет";
-// Fuzzy
 "empty-no-feed-action-message" = "Пока вы можете почитать ранее сохранённые страницы";
 "empty-no-article-message" = "К сожалению, не удалось загрузить статью";
 "empty-no-search-results-message" = "Ничего не найдено";
@@ -381,13 +385,12 @@
 "compass-direction" = "на $1 часов";
 "explore-featured-article-heading" = "Избранная статья";
 "explore-continue-reading-heading" = "Продолжить чтение";
-// Fuzzy
 "explore-nearby-heading" = "Места поблизости";
 "explore-continue-related-heading" = "Потому что вы читали";
 "explore-main-page-heading" = "Сегодня в Википедии";
 "explore-random-article-heading" = "Случайная статья";
 "explore-random-article-sub-heading" = "Английская Википедия";
 "explore-potd-heading" = "Изображение дня";
+"explore-most-read-heading" = "Самое читаемое в $1 Википедии";
 "explore-most-read-footer" = "Все самые читаемые статьи";
-// Fuzzy
 "explore-most-read-more-list-title" = "Самые читаемые статьи";

--- a/Wikipedia/Localizations/sv.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/sv.lproj/Localizable.strings
@@ -9,14 +9,14 @@
 // Author: Lokal Profil
 // Author: Macofe
 // Author: Platinawolf
+// Author: Rockyfelle
 // Author: WikiPhoenix
 
 "languages-title" = "Språk";
 "article-languages-label" = "Välj språk";
 "article-languages-cancel" = "Avbryt";
 "article-languages-downloading" = "Läser in artikelspråk...";
-// Fuzzy
-"article-languages-filter-placeholder" = "Språkfilter";
+"article-languages-filter-placeholder" = "Hitta språk";
 "article-read-more-title" = "Läs mer";
 "article-about-title" = "Om den här artikeln";
 "article-unable-to-load-section" = "Kunde inte hämta detta avsnitt. Prova att uppdatera artikeln för att kolla om det åtgärdar några problem.";
@@ -110,6 +110,7 @@
 "search-recent-clear-delete-all" = "Radera alla";
 "search-result-redirected-from" = "Omdirigerad från: $1";
 "settings-title" = "Inställningar";
+"settings-language" = "Wikipediaspråk";
 "settings-support" = "Stöd Wikipedia";
 "settings-language-bar" = "Visa språk vid sökfältet";
 "main-menu-title" = "Mer";
@@ -195,21 +196,22 @@
 "credits-external-libraries" = "Externa";
 "about-title" = "Om";
 "about-wikipedia" = "Wikipedia";
-// Fuzzy
 "about-contributors" = "Bidragsgivare";
-// Fuzzy
 "about-testers" = "Testare";
 "about-testers-details" = "Kvalitetssäkringstestad av $1";
-// Fuzzy
 "about-translators" = "Översättare";
 "about-translators-details" = "Denna app översattes av frivilliga översättare på $1";
-// Fuzzy
-"about-libraries" = "bibliotek som används";
+"about-libraries" = "Bibliotek som har använts";
 "about-libraries-license" = "Licens";
 "about-libraries-licenses" = "Licenser";
+"about-content-license" = "Innehållslicens";
+"about-content-license-details" = "Om inget annat anges är innehållet tillgängligt under $1.";
+"about-content-license-details-share-alike-license" = "Creative Commons Attribution-DelaLika";
 "about-libraries-licenses-title" = "Vi älskar öppen källkod $1";
-// Fuzzy
+"about-libraries-complete-list" = "Fullständig lista";
 "about-repositories" = "Förvar";
+"about-repositories-app-source-license" = "Källkoden är tillgänglig under $1.";
+"about-repositories-app-source-license-mit" = "MIT-licensen";
 "about-send-feedback" = "Skicka återkoppling om appen";
 "about-product-of" = "En produkt av $1";
 "about-wikimedia-foundation" = "Wikimedia Foundation";
@@ -217,6 +219,8 @@
 "share-menu-page-saved" = "Sparade för offline-läsning.";
 "share-menu-page-saved-access" = "Tips: för att komma åt dina sparade sidor, klicka på $1 ovan eller tryck länge på $2 nedan.";
 "share-custom-menu-item" = "Dela";
+"share-a-fact-share-menu-item" = "Dela-ett-faktum";
+"share-on-twitter-sign-off" = "via @Wikipedia";
 "share-article-name-on-wikipedia" = "\"$1\" på @Wikipedia:";
 "share-article-name-on-wikipedia-with-selected-text" = "\"$1\" på @Wikipedia: \"$2\"";
 "share-as-image" = "Dela som bild";
@@ -345,8 +349,8 @@
 "welcome-explore-sub-title" = "Ett nytt sätt att upptäcka intressanta artiklar varje dag";
 "welcome-explore-tell-me-more" = "Berätta mer";
 "welcome-explore-tell-me-more-about-explore" = "Mer om Utforska";
-// Fuzzy
-"welcome-explore-tell-me-more-details" = "När du besöker en artikel läggs relaterade artiklar automatiskt till ditt Utforskningsflöde. Detta ändrar inte hur vi samlar in din information och din läsningshistorik är fortfarande privat.";
+"welcome-explore-tell-me-more-details" = "När du läser en artikel läggs relaterade artiklar automatiskt till ditt Utforskningsflöde. Detta ändrar inte hur vi samlar in din information och din läsningshistorik är fortfarande privat.";
+"welcome-explore-tell-me-more-privacy" = "Ingen läsningslista eller profil lagras i våra servrar.";
 "welcome-explore-tell-me-more-done-button" = "Jag förstår";
 "welcome-explore-continue-button" = "Kom igång";
 "welcome-languages-title" = "Språk";
@@ -360,8 +364,7 @@
 "welcome-volunteer-thanks" = "$1 Tack!";
 "empty-no-feed-title" = "Ingen internetanslutning";
 "empty-no-feed-message" = "Du kan se dina rekommenderade artiklar när du har internetåtkomst";
-// Fuzzy
-"empty-no-feed-action-message" = "Du kan läsa sparade sidor under tiden";
+"empty-no-feed-action-message" = "Du kan fortfarande läsa sparade sidor";
 "empty-no-article-message" = "Tyvärr, kunde inte läsa in artikeln";
 "empty-no-search-results-message" = "Inga resultat hittades";
 "empty-no-saved-pages-title" = "Inga sparade sidor ännu";
@@ -378,7 +381,6 @@
 "compass-direction" = "mot klockan $1";
 "explore-featured-article-heading" = "Utmärkt artikel";
 "explore-continue-reading-heading" = "Fortsätt läsa";
-// Fuzzy
 "explore-nearby-heading" = "Platser i närheten";
 "explore-continue-related-heading" = "Eftersom du läste";
 "explore-main-page-heading" = "Idag på Wikipedia";

--- a/Wikipedia/Localizations/tr.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/tr.lproj/Localizable.strings
@@ -18,8 +18,7 @@
 "article-languages-label" = "Dil seçin";
 "article-languages-cancel" = "İptal";
 "article-languages-downloading" = "Madde dilleri yükleniyor...";
-// Fuzzy
-"article-languages-filter-placeholder" = "Dil Süzgeci";
+"article-languages-filter-placeholder" = "Dil bul";
 "article-read-more-title" = "Devamı";
 "article-about-title" = "Bu madde hakkında";
 "article-unable-to-load-section" = "Bu bölüm yüklenemedi. Sorunu gidermek için sayfayı yenilemeyi deneyin.";
@@ -113,6 +112,7 @@
 "search-recent-clear-delete-all" = "Tümünü Sil";
 "search-result-redirected-from" = "Şuradan yönlendirildi: $1";
 "settings-title" = "Ayarlar";
+"settings-language" = "Vikipedi dili";
 "settings-support" = "Vikipedi'yi destekleyin";
 "settings-language-bar" = "Aramada dilleri göster";
 "main-menu-title" = "Diğer";
@@ -351,8 +351,9 @@
 "welcome-explore-sub-title" = "Her gün ilginç maddeler keşfetmek için yeni bir yol";
 "welcome-explore-tell-me-more" = "Daha fazla bilgi";
 "welcome-explore-tell-me-more-about-explore" = "Keşfet hakkında daha fazla bilgi";
-// Fuzzy
-"welcome-explore-tell-me-more-details" = "Bir maddeyi açtığınızda, ilgili maddeler otomatik olarak Keşfet bölümünüze eklenir. Bu, bizim bilgi toplama usullerimizi değiştirmez ve okuma geçmişiniz yine gizli kalır.";
+"welcome-explore-tell-me-more-details" = "Bir maddeyi okuduğunuzda, ilgili maddeler otomatik olarak Keşfet bölümünüze eklenir. Bu, bizim bilgi toplama usullerimizi değiştirmez ve okuma geçmişiniz yine gizli kalır.";
+"welcome-explore-tell-me-more-related" = "Keşfet bölümü, daha önce okuduğunuz maddelere ilgili maddeleri size sunar.";
+"welcome-explore-tell-me-more-privacy" = "Sunucularımızda herhangi bir okuma listesi veya profil kaydedilmez.";
 "welcome-explore-tell-me-more-done-button" = "Anladım";
 "welcome-explore-continue-button" = "Kullanmaya başla";
 "welcome-languages-title" = "Diller";
@@ -366,8 +367,7 @@
 "welcome-volunteer-thanks" = "$1 Teşekkürler!";
 "empty-no-feed-title" = "İnternet Bağlantısı Yok";
 "empty-no-feed-message" = "İnternet bağlantınız olduğunda, size önerilen makaleleri görebilirsiniz";
-// Fuzzy
-"empty-no-feed-action-message" = "Bu arada kayıtlı sayfaları okuyabilirsiniz";
+"empty-no-feed-action-message" = "Hala kayıtlı sayfaları okuyabilirsiniz";
 "empty-no-article-message" = "Üzgünüz, makale yüklenemedi";
 "empty-no-search-results-message" = "Sonuç bulunamadı";
 "empty-no-saved-pages-title" = "Henüz kaydedilmiş bir sayfa yok";
@@ -384,7 +384,6 @@
 "compass-direction" = "saat $1 yönünde";
 "explore-featured-article-heading" = "Seçkin madde";
 "explore-continue-reading-heading" = "Okumaya devam et";
-// Fuzzy
 "explore-nearby-heading" = "Yakındaki yerler";
 "explore-continue-related-heading" = "Okuduklarına benzer";
 "explore-main-page-heading" = "Vikipedi'de Bugün";
@@ -393,5 +392,4 @@
 "explore-potd-heading" = "Günün resmi";
 "explore-most-read-heading" = "$1 Vikipedi'de en çok okunan maddeler";
 "explore-most-read-footer" = "Bütün en çok okunan maddeler";
-// Fuzzy
 "explore-most-read-more-list-title" = "En çok okunan maddeler";

--- a/Wikipedia/Localizations/zh-hans.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/zh-hans.lproj/Localizable.strings
@@ -16,8 +16,7 @@
 "article-languages-label" = "选择语言";
 "article-languages-cancel" = "取消";
 "article-languages-downloading" = "条目语言载入中...";
-// Fuzzy
-"article-languages-filter-placeholder" = "语言过滤器";
+"article-languages-filter-placeholder" = "查找语言";
 "article-read-more-title" = "阅读更多";
 "article-about-title" = "关于此条目";
 "article-unable-to-load-section" = "无法载入此章节。请尝试刷新条目以查看问题是否解决。";
@@ -111,6 +110,7 @@
 "search-recent-clear-delete-all" = "删除全部";
 "search-result-redirected-from" = "重定向自：$1";
 "settings-title" = "设置";
+"settings-language" = "维基百科语言";
 "settings-support" = "支持维基百科";
 "settings-language-bar" = "在搜索时显示语言";
 "main-menu-title" = "更多";
@@ -349,8 +349,9 @@
 "welcome-explore-sub-title" = "每天发现有趣条目的新方式";
 "welcome-explore-tell-me-more" = "告诉我更多";
 "welcome-explore-tell-me-more-about-explore" = "更多有关探索";
-// Fuzzy
-"welcome-explore-tell-me-more-details" = "当您访问一个条目时，相关条目会自动添加至您的探索订阅源中。这不会更改我们收集您信息的方式，并且您的阅读历史仍然是私人的。";
+"welcome-explore-tell-me-more-details" = "当您阅读一个条目时，相关条目会自动添加至您的探索订阅源中。这不会更改我们收集您信息的方式，并且您的阅读历史仍然是私人的。";
+"welcome-explore-tell-me-more-related" = "探索订阅显示与您阅读的条目相关的条目。";
+"welcome-explore-tell-me-more-privacy" = "在我们的服务器上没有存储阅读列表或概述。";
 "welcome-explore-tell-me-more-done-button" = "明白了";
 "welcome-explore-continue-button" = "入门";
 "welcome-languages-title" = "语言";
@@ -364,8 +365,7 @@
 "welcome-volunteer-thanks" = "$1感谢您！";
 "empty-no-feed-title" = "没有网络连接";
 "empty-no-feed-message" = "当您有网络连接时，您可以查看您推荐的条目";
-// Fuzzy
-"empty-no-feed-action-message" = "同时您可以阅读保存的页面";
+"empty-no-feed-action-message" = "您仍然可以阅读保存的页面";
 "empty-no-article-message" = "对不起，无法加载条目";
 "empty-no-search-results-message" = "找不到结果";
 "empty-no-saved-pages-title" = "尚无保存的页面";
@@ -382,8 +382,7 @@
 "compass-direction" = "$1点钟";
 "explore-featured-article-heading" = "特色条目";
 "explore-continue-reading-heading" = "继续阅读";
-// Fuzzy
-"explore-nearby-heading" = "附近地点";
+"explore-nearby-heading" = "地点接近";
 "explore-continue-related-heading" = "因为您阅读";
 "explore-main-page-heading" = "维基百科今日";
 "explore-random-article-heading" = "随机条目";
@@ -391,5 +390,4 @@
 "explore-potd-heading" = "每日图片";
 "explore-most-read-heading" = "$1维基百科上的最多阅读";
 "explore-most-read-footer" = "所有最多阅读的条目";
-// Fuzzy
 "explore-most-read-more-list-title" = "最多阅读的条目";


### PR DESCRIPTION
Would someone mind testing welcome-volunteer-thanks for Arabic? Not new to this patch but the regex references ($1, $2, ...) appear flipped in [Phabricator](https://phabricator.wikimedia.org/diffusion/APIW/browse/master/Wikipedia/ar.lproj/Localizable.strings;fa08cf6b42df187453e7e1946c32dcfc0227d775$70), [GitHub](https://github.com/wikimedia/wikipedia-ios/blob/master/Wikipedia/Localizations/ar.lproj/Localizable.strings#L88), and Atom. I think it's just a bug in these tools to show the references as RTL (1$, 2$, ...) and that they're actually LTR. In Vim and Sublime, they appear LTR. We had this problem in one of the first patches we did and IIRC flipped them to appear LTR in GitHub but I'm now questioning that choice because the Atom text search doesn't even work in these cases where the reference is shown as RTL. All other iOS and Android Hebrew and Arabic references appear LTR in all tools.

By the byte, Sed and Grep appear useless in either orientation. e.g.:

  sed -ri 's%(\d+)\$%a%g' Wikipedia/Localizations/ar.lproj/Localizable.strings
  sed -ri 's%\$(\d+)%a%g' Wikipedia/Localizations/ar.lproj/Localizable.strings

Has no effect. We'll need to come up with a better way to detect flips (maybe a JavaScript regex would work better?).