### PR TITLE
T115157:Regression: As a user, the references popup should dismiss when I interact with the content

### DIFF
--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -367,6 +367,7 @@ NSString* const WMFCCBySALicenseURL =
  */
 - (void)scrollViewWillBeginDragging:(UIScrollView*)scrollView {
     self.webView.scrollView.decelerationRate = UIScrollViewDecelerationRateNormal;
+    [self referencesHide];
 }
 
 #pragma mark - Zero


### PR DESCRIPTION
Dismiss the reference panel once the user scrolls the article.