### PR TITLE
Fix share crash

### DIFF
--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -385,7 +385,7 @@ NS_ASSUME_NONNULL_BEGIN
         _shareToolbarItem = [[UIBarButtonItem alloc] bk_initWithBarButtonSystemItem:UIBarButtonSystemItemAction
                                                                             handler:^(id sender){
             @strongify(self);
-            [self shareArticleWithTextSnippet:nil fromButton:sender];
+            [self shareArticleWithTextSnippet:nil fromButton:self->_shareToolbarItem];
         }];
     }
     return _shareToolbarItem;
@@ -741,6 +741,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)shareArticleWithTextSnippet:(nullable NSString*)text fromButton:(UIBarButtonItem*)button {
+    NSParameterAssert(button);
+    if(!button){
+        //If we get no button, we will crash below on iPad
+        //The assert above shoud help, but lets make sure we bail in prod
+        return;
+    }
     [self.shareFunnel logShareButtonTappedResultingInSelection:text];
 
     NSMutableArray* items = [NSMutableArray array];

--- a/Wikipedia/Code/WMFShareOptionsController.h
+++ b/Wikipedia/Code/WMFShareOptionsController.h
@@ -1,10 +1,3 @@
-//
-//  ShareOptionsViewController.h
-//  Wikipedia
-//
-//  Created by Adam Baso on 2/6/15.
-//  Copyright (c) 2015 Wikimedia Foundation. All rights reserved.
-//
 
 #import <UIKit/UIKit.h>
 
@@ -28,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
                     shareFunnel:(WMFShareFunnel*)funnel NS_DESIGNATED_INITIALIZER;
 
 /**
- * Initialize a new instance with an article and an optional snippet.
+ * Present the share options with the specified snippet, in the given viewcontroller, from the given button item.
  *
  * @param snippet           The snippet to share.
  * @param viewController    The view controller that will present the menus.
@@ -37,11 +30,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @note Truncating `snippet` is not necessary, as it's done internally by the share view's `UILabel`.
  */
 - (void)presentShareOptionsWithSnippet:(NSString*)snippet inViewController:(UIViewController*)viewController fromBarButtonItem:(UIBarButtonItem*)item;
-
-/**
- * Same as above, but presented from a view instead of a bar button item
- */
-- (void)presentShareOptionsWithSnippet:(NSString*)snippet inViewController:(UIViewController*)viewController fromView:(UIView*)view;
 
 @end
 

--- a/Wikipedia/Code/WMFShareOptionsController.m
+++ b/Wikipedia/Code/WMFShareOptionsController.m
@@ -1,10 +1,3 @@
-//
-//  ShareOptionsViewController.m
-//  Wikipedia
-//
-//  Created by Adam Baso on 2/6/15.
-//  Copyright (c) 2015 Wikimedia Foundation. All rights reserved.
-//
 
 #import "WMFShareOptionsController.h"
 
@@ -37,7 +30,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable, copy, nonatomic) NSString* snippet;
 @property (weak, nonatomic) UIViewController* containerViewController;
-@property (nullable, weak, nonatomic) UIView* originView;
 @property (nullable, strong, nonatomic) UIBarButtonItem* originButtonItem;
 
 @property (nullable, strong, nonatomic) UIView* grayOverlay;
@@ -54,7 +46,6 @@ NS_ASSUME_NONNULL_BEGIN
     [[WMFImageController sharedInstance] cancelFetchForURL:[NSURL wmf_optionalURLWithString:self.article.imageURL]];
     self.containerViewController = nil;
     self.originButtonItem        = nil;
-    self.originView              = nil;
     self.shareImage              = nil;
     self.snippet                 = nil;
 }
@@ -81,20 +72,11 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Public Presentation methods
 
 - (void)presentShareOptionsWithSnippet:(NSString*)snippet inViewController:(UIViewController*)viewController fromBarButtonItem:(UIBarButtonItem*)item {
-    self.snippet                 = [snippet copy];
     NSParameterAssert(item);
     NSParameterAssert(viewController);
+    self.snippet                 = snippet;
     self.containerViewController = viewController;
     self.originButtonItem        = item;
-    self.originView              = nil;
-    [self fetchImageThenShowShareCard];
-}
-
-- (void)presentShareOptionsWithSnippet:(NSString*)snippet inViewController:(UIViewController*)viewController fromView:(UIView*)view {
-    self.snippet                 = [snippet copy];
-    self.containerViewController = viewController;
-    self.originButtonItem        = nil;
-    self.originView              = view;
     [self fetchImageThenShowShareCard];
 }
 
@@ -329,12 +311,7 @@ NS_ASSUME_NONNULL_BEGIN
         [[UIActivityViewController alloc] initWithActivityItems:activityItems
                                           applicationActivities:@[]];
     UIPopoverPresentationController* presenter = [shareActivityVC popoverPresentationController];
-    if (self.originButtonItem) {
-        presenter.barButtonItem = self.originButtonItem;
-    } else {
-        presenter.sourceView = self.originView;
-        presenter.sourceRect = [self.containerViewController.view convertRect:self.originView.frame fromView:self.originView.superview];
-    }
+    presenter.barButtonItem = self.originButtonItem;
 
     shareActivityVC.excludedActivityTypes = @[
         UIActivityTypePrint,

--- a/Wikipedia/Code/WMFShareOptionsController.m
+++ b/Wikipedia/Code/WMFShareOptionsController.m
@@ -37,8 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable, copy, nonatomic) NSString* snippet;
 @property (weak, nonatomic) UIViewController* containerViewController;
-@property (nullable, weak, nonatomic) UIBarButtonItem* originButtonItem;
 @property (nullable, weak, nonatomic) UIView* originView;
+@property (nullable, strong, nonatomic) UIBarButtonItem* originButtonItem;
 
 @property (nullable, strong, nonatomic) UIView* grayOverlay;
 @property (nullable, strong, nonatomic) WMFShareOptionsView* shareOptions;

--- a/Wikipedia/Code/WMFShareOptionsController.m
+++ b/Wikipedia/Code/WMFShareOptionsController.m
@@ -82,6 +82,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)presentShareOptionsWithSnippet:(NSString*)snippet inViewController:(UIViewController*)viewController fromBarButtonItem:(UIBarButtonItem*)item {
     self.snippet                 = [snippet copy];
+    NSParameterAssert(item);
+    NSParameterAssert(viewController);
     self.containerViewController = viewController;
     self.originButtonItem        = item;
     self.originView              = nil;
@@ -307,6 +309,11 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Activity View Controller
 
 - (void)presentActivityViewControllerWithImage:(nullable UIImage*)image title:(NSString*)title {
+    if (!self.originButtonItem) {
+        //bailing here because we will crash below in production.
+        //The asserion above will catch this in development/beta.
+        return;
+    }
     NSString* parameter = image ? @"wprov=sfii1" : @"wprov=sfti1";
 
     NSURL* url = [[NSURL alloc] initWithString:[NSString stringWithFormat:@"%@?%@",


### PR DESCRIPTION
Was not able to reproduce.

It is iPad specific - only iOS 9 reports so far.

We are presenting the share popover without a bar button item

The item was a weak reference… which shouldn't have been a problem, but to be extra careful I am making it strong.

Additionally there are extra guards so as instead of crashing, we just bail out from sharing. 

