### PR TITLE
SPIKE - Rough find-in-page proof of concept.

### DIFF
--- a/Wikipedia/Code/WKScriptMessage+WMFScriptMessage.h
+++ b/Wikipedia/Code/WKScriptMessage+WMFScriptMessage.h
@@ -10,7 +10,8 @@ typedef NS_ENUM (NSInteger, WMFWKScriptMessageType) {
     WMFWKScriptMessageClickEdit,
     WMFWKScriptMessageNonAnchorTouchEndedWithoutDragging,
     WMFWKScriptMessageLateJavascriptTransform,
-    WMFWKScriptMessageArticleState
+    WMFWKScriptMessageArticleState,
+    WMFWKScriptMessageSearchMatchesFound
 };
 
 @interface WKScriptMessage (WMFScriptMessage)

--- a/Wikipedia/Code/WKScriptMessage+WMFScriptMessage.m
+++ b/Wikipedia/Code/WKScriptMessage+WMFScriptMessage.m
@@ -21,6 +21,8 @@
         return WMFWKScriptMessageArticleState;
     } else if ([name isEqualToString:@"sendJavascriptConsoleLogMessageToXcodeConsole"]) {
         return WMFWKScriptMessageConsoleMessage;
+    }else if ([name isEqualToString:@"searchMatchesFound"]) {
+        return WMFWKScriptMessageSearchMatchesFound;
     } else{
         return WMFWKScriptMessageUnknown;
     }
@@ -54,6 +56,9 @@
             break;
         case WMFWKScriptMessageConsoleMessage:
             return [NSDictionary class];
+            break;
+        case WMFWKScriptMessageSearchMatchesFound:
+            return [NSArray class];
             break;
         case WMFWKScriptMessageUnknown:
             return [NSNull class];

--- a/www/index-main.js
+++ b/www/index-main.js
@@ -3,5 +3,6 @@ var wmf = {};
 wmf.elementLocation = require("./js/elementLocation");
 wmf.transformer = require("./js/transformer");
 wmf.utilities = require("./js/utilities");
+wmf.search = require("./js/search");
 
 window.wmf = wmf;

--- a/www/js/search.js
+++ b/www/js/search.js
@@ -1,0 +1,90 @@
+// Based on the excellent blog post: http://www.icab.de/blog/2010/01/12/search-and-highlight-text-in-uiwebview/
+
+// We're using a global variable to store the number of occurrences
+var MyApp_SearchResultCount = 0;
+var MyApp_SearchResultMatches = [];
+
+// helper function, recursively searches in elements and their child nodes
+function MyApp_HighlightAllOccurencesOfStringForElement(element,keyword) {
+    if (element) {
+        if (element.nodeType == 3) {        // Text node
+            while (true) {
+                var value = element.nodeValue;  // Search for keyword in text node
+                var idx = value.toLowerCase().indexOf(keyword);
+                
+                if (idx < 0) break;             // not found, abort
+                
+                var span = document.createElement("span");
+                var text = document.createTextNode(value.substr(idx,keyword.length));
+                span.appendChild(text);
+                span.setAttribute("class","MyAppHighlight");
+
+var highlightSpanId = "find_match|" + MyApp_SearchResultCount;
+span.setAttribute("id", highlightSpanId);
+MyApp_SearchResultMatches.push({
+                               'highlightSpanId': highlightSpanId
+                               });
+                
+                span.style.backgroundColor="yellow";
+                span.style.color="black";
+                text = document.createTextNode(value.substr(idx+keyword.length));
+                element.deleteData(idx, value.length - idx);
+                var next = element.nextSibling;
+                element.parentNode.insertBefore(span, next);
+                element.parentNode.insertBefore(text, next);
+                element = text;
+                MyApp_SearchResultCount++;	// update the counter
+            }
+        } else if (element.nodeType == 1) { // Element node
+            if (element.style.display != "none" && element.nodeName.toLowerCase() != 'select') {
+                for (var i=element.childNodes.length-1; i>=0; i--) {
+                    MyApp_HighlightAllOccurencesOfStringForElement(element.childNodes[i],keyword);
+                }
+            }
+        }
+    }
+}
+
+// helper function, recursively removes the highlights in elements and their childs
+function MyApp_RemoveAllHighlightsForElement(element) {
+    if (element) {
+        if (element.nodeType == 1) {
+            if (element.getAttribute("class") == "MyAppHighlight") {
+                var text = element.removeChild(element.firstChild);
+                element.parentNode.insertBefore(text,element);
+                element.parentNode.removeChild(element);
+                return true;
+            } else {
+                var normalize = false;
+                for (var i=element.childNodes.length-1; i>=0; i--) {
+                    if (MyApp_RemoveAllHighlightsForElement(element.childNodes[i])) {
+                        normalize = true;
+                    }
+                }
+                if (normalize) {
+                    element.normalize();
+                }
+            }
+        }
+    }
+    return false;
+}
+
+// the main entry point to remove the highlights
+function MyApp_RemoveAllHighlights() {
+    MyApp_SearchResultCount = 0;
+    MyApp_SearchResultMatches = [];
+    MyApp_RemoveAllHighlightsForElement(document.body);
+}
+
+// the main entry point to start the search
+function MyApp_HighlightAllOccurencesOfString(keyword) {
+    MyApp_RemoveAllHighlights();
+    MyApp_HighlightAllOccurencesOfStringForElement(document.body, keyword.toLowerCase());
+    
+window.webkit.messageHandlers.searchMatchesFound.postMessage(MyApp_SearchResultMatches);
+    
+}
+
+exports.MyApp_HighlightAllOccurencesOfString = MyApp_HighlightAllOccurencesOfString;
+exports.MyApp_RemoveAllHighlights = MyApp_RemoveAllHighlights;


### PR DESCRIPTION
Load the Obama article in simulator then tap command shift M to
trigger memory warning. This will highlight all occurences of the
string "Obama" in the artice.

Native land send message to JS land to perform search for term "Obama".

JS land examines visible text elements, highlighting the matches, and
sends message back to native land with array of the id's of the spans
which were added around the matches to make them yellow.

Now if you repeatedly tap command shift M the native code will cycle
though the matches and scroll the web view to the next one.

![untitled 2 mov](https://cloud.githubusercontent.com/assets/3143487/16890226/87a1e6e4-4aa1-11e6-99de-b1aac92f314f.gif)

