### PR TITLE
Hack: Rough but functional fetching for en day pages data. (don't merge)

### DIFF
--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -1035,10 +1035,14 @@ NSString* const WMFCCBySALicenseURL =
         if (wikiLinks.count > 1) {
             // Hrefs found, remove first item which is cruft from componentsSeparatedByString.
             wikiLinks = [wikiLinks subarrayWithRange:NSMakeRange(1, wikiLinks.count - 1)];
-            wikiLinks = [wikiLinks bk_map:^id (NSString* stringStartingWithHrefValue) {
+            wikiLinks = [[wikiLinks bk_map:^id (NSString* stringStartingWithHrefValue) {
                 NSRange range = [stringStartingWithHrefValue rangeOfString:@"\""];
                 NSString* page = (range.location != NSNotFound) ? [stringStartingWithHrefValue wmf_safeSubstringToIndex:range.location] : stringStartingWithHrefValue;
                 return [@"/wiki/" stringByAppendingString:page];
+            }] bk_select:^ BOOL (NSString* wikiLink) {
+                NSRange range = [wikiLink rangeOfString:@"^/wiki/\\d+$" options:NSRegularExpressionSearch];
+                BOOL isYearLink = range.location != NSNotFound;
+                return !isYearLink;
             }];
         }
         
@@ -1049,8 +1053,9 @@ NSString* const WMFCCBySALicenseURL =
         
         return @{
                  @"year": @(year),
+                 @"year_page": [NSString stringWithFormat:@"/wiki/%ld", (long)year],
                  @"text": textAfterYear,
-                 @"pages": wikiLinks ? wikiLinks : @[]
+                 @"other_pages": wikiLinks ? wikiLinks : @[]
                  };
     }];
     return cleanedResults;


### PR DESCRIPTION
https://phabricator.wikimedia.org/T135771

Don't merge this obviously (presently it's just hooked up to the web view controller's memory warning method for quick testing in simulator), but it can be copied out as needed. 

Two examples are included:
- ON THIS DAY returns same results as 
https://en.m.wikipedia.org/wiki/Wikipedia:On_this_day/Today 

- FULL DAY RESULTS (events, births and deaths) returns same results as 
https://en.m.wikipedia.org/wiki/May_20
(results grouped by "events", "births" and "deaths")
Note: "Holidays and observances" isn't hooked up yet - the bk_select will have to be changed slightly.


An individual result looks like this:
<pre>
     {
        text = "The First Council of Nicaea, the first ecumenical council of the Christian Church, was formally opened in present-day Iznik, Turkey.";
        year = 325;
        pages =         (
            "/wiki/325",
            "/wiki/First_Council_of_Nicaea",
            "/wiki/Ecumenical_council",
            "/wiki/Christianity",
            "/wiki/Iznik"
        );
    }
</pre>

- "text" is clean html-free text for display
- "pages" are wiki pages which were formerly referenced in "text" before it was cleaned
- "year" is the year