### PR TITLE
Fix request "user agent" headers. Cover with tests.

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -786,6 +786,7 @@
 		B0265F281CB8988F00740525 /* WMFBaseRequestSerializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFBaseRequestSerializer.m; path = Wikipedia/Code/WMFBaseRequestSerializer.m; sourceTree = SOURCE_ROOT; };
 		B0265F2A1CB89CB600740525 /* AFHTTPRequestSerializer+WMFRequestHeaders.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "AFHTTPRequestSerializer+WMFRequestHeaders.h"; path = "Wikipedia/Code/AFHTTPRequestSerializer+WMFRequestHeaders.h"; sourceTree = SOURCE_ROOT; };
 		B0265F2B1CB89CB600740525 /* AFHTTPRequestSerializer+WMFRequestHeaders.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "AFHTTPRequestSerializer+WMFRequestHeaders.m"; path = "Wikipedia/Code/AFHTTPRequestSerializer+WMFRequestHeaders.m"; sourceTree = SOURCE_ROOT; };
+		B0265F2E1CBC2F3200740525 /* WMFArticleBaseFetcher_Testing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFArticleBaseFetcher_Testing.h; path = Wikipedia/Code/WMFArticleBaseFetcher_Testing.h; sourceTree = SOURCE_ROOT; };
 		B02B76A01CA9ED4400EDB253 /* ckb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ckb; path = ckb.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B02B76A11CA9ED4400EDB253 /* ckb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ckb; path = ckb.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B02B82721C696ECA00B19309 /* WMFSettingsTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFSettingsTableViewCell.h; path = Wikipedia/Code/WMFSettingsTableViewCell.h; sourceTree = SOURCE_ROOT; };
@@ -3115,6 +3116,7 @@
 			children = (
 				B0E803971C0CDB280065EBC0 /* WMFArticleFetcher.h */,
 				B0E803981C0CDB280065EBC0 /* WMFArticleFetcher.m */,
+				B0265F2E1CBC2F3200740525 /* WMFArticleBaseFetcher_Testing.h */,
 				B0E8039A1C0CDB3B0065EBC0 /* WMFArticleRequestSerializer.h */,
 				B0E8039B1C0CDB3B0065EBC0 /* WMFArticleRequestSerializer.m */,
 				B0E8039C1C0CDB3B0065EBC0 /* WMFArticleResponseSerializer.h */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		AA61D5DAA39C2A7CB97B4791 /* Pods_WikipediaUnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D04746551BF8DC9FF0160F /* Pods_WikipediaUnitTests.framework */; };
 		B00050141C52D73800515F70 /* UIApplication+RTL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00050131C52D73800515F70 /* UIApplication+RTL.swift */; };
 		B01162E81C24D3B200C3B52B /* WMFPageIssuesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B01162E71C24D3B200C3B52B /* WMFPageIssuesViewController.m */; };
+		B0265F291CB8988F00740525 /* WMFBaseRequestSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B0265F281CB8988F00740525 /* WMFBaseRequestSerializer.m */; };
+		B0265F2C1CB89CB600740525 /* AFHTTPRequestSerializer+WMFRequestHeaders.m in Sources */ = {isa = PBXBuildFile; fileRef = B0265F2B1CB89CB600740525 /* AFHTTPRequestSerializer+WMFRequestHeaders.m */; };
 		B02B82751C696ECA00B19309 /* WMFSettingsTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B02B82731C696ECA00B19309 /* WMFSettingsTableViewCell.m */; };
 		B02B82761C696ECA00B19309 /* WMFSettingsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B02B82741C696ECA00B19309 /* WMFSettingsTableViewCell.xib */; };
 		B063DE601C63FEE9002F2EDE /* UIToolbar+WMFStyling.m in Sources */ = {isa = PBXBuildFile; fileRef = B063DE5F1C63FEE9002F2EDE /* UIToolbar+WMFStyling.m */; };
