### PR TITLE
Fix crash when saving image URLs by aggressively rejecting nil (NSNul…

### DIFF
--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -422,7 +422,7 @@ static NSString* const MWKImageInfoFilename = @"ImageInfo.plist";
 }
 
 - (NSArray*)imageInfoForTitle:(MWKTitle*)title {
-    return [[NSArray arrayWithContentsOfFile:[self pathForTitleImageInfo:title]] bk_map:^MWKImageInfo*(id obj) {
+    return [[NSArray arrayWithContentsOfFile:[self pathForTitleImageInfo:title]] wmf_mapAndRejectNil:^MWKImageInfo*(id obj) {
         return [MWKImageInfo imageInfoWithExportedData:obj];
     }];
 }

--- a/Wikipedia/Code/NSURL+WMFExtras.h
+++ b/Wikipedia/Code/NSURL+WMFExtras.h
@@ -17,7 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)wmf_isSchemeless;
 
-- (NSString*)wmf_schemelessURLString;
+- (nullable NSString*)wmf_schemelessURLString;
+
+- (nullable NSURL*)wmf_schemelessURL;
 
 - (NSString*)wmf_mimeTypeForExtension;
 

--- a/Wikipedia/Code/NSURL+WMFExtras.m
+++ b/Wikipedia/Code/NSURL+WMFExtras.m
@@ -14,11 +14,24 @@
     return [self.wmf_schemelessURLString isEqualToString:url.wmf_schemelessURLString];
 }
 
