### PR TITLE
Use "Your languages" and "Other languages" section headers with article lang picker. Restyle it too.

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -85,6 +85,8 @@
 		B0AB163A1C7E5A3F002E566A /* UIViewController+WMFWelcomeNavigation.m in Sources */ = {isa = PBXBuildFile; fileRef = B0AB16391C7E5A3F002E566A /* UIViewController+WMFWelcomeNavigation.m */; };
 		B0AB163D1C7E742F002E566A /* UIButton+WMFWelcomeNextButton.m in Sources */ = {isa = PBXBuildFile; fileRef = B0AB163C1C7E742F002E566A /* UIButton+WMFWelcomeNextButton.m */; };
 		B0B0EC221C6999A9006F0D9C /* WMFSettingsMenuItem.m in Sources */ = {isa = PBXBuildFile; fileRef = B0B0EC211C6999A9006F0D9C /* WMFSettingsMenuItem.m */; };
+		B0B4CF0A1CC0500E0051DF7A /* WMFArticleLanguagesSectionHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = B0B4CF091CC0500E0051DF7A /* WMFArticleLanguagesSectionHeader.m */; };
+		B0B4CF0C1CC0501B0051DF7A /* WMFArticleLanguagesSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = B0B4CF0B1CC0501B0051DF7A /* WMFArticleLanguagesSectionHeader.xib */; };
 		B0C0B07E1C6D989000859AD5 /* WMFSettingsCellVisualTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B0C0B07C1C6D988800859AD5 /* WMFSettingsCellVisualTests.m */; };
 		B0E5E96F1C818E7100D8E267 /* UIView+WMFWelcomeFadeInAndUp.m in Sources */ = {isa = PBXBuildFile; fileRef = B0E5E96E1C818E7100D8E267 /* UIView+WMFWelcomeFadeInAndUp.m */; };
 		B0E5E9721C8237EC00D8E267 /* WMFWelcomeFadeInAndUpOnceViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B0E5E9711C8237EC00D8E267 /* WMFWelcomeFadeInAndUpOnceViewController.m */; };
@@ -847,6 +849,9 @@
 		B0AB163B1C7E742F002E566A /* UIButton+WMFWelcomeNextButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIButton+WMFWelcomeNextButton.h"; path = "Wikipedia/Code/UIButton+WMFWelcomeNextButton.h"; sourceTree = SOURCE_ROOT; };
 		B0AB163C1C7E742F002E566A /* UIButton+WMFWelcomeNextButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIButton+WMFWelcomeNextButton.m"; path = "Wikipedia/Code/UIButton+WMFWelcomeNextButton.m"; sourceTree = SOURCE_ROOT; };
 		B0B0EC211C6999A9006F0D9C /* WMFSettingsMenuItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFSettingsMenuItem.m; path = Wikipedia/Code/WMFSettingsMenuItem.m; sourceTree = SOURCE_ROOT; };
+		B0B4CF081CC0500E0051DF7A /* WMFArticleLanguagesSectionHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFArticleLanguagesSectionHeader.h; sourceTree = "<group>"; };
+		B0B4CF091CC0500E0051DF7A /* WMFArticleLanguagesSectionHeader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFArticleLanguagesSectionHeader.m; sourceTree = "<group>"; };
+		B0B4CF0B1CC0501B0051DF7A /* WMFArticleLanguagesSectionHeader.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = WMFArticleLanguagesSectionHeader.xib; sourceTree = "<group>"; };
 		B0C0B07C1C6D988800859AD5 /* WMFSettingsCellVisualTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFSettingsCellVisualTests.m; sourceTree = "<group>"; };
 		B0E5E96D1C818E7100D8E267 /* UIView+WMFWelcomeFadeInAndUp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIView+WMFWelcomeFadeInAndUp.h"; path = "Wikipedia/Code/UIView+WMFWelcomeFadeInAndUp.h"; sourceTree = SOURCE_ROOT; };
 		B0E5E96E1C818E7100D8E267 /* UIView+WMFWelcomeFadeInAndUp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIView+WMFWelcomeFadeInAndUp.m"; path = "Wikipedia/Code/UIView+WMFWelcomeFadeInAndUp.m"; sourceTree = SOURCE_ROOT; };
@@ -3901,6 +3906,9 @@
 			children = (
 				B0E806AE1C0CEB160065EBC0 /* LanguageCell.h */,
 				B0E806AF1C0CEB160065EBC0 /* LanguageCell.m */,
+				B0B4CF081CC0500E0051DF7A /* WMFArticleLanguagesSectionHeader.h */,
+				B0B4CF091CC0500E0051DF7A /* WMFArticleLanguagesSectionHeader.m */,
+				B0B4CF0B1CC0501B0051DF7A /* WMFArticleLanguagesSectionHeader.xib */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -5344,6 +5352,7 @@
 				B0E8032D1C0CD6E10065EBC0 /* WMFExploreSectionHeader.xib in Resources */,
 				B0E8035A1C0CD8420065EBC0 /* WMFImageGalleryDetailOverlayView.xib in Resources */,
 				0EBCA7511C17BD6D004F1FD9 /* AlertDesign.json in Resources */,
