### PR TITLE
Follow-up wordmark fix correcting making both storyboard wordmarks match.

### DIFF
--- a/Wikipedia/Code/Launch Screen.storyboard
+++ b/Wikipedia/Code/Launch Screen.storyboard
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                             </imageView>
                             <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="wikipedia-wordmark" translatesAutoresizingMaskIntoConstraints="NO" id="fjV-9r-LpR">
-                                <rect key="frame" x="163" y="254" width="275" height="67"/>
+                                <rect key="frame" x="180.5" y="258" width="240" height="59"/>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
@@ -38,10 +38,10 @@
                                 <exclude reference="Lxi-AY-Mcn"/>
                             </mask>
                             <mask key="constraints">
+                                <exclude reference="LoA-U6-c1U"/>
                                 <exclude reference="AFa-g5-4es"/>
                                 <exclude reference="Z3f-uh-Bvx"/>
                                 <exclude reference="tIM-gE-sXh"/>
-                                <exclude reference="LoA-U6-c1U"/>
                             </mask>
                         </variation>
                         <variation key="heightClass=regular-widthClass=compact">
@@ -49,10 +49,10 @@
                                 <include reference="Lxi-AY-Mcn"/>
                             </mask>
                             <mask key="constraints">
+                                <include reference="LoA-U6-c1U"/>
                                 <include reference="AFa-g5-4es"/>
                                 <include reference="Z3f-uh-Bvx"/>
                                 <include reference="tIM-gE-sXh"/>
-                                <include reference="LoA-U6-c1U"/>
                             </mask>
                         </variation>
                     </view>
@@ -64,6 +64,6 @@
     </scenes>
     <resources>
         <image name="splashscreen-background" width="414" height="736"/>
-        <image name="wikipedia-wordmark" width="275" height="67"/>
+        <image name="wikipedia-wordmark" width="240" height="59"/>
     </resources>
 </document>

--- a/Wikipedia/Code/WMFAppViewController.storyboard
+++ b/Wikipedia/Code/WMFAppViewController.storyboard
@@ -20,8 +20,8 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="N6E-ZW-sLh">
                                 <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="wikipedia-wordmark" translatesAutoresizingMaskIntoConstraints="NO" id="5c5-u5-qnE">
-                                        <rect key="frame" x="163" y="254.5" width="275" height="67"/>
+                                    <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="wikipedia-wordmark" translatesAutoresizingMaskIntoConstraints="NO" id="5c5-u5-qnE">
+                                        <rect key="frame" x="180.5" y="258.5" width="240" height="59"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="210" id="bR9-Sg-vRZ"/>
                                             <constraint firstAttribute="height" constant="192" id="nWb-XA-yli"/>
@@ -59,6 +59,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="wikipedia-wordmark" width="275" height="67"/>
+        <image name="wikipedia-wordmark" width="240" height="59"/>
     </resources>
 </document>


### PR DESCRIPTION
The last patch make them appear at different sizes and stutter when transitioning between them.

This may have been just because I didn't do a clean build, but figured I should update the storyboards just in case.