### PR TITLE
Fix ref panel link 3d touch crash.

### DIFF
--- a/Wikipedia/Code/ReferenceVC.m
+++ b/Wikipedia/Code/ReferenceVC.m
@@ -106,6 +106,7 @@
         -webkit-text-size-adjust: none;\
         -webkit-hyphens: auto;\
         word-break: break-word;\
+        -webkit-touch-callout: none !important; /* Hide the Safari 'Add to reading list' menu on long-press on links and other elements. */ \
      }\
     BODY{\
         padding-left:%f;\


### PR DESCRIPTION
https://phabricator.wikimedia.org/T140168

Repro steps:

- load "enwiki > Tyrannosaurus"
- tap second reference link - i.e. "[2]"
- do 3d touch on the link in the black reference panel at the bottom of the screen
- CRASH!