@@ -780,6 +782,10 @@
 		B00050131C52D73800515F70 /* UIApplication+RTL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+RTL.swift"; sourceTree = "<group>"; };
 		B01162E61C24D3B200C3B52B /* WMFPageIssuesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFPageIssuesViewController.h; path = WikipediaUnitTests/Code/WMFPageIssuesViewController.h; sourceTree = SOURCE_ROOT; };
 		B01162E71C24D3B200C3B52B /* WMFPageIssuesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFPageIssuesViewController.m; path = WikipediaUnitTests/Code/WMFPageIssuesViewController.m; sourceTree = SOURCE_ROOT; };
+		B0265F271CB8988F00740525 /* WMFBaseRequestSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFBaseRequestSerializer.h; path = Wikipedia/Code/WMFBaseRequestSerializer.h; sourceTree = SOURCE_ROOT; };
+		B0265F281CB8988F00740525 /* WMFBaseRequestSerializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFBaseRequestSerializer.m; path = Wikipedia/Code/WMFBaseRequestSerializer.m; sourceTree = SOURCE_ROOT; };
+		B0265F2A1CB89CB600740525 /* AFHTTPRequestSerializer+WMFRequestHeaders.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "AFHTTPRequestSerializer+WMFRequestHeaders.h"; path = "Wikipedia/Code/AFHTTPRequestSerializer+WMFRequestHeaders.h"; sourceTree = SOURCE_ROOT; };
+		B0265F2B1CB89CB600740525 /* AFHTTPRequestSerializer+WMFRequestHeaders.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "AFHTTPRequestSerializer+WMFRequestHeaders.m"; path = "Wikipedia/Code/AFHTTPRequestSerializer+WMFRequestHeaders.m"; sourceTree = SOURCE_ROOT; };
 		B02B76A01CA9ED4400EDB253 /* ckb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ckb; path = ckb.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B02B76A11CA9ED4400EDB253 /* ckb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ckb; path = ckb.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B02B82721C696ECA00B19309 /* WMFSettingsTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WMFSettingsTableViewCell.h; path = Wikipedia/Code/WMFSettingsTableViewCell.h; sourceTree = SOURCE_ROOT; };
@@ -3377,6 +3383,10 @@
 				B0E806761C0CE9940065EBC0 /* AFHTTPSessionManager+WMFConfig.m */,
 				0E138FB21CA440770037144F /* AFHTTPSessionManager+WMFCancelAll.h */,
 				0E138FB31CA440770037144F /* AFHTTPSessionManager+WMFCancelAll.m */,
+				B0265F271CB8988F00740525 /* WMFBaseRequestSerializer.h */,
+				B0265F281CB8988F00740525 /* WMFBaseRequestSerializer.m */,
+				B0265F2A1CB89CB600740525 /* AFHTTPRequestSerializer+WMFRequestHeaders.h */,
+				B0265F2B1CB89CB600740525 /* AFHTTPRequestSerializer+WMFRequestHeaders.m */,
 			);
 			name = Common;
 			sourceTree = "<group>";
@@ -5755,6 +5765,7 @@
 				B0AB16371C7E5762002E566A /* UINavigationBar+WMFTransparency.m in Sources */,
 				B0E802CD1C0CD2F70065EBC0 /* WMFPictureOfTheDaySectionController.m in Sources */,
 				B0E804451C0CDF850065EBC0 /* WikiGlyphButton.m in Sources */,
+				B0265F291CB8988F00740525 /* WMFBaseRequestSerializer.m in Sources */,
 				B0E805651C0CE0DC0065EBC0 /* UIWebView+WMFSuppressSelection.m in Sources */,
 				B0E8036D1C0CD98B0065EBC0 /* WMFTableOfContentsViewController.swift in Sources */,
 				B0E802F21C0CD4AC0065EBC0 /* WMFRandomSectionController.m in Sources */,
