### PR TITLE
Fix crash when self is nil in image protocol

### DIFF
--- a/Wikipedia/Code/WMFArticleImageProtocol.m
+++ b/Wikipedia/Code/WMFArticleImageProtocol.m
@@ -57,10 +57,16 @@ static NSString* const WMFArticleImageProtocolHost               = @"upload.wiki
     [[WMFImageController sharedInstance] fetchImageWithURL:self.request.URL]
     .thenInBackground(^(WMFImageDownload* download) {
         @strongify(self);
+        if(!self){
+            return;
+        }
         [self respondWithDataFromDownload:download];
     })
     .catch(^(NSError* err) {
         @strongify(self);
+        if(!self){
+            return;
+        }
         [self respondWithError:err];
     });
 }


### PR DESCRIPTION
Looks like we are getting deallocated - probably navigating away from an article?
Then we crash when the request is completed because self is gone.
Now we just bail.

https://phabricator.wikimedia.org/T129493