+				B0B4CF0C1CC0501B0051DF7A /* WMFArticleLanguagesSectionHeader.xib in Resources */,
 				0E69CD5B1C8773410095918B /* Launch Screen.storyboard in Resources */,
 				BCF012331AD2FA38008D3675 /* assets in Resources */,
 				B0E804121C0CDE480065EBC0 /* PreviewAndSaveViewController.storyboard in Resources */,
@@ -5728,6 +5737,7 @@
 				BC23E4DD1C223DCB00B5AFDE /* WMFArticleRevisionFetcher.m in Sources */,
 				B0E8045E1C0CDFFB0065EBC0 /* WMFLegacyImageDataMigration.swift in Sources */,
 				B0E803AB1C0CDBAD0065EBC0 /* WMFSavedPagesDataSource.m in Sources */,
+				B0B4CF0A1CC0500E0051DF7A /* WMFArticleLanguagesSectionHeader.m in Sources */,
 				B0E807DA1C0CF04A0065EBC0 /* MWKLocationSearchResult.m in Sources */,
 				B0E803781C0CD9C10065EBC0 /* WMFTableOfContentsHeader.swift in Sources */,
 				B0E803281C0CD6C80065EBC0 /* WMFSearchResponseSerializer.m in Sources */,

--- a/Wikipedia/Code/LanguageCell.m
+++ b/Wikipedia/Code/LanguageCell.m
@@ -6,9 +6,9 @@
 #import "UILabel+WMFStyling.h"
 #import "UITableViewCell+WMFEdgeToEdgeSeparator.h"
 
-static CGFloat const WMFPreferredLanguageFontSize = 22.f;
-static CGFloat const WMFPreferredTitleFontSize    = 17.f;
-static CGFloat const WMFOtherLanguageFontSize     = 17.f;
+static CGFloat const WMFPreferredLanguageFontSize = 15.f;
+static CGFloat const WMFPreferredTitleFontSize    = 12.f;
+static CGFloat const WMFOtherLanguageFontSize     = 15.f;
 static CGFloat const WMFOtherTitleFontSize        = 12.f;
 static CGFloat const WMFLanguageNameLabelHeight   = 18.f;
 
@@ -20,6 +20,8 @@ static CGFloat const WMFLanguageNameLabelHeight   = 18.f;
 @property (strong, nonatomic) IBOutlet UILabel* languageCodeLabel;
 
 @property (strong, nonatomic) IBOutlet NSLayoutConstraint* languageNameLabelHeight;
+@property (strong, nonatomic) IBOutlet UIView* separatorView;
+@property (strong, nonatomic) IBOutlet NSLayoutConstraint* separatorViewHeightConstraint;
 
 @end
 
@@ -86,6 +88,8 @@ static CGFloat const WMFLanguageNameLabelHeight   = 18.f;
     self.localizedLanguageLabel.text      = @"";
     self.languageCodeLabel.text           = @"";
     self.languageNameLabelHeight.constant = 0.f;
+    self.separatorView.backgroundColor = [UIColor wmf_settingsBackgroundColor];
+    self.separatorViewHeightConstraint.constant = 1.5;
 }
 
 @end

--- a/Wikipedia/Code/LanguageCell.m
+++ b/Wikipedia/Code/LanguageCell.m
@@ -79,6 +79,8 @@ static CGFloat const WMFLanguageNameLabelHeight   = 18.f;
     [super awakeFromNib];
     [self prepareForReuse];
     [self wmf_makeCellDividerBeEdgeToEdge];
+    self.separatorView.backgroundColor = [UIColor wmf_settingsBackgroundColor];
+    self.separatorViewHeightConstraint.constant = 1.5;
 }
 
 - (void)prepareForReuse {
@@ -88,8 +90,6 @@ static CGFloat const WMFLanguageNameLabelHeight   = 18.f;
     self.localizedLanguageLabel.text      = @"";
     self.languageCodeLabel.text           = @"";
     self.languageNameLabelHeight.constant = 0.f;
-    self.separatorView.backgroundColor = [UIColor wmf_settingsBackgroundColor];
-    self.separatorViewHeightConstraint.constant = 1.5;
 }
 
 @end

--- a/Wikipedia/Code/LanguageCell.m
+++ b/Wikipedia/Code/LanguageCell.m
@@ -4,6 +4,7 @@
 #import "LanguageCell.h"
 #import "WikipediaAppUtils.h"
 #import "UILabel+WMFStyling.h"
+#import "UITableViewCell+WMFEdgeToEdgeSeparator.h"
 
 static CGFloat const WMFPreferredLanguageFontSize = 22.f;
 static CGFloat const WMFPreferredTitleFontSize    = 17.f;