@@ -5996,6 +6007,7 @@
 				0E37F9001CAEE63C0076FF88 /* WMFRotationRespectingNavigationController.swift in Sources */,
 				B0E803BF1C0CDC360065EBC0 /* WMFArticleListTableViewCell+WMFSearch.m in Sources */,
 				B0E805451C0CE0DC0065EBC0 /* UIImage+WMFFocalImageDrawing.m in Sources */,
+				B0265F2C1CB89CB600740525 /* AFHTTPRequestSerializer+WMFRequestHeaders.m in Sources */,
 				B0E802E81C0CD4350065EBC0 /* WMFMainPagePlaceholderTableViewCell.m in Sources */,
 				B0E806F41C0CEBB60065EBC0 /* ReferenceGradientView.m in Sources */,
 				B0E804C81C0CE0B40065EBC0 /* NSAttributedString+WMFModify.m in Sources */,

--- a/Wikipedia/Code/AFHTTPRequestSerializer+WMFRequestHeaders.h
+++ b/Wikipedia/Code/AFHTTPRequestSerializer+WMFRequestHeaders.h
@@ -1,0 +1,8 @@
+#import <AFNetworking/AFNetworking.h>
+
+@interface AFHTTPRequestSerializer (WMFRequestHeaders)
+
+/// Configure the receiver to use WMF proprietary request headers.
+- (void)wmf_applyAppRequestHeaders;
+
+@end

--- a/Wikipedia/Code/AFHTTPRequestSerializer+WMFRequestHeaders.m
+++ b/Wikipedia/Code/AFHTTPRequestSerializer+WMFRequestHeaders.m
@@ -1,0 +1,18 @@
+#import "AFHTTPRequestSerializer+WMFRequestHeaders.h"
+#import "SessionSingleton.h"
+#import "ReadingActionFunnel.h"
+#import "WikipediaAppUtils.h"
+
+@implementation AFHTTPRequestSerializer (WMFRequestHeaders)
+
+- (void)wmf_applyAppRequestHeaders {
+    [self setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];
+    [self setValue:[WikipediaAppUtils versionedUserAgent] forHTTPHeaderField:@"User-Agent"];
+    // Add the app install ID to the header, but only if the user has not opted out of logging
+    if ([SessionSingleton sharedInstance].shouldSendUsageReports) {
+        ReadingActionFunnel* funnel = [[ReadingActionFunnel alloc] init];
+        [self setValue:funnel.appInstallID forHTTPHeaderField:@"X-WMF-UUID"];
+    }
+}
+
+@end

--- a/Wikipedia/Code/AFHTTPSessionManager+WMFConfig.h
+++ b/Wikipedia/Code/AFHTTPSessionManager+WMFConfig.h
@@ -10,7 +10,4 @@
  */
 + (instancetype)wmf_createDefaultManager;
 
-/// Configure the receiver to use WMF proprietary request headers.
-- (void)wmf_applyAppRequestHeaders;
-
 @end

--- a/Wikipedia/Code/AFHTTPSessionManager+WMFConfig.m
+++ b/Wikipedia/Code/AFHTTPSessionManager+WMFConfig.m
@@ -7,27 +7,14 @@
 //
 
 #import "AFHTTPSessionManager+WMFConfig.h"
-#import "SessionSingleton.h"
-#import "ReadingActionFunnel.h"
-#import "WikipediaAppUtils.h"
+#import "AFHTTPRequestSerializer+WMFRequestHeaders.h"
 
 @implementation AFHTTPSessionManager (WMFConfig)
 
 + (instancetype)wmf_createDefaultManager {
     AFHTTPSessionManager* manager = [self manager];
-    [manager wmf_applyAppRequestHeaders];
+    [manager.requestSerializer wmf_applyAppRequestHeaders];
     return manager;
-}
-
-- (void)wmf_applyAppRequestHeaders {
-    NSParameterAssert(self.requestSerializer);
-    [self.requestSerializer setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];
-    [self.requestSerializer setValue:[WikipediaAppUtils versionedUserAgent] forHTTPHeaderField:@"User-Agent"];
-    // Add the app install ID to the header, but only if the user has not opted out of logging
-    if ([SessionSingleton sharedInstance].shouldSendUsageReports) {
-        ReadingActionFunnel* funnel = [[ReadingActionFunnel alloc] init];
-        [self.requestSerializer setValue:funnel.appInstallID forHTTPHeaderField:@"X-WMF-UUID"];
-    }
 }
 
 @end

