### PR TITLE
Fix crash when wifi is off and switching from the explore tab to save

### DIFF
--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -186,6 +186,10 @@ NS_ASSUME_NONNULL_BEGIN
         [sum addIndex:(NSUInteger)obj.section];
         return sum;
     }];
+    
+    if([visibleSectionIndexes count] == 0){
+        return @[];
+    }
 
     return [[self.schemaManager.sections objectsAtIndexes:visibleSectionIndexes] wmf_mapAndRejectNil:^id (WMFExploreSection* obj) {
         return [self sectionControllerForSection:obj];


### PR DESCRIPTION
https://phabricator.wikimedia.org/T129477

Probably only 9.3… good to fix this now

`objectsAtIndexes:` hates it when you pass an empty index set.