### PR TITLE
Regression - Fix crash related to not properly handing thumbnail url from pdfs.

### DIFF
--- a/Wikipedia/Code/WMFImageURLParsing.m
+++ b/Wikipedia/Code/WMFImageURLParsing.m
@@ -8,7 +8,7 @@ static NSRegularExpression* WMFImageURLParsingRegex() {
     dispatch_once(&onceToken, ^{
         // TODO: try to read serialized regex from disk to prevent needless pattern compilation on next app run
         NSError* patternCompilationError;
-        imageNameFromURLRegex = [NSRegularExpression regularExpressionWithPattern:@"^\\d+px-(.*)"
+        imageNameFromURLRegex = [NSRegularExpression regularExpressionWithPattern:@"^(page\\d+-)?\\d+px-(.*)"
                                                                           options:0
                                                                             error:&patternCompilationError];
         NSCParameterAssert(!patternCompilationError);
@@ -34,26 +34,10 @@ NSString* WMFParseImageNameFromSourceURL(NSString* sourceURL)  __attribute__((ov
         return nil;
     }
 
-    /*
-       For URLs in form "https://upload.wikimedia.org/.../Filename.jpg/XXXpx-Filename.jpg" try to acquire filename via
-       the second to last path component, which has only one extension.
-     */
-    NSString* filenameComponent = pathComponents[pathComponents.count - 2];
-    if ([[filenameComponent.pathExtension wmf_asMIMEType] hasPrefix:@"image"]) {
-        return filenameComponent;
-    }
-
-    NSString* thumbOrFileComponent = [pathComponents lastObject];
-    NSArray* matches               = [WMFImageURLParsingRegex() matchesInString:thumbOrFileComponent
-                                                                        options:0
-                                                                          range:NSMakeRange(0, [thumbOrFileComponent length])];
-    
-    if (matches.count > 0 && WMFIsThumbURLString(sourceURL)) {
-        // Found a "XXXpx-" prefix, extract substring and return as filename
-        return [thumbOrFileComponent substringWithRange:[matches[0] rangeAtIndex:1]];
-    } else {
-        // No "XXXpx-" prefix found, return the entire last component, as the URL is (probably) in the form //.../Filename.jpg
-        return thumbOrFileComponent;
+    if (!WMFIsThumbURLString(sourceURL)) {
+        return [sourceURL lastPathComponent];
+    }else{
+        return pathComponents[pathComponents.count - 2];
     }
 }
 
@@ -75,11 +59,23 @@ NSInteger WMFParseSizePrefixFromSourceURL(NSString* sourceURL)  __attribute__((o
     if (!fileName || (fileName.length == 0)) {
         return NSNotFound;
     }
-    NSRange range = [fileName rangeOfString:@"px-"];
-    if (range.location == NSNotFound) {
+    NSRange pxRange = [fileName rangeOfString:@"px-"];
+    if (pxRange.location == NSNotFound) {
         return NSNotFound;
     } else {
-        NSInteger result = [fileName substringToIndex:range.location].integerValue;
+        NSString *stringBeforePx = [fileName substringToIndex:pxRange.location];
+        NSRange dashRange = [stringBeforePx rangeOfString:@"-"];
+        NSInteger result = NSNotFound;
+        if (dashRange.location == NSNotFound) {
+             //stringBeforePx is "200" for the following:
+             //upload.wikimedia.org/wikipedia/commons/thumb/4/41/200px-Potato.jpg/
+            result = stringBeforePx.integerValue;
+        }else{
+             //stringBeforePx is "page1-240" for the following:
+             //upload.wikimedia.org/wikipedia/commons/thumb/6/65/A_Fish_and_a_Gift.pdf/page1-240px-A_Fish_and_a_Gift.pdf.jpg
+            NSString *stringAfterDash = [stringBeforePx substringFromIndex:dashRange.location+1];
+            result = stringAfterDash.integerValue;
+        }
         return (result == 0) ? NSNotFound : result;
     }
 }
@@ -106,7 +102,13 @@ NSString* WMFChangeImageSourceURLSizePrefix(NSString* sourceURL, NSUInteger newS
     NSString* lastPathComponent = [sourceURL lastPathComponent];
     
     if (WMFParseSizePrefixFromSourceURL(sourceURL) == NSNotFound || !WMFIsThumbURLString(sourceURL)) {
-        NSString* urlWithSizeVariantLastPathComponent = [sourceURL stringByAppendingString:[NSString stringWithFormat:@"/%lupx-%@", (unsigned long)newSizePrefix, lastPathComponent]];
+        NSString* sizeVariantLastPathComponent = [NSString stringWithFormat:@"%lupx-%@", (unsigned long)newSizePrefix, lastPathComponent];
+        
+        if([[sourceURL pathExtension] isEqualToString:@"pdf"]){
+            sizeVariantLastPathComponent = [NSString stringWithFormat:@"page1-%@.jpg", sizeVariantLastPathComponent];
+        }
+        
+        NSString* urlWithSizeVariantLastPathComponent = [[sourceURL stringByAppendingString:@"/" ] stringByAppendingString:sizeVariantLastPathComponent];
 
         NSString* urlWithThumbPath = [urlWithSizeVariantLastPathComponent stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@"%@%@/", wikipediaString, site] withString:[NSString stringWithFormat:@"%@%@/thumb/", wikipediaString, site]];
 
@@ -121,9 +123,6 @@ NSString* WMFChangeImageSourceURLSizePrefix(NSString* sourceURL, NSUInteger newS
             [WMFImageURLParsingRegex() stringByReplacingMatchesInString:sourceURL
                                                                 options:NSMatchingAnchored
                                                                   range:rangeOfLastPathComponent
-                                                           withTemplate:[NSString stringWithFormat:@"%lupx-$1", (unsigned long)newSizePrefix]];
+                                                           withTemplate:[NSString stringWithFormat:@"$1%lupx-$2", (unsigned long)newSizePrefix]];
     }
 }
-
-
-

--- a/WikipediaUnitTests/Code/MWKImageInfo+MWKImageComparisonTests.m
+++ b/WikipediaUnitTests/Code/MWKImageInfo+MWKImageComparisonTests.m
@@ -1,11 +1,3 @@
-//
-//  MWKImageInfo+MWKImageComparisonTests.m
-//  Wikipedia
-//
-//  Created by Brian Gerstle on 2/12/15.
-//  Copyright (c) 2015 Wikimedia Foundation. All rights reserved.
-//
-
 #import "MWKImageInfo+MWKImageComparison.h"
 #import <XCTest/XCTest.h>
 
@@ -21,16 +13,16 @@
 @implementation MWKImageInfo_MWKImageComparisonTests
 
 - (void)testAssociation {
-    MWKImage* image    = [MWKImage imageAssociatedWithSourceURL:@"some_file_name.jpg/400px-some_file_name.jpg"];
-    MWKImageInfo* info = [MWKImageInfo infoAssociatedWithSourceURL:@"some_file_name.jpg/800px-some_file_name.jpg"];
+    MWKImage* image    = [MWKImage imageAssociatedWithSourceURL:@"/thumb/some_file_name.jpg/400px-some_file_name.jpg"];
+    MWKImageInfo* info = [MWKImageInfo infoAssociatedWithSourceURL:@"/thumb/some_file_name.jpg/800px-some_file_name.jpg"];
     assertThat(image.infoAssociationValue, is(equalTo(info.imageAssociationValue)));
     XCTAssertTrue([info isAssociatedWithImage:image]);
     XCTAssertTrue([image isAssociatedWithInfo:info]);
 }
 
 - (void)testDisassociation {
-    MWKImage* image    = [MWKImage imageAssociatedWithSourceURL:@"some_file_name.jpg/400px-some_file_name.jpg"];
-    MWKImageInfo* info = [MWKImageInfo infoAssociatedWithSourceURL:@"other_file_name.jpg/800px-other_file_name.jpg"];
+    MWKImage* image    = [MWKImage imageAssociatedWithSourceURL:@"/thumb/some_file_name.jpg/400px-some_file_name.jpg"];
+    MWKImageInfo* info = [MWKImageInfo infoAssociatedWithSourceURL:@"/thumb/other_file_name.jpg/800px-other_file_name.jpg"];
     assertThat([image infoAssociationValue], isNot(equalTo([info imageAssociationValue])));
     XCTAssertFalse([info isAssociatedWithImage:image]);
 }

--- a/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
+++ b/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
@@ -178,11 +178,42 @@
                is(equalTo(@"Iceberg_with_hole_near_Sandersons_Hope_2007-07-28_2.svg")));
 }
 
+- (void)testSizePrefixWhenCanonicalFileIsPDF {
+    NSString* testURL = @"//upload.wikimedia.org/wikipedia/commons/thumb/6/65/A_Fish_and_a_Gift.pdf/page1-240px-A_Fish_and_a_Gift.pdf.jpg";
+    XCTAssertEqual(WMFParseSizePrefixFromSourceURL(testURL), 240);
+}
+
+- (void)testParseCanonicalFileNameWhenCanonicalFileIsPDF {
+    NSString* testURLString = @"https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/A_Fish_and_a_Gift.pdf/page1-240px-A_Fish_and_a_Gift.pdf.jpg";
+    assertThat(WMFParseImageNameFromSourceURL(testURLString),
+               is(equalTo(@"A_Fish_and_a_Gift.pdf")));
+}
+
+- (void)testSizePrefixChangeWhenCanonicalFileIsPDFWithSizePrefix {
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/A_Fish_and_a_Gift.pdf/page1-240px-A_Fish_and_a_Gift.pdf.jpg", 480),
+               is(equalTo(@"https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/A_Fish_and_a_Gift.pdf/page1-480px-A_Fish_and_a_Gift.pdf.jpg")));
+}
+
+- (void)testSizePrefixChangeWhenCanonicalFileIsPDFWithSizePrefixPage2 {
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/A_Fish_and_a_Gift.pdf/page2-240px-A_Fish_and_a_Gift.pdf.jpg", 480),
+               is(equalTo(@"https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/A_Fish_and_a_Gift.pdf/page2-480px-A_Fish_and_a_Gift.pdf.jpg")));
+}
+
+- (void)testSizePrefixChangeWhenCanonicalFileIsPDFWithoutSizePrefix {
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"//upload.wikimedia.org/wikipedia/commons/6/65/A_Fish_and_a_Gift.pdf", 240),
+               is(equalTo(@"//upload.wikimedia.org/wikipedia/commons/thumb/6/65/A_Fish_and_a_Gift.pdf/page1-240px-A_Fish_and_a_Gift.pdf.jpg")));
+}
+
 - (void)testSizePrefixChangeOnCanonicalImageURLWithSizePrefixInFileName {
     // Normally images only have "XXXpx-" size prefix when returned from the thumbnail scaler, but there's nothing stopping users from uploading images with "XXXpx-" size prefix in the canonical name.
     // (See last image on "enwiki > Geothermal gradient")
     assertThat(WMFChangeImageSourceURLSizePrefix(@"//upload.wikimedia.org/wikipedia/commons/0/0b/300px-Geothermgradients.png", 100),
                is(equalTo(@"//upload.wikimedia.org/wikipedia/commons/thumb/0/0b/300px-Geothermgradients.png/100px-300px-Geothermgradients.png")));
+}
+
+- (void)testResizePrefixChangeOnCanonicalImageURLWithSizePrefixInFileName {
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"//upload.wikimedia.org/wikipedia/commons/thumb/0/0b/300px-Geothermgradients.png/100px-300px-Geothermgradients.png", 200),
+               is(equalTo(@"//upload.wikimedia.org/wikipedia/commons/thumb/0/0b/300px-Geothermgradients.png/200px-300px-Geothermgradients.png")));
 }
 
 - (void)testParseImageNameFromCanonicalImageURLWithSizePrefixInFileName {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T140714

Saving "enwiki > Tatar language" was causing crash.

The image scaler handles serving up thumbnails for PDFs a little differently - note the "**page1-**" prefix preceding the "**240px-**" size prefix:
https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/A_Fish_and_a_Gift.pdf/page1-240px-A_Fish_and_a_Gift.pdf.jpg