--- a/Wikipedia/Code/WMFArticleBaseFetcher_Testing.h
+++ b/Wikipedia/Code/WMFArticleBaseFetcher_Testing.h
@@ -1,0 +1,7 @@
+#import "WMFArticleFetcher.h"
+
+@interface WMFArticleBaseFetcher ()
+
+@property (nonatomic, strong) AFHTTPSessionManager* operationManager;
+
+@end

--- a/Wikipedia/Code/WMFArticleFetcher.h
+++ b/Wikipedia/Code/WMFArticleFetcher.h
@@ -23,8 +23,6 @@ extern NSString* const WMFArticleFetcherErrorCachedFallbackArticleKey;
 - (void)cancelFetchForPageTitle:(MWKTitle*)pageTitle;
 - (void)cancelAllFetches;
 
-@property (nonatomic, strong) AFHTTPSessionManager* operationManager;
-
 @end
 
 @interface WMFArticleFetcher : WMFArticleBaseFetcher

--- a/Wikipedia/Code/WMFArticleFetcher.h
+++ b/Wikipedia/Code/WMFArticleFetcher.h
@@ -4,6 +4,7 @@
 @class MWKTitle;
 @class MWKDataStore;
 @class MWKArticle;
+@class AFHTTPSessionManager;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,6 +22,8 @@ extern NSString* const WMFArticleFetcherErrorCachedFallbackArticleKey;
 - (BOOL)isFetchingArticleForTitle:(MWKTitle*)pageTitle;
 - (void)cancelFetchForPageTitle:(MWKTitle*)pageTitle;
 - (void)cancelAllFetches;
+
+@property (nonatomic, strong) AFHTTPSessionManager* operationManager;
 
 @end
 

--- a/Wikipedia/Code/WMFArticleFetcher.m
+++ b/Wikipedia/Code/WMFArticleFetcher.m
@@ -27,7 +27,7 @@
 #import "MWKSection.h"
 #import "MWKArticle+HTMLImageImport.h"
 #import "AFHTTPSessionManager+WMFCancelAll.h"
