### PR TITLE
Switch request for top article details to POST from GET.

### DIFF
--- a/Wikipedia/Code/AFHTTPSessionManager+WMFDesktopRetry.h
+++ b/Wikipedia/Code/AFHTTPSessionManager+WMFDesktopRetry.h
@@ -60,4 +60,57 @@
  */
 - (AnyPromise*)wmf_GETWithSite:(MWKSite*)site parameters:(id)parameters;
 
+/**
+ *  Executes a POST using a mobile url.
+ *  If the request fails with the mobile URL for a known reason,
+ *  the request will automatically be re-attempted with the desktop URL
+ *
+ *  @param mobileURLString  The mobile URL
+ *  @param desktopURLString The desktop URL
+ *  @param parameters       The parameters for the request (same as normal POST:)
+ *  @param success          The retry block - called if a retry is executed. Use this to get the new operation.
+ *  @param success          The success block (same as normal POST:)
+ *  @param failure          The failure block (same as normal POST:)
+ *
+ *  @return The operation
+ */
+- (NSURLSessionDataTask*)wmf_POSTWithMobileURLString:(NSString*)mobileURLString
+                                    desktopURLString:(NSString*)desktopURLString
+                                          parameters:(id)parameters
+                                               retry:(void (^)(NSURLSessionDataTask* retryOperation, NSError* error))retry
+                                             success:(void (^)(NSURLSessionDataTask* operation, id responseObject))success
+                                             failure:(void (^)(NSURLSessionDataTask* operation, NSError* error))failure;
+
+/**
+ *  Send a @c POST request to the given site, falling back to desktop URL if the mobile URL fails.
+ *
+ *  @param site The site to send the request to, using its API endpoints. First mobile, then desktop.
+ *
+ *  @see wmf_POSTWithMobileURLString:desktopURLString:parameters:retry:success:failure:
+ *
+ *  @return The operation which represents the state of the request.
+ */
+- (NSURLSessionDataTask*)wmf_POSTWithSite:(MWKSite*)site
+                               parameters:(id)parameters
+                                    retry:(void (^)(NSURLSessionDataTask* retryOperation, NSError* error))retry
+                                  success:(void (^)(NSURLSessionDataTask* operation, id responseObject))success
+                                  failure:(void (^)(NSURLSessionDataTask* operation, NSError* error))failure;
+
+/**
+ *  Send a @c POST request to the given site, falling back to desktop URL if the mobile URL fails.
+ *
+ *  Convenience, promise-based alternative to block-based API.  Omits the retry parameter & operation return for the
+ *  simple case which doesn't need cancellation.
+ *
+ *  @param site       The site to send the request to, using its API endpoints. First mobile, then desktop.
+ *
+ *  @param parameters The parameters which will be passed to the receiver's @c requestSerializer.
+ *
+ *  @return A promise which will be resolved with the successful response of the request, or rejected with any errors
+ *          that occur.
+ *
+ *  @see wmf_POSTWithMobileURLString:desktopURLString:parameters:retry:success:failure:
+ */
+- (AnyPromise*)wmf_POSTWithSite:(MWKSite*)site parameters:(id)parameters;
+
 @end

--- a/Wikipedia/Code/AFHTTPSessionManager+WMFDesktopRetry.m
+++ b/Wikipedia/Code/AFHTTPSessionManager+WMFDesktopRetry.m
@@ -62,4 +62,60 @@
     }];
 }
 
+- (NSURLSessionDataTask*)wmf_POSTWithMobileURLString:(NSString*)mobileURLString
+                                   desktopURLString:(NSString*)desktopURLString
+                                         parameters:(id)parameters
+                                              retry:(void (^)(NSURLSessionDataTask* retryOperation, NSError* error))retry
+                                            success:(void (^)(NSURLSessionDataTask* operation, id responseObject))success
+                                            failure:(void (^)(NSURLSessionDataTask* operation, NSError* error))failure {
+    return [self POST:mobileURLString parameters:parameters progress:NULL success:^(NSURLSessionDataTask* _Nonnull operation, id _Nonnull responseObject) {
+        if (success) {
+            success(operation, responseObject);
+        }
+    } failure:^(NSURLSessionDataTask* _Nonnull operation, NSError* _Nonnull error) {
+        if ([error wmf_shouldFallbackToDesktopURLError]) {
+            NSURLSessionDataTask* operation = [self POST:desktopURLString parameters:parameters progress:NULL success:^(NSURLSessionDataTask* _Nonnull operation, id _Nonnull responseObject) {
+                if (success) {
+                    success(operation, responseObject);
+                }
+            } failure:^(NSURLSessionDataTask* _Nonnull operation, NSError* _Nonnull error) {
+                if (failure) {
+                    failure(operation, error);
+                }
+            }];
+            if (retry) {
+                retry(operation, error);
+            }
+        } else {
+            if (failure) {
+                failure(operation, error);
+            }
+        }
+    }];
+}
+
+- (NSURLSessionDataTask*)wmf_POSTWithSite:(MWKSite*)site
+                              parameters:(id)parameters
+                                   retry:(void (^)(NSURLSessionDataTask* retryOperation, NSError* error))retry
+                                 success:(void (^)(NSURLSessionDataTask* operation, id responseObject))success
+                                 failure:(void (^)(NSURLSessionDataTask* operation, NSError* error))failure {
+    return [self wmf_POSTWithMobileURLString:[site apiEndpoint:YES].absoluteString
+                           desktopURLString:[site apiEndpoint:NO].absoluteString
+                                 parameters:parameters
+                                      retry:retry
+                                    success:success
+                                    failure:failure];
+}
+
+- (AnyPromise*)wmf_POSTWithSite:(MWKSite*)site
+                    parameters:(id)parameters {
+    return [AnyPromise promiseWithResolverBlock:^(PMKResolver _Nonnull resolve) {
+        [self wmf_POSTWithSite:site parameters:parameters retry:nil success:^(NSURLSessionDataTask* operation, id responseObject) {
+            resolve(responseObject);
+        } failure:^(NSURLSessionDataTask* operation, NSError* error) {
+            resolve(error);
+        }];
+    }];
+}
+
 @end

--- a/Wikipedia/Code/WMFArticlePreviewFetcher.m
+++ b/Wikipedia/Code/WMFArticlePreviewFetcher.m
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
     params.thumbnailWidth = thumbnailWidth;
 
     @weakify(self);
-    return [self.operationManager wmf_GETWithSite:site parameters:params]
+    return [self.operationManager wmf_POSTWithSite:site parameters:params]
            .thenInBackground(^id (NSArray<MWKSearchResult*>* unsortedPreviews) {
         @strongify(self);
         if (!self) {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T128120

POST wont have the size issue encoding long non-latin title list is sometimes causing with GET url.

Confirmed switching to POST fixes it - I cranked the number of titles being sent in the secondary request to 250 and reproduced the same failure. Then switched to POST and it started working again. #