### PR TITLE
only redefine NSLog on non debug builds

### DIFF
--- a/Wikipedia/Code/WMFLogging.h
+++ b/Wikipedia/Code/WMFLogging.h
@@ -15,9 +15,11 @@ static const DDLogLevel ddLogLevel = DDLogLevelDebug;
 
 #else
 
+// Redefine NSLog to be a default CocoaLumberjack log.
+#define NSLog(...) DDLogDebug(__VA_ARGS__)
+
 static const DDLogLevel ddLogLevel = DDLogLevelWarning;
 
 #endif
 
-// Redefine NSLog to be a default CocoaLumberjack log.
-#define NSLog(...) DDLogDebug(__VA_ARGS__)
+


### PR DESCRIPTION
Often it’s handy to be able to set a breakpoint after an `NSLog(` statement and be guaranteed the output is there. Since DDLogDebug is async, it won’t always be there. This change keeps NSLog as an NSLog unless DEBUG