-
+#import "WMFArticleBaseFetcher_Testing.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Wikipedia/Code/WMFArticleFetcher.m
+++ b/Wikipedia/Code/WMFArticleFetcher.m
@@ -169,6 +169,8 @@ NSString* const WMFArticleFetcherErrorCachedFallbackArticleKey = @"WMFArticleFet
     if (self) {
         self.operationManager.requestSerializer  = [WMFArticleRequestSerializer serializer];
         self.operationManager.responseSerializer = [WMFArticleResponseSerializer serializer];
+        [self.operationManager wmf_applyAppRequestHeaders];
+        
         self.dataStore                           = dataStore;
         self.revisionFetcher                     = [[WMFArticleRevisionFetcher alloc] init];
 

--- a/Wikipedia/Code/WMFArticleFetcher.m
+++ b/Wikipedia/Code/WMFArticleFetcher.m
@@ -168,7 +168,6 @@ NSString* const WMFArticleFetcherErrorCachedFallbackArticleKey = @"WMFArticleFet
     if (self) {
         self.operationManager.requestSerializer  = [WMFArticleRequestSerializer serializer];
         self.operationManager.responseSerializer = [WMFArticleResponseSerializer serializer];
-        [self.operationManager wmf_applyAppRequestHeaders];
         
         self.dataStore                           = dataStore;
         self.revisionFetcher                     = [[WMFArticleRevisionFetcher alloc] init];

--- a/Wikipedia/Code/WMFArticleFetcher.m
+++ b/Wikipedia/Code/WMFArticleFetcher.m
@@ -37,7 +37,6 @@ NSString* const WMFArticleFetcherErrorCachedFallbackArticleKey = @"WMFArticleFet
 
 @interface WMFArticleBaseFetcher ()
 
-@property (nonatomic, strong) AFHTTPSessionManager* operationManager;
 @property (nonatomic, strong) NSMapTable* operationsKeyedByTitle;
 @property (nonatomic, strong) dispatch_queue_t operationsQueue;
 

--- a/Wikipedia/Code/WMFArticlePreviewFetcher.m
+++ b/Wikipedia/Code/WMFArticlePreviewFetcher.m
@@ -12,6 +12,7 @@
 #import "WMFNumberOfExtractCharacters.h"
 #import "NSDictionary+WMFCommonParams.h"
 #import "WMFNetworkUtilities.h"
+#import "WMFBaseRequestSerializer.h"
 
 //Models
 #import "MWKSearchResult.h"
@@ -30,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface WMFArticlePreviewRequestSerializer : AFHTTPRequestSerializer
+@interface WMFArticlePreviewRequestSerializer : WMFBaseRequestSerializer
 
 @end
 

--- a/Wikipedia/Code/WMFArticleRequestSerializer.h
+++ b/Wikipedia/Code/WMFArticleRequestSerializer.h
@@ -1,6 +1,6 @@
 
-#import <AFNetworking/AFURLRequestSerialization.h>
+#import "WMFBaseRequestSerializer.h"
 
-@interface WMFArticleRequestSerializer : AFHTTPRequestSerializer
+@interface WMFArticleRequestSerializer : WMFBaseRequestSerializer
 
 @end

--- a/Wikipedia/Code/WMFBaseRequestSerializer.h
+++ b/Wikipedia/Code/WMFBaseRequestSerializer.h
@@ -1,0 +1,5 @@
+#import <AFNetworking/AFURLRequestSerialization.h>
+
+@interface WMFBaseRequestSerializer : AFHTTPRequestSerializer
+
+@end

--- a/Wikipedia/Code/WMFBaseRequestSerializer.m
+++ b/Wikipedia/Code/WMFBaseRequestSerializer.m
@@ -1,0 +1,14 @@
+#import "WMFBaseRequestSerializer.h"
+#import "AFHTTPRequestSerializer+WMFRequestHeaders.h"
+
+@implementation WMFBaseRequestSerializer
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        [self wmf_applyAppRequestHeaders];
+    }
+    return self;
+}
+
+@end

--- a/Wikipedia/Code/WMFEnglishFeaturedTitleFetcher.m
+++ b/Wikipedia/Code/WMFEnglishFeaturedTitleFetcher.m
@@ -18,17 +18,17 @@
 #import "MWKTitle.h"
 #import "MWKSearchResult.h"
 #import "NSDictionary+WMFCommonParams.h"
-
+#import "WMFBaseRequestSerializer.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface WMFEnglishFeaturedTitleRequestSerializer : AFHTTPRequestSerializer
+@interface WMFEnglishFeaturedTitleRequestSerializer : WMFBaseRequestSerializer
 @end
 
 @interface WMFEnglishFeaturedTitleResponseSerializer : WMFApiJsonResponseSerializer
 @end
 
-@interface WMFTitlePreviewRequestSerializer : AFHTTPRequestSerializer
+@interface WMFTitlePreviewRequestSerializer : WMFBaseRequestSerializer
 @end
 
 @interface WMFEnglishFeaturedTitleFetcher ()

--- a/Wikipedia/Code/WMFLocationSearchFetcher.m
+++ b/Wikipedia/Code/WMFLocationSearchFetcher.m
@@ -8,6 +8,7 @@
 #import "WMFSearchResponseSerializer.h"
 #import <Mantle/Mantle.h>
 #import "UIScreen+WMFImageWidth.h"
