### PR TITLE
Legal footer and link to creative commons

### DIFF
--- a/Wikipedia/Code/AboutViewController.plist
+++ b/Wikipedia/Code/AboutViewController.plist
@@ -5,7 +5,7 @@
 	<key>urls</key>
 	<dict>
 		<key>sharealike</key>
-		<string>https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License</string>
+		<string>https://creativecommons.org/licenses/by-sa/3.0/</string>
 		<key>mit</key>
 		<string>https://raw.githubusercontent.com/wikimedia/wikipedia-ios/master/LICENSE.txt</string>
 		<key>tsg</key>

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -40,7 +40,7 @@ typedef NS_ENUM (NSInteger, WMFWebViewAlertType) {
 };
 
 NSString* const WMFLicenseTitleOnENWiki =
-    @"Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License";
+    @"creativecommons:by-sa/3.0";
 
 @interface WebViewController () <ReferencesVCDelegate>
 

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -273,7 +273,7 @@
 "page_protected_can_not_edit" = "You do not have the rights to edit this page";
 "page_protected_can_not_edit_title" = "This page is protected";
 
-"license-footer-text" = "Content is available under $1";
+"license-footer-text" = "Content is available under $1 unless otherwise noted.";
 "license-footer-name" = "CC BY-SA 3.0";
 
 "table-of-contents-heading" = "Contents";


### PR DESCRIPTION
T126556

Updating the legal footer, to use the same text and link as mobile-web. Also update from our internal license link, ot the official one a creativecommons, as mobile-web does.