### PR TITLE
Shorten captcha string. Make captcha text box use natural alignment.

### DIFF
--- a/Wikipedia/Code/CaptchaViewController.storyboard
+++ b/Wikipedia/Code/CaptchaViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="sIA-fC-CW8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="sIA-fC-CW8">
     <dependencies>
         <deployment identifier="iOS"/>
         <development version="5100" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
     <scenes>
         <!--Captcha View Controller-->
@@ -30,10 +30,10 @@
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                             </button>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="gPg-cg-Yjy">
-                                <rect key="frame" x="20" y="140" width="280" height="30"/>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="gPg-cg-Yjy">
+                                <rect key="frame" x="15" y="140" width="290" height="30"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="280" id="6wn-Hx-rhl"/>
+                                    <constraint firstAttribute="width" constant="290" id="6wn-Hx-rhl"/>
                                     <constraint firstAttribute="height" constant="30" id="FGZ-UY-edA"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -353,7 +353,7 @@
 "page-edit-history" = "Full edit history";
 
 "captcha-reload" = "Show another captcha";
-"captcha-prompt" = "Enter CAPTCHA text from the image";
+"captcha-prompt" = "Enter CAPTCHA text";
 
 "mwk-empty-title-error" = "Unable to perform operation with empty title.";
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T113178

- [x] Shorten captcha prompt to say "Enter captcha text" so it doesn't get truncated with verbose translations.
- [x] Make the text use natural text alignment so in RTL languages it will move to right side.

**Before**
![screen shot 2016-03-10 at 2 48 15 pm](https://cloud.githubusercontent.com/assets/3143487/13687322/6aeb1c0e-e6cf-11e5-9325-e68993768c31.png)

**After**
![screen shot 2016-03-10 at 2 49 18 pm](https://cloud.githubusercontent.com/assets/3143487/13687323/6aed5366-e6cf-11e5-84f5-6392773a350d.png)