### PR TITLE
Made article license footer wrap and not break pull to refresh.

### DIFF
--- a/Wikipedia/Code/WMFArticleFooterView.xib
+++ b/Wikipedia/Code/WMFArticleFooterView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -13,29 +13,25 @@
             <subviews>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" image="wikipedia" translatesAutoresizingMaskIntoConstraints="NO" id="ZqI-Ty-tND">
                     <rect key="frame" x="237" y="50" width="126" height="24"/>
-                    <animations/>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4K7-VX-YPh">
-                    <rect key="frame" x="279" y="113" width="42" height="20.5"/>
-                    <animations/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4K7-VX-YPh">
+                    <rect key="frame" x="10" y="113" width="580" height="20.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cK9-Id-Vsx">
-                    <rect key="frame" x="279" y="113" width="42" height="20.5"/>
-                    <animations/>
+                    <rect key="frame" x="10" y="113" width="580" height="20.5"/>
                 </button>
             </subviews>
-            <animations/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="4K7-VX-YPh" firstAttribute="centerX" secondItem="ZqI-Ty-tND" secondAttribute="centerX" id="E90-xR-JMq"/>
                 <constraint firstItem="ZqI-Ty-tND" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="Fm6-U2-Uoz"/>
                 <constraint firstItem="4K7-VX-YPh" firstAttribute="leading" secondItem="cK9-Id-Vsx" secondAttribute="leading" id="IKL-IO-YCx"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="4K7-VX-YPh" secondAttribute="trailing" constant="10" id="Z2P-Lq-vUY"/>
+                <constraint firstAttribute="trailing" secondItem="4K7-VX-YPh" secondAttribute="trailing" constant="10" id="Z2P-Lq-vUY"/>
                 <constraint firstItem="ZqI-Ty-tND" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="50" id="gXT-je-VqF"/>
-                <constraint firstItem="4K7-VX-YPh" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="leading" constant="10" id="kfl-Wv-79Z"/>
+                <constraint firstItem="4K7-VX-YPh" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="10" id="kfl-Wv-79Z"/>
                 <constraint firstItem="4K7-VX-YPh" firstAttribute="trailing" secondItem="cK9-Id-Vsx" secondAttribute="trailing" id="l1M-Za-vAB"/>
                 <constraint firstItem="4K7-VX-YPh" firstAttribute="bottom" secondItem="cK9-Id-Vsx" secondAttribute="bottom" id="lie-3C-CdZ"/>
                 <constraint firstItem="4K7-VX-YPh" firstAttribute="top" secondItem="cK9-Id-Vsx" secondAttribute="top" id="qXS-xi-qeh"/>
@@ -55,7 +51,6 @@
         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="1Hs-xL-x0b">
             <rect key="frame" x="0.0" y="0.0" width="46" height="30"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <animations/>
             <state key="normal" title="Button"/>
             <point key="canvasLocation" x="613" y="680"/>
         </button>


### PR DESCRIPTION
Switched side padding constraints from ">= 10" to "== 10" and it worked with both the pull to refresh and the centered wrapping license label.

![refresh mov](https://cloud.githubusercontent.com/assets/3143487/14544913/4ae87d10-0250-11e6-8e6d-2c23e3a25277.gif)