### PR TITLE
T136070 - Change [external/internal] link icons for privacy policy

### DIFF
--- a/Wikipedia/Code/WMFSettingsMenuItem.m
+++ b/Wikipedia/Code/WMFSettingsMenuItem.m
@@ -76,7 +76,7 @@
                                                     title:MWLocalizedString(@"main-menu-privacy-policy", nil)
                                                  iconName:@"settings-privacy"
                                                 iconColor:[UIColor wmf_colorWithHex:0x884FDC alpha:1.0]
-                                           disclosureType:WMFSettingsMenuItemDisclosureType_ViewController
+                                           disclosureType:WMFSettingsMenuItemDisclosureType_ExternalLink
                                            disclosureText:nil
                                                isSwitchOn:NO];
         }
@@ -86,7 +86,7 @@
                                                     title:MWLocalizedString(@"main-menu-terms-of-use", nil)
                                                  iconName:@"settings-terms"
                                                 iconColor:[UIColor wmf_colorWithHex:0x99A1A7 alpha:1.0]
-                                           disclosureType:WMFSettingsMenuItemDisclosureType_ViewController
+                                           disclosureType:WMFSettingsMenuItemDisclosureType_ExternalLink
                                            disclosureText:nil
                                                isSwitchOn:NO];
         }


### PR DESCRIPTION
On the settings screen, privacy policy and terms of use buttons should use the external link icon, [instead of] the [internal link] > icon.
Ticket#2016052310026686