### PR TITLE
T135243 add crash protection for nil language

### DIFF
--- a/Wikipedia/Code/WMFMostReadSectionController.m
+++ b/Wikipedia/Code/WMFMostReadSectionController.m
@@ -144,7 +144,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSAttributedString*)headerTitle {
     // fall back to language code if it can't be localized
-    NSString* language        = [[NSLocale currentLocale] wmf_localizedLanguageNameForCode:self.site.language] ? : self.site.language;
+    NSString* language = [[NSLocale currentLocale] wmf_localizedLanguageNameForCode:self.site.language] ? : self.site.language;
+    
+    //crash protection if language is nil
+    if (!language) {
+        language = @"";
+    }
+
     NSString* headingWithSite =
         [MWLocalizedString(@"explore-most-read-heading", nil) stringByReplacingOccurrencesOfString:@"$1"
                                                                                         withString:language];

--- a/Wikipedia/Code/WMFMostReadSectionController.m
+++ b/Wikipedia/Code/WMFMostReadSectionController.m
@@ -145,17 +145,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSAttributedString*)headerTitle {
     // fall back to language code if it can't be localized
     NSString* language = [[NSLocale currentLocale] wmf_localizedLanguageNameForCode:self.site.language] ? : self.site.language;
+
+    NSString* heading = nil;
     
     //crash protection if language is nil
-    if (!language) {
-        language = @"";
-    }
-
-    NSString* headingWithSite =
+    if (language) {
+        heading =
         [MWLocalizedString(@"explore-most-read-heading", nil) stringByReplacingOccurrencesOfString:@"$1"
                                                                                         withString:language];
+    } else {
+        heading = MWLocalizedString(@"explore-most-read-generic-heading", nil);
+    }
+
     NSDictionary* attributes = @{NSForegroundColorAttributeName: [UIColor wmf_exploreSectionHeaderTitleColor]};
-    return [[NSAttributedString alloc] initWithString:headingWithSite attributes:attributes];
+    return [[NSAttributedString alloc] initWithString:heading attributes:attributes];
 }
 
 - (NSAttributedString*)headerSubTitle {

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -446,6 +446,7 @@
 "explore-random-article-sub-heading" = "English Wikipedia";
 "explore-potd-heading" = "Picture of the day";
 "explore-most-read-heading" = "Top read on $1 Wikipedia";
+"explore-most-read-generic-heading" = "Top read";
 "explore-most-read-footer" = "All top read articles";
 "explore-most-read-footer-for-date" = "All top read articles on $1";
 "explore-most-read-more-list-title" = "Top articles";

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -399,6 +399,7 @@
 "explore-random-article-sub-heading" = "Subtext beneath the 'Random article' header with name of Wikipedia in this language.";
 "explore-potd-heading" = "Text for 'Picture of the day' header";
 "explore-most-read-heading" = "Text for 'Most read articles' explore section header. $1 is substituted for the localized language name (e.g. 'English' or 'Espanol').";
+"explore-most-read-generic-heading" = "Text for 'Most read articles' explore section header used when no language is present";
 "explore-most-read-footer" = "Text which shown on the footer beneath 'Most read articles', which presents a longer list of 'most read' articles when tapped.";
 "explore-most-read-footer-for-date" = "Text which shown on the footer beneath 'Most read articles', which presents a longer list of 'most read' articles for a given date when tapped. $1 will be substituted with the date";
 "explore-most-read-more-list-title" = "Title for the view displaying longer list of top read articles.";


### PR DESCRIPTION
this is the most basic fix - it will unfortunately result in a blank space where the language name should be. An alternative fix would be to add an additional localization for a generic “Top Read on Wikipedia” and use that in this case. Or, figure out why language is nil in the first place.