### PR TITLE
fix crash by checking for nan

### DIFF
--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -489,6 +489,10 @@ NSString* const WMFLicenseTitleOnENWiki =
 - (void)tocScrollWebViewToPoint:(CGPoint)point
                        duration:(CGFloat)duration
                     thenHideTOC:(BOOL)hideTOC {
+    if(isnan(point.x) || isnan(point.y)){
+        return;
+        DDLogError(@"Attempted to scroll ToC to Nan value, ignoring");
+    }
     [UIView animateWithDuration:duration
                           delay:0.0f
                         options:UIViewAnimationOptionBeginFromCurrentState


### PR DESCRIPTION
Sometimes we get Nan from the web view when asking for the location of elements.

now we bail if we see it and log an error

https://phabricator.wikimedia.org/T129393