### PR TITLE
Don't show language codes in top read feed header T133420

### DIFF
--- a/Wikipedia/Code/NSLocale+WMFExtras.swift
+++ b/Wikipedia/Code/NSLocale+WMFExtras.swift
@@ -11,6 +11,13 @@ extension NSLocale {
         return (langCode == "en" || langCode.hasPrefix("en-")) ? true : false;
     }
     func wmf_localizedLanguageNameForCode(code: String) -> String? {
-        return self.displayNameForKey(NSLocaleLanguageCode, value: code)
+        var ISOLanguageCode:String
+        switch code {
+        case "als": //wiki language codes don't map 1:1 to ISOLanguageCodes
+            ISOLanguageCode = "gsw"
+        default:
+            ISOLanguageCode = code
+        }
+        return self.displayNameForKey(NSLocaleLanguageCode, value: ISOLanguageCode)
     }
 }

--- a/Wikipedia/Code/NSLocale+WMFExtras.swift
+++ b/Wikipedia/Code/NSLocale+WMFExtras.swift
@@ -11,13 +11,6 @@ extension NSLocale {
         return (langCode == "en" || langCode.hasPrefix("en-")) ? true : false;
     }
     func wmf_localizedLanguageNameForCode(code: String) -> String? {
-        var ISOLanguageCode:String
-        switch code {
-        case "als": //wiki language codes don't map 1:1 to ISOLanguageCodes
-            ISOLanguageCode = "gsw"
-        default:
-            ISOLanguageCode = code
-        }
-        return self.displayNameForKey(NSLocaleLanguageCode, value: ISOLanguageCode)
+        return self.displayNameForKey(NSLocaleLanguageCode, value: code)
     }
 }

--- a/Wikipedia/Code/WMFMostReadSectionController.m
+++ b/Wikipedia/Code/WMFMostReadSectionController.m
@@ -144,7 +144,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSAttributedString*)headerTitle {
     // fall back to language code if it can't be localized
-    NSString* language = [[NSLocale currentLocale] wmf_localizedLanguageNameForCode:self.site.language] ? : self.site.language;
+    NSString* language = [[NSLocale currentLocale] wmf_localizedLanguageNameForCode:self.site.language];
 
     NSString* heading = nil;
     


### PR DESCRIPTION
This fix has two parts corresponding to the two commits - the first commit is a fallback on showing the generic title "Top Read Articles on Wikipedia" rather than "Top Read Articles on als Wikipedia"

The second commit is an attempt to add a mapping from wikipedia language code to ISO language code, which shows "Top Read Articles on Swiss German Wikipedia". I'm not sure this part is necessary, but if it is included, it would be good to find a more complete list of the mapping from wiki language to ISO language.