### PR TITLE
Fix for revision warnings (hopefully all). Wasn't handling redirected titles.

### DIFF
--- a/Wikipedia/Code/WMFArticleRevisionFetcher.m
+++ b/Wikipedia/Code/WMFArticleRevisionFetcher.m
@@ -46,6 +46,7 @@
                 @"formatversion": @2,
                 @"action": @"query",
                 @"prop": @"revisions",
+                @"redirects": @1,
                 @"titles": title.text,
                 @"rvlimit": @(numberOfResults),
                 @"rvendid": @(revisionId),


### PR DESCRIPTION
https://phabricator.wikimedia.org/T129900

The following returns no revisions:
https://en.m.wikipedia.org/w/api.php?action=query&continue=&format=jsonfm&formatversion=2&prop=revisions&rvendid=710520884&rvlimit=1&rvprop=ids%7Csize%7Cflags&titles=African_American

But this does:
https://en.m.wikipedia.org/w/api.php?action=query&continue=&format=jsonfm&formatversion=2&prop=revisions&rvendid=710520884&rvlimit=1&rvprop=ids%7Csize%7Cflags&titles=African_American&redirects=1
(note the addition of `redirects=1` at the end)