### PR TITLE
Fix for image overlay licence text extending over info button.

### DIFF
--- a/Wikipedia/Code/WMFImageGalleryDetailOverlayView.xib
+++ b/Wikipedia/Code/WMFImageGalleryDetailOverlayView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10109" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10083"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -31,7 +31,7 @@
                         <action selector="didTapOwnerButton" destination="iN0-l3-epB" eventType="touchUpInside" id="jaw-0w-iI9"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="infoLight" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2dn-jB-W86">
+                <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="infoLight" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2dn-jB-W86">
                     <rect key="frame" x="396" y="224" width="22" height="26"/>
                     <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <connections>
@@ -44,28 +44,15 @@
                 <constraint firstItem="I6f-Vm-XuX" firstAttribute="top" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="top" constant="50" id="0L5-I0-Yi9"/>
                 <constraint firstItem="I6f-Vm-XuX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="2k3-u8-8nA"/>
                 <constraint firstItem="2dn-jB-W86" firstAttribute="top" secondItem="I6f-Vm-XuX" secondAttribute="bottom" constant="12" id="56h-aE-LPJ"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="l6E-b6-poB" secondAttribute="trailing" constant="20" symbolic="YES" id="7RJ-RE-3u1"/>
-                <constraint firstItem="2dn-jB-W86" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="l6E-b6-poB" secondAttribute="trailing" constant="8" id="H6b-GK-jCk"/>
                 <constraint firstItem="l6E-b6-poB" firstAttribute="leading" secondItem="I6f-Vm-XuX" secondAttribute="leading" id="Khe-Sx-wKS"/>
                 <constraint firstAttribute="bottom" secondItem="l6E-b6-poB" secondAttribute="bottom" constant="12" id="PWz-xR-vOr"/>
                 <constraint firstItem="2dn-jB-W86" firstAttribute="trailing" secondItem="I6f-Vm-XuX" secondAttribute="trailing" id="aRE-ep-0ka"/>
                 <constraint firstAttribute="bottom" secondItem="2dn-jB-W86" secondAttribute="bottom" constant="12" id="bhl-iP-XNu"/>
-                <constraint firstItem="l6E-b6-poB" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="e6B-Lc-WcL"/>
+                <constraint firstItem="2dn-jB-W86" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="l6E-b6-poB" secondAttribute="trailing" constant="10" id="eBk-Yr-coi"/>
                 <constraint firstItem="l6E-b6-poB" firstAttribute="top" secondItem="I6f-Vm-XuX" secondAttribute="bottom" constant="12" id="eSj-hx-LwA"/>
-                <constraint firstAttribute="trailing" secondItem="l6E-b6-poB" secondAttribute="trailing" constant="20" symbolic="YES" id="jVU-lo-Wm4"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="l6E-b6-poB" secondAttribute="trailing" constant="20" symbolic="YES" id="plD-UM-3Zz"/>
                 <constraint firstAttribute="trailing" secondItem="I6f-Vm-XuX" secondAttribute="trailing" constant="20" symbolic="YES" id="tll-y7-tNL"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <variation key="default">
-                <mask key="constraints">
-                    <exclude reference="7RJ-RE-3u1"/>
-                    <exclude reference="e6B-Lc-WcL"/>
-                    <exclude reference="jVU-lo-Wm4"/>
-                    <exclude reference="plD-UM-3Zz"/>
-                    <exclude reference="H6b-GK-jCk"/>
-                </mask>
-            </variation>
             <connections>
                 <outlet property="imageDescriptionLabel" destination="I6f-Vm-XuX" id="fUv-oF-GNJ"/>
                 <outlet property="infoButton" destination="2dn-jB-W86" id="bQd-Un-wet"/>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T128927

**Before**
![screen shot 2016-03-10 at 12 58 29 pm](https://cloud.githubusercontent.com/assets/3143487/13684271/d0d71f6e-e6bf-11e5-91e4-0c984c5c15b6.png)

**After**
![screen shot 2016-03-10 at 12 57 57 pm](https://cloud.githubusercontent.com/assets/3143487/13684270/d0b9132a-e6bf-11e5-9fad-3fed0292aef7.png)