### PR TITLE
Fix IP edits (maybe?) plus a few boyscouts

### DIFF
--- a/Wikipedia/Code/AccountCreationViewController.m
+++ b/Wikipedia/Code/AccountCreationViewController.m
@@ -320,8 +320,8 @@
         // Background thread
         NSURL* captchaImageUrl = [NSURL URLWithString:
                                   [NSString stringWithFormat:@"https://%@.m.%@%@",
-                                   [SessionSingleton sharedInstance].currentArticleSite.language,
-                                   [SessionSingleton sharedInstance].currentArticleSite.domain,
+                                   [[NSUserDefaults standardUserDefaults] wmf_appSite].language,
+                                   [[NSUserDefaults standardUserDefaults] wmf_appSite].domain,
                                    self.captchaUrl
                                   ]
                                  ];
@@ -344,7 +344,7 @@
     [[WMFAlertManager sharedInstance] showAlert:MWLocalizedString(@"account-creation-captcha-obtaining", nil) sticky:NO dismissPreviousAlerts:YES tapCallBack:NULL];
 
     [[QueuesSingleton sharedInstance].accountCreationFetchManager wmf_cancelAllTasksWithCompletionHandler:^{
-        (void)[[CaptchaResetter alloc] initAndResetCaptchaForDomain:[SessionSingleton sharedInstance].currentArticleSite.language
+        (void)[[CaptchaResetter alloc] initAndResetCaptchaForDomain:[[NSUserDefaults standardUserDefaults] wmf_appSite].language
                                                         withManager:[QueuesSingleton sharedInstance].accountCreationFetchManager
                                                  thenNotifyDelegate:self];
     }];
@@ -490,7 +490,7 @@
     // Save!
     [[WMFAlertManager sharedInstance] showAlert:MWLocalizedString(@"account-creation-saving", nil) sticky:YES dismissPreviousAlerts:YES tapCallBack:NULL];
     [[QueuesSingleton sharedInstance].accountCreationFetchManager wmf_cancelAllTasksWithCompletionHandler:^{
-        (void)[[AccountCreationTokenFetcher alloc] initAndFetchTokenForDomain:[SessionSingleton sharedInstance].currentArticleSite.language
+        (void)[[AccountCreationTokenFetcher alloc] initAndFetchTokenForDomain:[[NSUserDefaults standardUserDefaults] wmf_appSite].language
                                                                      userName:self.usernameField.text
                                                                      password:self.passwordField.text
                                                                         email:self.emailField.text

--- a/Wikipedia/Code/EventLoggingFunnel.m
+++ b/Wikipedia/Code/EventLoggingFunnel.m
@@ -9,8 +9,9 @@
 #import "EventLoggingFunnel.h"
 #import "EventLogger.h"
 #import "QueuesSingleton.h"
-#import "SessionSingleton.h"
 #import "MediaWikiKit.h"
+#import "Wikipedia-Swift.h"
+#import "SessionSingleton.h"
 
 @implementation EventLoggingFunnel
 
@@ -28,8 +29,7 @@
 }
 
 - (void)log:(NSDictionary*)eventData {
-    SessionSingleton* session = [SessionSingleton sharedInstance];
-    NSString* wiki            = [session.currentArticleSite.language stringByAppendingString:@"wiki"];
+    NSString* wiki = [[[NSUserDefaults standardUserDefaults] wmf_appSite].language stringByAppendingString:@"wiki"];
     [self log:eventData wiki:wiki];
 }
 

--- a/Wikipedia/Code/EventLoggingFunnel.m
+++ b/Wikipedia/Code/EventLoggingFunnel.m
@@ -9,9 +9,8 @@
 #import "EventLoggingFunnel.h"
 #import "EventLogger.h"
 #import "QueuesSingleton.h"
-#import "MediaWikiKit.h"
-#import "Wikipedia-Swift.h"
 #import "SessionSingleton.h"
+#import "MediaWikiKit.h"
 
 @implementation EventLoggingFunnel
 
@@ -29,7 +28,8 @@
 }
 
 - (void)log:(NSDictionary*)eventData {
-    NSString* wiki = [[[NSUserDefaults standardUserDefaults] wmf_appSite].language stringByAppendingString:@"wiki"];
+    SessionSingleton* session = [SessionSingleton sharedInstance];
+    NSString* wiki            = [session.currentArticleSite.language stringByAppendingString:@"wiki"];
     [self log:eventData wiki:wiki];
 }
 

--- a/Wikipedia/Code/LoginViewController.m
+++ b/Wikipedia/Code/LoginViewController.m
@@ -278,7 +278,7 @@
     self.failBlock = (!failBlock) ? ^(){} : failBlock;
 
     [[QueuesSingleton sharedInstance].loginFetchManager wmf_cancelAllTasksWithCompletionHandler:^{
-        (void)[[LoginTokenFetcher alloc] initAndFetchTokenForDomain:[SessionSingleton sharedInstance].currentArticleSite.language
+        (void)[[LoginTokenFetcher alloc] initAndFetchTokenForDomain:[[NSUserDefaults standardUserDefaults] wmf_appSite].language
                                                            userName:userName
                                                            password:password
                                                         withManager:[QueuesSingleton sharedInstance].loginFetchManager
@@ -292,7 +292,7 @@
     // long as we can to lessen number of server requests. Uses user tokens as templates for copying
     // session tokens. See "recreateCookie:usingCookieAsTemplate:" for details.
 
-    NSString* domain = [SessionSingleton sharedInstance].currentArticleSite.language;
+    NSString* domain = [[NSUserDefaults standardUserDefaults] wmf_appSite].language;
 
     NSString* cookie1Name = [NSString stringWithFormat:@"%@wikiSession", domain];
     NSString* cookie2Name = [NSString stringWithFormat:@"%@wikiUserID", domain];

--- a/Wikipedia/Code/PreviewAndSaveViewController.m
+++ b/Wikipedia/Code/PreviewAndSaveViewController.m
@@ -539,7 +539,9 @@ typedef NS_ENUM (NSInteger, WMFPreviewAndSaveMode) {
         switch (status) {
             case FETCH_FINAL_STATUS_SUCCEEDED: {
                 [self.funnel logSavedRevision:[fetchedData[@"newrevid"] intValue]];
-                [self.delegate previewViewControllerDidSave:self];
+                dispatchOnMainQueue(^{
+                    [self.delegate previewViewControllerDidSave:self];
+                });
             }
             break;
 

--- a/Wikipedia/Code/SectionEditorViewController.m
+++ b/Wikipedia/Code/SectionEditorViewController.m
@@ -179,9 +179,7 @@
         (void)[[WikiTextSectionFetcher alloc] initAndFetchWikiTextForSection:self.section
                                                                  withManager:[QueuesSingleton sharedInstance].sectionWikiTextDownloadManager
                                                           thenNotifyDelegate:self];
-
     }];
-
 }
 
 - (NSAttributedString*)getAttributedString:(NSString*)string {

--- a/Wikipedia/Code/SessionSingleton.h
+++ b/Wikipedia/Code/SessionSingleton.h
@@ -55,4 +55,10 @@
 
 - (NSURL*)urlForLanguage:(NSString*)language WMF_TECH_DEBT_DEPRECATED_MSG("Use -[MWKSite apiEndpoint] instead.");
 
+
+/**
+ *  Logs in the user using saved credentials
+ */
+- (void)autoLogin;
+
 @end

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -211,6 +211,8 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreScreen = 24 * 60 * 60;
         return;
     }
     
+    [self.session autoLogin];
+    
     if(self.unprocessedUserActivity){
         [self processUserActivity:self.unprocessedUserActivity];
     }else if(self.unprocessedShortcutItem){

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -670,6 +670,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Article Fetching
 
 - (void)fetchArticleForce:(BOOL)force {
+    NSAssert([[NSThread currentThread] isMainThread], @"Not on main thread!");
     NSAssert(self.isViewLoaded, @"Should only fetch article when view is loaded so we can update its state.");
     if (!force && self.article) {
         return;

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -117,6 +117,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic, nullable) NSTimer* significantlyViewedTimer;
 
+/**
+ *  We need to do this to prevent auto loading from occuring,
+ *  if we do something to the article like edit it and force a reload
+ */
+@property (nonatomic, assign) BOOL skipFetchOnViewDidAppear;
+
 @end
 
 @implementation WMFArticleViewController
@@ -602,8 +608,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [self registerForPreviewingIfAvailable];
-    [self fetchArticleIfNeeded];
 
+    if (!self.skipFetchOnViewDidAppear) {
+        [self fetchArticleIfNeeded];
+    }
+    self.skipFetchOnViewDidAppear = NO;
     [self startSignificantlyViewedTimer];
 }
 
@@ -991,6 +1000,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - SectionEditorViewControllerDelegate
 
 - (void)sectionEditorFinishedEditing:(SectionEditorViewController*)sectionEditorViewController {
+    self.skipFetchOnViewDidAppear = YES;
     [self dismissViewControllerAnimated:YES completion:NULL];
     [self fetchArticle];
 }


### PR DESCRIPTION
(Potentially) Fixes IP edits by logging in the user when the app is resumed.

I say potentially because I wasn't able to reproduce. The thought is that our tokens are expiring and we have no logic to renew our tokens. We should be doing this on launch to ensure we are logged in. That is what this pull request does. We will need to deploy to see if this actually helps.

I definitely "repeated" myself here… since the logic for logins is in a view controller and not a model controller / headless object.

I would like to address that (as well as modernizing the fetcher logic) in a larger engineering task:
https://phabricator.wikimedia.org/T132700

This also fixes some issues with updates on a background thread and where we would do a double fetch and it might prevent the article from being updated after an edit.


