### PR TITLE
Adding magic tap support

### DIFF
--- a/Wikipedia/Code/WMFTableOfContentsViewController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsViewController.swift
@@ -246,5 +246,11 @@ public class WMFTableOfContentsViewController: UIViewController,
     public override func accessibilityPerformEscape() -> Bool {
         return didRequestClose(nil)
     }
+    
+    // MARK: - UIAccessibilityAction
+    public override func accessibilityPerformMagicTap() -> Bool {
+        return didRequestClose(nil)
+    }
+
 }
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T124820

We can now close the table of contents in 2 ways:
1. Standard Escape gesture (WHICH HAS BEEN WORKING!!!!) - draw a "Z" with 2 fingers
2. Magic Tap - Double tap with 2 fingers

So the escape gesture should be known by our accessibility user and should have been working. It is working for me now. Not sure if this ticket was still valid.

As a nicety I provided the magic tap gesture which is simpler as a close action as well.


@montehurd if you want to test… put your phone in accessibility mode and perform the gestures above on the ToC

Also see "Responding to Special VoiceOver Gestures": https://developer.apple.com/library/ios/featuredarticles/ViewControllerPGforiPhoneOS/SupportingAccessibility.html


To be clear - the close button is still unreadable by voiceover.
However, it is unneeded. Just like the text size popover, the ToC can be dismissed using the standard voiceover escape gesture.
