### PR TITLE
Add custom URL scheme wikipedia to Info plist.

### DIFF
--- a/Wikipedia/Wikipedia-Info.plist
+++ b/Wikipedia/Wikipedia-Info.plist
@@ -20,6 +20,17 @@
 	<string>5.0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>None</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>wikipedia</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>851.1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
Please see https://phabricator.wikimedia.org/T135048. It would be nice to be able to launch the Wikipedia app from other apps. Thanks.