### PR TITLE
Fix universal links crash.

### DIFF
--- a/Wikipedia/Code/MWKSite.m
+++ b/Wikipedia/Code/MWKSite.m
@@ -41,18 +41,22 @@ typedef NS_ENUM (NSUInteger, MWKSiteNSCodingSchemaVersion) {
         DDLogError(@"Can't form site from incomplete URL: %@", url);
         return nil;
     }
-    NSRange range    = NSMakeRange(hostComponents.count - 2, hostComponents.count - 1);
-    NSString* domain = [[hostComponents subarrayWithRange:range] componentsJoinedByString:@"."];
 
     if ([url.host containsString:@"mediawiki"]) {
+        NSRange range    = NSMakeRange(hostComponents.count - 2, hostComponents.count - 1);
+        NSString* domain = [[hostComponents subarrayWithRange:range] componentsJoinedByString:@"."];
         return [self initWithDomain:domain language:nil];
-    } else {
-        [hostComponents removeObject:@"m"];
+    }else{
         NSString* language = [hostComponents firstObject];
         if (!language.length) {
             DDLogError(@"Can't form site empty language URL component: %@", url);
             return nil;
         }
+        //strip mobile domain
+        [hostComponents removeObject:@"m"];
+        
+        NSString* domain =
+        [[hostComponents subarrayWithRange:NSMakeRange(1, hostComponents.count - 1)] componentsJoinedByString:@"."];
         return [self initWithDomain:domain language:language];
     }
 }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T134028

Repro steps:
Tap wikipedia link in Safari.