@@ -75,6 +76,7 @@ static CGFloat const WMFLanguageNameLabelHeight   = 18.f;
 - (void)awakeFromNib {
     [super awakeFromNib];
     [self prepareForReuse];
+    [self wmf_makeCellDividerBeEdgeToEdge];
 }
 
 - (void)prepareForReuse {

--- a/Wikipedia/Code/LanguagesViewController.m
+++ b/Wikipedia/Code/LanguagesViewController.m
@@ -27,7 +27,7 @@ static CGFloat const WMFLanguageHeaderFontSize = 12.f;
 @property (strong, nonatomic) MWKLanguageFilter* languageFilter;
 @property (strong, nonatomic) MWKTitleLanguageController* titleLanguageController;
 @property (strong, nonatomic) IBOutlet NSLayoutConstraint* languageFilterTopSpaceConstraint;
-@property (strong, nonatomic) IBOutlet NSLayoutConstraint* filterdividerHeightConstraint;
+@property (strong, nonatomic) IBOutlet NSLayoutConstraint* filterDividerHeightConstraint;
 
 @end
 
@@ -84,7 +84,7 @@ static CGFloat const WMFLanguageHeaderFontSize = 12.f;
     self.languageFilterField.placeholder  = MWLocalizedString(@"article-languages-filter-placeholder", nil);
 
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
-    self.filterdividerHeightConstraint.constant = 0.5f;
+    self.filterDividerHeightConstraint.constant = 0.5f;
 }
 
 - (void)viewDidAppear:(BOOL)animated {

--- a/Wikipedia/Code/LanguagesViewController.m
+++ b/Wikipedia/Code/LanguagesViewController.m
@@ -103,38 +103,14 @@ static CGFloat const WMFLanguageHeaderFontSize = 12.f;
 }
 
 - (void)downloadArticlelanguages {
-    [[WMFAlertManager sharedInstance] showAlert:MWLocalizedString(@"article-languages-downloading", nil) sticky:YES dismissPreviousAlerts:NO tapCallBack:NULL];
-    // (temporarily?) hide search field while loading languages since the default alert UI covers the search field
-    [self setLanguageFilterHidden:YES animated:NO];
-
     @weakify(self);
     [self.titleLanguageController
      fetchLanguagesWithSuccess:^{
         @strongify(self)
-        //This can fire rather quickly, lets give the user a chance to read the message before we dismiss
-        dispatchOnMainQueueAfterDelayInSeconds(1.0, ^{
-            [[WMFAlertManager sharedInstance] dismissAlert];
-        });
-        [self setLanguageFilterHidden:NO animated:YES];
         [self reloadDataSections];
     } failure:^(NSError* __nonnull error) {
         [[WMFAlertManager sharedInstance] showErrorAlert:error sticky:YES dismissPreviousAlerts:YES tapCallBack:NULL];
     }];
-}
-
-#pragma mark - Search Bar Visibility
-
-- (void)setLanguageFilterHidden:(BOOL)hidden animated:(BOOL)animated {
-    dispatch_block_t updateConstraint = ^{
-        // iOS7: need to do this w/ an IBOutlet due to some conflict between Masonry & layout guides
-        self.languageFilterTopSpaceConstraint.constant = hidden ? -self.languageFilterField.frame.size.height : 0.f;
-        [self.languageFilterField layoutIfNeeded];
-    };
-    if (animated) {
-        [UIView animateWithDuration:[CATransaction animationDuration] animations:updateConstraint];
-    } else {
-        updateConstraint();
-    }
 }
 
 #pragma mark - Top menu

--- a/Wikipedia/Code/LanguagesViewController.m
+++ b/Wikipedia/Code/LanguagesViewController.m
@@ -16,11 +16,7 @@
 #import "MediaWikiKit.h"
 #import "Wikipedia-Swift.h"
 
-static CGFloat const WMFLanguagesSectionFooterHeight = 10.f;
-static CGFloat const WMFOtherLanguageRowHeight       = 138.f;
-
-// This assumes the language cell is configured in IB by LanguagesViewController
-static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectionSeparator";
+static CGFloat const WMFOtherLanguageRowHeight = 138.f;
 
 @interface LanguagesViewController ()
 <UISearchBarDelegate>
@@ -70,9 +66,6 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
 
     self.tableView.backgroundColor = [UIColor wmf_settingsBackgroundColor];
 
-    [self.tableView registerClass:[UITableViewHeaderFooterView class]
-     forHeaderFooterViewReuseIdentifier:LangaugesSectionFooterReuseIdentifier];
-
     self.tableView.estimatedRowHeight = WMFOtherLanguageRowHeight;
     self.tableView.rowHeight          = UITableViewAutomaticDimension;
 
@@ -84,8 +77,10 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
     if ([self.languageFilterField respondsToSelector:@selector(setReturnKeyType:)]) {
         [self.languageFilterField setReturnKeyType:UIReturnKeyDone];
     }
