### PR TITLE
Fix saved pages and history deletion confirmation position on iPad.

### DIFF
--- a/Wikipedia/Code/WMFArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFArticleListTableViewController.m
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
                 [self.tableView reloadData];
             }];
             [sheet bk_setCancelButtonWithTitle:[self deleteCancelText] handler:NULL];
-            [sheet showFromTabBar:self.navigationController.tabBarController.tabBar];
+            [sheet showFromBarButtonItem:sender animated:YES];
         }];
     } else {
         self.navigationItem.leftBarButtonItem = nil;

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -509,7 +509,14 @@ NS_ASSUME_NONNULL_BEGIN
         @weakify(controller);
         [header.rightButton bk_addEventHandler:^(id sender) {
             @strongify(controller);
-            [[(id < WMFHeaderMenuProviding >)controller menuActionSheet] showFromTabBar:self.navigationController.tabBarController.tabBar];
+            @strongify(self);
+            if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+                CGRect frame = ((UIButton*)sender).frame;
+                frame.origin.y = 0.f;
+                [[(id < WMFHeaderMenuProviding >)controller menuActionSheet] showFromRect:frame inView:((UIButton*)sender).superview animated:YES];
+            } else {
+                [[(id < WMFHeaderMenuProviding >)controller menuActionSheet] showFromTabBar:self.navigationController.tabBarController.tabBar];
+            }
         } forControlEvents:UIControlEventTouchUpInside];
     } else if ([controller conformsToProtocol:@protocol(WMFHeaderActionProviding)]) {
         header.rightButtonEnabled = YES;


### PR DESCRIPTION
#683 https://phabricator.wikimedia.org/T133958

----
Saved Pages / History:
----

**BEFORE:**
![ipad_air_2_-_clear_saved_pages_action_sheet](https://cloud.githubusercontent.com/assets/3143487/15127829/3ec4bcd2-15ed-11e6-9d9d-9e6241c995ce.png)

**AFTER:**
![screen shot 2016-05-09 at 1 52 40 pm](https://cloud.githubusercontent.com/assets/3143487/15127843/522dd48e-15ed-11e6-9770-1682862d98e4.png)

----
Explore Feed:
----

**BEFORE:**
![screen shot 2016-05-09 at 2 41 35 pm](https://cloud.githubusercontent.com/assets/3143487/15129044/29b71e50-15f4-11e6-9863-99819c1514e9.png)

**AFTER:**
![screen shot 2016-05-09 at 2 37 43 pm](https://cloud.githubusercontent.com/assets/3143487/15129053/2d5bafee-15f4-11e6-8a0f-eda3e00b180a.png)