-- (NSString*)wmf_schemelessURLString {
+- (nullable NSString*)wmf_schemelessURLString {
     if (self.scheme.length) {
         return [self.absoluteString wmf_safeSubstringFromIndex:self.scheme.length + 1];
     } else {
         return self.absoluteString;
+    }
+}
+
+- (nullable NSURL*)wmf_schemelessURL {
+    if (self.scheme.length) {
+        NSString* string = [self wmf_schemelessURLString];
+        if(string.length > 0){
+            return [NSURL URLWithString:string];
+        }else{
+            return nil;
+        }
+    } else {
+        return self;
     }
 }
 

--- a/Wikipedia/Code/WMFImageURLParsing.m
+++ b/Wikipedia/Code/WMFImageURLParsing.m
@@ -16,6 +16,10 @@ static NSRegularExpression* WMFImageURLParsingRegex() {
     return imageNameFromURLRegex;
 }
 
+BOOL WMFIsThumbSourceURL(NSString* URLString){
+    return ([URLString rangeOfString:@"/thumb/"].location != NSNotFound);
+}
+
 NSString* WMFParseImageNameFromSourceURL(NSURL* sourceURL)  __attribute__((overloadable)){
     return WMFParseImageNameFromSourceURL(sourceURL.absoluteString);
 }
@@ -43,10 +47,8 @@ NSString* WMFParseImageNameFromSourceURL(NSString* sourceURL)  __attribute__((ov
     NSArray* matches               = [WMFImageURLParsingRegex() matchesInString:thumbOrFileComponent
                                                                         options:0
                                                                           range:NSMakeRange(0, [thumbOrFileComponent length])];
-    NSString* thumbString    = @"/thumb/";
-    NSRange thumbStringRange = [sourceURL rangeOfString:thumbString];
     
-    if (matches.count > 0 && (thumbStringRange.location != NSNotFound)) {
+    if (matches.count > 0 && WMFIsThumbSourceURL(sourceURL)) {
         // Found a "XXXpx-" prefix, extract substring and return as filename
         return [thumbOrFileComponent substringWithRange:[matches[0] rangeAtIndex:1]];
     } else {
@@ -102,11 +104,8 @@ NSString* WMFChangeImageSourceURLSizePrefix(NSString* sourceURL, NSUInteger newS
     }
 
     NSString* lastPathComponent = [sourceURL lastPathComponent];
-
-    NSString* thumbString    = @"/thumb/";
-    NSRange thumbStringRange = [sourceURL rangeOfString:thumbString];
     
-    if (WMFParseSizePrefixFromSourceURL(sourceURL) == NSNotFound || (thumbStringRange.location == NSNotFound)) {
+    if (WMFParseSizePrefixFromSourceURL(sourceURL) == NSNotFound || !WMFIsThumbSourceURL(sourceURL)) {
         NSString* urlWithSizeVariantLastPathComponent = [sourceURL stringByAppendingString:[NSString stringWithFormat:@"/%lupx-%@", (unsigned long)newSizePrefix, lastPathComponent]];
 
         NSString* urlWithThumbPath = [urlWithSizeVariantLastPathComponent stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@"%@%@/", wikipediaString, site] withString:[NSString stringWithFormat:@"%@%@/thumb/", wikipediaString, site]];

--- a/Wikipedia/Code/WMFImageURLParsing.m
+++ b/Wikipedia/Code/WMFImageURLParsing.m
@@ -16,7 +16,7 @@ static NSRegularExpression* WMFImageURLParsingRegex() {
     return imageNameFromURLRegex;
 }
 
-BOOL WMFIsThumbSourceURL(NSString* URLString){
+BOOL WMFIsThumbURLString(NSString* URLString){
     return ([URLString rangeOfString:@"/thumb/"].location != NSNotFound);
 }
 
@@ -48,7 +48,7 @@ NSString* WMFParseImageNameFromSourceURL(NSString* sourceURL)  __attribute__((ov
                                                                         options:0
                                                                           range:NSMakeRange(0, [thumbOrFileComponent length])];
     
-    if (matches.count > 0 && WMFIsThumbSourceURL(sourceURL)) {
+    if (matches.count > 0 && WMFIsThumbURLString(sourceURL)) {
         // Found a "XXXpx-" prefix, extract substring and return as filename
         return [thumbOrFileComponent substringWithRange:[matches[0] rangeAtIndex:1]];
     } else {
@@ -105,7 +105,7 @@ NSString* WMFChangeImageSourceURLSizePrefix(NSString* sourceURL, NSUInteger newS
 
     NSString* lastPathComponent = [sourceURL lastPathComponent];
     
-    if (WMFParseSizePrefixFromSourceURL(sourceURL) == NSNotFound || !WMFIsThumbSourceURL(sourceURL)) {
+    if (WMFParseSizePrefixFromSourceURL(sourceURL) == NSNotFound || !WMFIsThumbURLString(sourceURL)) {
         NSString* urlWithSizeVariantLastPathComponent = [sourceURL stringByAppendingString:[NSString stringWithFormat:@"/%lupx-%@", (unsigned long)newSizePrefix, lastPathComponent]];
 
         NSString* urlWithThumbPath = [urlWithSizeVariantLastPathComponent stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@"%@%@/", wikipediaString, site] withString:[NSString stringWithFormat:@"%@%@/thumb/", wikipediaString, site]];

--- a/Wikipedia/Code/WMFImageURLParsing.m
+++ b/Wikipedia/Code/WMFImageURLParsing.m
@@ -43,8 +43,10 @@ NSString* WMFParseImageNameFromSourceURL(NSString* sourceURL)  __attribute__((ov
     NSArray* matches               = [WMFImageURLParsingRegex() matchesInString:thumbOrFileComponent
                                                                         options:0
                                                                           range:NSMakeRange(0, [thumbOrFileComponent length])];
-
-    if (matches.count > 0) {
+    NSString* thumbString    = @"/thumb/";
+    NSRange thumbStringRange = [sourceURL rangeOfString:thumbString];
+    
+    if (matches.count > 0 && (thumbStringRange.location != NSNotFound)) {
         // Found a "XXXpx-" prefix, extract substring and return as filename
         return [thumbOrFileComponent substringWithRange:[matches[0] rangeAtIndex:1]];
     } else {
@@ -101,7 +103,10 @@ NSString* WMFChangeImageSourceURLSizePrefix(NSString* sourceURL, NSUInteger newS
 
     NSString* lastPathComponent = [sourceURL lastPathComponent];
 
-    if (WMFParseSizePrefixFromSourceURL(sourceURL) == NSNotFound) {
+    NSString* thumbString    = @"/thumb/";
+    NSRange thumbStringRange = [sourceURL rangeOfString:thumbString];
+    
+    if (WMFParseSizePrefixFromSourceURL(sourceURL) == NSNotFound || (thumbStringRange.location == NSNotFound)) {
         NSString* urlWithSizeVariantLastPathComponent = [sourceURL stringByAppendingString:[NSString stringWithFormat:@"/%lupx-%@", (unsigned long)newSizePrefix, lastPathComponent]];
 
         NSString* urlWithThumbPath = [urlWithSizeVariantLastPathComponent stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@"%@%@/", wikipediaString, site] withString:[NSString stringWithFormat:@"%@%@/thumb/", wikipediaString, site]];

--- a/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
+++ b/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
@@ -172,10 +172,24 @@
                is(equalTo(@"//upload.wikimedia.org/wikipedia//")));
 }
 
-- (void)testSVG {
+- (void)testParseImageNameFromURLofSVG {
     NSString* testURLString = @"//upload.wikimedia.org/wikipedia/commons/thumb/4/41/Iceberg_with_hole_near_Sandersons_Hope_2007-07-28_2.svg/640px-Iceberg_with_hole_near_Sandersons_Hope_2007-07-28_2.svg.png";
     assertThat(WMFParseImageNameFromSourceURL(testURLString),
                is(equalTo(@"Iceberg_with_hole_near_Sandersons_Hope_2007-07-28_2.svg")));
+}
+
+- (void)testSizePrefixChangeOnCanonicalImageURLWithSizePrefixInFileName {
+    // Normally images only have "XXXpx-" size prefix when returned from the thumbnail scaler, but there's nothing stopping users from uploading images with "XXXpx-" size prefix in the canonical name.
+    // (See last image on "enwiki > Geothermal gradient")
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"//upload.wikimedia.org/wikipedia/commons/0/0b/300px-Geothermgradients.png", 100),
+               is(equalTo(@"//upload.wikimedia.org/wikipedia/commons/thumb/0/0b/300px-Geothermgradients.png/100px-300px-Geothermgradients.png")));
+}
+
+- (void)testParseImageNameFromCanonicalImageURLWithSizePrefixInFileName {
+    NSString* testURLString = @"//upload.wikimedia.org/wikipedia/commons/0/0b/300px-Geothermgradients.png";
+    assertThat(WMFParseImageNameFromSourceURL(testURLString),
+               is(equalTo(@"300px-Geothermgradients.png")));
+    //                      ^ the canonical image has the size in the file name, so "300px-" is correct here.
 }
 
 @end


### PR DESCRIPTION
…l) URLs

- Reject nil URLs when retrieving imageInfoForTitle from the datastore
- Check for the proper class (MWKImageInfo) before mapping to a URL (previously a KVO key value coding call on an unknown class)
- Check for the proper class (NSURL) before mapping to a scheme less URL (previously assumed it was an NSURL and crashed)

- Additionally refactor both scheme removal code paths into one (in NSURL category)