### PR TITLE
Handle parsing of thumbnailer image urls from canonical TIF files.

### DIFF
--- a/Wikipedia/Code/AppDelegate.m
+++ b/Wikipedia/Code/AppDelegate.m
@@ -97,9 +97,10 @@
 
     [self updateDynamicIconShortcutItems];
 
-    
-    NSURL *documentsURL = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
-    NSLog(@"%@", documentsURL);
+#if DEBUG
+    NSLog(@"\n\nSimulator documents directory:\n\t%@\n\n",
+          [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) lastObject]);
+#endif
 
     return YES;
 }

--- a/Wikipedia/Code/WMFImageURLParsing.m
+++ b/Wikipedia/Code/WMFImageURLParsing.m
@@ -8,7 +8,7 @@ static NSRegularExpression* WMFImageURLParsingRegex() {
     dispatch_once(&onceToken, ^{
         // TODO: try to read serialized regex from disk to prevent needless pattern compilation on next app run
         NSError* patternCompilationError;
-        imageNameFromURLRegex = [NSRegularExpression regularExpressionWithPattern:@"^(page\\d+-)?\\d+px-(.*)"
+        imageNameFromURLRegex = [NSRegularExpression regularExpressionWithPattern:@"^(lossy-)?(page\\d+-)?\\d+px-(.*)"
                                                                           options:0
                                                                             error:&patternCompilationError];
         NSCParameterAssert(!patternCompilationError);
@@ -64,16 +64,16 @@ NSInteger WMFParseSizePrefixFromSourceURL(NSString* sourceURL)  __attribute__((o
         return NSNotFound;
     } else {
         NSString *stringBeforePx = [fileName substringToIndex:pxRange.location];
-        NSRange dashRange = [stringBeforePx rangeOfString:@"-"];
+        NSRange lastDashRange = [stringBeforePx rangeOfString:@"-" options:NSBackwardsSearch];
         NSInteger result = NSNotFound;
-        if (dashRange.location == NSNotFound) {
+        if (lastDashRange.location == NSNotFound) {
              //stringBeforePx is "200" for the following:
              //upload.wikimedia.org/wikipedia/commons/thumb/4/41/200px-Potato.jpg/
             result = stringBeforePx.integerValue;
         }else{
              //stringBeforePx is "page1-240" for the following:
              //upload.wikimedia.org/wikipedia/commons/thumb/6/65/A_Fish_and_a_Gift.pdf/page1-240px-A_Fish_and_a_Gift.pdf.jpg
-            NSString *stringAfterDash = [stringBeforePx substringFromIndex:dashRange.location+1];
+            NSString *stringAfterDash = [stringBeforePx substringFromIndex:lastDashRange.location+1];
             result = stringAfterDash.integerValue;
         }
         return (result == 0) ? NSNotFound : result;
@@ -106,6 +106,8 @@ NSString* WMFChangeImageSourceURLSizePrefix(NSString* sourceURL, NSUInteger newS
         
         if([[sourceURL pathExtension] isEqualToString:@"pdf"]){
             sizeVariantLastPathComponent = [NSString stringWithFormat:@"page1-%@.jpg", sizeVariantLastPathComponent];
+        }else if([[sourceURL pathExtension] isEqualToString:@"tif"]){
+            sizeVariantLastPathComponent = [NSString stringWithFormat:@"lossy-page1-%@.jpg", sizeVariantLastPathComponent];
         }
         
         NSString* urlWithSizeVariantLastPathComponent = [[sourceURL stringByAppendingString:@"/" ] stringByAppendingString:sizeVariantLastPathComponent];
@@ -123,6 +125,6 @@ NSString* WMFChangeImageSourceURLSizePrefix(NSString* sourceURL, NSUInteger newS
             [WMFImageURLParsingRegex() stringByReplacingMatchesInString:sourceURL
                                                                 options:NSMatchingAnchored
                                                                   range:rangeOfLastPathComponent
-                                                           withTemplate:[NSString stringWithFormat:@"$1%lupx-$2", (unsigned long)newSizePrefix]];
+                                                           withTemplate:[NSString stringWithFormat:@"$1$2%lupx-$3", (unsigned long)newSizePrefix]];
     }
 }

--- a/Wikipedia/Code/WMFImageURLParsing.m
+++ b/Wikipedia/Code/WMFImageURLParsing.m
@@ -8,7 +8,7 @@ static NSRegularExpression* WMFImageURLParsingRegex() {
     dispatch_once(&onceToken, ^{
         // TODO: try to read serialized regex from disk to prevent needless pattern compilation on next app run
         NSError* patternCompilationError;
-        imageNameFromURLRegex = [NSRegularExpression regularExpressionWithPattern:@"^(lossy-)?(page\\d+-)?\\d+px-(.*)"
+        imageNameFromURLRegex = [NSRegularExpression regularExpressionWithPattern:@"^(lossy-|lossless-)?(page\\d+-)?\\d+px-(.*)"
                                                                           options:0
                                                                             error:&patternCompilationError];
         NSCParameterAssert(!patternCompilationError);

--- a/Wikipedia/Code/WMFImageURLParsing.m
+++ b/Wikipedia/Code/WMFImageURLParsing.m
@@ -104,9 +104,10 @@ NSString* WMFChangeImageSourceURLSizePrefix(NSString* sourceURL, NSUInteger newS
     if (WMFParseSizePrefixFromSourceURL(sourceURL) == NSNotFound || !WMFIsThumbURLString(sourceURL)) {
         NSString* sizeVariantLastPathComponent = [NSString stringWithFormat:@"%lupx-%@", (unsigned long)newSizePrefix, lastPathComponent];
         
-        if([[sourceURL pathExtension] isEqualToString:@"pdf"]){
+        NSString* lowerCasePathExtension = [[sourceURL pathExtension] lowercaseString];
+        if([lowerCasePathExtension isEqualToString:@"pdf"]){
             sizeVariantLastPathComponent = [NSString stringWithFormat:@"page1-%@.jpg", sizeVariantLastPathComponent];
-        }else if([[sourceURL pathExtension] isEqualToString:@"tif"]){
+        }else if([lowerCasePathExtension isEqualToString:@"tif"] || [lowerCasePathExtension isEqualToString:@"tiff"]){
             sizeVariantLastPathComponent = [NSString stringWithFormat:@"lossy-page1-%@.jpg", sizeVariantLastPathComponent];
         }
         

--- a/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
+++ b/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
@@ -157,6 +157,16 @@
                is(equalTo(@"//upload.wikimedia.org/wikipedia/commons/thumb/200px-/4/41/123px-Potato.jpg/")));
 }
 
+- (void)testSizePrefixChange_jpeg {
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"https://upload.wikimedia.org/wikipedia/commons/4/48/Oat10.jpeg", 123),
+               is(equalTo(@"https://upload.wikimedia.org/wikipedia/commons/thumb/4/48/Oat10.jpeg/123px-Oat10.jpeg")));
+}
+
+- (void)testSizePrefixChange_JPEG {
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"https://upload.wikimedia.org/wikipedia/commons/4/48/Oat10.JPEG", 123),
+               is(equalTo(@"https://upload.wikimedia.org/wikipedia/commons/thumb/4/48/Oat10.JPEG/123px-Oat10.JPEG")));
+}
+
 - (void)testSizePrefixChangeOnENWikiURL {
     assertThat(WMFChangeImageSourceURLSizePrefix(@"//upload.wikimedia.org/wikipedia/en/6/69/PercevalShooting.jpg", 123),
                is(equalTo(@"//upload.wikimedia.org/wikipedia/en/thumb/6/69/PercevalShooting.jpg/123px-PercevalShooting.jpg")));
@@ -268,6 +278,16 @@
 - (void)testSizePrefixChangeWhenCanonicalFileIsTIFWithSizePrefixPage2_lossless {
     assertThat(WMFChangeImageSourceURLSizePrefix(@"//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossless-page2-220px-Gerald_Ford_-_NARA_-_530680.tif.png", 480),
                is(equalTo(@"//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossless-page2-480px-Gerald_Ford_-_NARA_-_530680.tif.png"))); //Note: this page2 variant doesn't actually exist.
+}
+
+- (void)testSizePrefixChangeWhenCanonicalFileIsTIFF_lowercase {
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"https://upload.wikimedia.org/wikipedia/commons/f/f8/Funk.tiff", 797),
+               is(equalTo(@"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f8/Funk.tiff/lossy-page1-797px-Funk.tiff.jpg")));
+}
+
+- (void)testSizePrefixChangeWhenCanonicalFileIsTIFF_uppercase {
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"https://upload.wikimedia.org/wikipedia/commons/5/55/Charles_Vanderhoop%2C_Jr.%2C_Gay_Head_Light_Assistant_Keeper%2C_with_visiting_island_school_children.TIFF", 800),
+               is(equalTo(@"https://upload.wikimedia.org/wikipedia/commons/thumb/5/55/Charles_Vanderhoop%2C_Jr.%2C_Gay_Head_Light_Assistant_Keeper%2C_with_visiting_island_school_children.TIFF/lossy-page1-800px-Charles_Vanderhoop%2C_Jr.%2C_Gay_Head_Light_Assistant_Keeper%2C_with_visiting_island_school_children.TIFF.jpg")));
 }
 
 @end

--- a/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
+++ b/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
@@ -223,30 +223,51 @@
     //                      ^ the canonical image has the size in the file name, so "300px-" is correct here.
 }
 
-- (void)testSizePrefixWhenCanonicalFileIsTIF {
+- (void)testSizePrefixWhenCanonicalFileIsTIF_lossy {
     NSString* testURL = @"//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page1-220px-Gerald_Ford_-_NARA_-_530680.tif.jpg";
     XCTAssertEqual(WMFParseSizePrefixFromSourceURL(testURL), 220);
 }
 
-- (void)testParseCanonicalFileNameWhenCanonicalFileIsTIF {
+- (void)testParseCanonicalFileNameWhenCanonicalFileIsTIF_lossy {
     NSString* testURLString = @"https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page1-220px-Gerald_Ford_-_NARA_-_530680.tif.jpg";
     assertThat(WMFParseImageNameFromSourceURL(testURLString),
                is(equalTo(@"Gerald_Ford_-_NARA_-_530680.tif")));
 }
 
-- (void)testSizePrefixChangeWhenCanonicalFileIsTIFWithSizePrefix {
+- (void)testSizePrefixChangeWhenCanonicalFileIsTIFWithSizePrefix_lossy {
     assertThat(WMFChangeImageSourceURLSizePrefix(@"https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page1-220px-Gerald_Ford_-_NARA_-_530680.tif.jpg", 480),
                is(equalTo(@"https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page1-480px-Gerald_Ford_-_NARA_-_530680.tif.jpg")));
 }
 
-- (void)testSizePrefixChangeWhenCanonicalFileIsTIFWithSizePrefixPage2 {
+- (void)testSizePrefixChangeWhenCanonicalFileIsTIFWithSizePrefixPage2_lossy {
     assertThat(WMFChangeImageSourceURLSizePrefix(@"//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page2-220px-Gerald_Ford_-_NARA_-_530680.tif.jpg", 480),
                is(equalTo(@"//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page2-480px-Gerald_Ford_-_NARA_-_530680.tif.jpg"))); //Note: this page2 variant doesn't actually exist.
 }
 
-- (void)testSizePrefixChangeWhenCanonicalFileIsTIFWithoutSizePrefix {
+- (void)testSizePrefixChangeWhenCanonicalFileIsTIFWithoutSizePrefix_lossy {
     assertThat(WMFChangeImageSourceURLSizePrefix(@"//upload.wikimedia.org/wikipedia/commons/d/d0/Gerald_Ford_-_NARA_-_530680.tif", 240),
                is(equalTo(@"//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page1-240px-Gerald_Ford_-_NARA_-_530680.tif.jpg")));
+}
+
+- (void)testSizePrefixWhenCanonicalFileIsTIF_lossless {
+    NSString* testURL = @"//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossless-page1-220px-Gerald_Ford_-_NARA_-_530680.tif.png";
+    XCTAssertEqual(WMFParseSizePrefixFromSourceURL(testURL), 220);
+}
+
+- (void)testParseCanonicalFileNameWhenCanonicalFileIsTIF_lossless {
+    NSString* testURLString = @"https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossless-page1-220px-Gerald_Ford_-_NARA_-_530680.tif.png";
+    assertThat(WMFParseImageNameFromSourceURL(testURLString),
+               is(equalTo(@"Gerald_Ford_-_NARA_-_530680.tif")));
+}
+
+- (void)testSizePrefixChangeWhenCanonicalFileIsTIFWithSizePrefix_lossless {
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossless-page1-220px-Gerald_Ford_-_NARA_-_530680.tif.png", 480),
+               is(equalTo(@"https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossless-page1-480px-Gerald_Ford_-_NARA_-_530680.tif.png")));
+}
+
+- (void)testSizePrefixChangeWhenCanonicalFileIsTIFWithSizePrefixPage2_lossless {
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossless-page2-220px-Gerald_Ford_-_NARA_-_530680.tif.png", 480),
+               is(equalTo(@"//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossless-page2-480px-Gerald_Ford_-_NARA_-_530680.tif.png"))); //Note: this page2 variant doesn't actually exist.
 }
 
 @end

--- a/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
+++ b/WikipediaUnitTests/Code/WMFImageURLParsingTests.m
@@ -223,4 +223,30 @@
     //                      ^ the canonical image has the size in the file name, so "300px-" is correct here.
 }
 
+- (void)testSizePrefixWhenCanonicalFileIsTIF {
+    NSString* testURL = @"//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page1-220px-Gerald_Ford_-_NARA_-_530680.tif.jpg";
+    XCTAssertEqual(WMFParseSizePrefixFromSourceURL(testURL), 220);
+}
+
+- (void)testParseCanonicalFileNameWhenCanonicalFileIsTIF {
+    NSString* testURLString = @"https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page1-220px-Gerald_Ford_-_NARA_-_530680.tif.jpg";
+    assertThat(WMFParseImageNameFromSourceURL(testURLString),
+               is(equalTo(@"Gerald_Ford_-_NARA_-_530680.tif")));
+}
+
+- (void)testSizePrefixChangeWhenCanonicalFileIsTIFWithSizePrefix {
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page1-220px-Gerald_Ford_-_NARA_-_530680.tif.jpg", 480),
+               is(equalTo(@"https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page1-480px-Gerald_Ford_-_NARA_-_530680.tif.jpg")));
+}
+
+- (void)testSizePrefixChangeWhenCanonicalFileIsTIFWithSizePrefixPage2 {
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page2-220px-Gerald_Ford_-_NARA_-_530680.tif.jpg", 480),
+               is(equalTo(@"//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page2-480px-Gerald_Ford_-_NARA_-_530680.tif.jpg"))); //Note: this page2 variant doesn't actually exist.
+}
+
+- (void)testSizePrefixChangeWhenCanonicalFileIsTIFWithoutSizePrefix {
+    assertThat(WMFChangeImageSourceURLSizePrefix(@"//upload.wikimedia.org/wikipedia/commons/d/d0/Gerald_Ford_-_NARA_-_530680.tif", 240),
+               is(equalTo(@"//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Gerald_Ford_-_NARA_-_530680.tif/lossy-page1-240px-Gerald_Ford_-_NARA_-_530680.tif.jpg")));
+}
+
 @end


### PR DESCRIPTION
**See phab ticket for details:**
https://phabricator.wikimedia.org/T140854

----

**TODO:**

- [x] check other file type handlers to see if there are other type-specific thumbnailer url syntaxes we need to handle. 

----

**RELEVANT MEDIAWIKI CODE:**

Mediawiki core appears to deal with common image type thumbnailing (jpg, png etc) with:
https://github.com/wikimedia/mediawiki/blob/master/thumb.php

Checked the following extensions list:
https://www.mediawiki.org/wiki/Category:Extensions_used_on_Wikimedia

From the list above these 2 seemed the relevant ones:
https://www.mediawiki.org/wiki/Extension:PdfHandler
https://www.mediawiki.org/wiki/Extension:PagedTiffHandler

----

**RESULTS:**

By examining the PagedTiffHandler, noticed "lossless" "png" syntax which needed to be supported in addition to the "lossy" "jpg" syntax.