-    self.languageFilterField.barTintColor = [UIColor wmf_settingsBackgroundColor];;
+    self.languageFilterField.barTintColor = [UIColor wmf_settingsBackgroundColor];
     self.languageFilterField.placeholder  = MWLocalizedString(@"article-languages-filter-placeholder", nil);
+
+    self.tableView.separatorStyle = UITableViewCellSeparatorStyleSingleLine;
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -268,23 +263,30 @@ static NSString* const LangaugesSectionFooterReuseIdentifier = @"LanguagesSectio
     }
 }
 
-#pragma mark - UITableViewDelegate
-
-- (CGFloat)tableView:(UITableView*)tableView heightForFooterInSection:(NSInteger)section {
-    if ([self isPreferredSection:section] && self.languageFilter.filteredPreferredLanguages.count > 0) {
-        // collapse footer when empty, removing needless padding of "other" section from top of table
-        return WMFLanguagesSectionFooterHeight;
-    } else {
-        return 0.f;
+- (nullable NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+    if ([self tableView:tableView numberOfRowsInSection:section] == 0){
+        return nil;
+    }else{
+        NSString *title = ([self isPreferredSection:section]) ? MWLocalizedString(@"article-languages-yours", nil) : MWLocalizedString(@"article-languages-others", nil);
+        return [title uppercaseStringWithLocale:[NSLocale currentLocale]];
     }
 }
 
-// using footers instead of headers because footers don't "stick"
-- (UIView*)tableView:(UITableView*)tableView viewForFooterInSection:(NSInteger)section {
-    UITableViewHeaderFooterView* footerView =
-        [tableView dequeueReusableHeaderFooterViewWithIdentifier:LangaugesSectionFooterReuseIdentifier];
-    footerView.contentView.backgroundColor = [UIColor wmf_settingsBackgroundColor];;
-    return footerView;
+#pragma mark - UITableViewDelegate
+
+- (CGFloat)tableView:(UITableView*)tableView heightForFooterInSection:(NSInteger)section {
+    // HAX: hide line separators which appear before sections/rows load
+    return 0.1f;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UITableViewHeaderFooterView *)view forSection:(NSInteger)section {
+    view.textLabel.font = [UIFont systemFontOfSize:12];
+    view.textLabel.textColor = [UIColor wmf_customGray];
+    view.contentView.backgroundColor = [UIColor wmf_settingsBackgroundColor];
+}
+
+- (CGFloat)tableView:(UITableView*)tableView heightForHeaderInSection:(NSInteger)section {
+    return ([self tableView:tableView numberOfRowsInSection:section] == 0) ? 0 : 56.0;
 }
 
 - (void)tableView:(UITableView*)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath {

--- a/Wikipedia/Code/LanguagesViewController.m
+++ b/Wikipedia/Code/LanguagesViewController.m
@@ -15,10 +15,10 @@
 #import <Masonry/Masonry.h>
 #import "MediaWikiKit.h"
 #import "Wikipedia-Swift.h"
+#import "WMFArticleLanguagesSectionHeader.h"
 
 static CGFloat const WMFOtherLanguageRowHeight = 138.f;
 static CGFloat const WMFLanguageHeaderHeight = 57.f;
-static CGFloat const WMFLanguageHeaderFontSize = 12.f;
 
 @interface LanguagesViewController ()
 <UISearchBarDelegate>
@@ -85,6 +85,8 @@ static CGFloat const WMFLanguageHeaderFontSize = 12.f;
 
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.filterDividerHeightConstraint.constant = 0.5f;
+
+    [self.tableView registerNib:[WMFArticleLanguagesSectionHeader wmf_classNib] forHeaderFooterViewReuseIdentifier:[WMFArticleLanguagesSectionHeader wmf_nibName]];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -249,27 +251,20 @@ static CGFloat const WMFLanguageHeaderFontSize = 12.f;
     return ([self tableView:self.tableView numberOfRowsInSection:section] > 0);
 }
 
-- (UIView*)tableView:(UITableView*)tableView viewForHeaderInSection:(NSInteger)section {
-    if ([self shouldShowHeaderForSection:section]){
-        UIView* containerView             = [[UIView alloc] initWithFrame:CGRectZero];
-        containerView.backgroundColor     = [UIColor wmf_settingsBackgroundColor];
-        containerView.autoresizesSubviews = YES;
+- (NSString*)titleForHeaderInSection:(NSInteger)section {
+    NSString *title = ([self isPreferredSection:section]) ? MWLocalizedString(@"article-languages-yours", nil) : MWLocalizedString(@"article-languages-others", nil);
+    return [title uppercaseStringWithLocale:[NSLocale currentLocale]];;
+}
 
-        UILabel* label                                  = [[UILabel alloc] init];
-        label.translatesAutoresizingMaskIntoConstraints = NO;
-        label.font                                      = [UIFont systemFontOfSize:WMFLanguageHeaderFontSize];
-        label.textColor                                 = [UIColor wmf_customGray];
-        label.textAlignment                             = NSTextAlignmentNatural;
-        
-        NSString *title = ([self isPreferredSection:section]) ? MWLocalizedString(@"article-languages-yours", nil) : MWLocalizedString(@"article-languages-others", nil);
-        label.text      = [title uppercaseStringWithLocale:[NSLocale currentLocale]];
-        
-        [containerView addSubview:label];
-        
-        [label mas_makeConstraints:^(MASConstraintMaker* make) {
-            make.leading.and.trailing.top.and.bottom.equalTo(containerView).insets(UIEdgeInsetsMake(23, 18, 0, 18));
-        }];
-        return containerView;
+- (void)configureHeader:(WMFArticleLanguagesSectionHeader*)header forSection:(NSInteger)section {
+    header.title = [self titleForHeaderInSection:section];
+}
+
+- (nullable UIView*)tableView:(UITableView*)tableView viewForHeaderInSection:(NSInteger)section; {
+    if ([self shouldShowHeaderForSection:section]){
+        WMFArticleLanguagesSectionHeader* header = (id)[tableView dequeueReusableHeaderFooterViewWithIdentifier:[WMFArticleLanguagesSectionHeader wmf_nibName]];
+        [self configureHeader:header forSection:section];
+        return header;
     }else{
         return nil;
     }

--- a/Wikipedia/Code/LanguagesViewController.storyboard
+++ b/Wikipedia/Code/LanguagesViewController.storyboard
@@ -48,15 +48,15 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QuT-sm-MtF" userLabel="Container View">
-                                                    <rect key="frame" x="18" y="10" width="284" height="118"/>
+                                                    <rect key="frame" x="18" y="10" width="284" height="117"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Localized language name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rLN-Zb-UJl" userLabel="Localized language name">
-                                                            <rect key="frame" x="0.0" y="0.0" width="284" height="64"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="284" height="63"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="748" text="Article title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ib6-Zk-jUw" userLabel="Article title">
-                                                            <rect key="frame" x="0.0" y="64" width="284" height="18"/>
+                                                            <rect key="frame" x="0.0" y="63" width="284" height="18"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="18" placeholder="YES" id="Vuo-LR-40O"/>
                                                             </constraints>
@@ -65,7 +65,7 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Language name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wVn-n7-pdy" userLabel="Language name">
-                                                            <rect key="frame" x="0.0" y="82" width="284" height="18"/>
+                                                            <rect key="frame" x="0.0" y="81" width="284" height="18"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="18" id="jOO-T3-pcc"/>
                                                             </constraints>
@@ -74,7 +74,7 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lQo-0f-Md2" userLabel="Language code">
-                                                            <rect key="frame" x="0.0" y="100" width="284" height="18"/>
+                                                            <rect key="frame" x="0.0" y="99" width="284" height="18"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="18" id="QuJ-cG-Rpw"/>
                                                             </constraints>
@@ -113,7 +113,7 @@
                                                 <constraint firstAttribute="trailing" secondItem="Pub-Ik-4Ne" secondAttribute="trailing" id="OBz-Rm-Ffm"/>
                                                 <constraint firstItem="Pub-Ik-4Ne" firstAttribute="leading" secondItem="u7F-wb-Bsy" secondAttribute="leading" id="Thf-9y-vnP"/>
                                                 <constraint firstAttribute="trailingMargin" secondItem="QuT-sm-MtF" secondAttribute="trailing" constant="10" id="XM2-T9-UEr"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="QuT-sm-MtF" secondAttribute="bottom" constant="2" id="kqP-vV-Kec"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="QuT-sm-MtF" secondAttribute="bottom" constant="3" id="kqP-vV-Kec"/>
                                                 <constraint firstItem="QuT-sm-MtF" firstAttribute="top" secondItem="u7F-wb-Bsy" secondAttribute="topMargin" constant="2" id="pmH-dB-0Qz"/>
                                                 <constraint firstItem="QuT-sm-MtF" firstAttribute="leading" secondItem="u7F-wb-Bsy" secondAttribute="leadingMargin" constant="10" id="q95-c0-ppO"/>
                                             </constraints>

--- a/Wikipedia/Code/LanguagesViewController.storyboard
+++ b/Wikipedia/Code/LanguagesViewController.storyboard
@@ -151,7 +151,7 @@
                     </view>
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <connections>
-                        <outlet property="filterdividerHeightConstraint" destination="ARZ-wg-hsQ" id="daE-ok-baE"/>
+                        <outlet property="filterDividerHeightConstraint" destination="ARZ-wg-hsQ" id="CEi-NN-6ei"/>
                         <outlet property="languageFilterField" destination="HRn-z3-mks" id="hss-pu-GZS"/>
                         <outlet property="languageFilterTopSpaceConstraint" destination="XGZ-SO-FBB" id="Xme-7X-Dz6"/>
                         <outlet property="tableView" destination="iFX-H4-bkt" id="k4b-bt-h64"/>

--- a/Wikipedia/Code/LanguagesViewController.storyboard
+++ b/Wikipedia/Code/LanguagesViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vqp-1K-wjM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vqp-1K-wjM">
     <dependencies>
         <deployment identifier="iOS"/>
         <development version="5100" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -19,8 +19,25 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
+                            <searchBar contentMode="redraw" searchBarStyle="prominent" translatesAutoresizingMaskIntoConstraints="NO" id="HRn-z3-mks">
+                                <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="6qh-TC-frw"/>
+                                </constraints>
+                                <textInputTraits key="textInputTraits" returnKeyType="done"/>
+                                <connections>
+                                    <outlet property="delegate" destination="vqp-1K-wjM" id="ug3-82-kt2"/>
+                                </connections>
+                            </searchBar>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yiR-cM-LIv" userLabel="Divider">
+                                <rect key="frame" x="0.0" y="64" width="320" height="1"/>
+                                <color key="backgroundColor" red="0.87058823529999996" green="0.87058823529999996" blue="0.87058823529999996" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="ARZ-wg-hsQ"/>
+                                </constraints>
+                            </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="iFX-H4-bkt">
-                                <rect key="frame" x="0.0" y="64" width="320" height="504"/>
+                                <rect key="frame" x="0.0" y="65" width="320" height="503"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="gray" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="LanguageCell" rowHeight="138" id="aOG-CK-VHw" customClass="LanguageCell">
@@ -30,16 +47,16 @@
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="138"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QuT-sm-MtF">
-                                                    <rect key="frame" x="28" y="13" width="264" height="112"/>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QuT-sm-MtF" userLabel="Container View">
+                                                    <rect key="frame" x="18" y="10" width="284" height="118"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Localized language name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rLN-Zb-UJl" userLabel="Localized language name">
-                                                            <rect key="frame" x="0.0" y="0.0" width="264" height="58"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="284" height="64"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="748" text="Article title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ib6-Zk-jUw" userLabel="Article title">
-                                                            <rect key="frame" x="0.0" y="58" width="264" height="18"/>
+                                                            <rect key="frame" x="0.0" y="64" width="284" height="18"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="18" placeholder="YES" id="Vuo-LR-40O"/>
                                                             </constraints>
@@ -48,7 +65,7 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Language name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wVn-n7-pdy" userLabel="Language name">
-                                                            <rect key="frame" x="0.0" y="76" width="264" height="18"/>
+                                                            <rect key="frame" x="0.0" y="82" width="284" height="18"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="18" id="jOO-T3-pcc"/>
                                                             </constraints>
@@ -57,7 +74,7 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lQo-0f-Md2" userLabel="Language code">
-                                                            <rect key="frame" x="0.0" y="94" width="264" height="18"/>
+                                                            <rect key="frame" x="0.0" y="100" width="284" height="18"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="18" id="QuJ-cG-Rpw"/>
                                                             </constraints>
@@ -83,12 +100,22 @@
                                                         <constraint firstItem="ib6-Zk-jUw" firstAttribute="leading" secondItem="QuT-sm-MtF" secondAttribute="leading" id="yq6-IZ-DYQ"/>
                                                     </constraints>
                                                 </view>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pub-Ik-4Ne" userLabel="Separator View">
+                                                    <rect key="frame" x="0.0" y="136" width="320" height="2"/>
+                                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="2" id="Sfs-dR-P07"/>
+                                                    </constraints>
+                                                </view>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="trailingMargin" secondItem="QuT-sm-MtF" secondAttribute="trailing" constant="20" id="XM2-T9-UEr"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="QuT-sm-MtF" secondAttribute="bottom" constant="5" id="kqP-vV-Kec"/>
-                                                <constraint firstItem="QuT-sm-MtF" firstAttribute="top" secondItem="u7F-wb-Bsy" secondAttribute="topMargin" constant="5" id="pmH-dB-0Qz"/>
-                                                <constraint firstItem="QuT-sm-MtF" firstAttribute="leading" secondItem="u7F-wb-Bsy" secondAttribute="leadingMargin" constant="20" id="q95-c0-ppO"/>
+                                                <constraint firstAttribute="bottom" secondItem="Pub-Ik-4Ne" secondAttribute="bottom" id="FUN-dg-eoC"/>
+                                                <constraint firstAttribute="trailing" secondItem="Pub-Ik-4Ne" secondAttribute="trailing" id="OBz-Rm-Ffm"/>
+                                                <constraint firstItem="Pub-Ik-4Ne" firstAttribute="leading" secondItem="u7F-wb-Bsy" secondAttribute="leading" id="Thf-9y-vnP"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="QuT-sm-MtF" secondAttribute="trailing" constant="10" id="XM2-T9-UEr"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="QuT-sm-MtF" secondAttribute="bottom" constant="2" id="kqP-vV-Kec"/>
+                                                <constraint firstItem="QuT-sm-MtF" firstAttribute="top" secondItem="u7F-wb-Bsy" secondAttribute="topMargin" constant="2" id="pmH-dB-0Qz"/>
+                                                <constraint firstItem="QuT-sm-MtF" firstAttribute="leading" secondItem="u7F-wb-Bsy" secondAttribute="leadingMargin" constant="10" id="q95-c0-ppO"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
@@ -97,6 +124,8 @@
                                             <outlet property="languageNameLabel" destination="wVn-n7-pdy" id="uca-Ov-HGk"/>
                                             <outlet property="languageNameLabelHeight" destination="jOO-T3-pcc" id="l7k-8K-VGq"/>
                                             <outlet property="localizedLanguageLabel" destination="rLN-Zb-UJl" id="SAQ-ks-taJ"/>
+                                            <outlet property="separatorView" destination="Pub-Ik-4Ne" id="A8M-CI-VQ1"/>
+                                            <outlet property="separatorViewHeightConstraint" destination="Sfs-dR-P07" id="Hxf-bS-4sJ"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>
@@ -105,30 +134,24 @@
                                     <outlet property="delegate" destination="vqp-1K-wjM" id="lRQ-Yf-fLg"/>
                                 </connections>
                             </tableView>
-                            <searchBar contentMode="redraw" searchBarStyle="prominent" translatesAutoresizingMaskIntoConstraints="NO" id="HRn-z3-mks">
-                                <rect key="frame" x="0.0" y="20" width="320" height="44"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="6qh-TC-frw"/>
-                                </constraints>
-                                <textInputTraits key="textInputTraits" returnKeyType="done"/>
-                                <connections>
-                                    <outlet property="delegate" destination="vqp-1K-wjM" id="ug3-82-kt2"/>
-                                </connections>
-                            </searchBar>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
+                            <constraint firstAttribute="trailing" secondItem="yiR-cM-LIv" secondAttribute="trailing" id="208-my-edH"/>
+                            <constraint firstItem="iFX-H4-bkt" firstAttribute="top" secondItem="yiR-cM-LIv" secondAttribute="bottom" id="3Yl-jl-5lt"/>
                             <constraint firstAttribute="trailing" secondItem="HRn-z3-mks" secondAttribute="trailing" id="56v-Xv-cFF"/>
-                            <constraint firstItem="iFX-H4-bkt" firstAttribute="top" secondItem="HRn-z3-mks" secondAttribute="bottom" id="8PI-c3-Vlu"/>
                             <constraint firstItem="HRn-z3-mks" firstAttribute="leading" secondItem="myx-u3-Hjg" secondAttribute="leading" id="CZR-cx-kAz"/>
                             <constraint firstAttribute="trailing" secondItem="iFX-H4-bkt" secondAttribute="trailing" id="Obk-X3-7Sz"/>
                             <constraint firstItem="HRn-z3-mks" firstAttribute="top" secondItem="gGs-4d-iMW" secondAttribute="bottom" id="XGZ-SO-FBB"/>
                             <constraint firstItem="i1a-f9-VJ9" firstAttribute="top" secondItem="iFX-H4-bkt" secondAttribute="bottom" id="XpI-qv-xig"/>
+                            <constraint firstItem="yiR-cM-LIv" firstAttribute="leading" secondItem="myx-u3-Hjg" secondAttribute="leading" id="a6z-9y-lqy"/>
                             <constraint firstItem="iFX-H4-bkt" firstAttribute="leading" secondItem="myx-u3-Hjg" secondAttribute="leading" id="lcB-co-f32"/>
+                            <constraint firstItem="yiR-cM-LIv" firstAttribute="top" secondItem="HRn-z3-mks" secondAttribute="bottom" id="xi9-PT-aLF"/>
                         </constraints>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <connections>
+                        <outlet property="filterdividerHeightConstraint" destination="ARZ-wg-hsQ" id="daE-ok-baE"/>
                         <outlet property="languageFilterField" destination="HRn-z3-mks" id="hss-pu-GZS"/>
                         <outlet property="languageFilterTopSpaceConstraint" destination="XGZ-SO-FBB" id="Xme-7X-Dz6"/>
                         <outlet property="tableView" destination="iFX-H4-bkt" id="k4b-bt-h64"/>

--- a/Wikipedia/Code/WMFArticleLanguagesSectionHeader.h
+++ b/Wikipedia/Code/WMFArticleLanguagesSectionHeader.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface WMFArticleLanguagesSectionHeader : UITableViewHeaderFooterView
+
+@property (strong, nonatomic) NSString* title;
+
+@end

--- a/Wikipedia/Code/WMFArticleLanguagesSectionHeader.h
+++ b/Wikipedia/Code/WMFArticleLanguagesSectionHeader.h
@@ -2,6 +2,6 @@
 
 @interface WMFArticleLanguagesSectionHeader : UITableViewHeaderFooterView
 
-@property (strong, nonatomic) NSString* title;
+- (void)setTitle:(NSString*)title;
 
 @end

--- a/Wikipedia/Code/WMFArticleLanguagesSectionHeader.m
+++ b/Wikipedia/Code/WMFArticleLanguagesSectionHeader.m
@@ -14,10 +14,6 @@ static CGFloat const WMFLanguageHeaderFontSize = 12.f;
     self.titleLabel.text = title;
 }
 
-- (NSString *)title {
-    return self.titleLabel.text;
-}
-
 - (void)awakeFromNib {
     [super awakeFromNib];
     

--- a/Wikipedia/Code/WMFArticleLanguagesSectionHeader.m
+++ b/Wikipedia/Code/WMFArticleLanguagesSectionHeader.m
@@ -1,0 +1,32 @@
+#import "WMFArticleLanguagesSectionHeader.h"
+
+static CGFloat const WMFLanguageHeaderFontSize = 12.f;
+
+@interface WMFArticleLanguagesSectionHeader()
+
+@property (strong, nonatomic) IBOutlet UILabel* titleLabel;
+
+@end
+
+@implementation WMFArticleLanguagesSectionHeader
+
+- (void)setTitle:(NSString*)title {
+    self.titleLabel.text = title;
+}
+
+- (NSString *)title {
+    return self.titleLabel.text;
+}
+
+- (void)awakeFromNib {
+    [super awakeFromNib];
+    
+    UIView * backgroundView = [[UIView alloc] initWithFrame:self.bounds];
+    backgroundView.backgroundColor = [UIColor wmf_settingsBackgroundColor];
+    self.backgroundView = backgroundView;
+    
+    self.titleLabel.font = [UIFont systemFontOfSize:WMFLanguageHeaderFontSize];
+    self.titleLabel.textColor = [UIColor wmf_customGray];
+}
+
+@end

--- a/Wikipedia/Code/WMFArticleLanguagesSectionHeader.xib
+++ b/Wikipedia/Code/WMFArticleLanguagesSectionHeader.xib
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" restorationIdentifier="WMFArticleLanguagesSectionHeader" id="iN0-l3-epB" customClass="WMFArticleLanguagesSectionHeader">
+            <rect key="frame" x="0.0" y="0.0" width="341" height="68"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M1q-e8-8VS">
+                    <rect key="frame" x="18" y="37" width="305" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="M1q-e8-8VS" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="18" id="UfA-FP-uBf"/>
+                <constraint firstAttribute="trailing" secondItem="M1q-e8-8VS" secondAttribute="trailing" constant="18" id="gWU-tJ-6Sh"/>
+                <constraint firstAttribute="bottom" secondItem="M1q-e8-8VS" secondAttribute="bottom" constant="10" id="hDc-Rm-Qsa"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="titleLabel" destination="M1q-e8-8VS" id="WQ8-if-LXk"/>
+            </connections>
+            <point key="canvasLocation" x="272.5" y="180"/>
+        </view>
+    </objects>
+</document>

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -8,6 +8,8 @@
 "article-unable-to-load-section" = "Unable to load this section. Try refreshing the article to see if it fixes the problem.";
 "article-unable-to-load-article" = "Unable to load article.";
 "article-related-articles-title" = "Related articles";
+"article-languages-yours" = "Your languages";
+"article-languages-others" = "Other languages";
 
 "info-box-title" = "Quick facts";
 "info-box-close-text" = "Close";

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"languages-title" = "Languages";
+"languages-title" = "Change language";
 "article-languages-label" = "Choose language";
 "article-languages-cancel" = "Cancel";
 "article-languages-downloading" = "Loading article languages...";

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -18,6 +18,8 @@
 "article-languages-cancel" = "Button text for dismissing the language selector screen.\n{{Identical|Cancel}}";
 "article-languages-downloading" = "Alert text shown when obtaining list of languages in which an article is available";
 "article-languages-filter-placeholder" = "Filter languages text box placeholder text.";
+"article-languages-yours" = "Title for list of user's preferred languages";
+"article-languages-others" = "Title for list of languages not in user's preferred languages";
 "article-read-more-title" = "The text that is displayed before the read more section at the bottom of an article\n{{Identical|Read more}}";
 "article-about-title" = "The text that is displayed before the 'about' section at the bottom of an article";
 "article-unable-to-load-section" = "Displayed within the article content when a section fails to render for some reason.";


### PR DESCRIPTION
https://phabricator.wikimedia.org/T130675#2205878

- [x] Use "Your languages" and "Other languages" section headers 
- [x] Update title to "Change language"
- [x] Update text sizes
- [x] Update paddings
- [x] Add thin separator beneath filter box
- [x] Add thicker separator between cells
- [x] Hide "Your languages" and "Other languages" headers if no respective langs for article
- [x] Remove the alert (per @nirzar)

![article langs mov](https://cloud.githubusercontent.com/assets/3143487/14515947/433f930c-01b3-11e6-9967-6684d20a5c60.gif)

![screen shot 2016-04-13 at 8 07 25 pm](https://cloud.githubusercontent.com/assets/3143487/14515970/6f4b2e66-01b3-11e6-9780-6dd42977e461.png)