+#import "WMFBaseRequestSerializer.h"
 
 //Promises
 #import "Wikipedia-Swift.h"
@@ -27,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) NSUInteger numberOfResults;
 @end
 
-@interface WMFLocationSearchRequestSerializer : AFHTTPRequestSerializer
+@interface WMFLocationSearchRequestSerializer : WMFBaseRequestSerializer
 @end
 
 #pragma mark - Fetcher Implementation

--- a/Wikipedia/Code/WMFRelatedSearchFetcher.m
+++ b/Wikipedia/Code/WMFRelatedSearchFetcher.m
@@ -7,6 +7,7 @@
 #import "AFHTTPSessionManager+WMFDesktopRetry.h"
 #import "WMFMantleJSONResponseSerializer.h"
 #import <Mantle/Mantle.h>
+#import "WMFBaseRequestSerializer.h"
 
 //Promises
 #import "Wikipedia-Swift.h"
@@ -30,7 +31,7 @@ NSUInteger const WMFMaxRelatedSearchResultLimit = 20;
 
 @end
 
-@interface WMFRelatedSearchRequestSerializer : AFHTTPRequestSerializer
+@interface WMFRelatedSearchRequestSerializer : WMFBaseRequestSerializer
 @end
 
 #pragma mark - Fetcher Implementation

--- a/Wikipedia/Code/WMFSearchFetcher.m
+++ b/Wikipedia/Code/WMFSearchFetcher.m
@@ -10,6 +10,7 @@
 #import "WMFMantleJSONResponseSerializer.h"
 
 #import "UIScreen+WMFImageWidth.h"
+#import "WMFBaseRequestSerializer.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -24,7 +25,7 @@ NSUInteger const WMFMaxSearchResultLimit = 24;
 
 @end
 
-@interface WMFSearchRequestSerializer : AFHTTPRequestSerializer
+@interface WMFSearchRequestSerializer : WMFBaseRequestSerializer
 @end
 
 

--- a/WikipediaUnitTests/Code/ArticleFetcherTests.m
+++ b/WikipediaUnitTests/Code/ArticleFetcherTests.m
@@ -96,4 +96,26 @@
     assertThat(@([savedArticleAfterSecondFetch isDeeplyEqualToArticle:firstFetchResult]), isTrue());
 }
 
+-(NSDictionary *)requestHeaders {
+    return self.articleFetcher.operationManager.requestSerializer.HTTPRequestHeaders;
+}
+
+- (void)testRequestHeadersForWikipediaAppUserAgent {
+    NSString* userAgent = [self requestHeaders][@"User-Agent"];
+    assertThat(@([userAgent hasPrefix:@"WikipediaApp/"]), isTrue());
+}
+
+- (void)testRequestHeadersForGZIPAcceptEncoding {
+    NSString* acceptEncoding = [self requestHeaders][@"Accept-Encoding"];
+    assertThat(acceptEncoding, is(equalTo(@"gzip")));
+}
+
+- (void)testRequestHeadersForOptInUUID {
+    if ([SessionSingleton sharedInstance].shouldSendUsageReports) {
+        assertThat(@([self requestHeaders][@"X-WMF-UUID"] != nil), isTrue());
+    }else{
+        assertThat(@([self requestHeaders][@"X-WMF-UUID"] == nil), isTrue());
+    }
+}
+
 @end

--- a/WikipediaUnitTests/Code/ArticleFetcherTests.m
+++ b/WikipediaUnitTests/Code/ArticleFetcherTests.m
@@ -17,6 +17,7 @@
 #import "SessionSingleton.h"
 #import <Nocilla/Nocilla.h>
 #import "Wikipedia-Swift.h"
+#import "WMFArticleBaseFetcher_Testing.h"
 
 #import "XCTestCase+PromiseKit.h"
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T131824

- request `user agent` headers now properly begin with `WikipediaApp`, as needed for analytics
- added tests for `mobileview` request header user agent, gzip encoding, and opt-in uuid