### PR TITLE
Multilanguage icon state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 osx_image: xcode7.3
 env:
-  - IOS_VER="9.2" FL_ARGS="verify"
+  - IOS_VER="9.3" FL_ARGS="verify"
     #  - IOS_VER="9.2" FL_ARGS="analyze"
     #  - IOS_VER="9.2" FL_ARGS="verify scheme:WikipediaRTL"
     #  - IOS_VER="8.4" FL_ARGS="verify sim_os:${IOS_VER}"

--- a/Wikipedia/Code/MWKArticle.h
+++ b/Wikipedia/Code/MWKArticle.h
@@ -49,6 +49,7 @@ static const NSInteger kMWKArticleSectionNone = -1;
 @property (readonly, copy, nonatomic) NSString* displaytitle;              // optional
 @property (readonly, strong, nonatomic) MWKProtectionStatus* protection;     // required
 @property (readonly, assign, nonatomic) BOOL editable;                       // required
+@property (readonly, assign, nonatomic) BOOL hasMultipleLanguages;
 
 /// Whether or not the receiver is the main page for its @c site.
 @property (readonly, assign, nonatomic, getter = isMain) BOOL main;

--- a/Wikipedia/Code/MWKArticle.m
+++ b/Wikipedia/Code/MWKArticle.m
@@ -381,6 +381,10 @@ static MWKArticleSchemaVersion const MWKArticleCurrentSchemaVersion = MWKArticle
     return _images;
 }
 
+- (BOOL)hasMultipleLanguages {
+    return self.languagecount > 0;
+}
+
 #pragma mark - protection status methods
 
 - (MWKProtectionStatus*)requiredProtectionStatus:(NSString*)key dict:(NSDictionary*)dict {

--- a/Wikipedia/Code/MWKArticle.m
+++ b/Wikipedia/Code/MWKArticle.m
@@ -382,6 +382,9 @@ static MWKArticleSchemaVersion const MWKArticleCurrentSchemaVersion = MWKArticle
 }
 
 - (BOOL)hasMultipleLanguages {
+    if (self.isMain) {
+        return NO;
+    }
     return self.languagecount > 0;
 }
 

--- a/Wikipedia/Code/WMFArticleFooterMenuDataSource.m
+++ b/Wikipedia/Code/WMFArticleFooterMenuDataSource.m
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSMutableArray<WMFArticleFooterMenuItem*>* menuItems = [NSMutableArray arrayWithCapacity:4];
 
-    if (article.languagecount > 0) {
+    if (article.hasMultipleLanguages) {
         [menuItems addObject:makeItem(WMFArticleFooterMenuItemTypeLanguages,
                                       [MWSiteLocalizedString(article.title.site, @"page-read-in-other-languages", nil) stringByReplacingOccurrencesOfString:@"$1" withString:[NSString stringWithFormat:@"%d", article.languagecount]],
                                       nil, @"footer-switch-language")];

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -293,7 +293,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)hasLanguages {
-    return self.article.languagecount > 0;
+    return self.article.hasMultipleLanguages;
 }
 
 - (BOOL)hasTableOfContents {

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -293,7 +293,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)hasLanguages {
-    return self.article.languagecount > 1;
+    return self.article.languagecount > 0;
 }
 
 - (BOOL)hasTableOfContents {

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -348,7 +348,7 @@
 
 "page-issues" = "Page issues";
 "page-similar-titles" = "Similar pages";
-"page-read-in-other-languages" = "Available in $1 languages";
+"page-read-in-other-languages" = "Available in $1 other languages";
 "page-last-edited" = "Edited $1 days ago";
 "page-edit-history" = "Full edit history";
 

--- a/WikipediaUnitTests/Code/MWKArticleExtractionTests.m
+++ b/WikipediaUnitTests/Code/MWKArticleExtractionTests.m
@@ -37,8 +37,10 @@
     [self.article importMobileViewJSON:mainPageMobileView];
 
     NSAssert([self.article isMain], @"supposed to be testing main pages!");
-
+    
     assertThat(self.article.shareSnippet, is(@"Gary Cooper was an American film actor known for his natural, authentic, and understated acting style. He was a movie star from the end of the silent film era through the end of the golden age of Classical Hollywood. Cooper began his career as a film extra and stunt rider and soon established himself as a Western hero in films such as The Virginian. He played the lead in adventure films and dramas such as A Farewell to Arms and The Lives of a Bengal Lancer, and extended his range of performances to include roles in most major film genres. He portrayed champions of the common man in films such as Mr. Deeds Goes to Town, Meet John Doe, Sergeant York, The Pride of the Yankees, and For Whom the Bell Tolls. In his later years, he delivered award-winning performances in High Noon and Friendly Persuasion. Cooper received three Academy Awards and appeared on the Motion Picture Herald exhibitors poll of top ten film personalities every year from 1936 to 1958. His screen persona embodied the American folk hero. Ongoing: Nepal earthquake – Yemeni Civil WarRecent deaths: Ruth Rendell – Maya Plisetskaya"));
+    
+    assertThatBool(self.article.hasMultipleLanguages, is(@(NO)));
 }
 
 - (void)testExpectedSnippetForObamaArticle {
@@ -47,6 +49,8 @@
         [MWKTitle titleWithString:@"foo" site:[MWKSite siteWithDomain:@"wikipedia.org" language:@"en"]];
     self.article = [[MWKArticle alloc] initWithTitle:dummyTitle dataStore:nil dict:obamaMobileViewJSON[@"mobileview"]];
     assertThat(self.article.shareSnippet, is(@"Barack Hussein Obama II is the 44th and current President of the United States, and the first African American to hold the office. Born in Honolulu, Hawaii, Obama is a graduate of Columbia University and Harvard Law School, where he served as president of the Harvard Law Review. He was a community organizer in Chicago before earning his law degree. He worked as a civil rights attorney and taught constitutional law at the University of Chicago Law School from 1992 to 2004. He served three terms representing the 13th District in the Illinois Senate from 1997 to 2004, running unsuccessfully for the United States House of Representatives in 2000."));
+    
+    assertThatBool(self.article.hasMultipleLanguages, is(@(YES)));
 }
 
 - (void)testExpectedSummaryForObamaArticle {


### PR DESCRIPTION
[T131081 language icon disabled despite multiple languages](https://phabricator.wikimedia.org/T131081)

There are 4 small parts to this PR. 

1. Article language count is zero indexed. Whether an article has multiple languages was being checked in two places, `WMFArticleFooterMenuDataSource` and `WMFArticleViewController`. `WMFArticleViewController` was saying there are multiple languages if the language count is greater than one, which is an off by one error. Part one fixes that off by one error

2. Because that logic exists in two places, part 2 centralizes the logic as a property on `MWKArticle`

3. Part 3 addresses a different related issue I noticed. On the Main Page, the app is currently showing many languages for the main page feature, even though no other languages are available. This is because the `languagecount` field works differently for the Main Page articles. Part 3 here adds logic to say that if the article title is main, there is only one language.

4 copy update [T131080](https://phabricator.wikimedia.org/T131080)


EDIT: The build on this was failing even though tests were passing locally. I took a look at the `travis.yml` file and noticed `- IOS_VER="9.2" FL_ARGS="verify"`

After bumping that to `9.3` tests are passing. I suspect this is the reason https://github.com/wikimedia/wikipedia-ios/pull/639 failed as well. I'm guessing this sets an environment variable fastlane picks up for some checks?