### PR TITLE
Fix crash when showing main page due to tripping a toc assertion

### DIFF
--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -204,6 +204,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self updateToolbar];
     [self createTableOfContentsViewControllerIfNeeded];
     [self updateWebviewFootersIfNeeded];
+    [self updateTableOfContentsForFootersIfNeeded];
     [self observeArticleUpdates];
 }
 
@@ -492,6 +493,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Article Footers
 
+- (void)updateTableOfContentsForFootersIfNeeded{
+    if ([self.article.title isNonStandardTitle]) {
+        return;
+    }
+    if(![self hasTableOfContents]){
+        return;
+    }
+    
+    BOOL includeReadMore = [self hasReadMore] && [self.readMoreListViewController hasResults];
+    
+    [self appendItemsToTableOfContentsIncludingAboutThisArticle:[self hasAboutThisArticle] includeReadMore:includeReadMore];
+
+}
+
 - (void)updateWebviewFootersIfNeeded {
     if ([self.article.title isNonStandardTitle]) {
         return;
@@ -508,8 +523,6 @@ NS_ASSUME_NONNULL_BEGIN
     if (includeReadMore) {
         [footerVCs addObject:self.readMoreListViewController];
     }
-    
-    [self appendItemsToTableOfContentsIncludingAboutThisArticle:[self hasAboutThisArticle] includeReadMore:includeReadMore];
     
     [self.webViewController setFooterViewControllers:footerVCs];
 }
@@ -830,6 +843,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
         // update footers to include read more if there are results
         [self updateWebviewFootersIfNeeded];
+        [self updateTableOfContentsForFootersIfNeeded];
     })
     .catch(^(NSError* error){
         DDLogError(@"Read More Fetch Error: %@", error);

--- a/Wikipedia/Code/WMFShareOptionsController.m
+++ b/Wikipedia/Code/WMFShareOptionsController.m
@@ -86,6 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
     @weakify(self);
     [[WMFImageController sharedInstance] fetchImageWithURL:[NSURL wmf_optionalURLWithString:self.article.imageURL] failure:^(NSError * _Nonnull error) {
         DDLogInfo(@"Ignoring share card image error: %@", error);
+        [self showShareOptionsWithImage:nil];
     } success:^(WMFImageDownload * _Nonnull download) {
         @strongify(self);
         [self showShareOptionsWithImage:download.image];


### PR DESCRIPTION
The crash came when trying to add items to the ToC on an article which should not show a ToC

This fix just separates the footer and ToC logic so it can be called at the appropriate times.