### PR TITLE
Fix main page caching

### DIFF
--- a/Wikipedia/Code/MWKDataHousekeeping.m
+++ b/Wikipedia/Code/MWKDataHousekeeping.m
@@ -58,7 +58,7 @@
         // Iterate through all articles and de-cache the ones that aren't on the keep list
         // Cached metadata, section text, and images will be removed along with their articles.
         [dataStore iterateOverArticles:^(MWKArticle* article) {
-            if (![articlesToSave containsObject:article.title]) {
+            if (![articlesToSave containsObject:article.title] || [article isMain]) {
                 DDLogInfo(@"Pruning unsaved article %@", article.title);
                 [article remove];
             }

--- a/Wikipedia/Code/MWKDataStore.h
+++ b/Wikipedia/Code/MWKDataStore.h
@@ -75,14 +75,60 @@ extern NSString* const MWKArticleKey;
 - (NSString*)pathForTitleImageInfo:(MWKTitle*)title;
 
 // Raw save methods
+
+/**
+ *  Saves the article to the store
+ *  This is a non-op if the article is a main page
+ *
+ *  @param article the article to save
+ */
 - (void)saveArticle:(MWKArticle*)article;
+
+/**
+ *  Saves the section to the store
+ *  This is a non-op if the section.article is a main page
+ *
+ *  @param section the section to save
+ */
 - (void)saveSection:(MWKSection*)section;
+
+/**
+ *  Saves the section to the store
+ *  This is a non-op if the section.article is a main page
+ *
+ *  @param html    The text to save
+ *  @param section the section to save
+ */
 - (void)saveSectionText:(NSString*)html section:(MWKSection*)section;
+
+/**
+ *  Saves the image to the store
+ *  This is a non-op if the image.article is a main page
+ *
+ *  @param image The image to save
+ */
 - (void)saveImage:(MWKImage*)image;
+
+/**
+ *  Saves the image to the store
+ *  This is a non-op if the image.article is a main page
+ *
+ *  @param data  The data to save
+ *  @param image The image to save
+ */
 - (void)saveImageData:(NSData*)data image:(MWKImage*)image;
+
+
 - (BOOL)saveHistoryList:(MWKHistoryList*)list error:(NSError**)error;
 - (BOOL)saveSavedPageList:(MWKSavedPageList*)list error:(NSError**)error;
 - (BOOL)saveRecentSearchList:(MWKRecentSearchList*)list error:(NSError**)error;
+
+/**
+ *  Saves the image list to the store
+ *  This is a non-op if the image.article is a main page
+ *
+ *  @param imageList The image list to save
+ */
 - (void)saveImageList:(MWKImageList*)imageList;
 
 - (void)deleteArticle:(MWKArticle*)article;

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -219,6 +219,9 @@ static NSString* const MWKImageInfoFilename = @"ImageInfo.plist";
     if (article.title.text == nil) {
         return;
     }
+    if([article isMain]){
+        return;
+    }
     NSString* path       = [self pathForArticle:article];
     NSDictionary* export = [article dataExport];
     [self saveDictionary:export path:path name:@"Article.plist"];
@@ -229,23 +232,35 @@ static NSString* const MWKImageInfoFilename = @"ImageInfo.plist";
 }
 
 - (void)saveSection:(MWKSection*)section {
+    if([section.article isMain]){
+        return;
+    }
     NSString* path       = [self pathForSection:section];
     NSDictionary* export = [section dataExport];
     [self saveDictionary:export path:path name:@"Section.plist"];
 }
 
 - (void)saveSectionText:(NSString*)html section:(MWKSection*)section {
+    if([section.article isMain]){
+        return;
+    }
     NSString* path = [self pathForSection:section];
     [self saveString:html path:path name:@"Section.html"];
 }
 
 - (void)saveImage:(MWKImage*)image {
+    if([image.article isMain]){
+        return;
+    }
     NSString* path       = [self pathForImage:image];
     NSDictionary* export = [image dataExport];
     [self saveDictionary:export path:path name:@"Image.plist"];
 }
 
 - (void)saveImageData:(NSData*)data image:(MWKImage*)image {
+    if([image.article isMain]){
+        return;
+    }
     NSString* path     = [self pathForImage:image];
     NSString* filename = [@"Image" stringByAppendingPathExtension:image.extension];
 
@@ -275,6 +290,9 @@ static NSString* const MWKImageInfoFilename = @"ImageInfo.plist";
 }
 
 - (void)saveImageList:(MWKImageList*)imageList {
+    if([imageList.article isMain]){
+        return;
+    }
     NSString* path;
     if (imageList.section) {
         path = [self pathForSection:imageList.section];


### PR DESCRIPTION
https://phabricator.wikimedia.org/T131377

It boils down to the fact that revision ids don't change on the main page when the content updates.

So it always looks like we have the current version. :cry: 

Now:
- We ignore the revision id for main pages, and always fetch
- We never cache main pages
- We clear out all main page doing house keeping

Fixed!

I also filed a ticket to investigate moving away from the revision id checks:
https://phabricator.wikimedia.org/T131521