### PR TITLE
Fix for image peeking not working for many images.

### DIFF
--- a/Wikipedia/Code/MWKImageList.h
+++ b/Wikipedia/Code/MWKImageList.h
@@ -28,8 +28,6 @@
 
 - (void)addImageURL:(NSString*)imageURL;
 
-- (BOOL)hasImageURL:(NSURL*)imageURL;
-
 - (BOOL)hasImageURLString:(NSString*)imageURLString;
 
 - (MWKImage*)imageWithURL:(NSString*)imageURL;

--- a/Wikipedia/Code/MWKImageList.h
+++ b/Wikipedia/Code/MWKImageList.h
@@ -28,8 +28,6 @@
 
 - (void)addImageURL:(NSString*)imageURL;
 
-- (BOOL)hasImageURLString:(NSString*)imageURLString;
-
 - (MWKImage*)imageWithURL:(NSString*)imageURL;
 
 - (NSUInteger)indexOfImage:(MWKImage*)image;

--- a/Wikipedia/Code/MWKImageList.m
+++ b/Wikipedia/Code/MWKImageList.m
@@ -108,10 +108,6 @@
     return [self.article.dataStore imageWithURL:imageURL article:self.article];
 }
 
-- (BOOL)hasImageURL:(NSURL*)imageURL {
-    return [self hasImageURLString:[imageURL wmf_schemelessURLString]];
-}
-
 - (BOOL)hasImageURLString:(NSString*)imageURLString {
     if (imageURLString && imageURLString.length > 0 && [self.mutableEntries containsObject:imageURLString]) {
         return YES;

--- a/Wikipedia/Code/MWKImageList.m
+++ b/Wikipedia/Code/MWKImageList.m
@@ -108,14 +108,6 @@
     return [self.article.dataStore imageWithURL:imageURL article:self.article];
 }
 
-- (BOOL)hasImageURLString:(NSString*)imageURLString {
-    if (imageURLString && imageURLString.length > 0 && [self.mutableEntries containsObject:imageURLString]) {
-        return YES;
-    } else {
-        return NO;
-    }
-}
-
 - (MWKImage*)imageWithURL:(NSString*)imageURL {
     return [self.article imageWithURL:imageURL];
 }

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1102,7 +1102,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable UIViewController*)viewControllerForImageURL:(nullable NSURL*)url {
-    if (!url || ![self.article.images hasImageURL:url]) {
+    if (!url || ![self.article.images imageSizeVariants:url.absoluteString]) {
         return nil;
     }
     


### PR DESCRIPTION
The problem is the decision whether to peek for an image was
controlled by MWKImageList's "hasImageURL" method, which checked
if the article's image list has a match for image. This check
is based on image url, but the image list no longer seems to
have the exact urls which the image tag's "src" used.

The reason things are out of sync is we are building the
imageList when the article data is saved post fetch, but the
image tag "src" attribute value isn't changed until after
this - at the time the html is about to be used.

One potential fix would be to change the image tag's "src"
values *before* we save the article data, but we can't do
that because the "secret" string we place in the url changes
between app cold starts. This means the proxy server would
ignore these requests after a restart.

I'm going to investigate doing away with the imageList
entirely. Benefits would include being able to do away with
all imageList logic *and* no longer having to do an XPath
parse before saving the article html.