### PR TITLE
Use desktop domain for non Zero rated requests to restore img widening.

### DIFF
--- a/Wikipedia/Code/WMFArticleFetcher.m
+++ b/Wikipedia/Code/WMFArticleFetcher.m
@@ -74,6 +74,11 @@ NSString* const WMFArticleFetcherErrorCachedFallbackArticleKey = @"WMFArticleFet
         resolve([NSError wmf_errorWithType:WMFErrorTypeStringMissingParameter userInfo:nil]);
     }
 
+    // Force desktop domain if not Zero rated.
+    if (![SessionSingleton sharedInstance].zeroConfigState.disposition) {
+        useDeskTopURL = YES;
+    }
+
     NSURL* url = useDeskTopURL ? [pageTitle.site apiEndpoint] : [pageTitle.site mobileApiEndpoint];
 
     NSURLSessionDataTask* operation = [self.operationManager GET:url.absoluteString parameters:pageTitle progress:^(NSProgress* _Nonnull downloadProgress) {

--- a/WikipediaUnitTests/Code/ArticleFetcherTests.m
+++ b/WikipediaUnitTests/Code/ArticleFetcherTests.m
@@ -56,6 +56,7 @@
     MWKSite* site        = [MWKSite siteWithDomain:@"wikipedia.org" language:@"en"];
     MWKTitle* dummyTitle = [site titleWithString:@"Foo"];
     NSURL* url           = [site mobileApiEndpoint];
+    url           = [site apiEndpoint];
 
     NSData* json = [[self wmf_bundle] wmf_dataFromContentsOfFile:@"Obama" ofType:@"json"];
 

--- a/WikipediaUnitTests/Code/MWKSiteInfoFetcherTests.m
+++ b/WikipediaUnitTests/Code/MWKSiteInfoFetcherTests.m
@@ -56,7 +56,7 @@
 
     NSRegularExpression* anyRequestFromTestSite =
         [NSRegularExpression regularExpressionWithPattern:
-         [NSString stringWithFormat:@"%@.*", [[testSite apiEndpoint:YES] absoluteString]] options:0 error:nil];
+         [NSString stringWithFormat:@"%@.*", [[testSite apiEndpoint:NO] absoluteString]] options:0 error:nil];
 
     stubRequest(@"GET", anyRequestFromTestSite)
     .andReturn(200)

--- a/WikipediaUnitTests/Code/WMFENFeaturedTitleFetcherTests.m
+++ b/WikipediaUnitTests/Code/WMFENFeaturedTitleFetcherTests.m
@@ -39,14 +39,14 @@
     testDateComponents.day      = 10;
     testDateComponents.year     = 2015;
 
-    NSString* testDatePattern = @"https://en\\.m\\.wikipedia\\.org.*TFA_title/November%2010%2C%202015.*";
+    NSString* testDatePattern = @"https://en\\.wikipedia\\.org.*TFA_title/November%2010%2C%202015.*";
 
     NSRegularExpression* tfaTitleRequest =
         [NSRegularExpression regularExpressionWithPattern:testDatePattern options:0 error:nil];
 
     // expected title matches the one in the JSON fixture
     NSRegularExpression* previewRequest =
-        [NSRegularExpression regularExpressionWithPattern:@"https://en\\.m\\.wikipedia\\.org.*titles=Mackensen-class%20battlecruiser.*" options:0 error:nil];
+        [NSRegularExpression regularExpressionWithPattern:@"https://en\\.wikipedia\\.org.*titles=Mackensen-class%20battlecruiser.*" options:0 error:nil];
 
     stubRequest(@"GET", tfaTitleRequest)
     .andReturn(200)


### PR DESCRIPTION
https://phabricator.wikimedia.org/T137595

Also fixes some article image taps not loading in gallery.

Android has switched to do same. Issue arose because "m." endpoint
html now is missing img tag "srcset" for some(most?) images. The
desktop endpoint is not affected however and still has srcset.