### PR TITLE
handle null case for article history delta

### DIFF
--- a/Wikipedia/Code/PageHistoryFetcher.m
+++ b/Wikipedia/Code/PageHistoryFetcher.m
@@ -73,7 +73,7 @@
         @"action": @"query",
         @"prop": @"revisions",
         @"rvprop": @"ids|timestamp|user|size|parsedcomment",
-        @"rvlimit": @50,
+        @"rvlimit": @51,
         @"rvdir": @"older",
         @"titles": title.text,
         @"continue": @"",
@@ -124,6 +124,7 @@
 
             [self calculateCharacterDeltasForRevisions:revisionsByDaySorted
                                        fromParentSizes:parentSizes];
+            [self pruneIncompleteRevisionFromRevisions:revisionsByDaySorted];
 
             output = revisionsByDaySorted;
         }
@@ -148,6 +149,14 @@
                 }
             }
         }
+    }
+}
+
+- (void)pruneIncompleteRevisionFromRevisions:(NSMutableArray*)revisions {
+    //Unless the last item is the oldest, remove it since we don't know its characterDelta
+    NSNumber *parentId = revisions.lastObject[@"parentId"];
+    if (parentId == nil || parentId.integerValue != 0) {
+        [revisions removeLastObject];
     }
 }
 

--- a/Wikipedia/Code/PageHistoryFetcher.m
+++ b/Wikipedia/Code/PageHistoryFetcher.m
@@ -153,10 +153,16 @@
 }
 
 - (void)pruneIncompleteRevisionFromRevisions:(NSMutableArray*)revisions {
-    //Unless the last item is the oldest, remove it since we don't know its characterDelta
-    NSNumber *parentId = revisions.lastObject[@"parentId"];
-    if (parentId == nil || parentId.integerValue != 0) {
-        [revisions removeLastObject];
+    NSDictionary *lastDayRevisionsMeta = revisions.lastObject;
+    NSMutableArray *lastDayRevisions = lastDayRevisionsMeta[@"revisions"];
+    NSNumber *lastRevisionParentId = lastDayRevisions.lastObject[@"parentid"];
+
+    if (lastRevisionParentId == nil || lastRevisionParentId.integerValue != 0) {
+        if (lastDayRevisions.count <= 1) {
+            [revisions removeLastObject];
+        } else {
+            [lastDayRevisions removeLastObject];
+        }
     }
 }
 


### PR DESCRIPTION
[Ticket: T127373 article history item null delta](https://phabricator.wikimedia.org/T127373)
article history delta is calculated between two items
we can't know the delta of the last item unless it is the first item ever created
this bumps the number of items requested and doesn't show the final item received
unless it is the first in the article history

If someone could point me to the preferred pattern for adding tests to these fetchers I'd be happy to add some or update existing.