### PR TITLE
Fix bug where the search results aren't updated on the first view of …

### DIFF
--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -692,20 +692,20 @@ static NSString* const WMFDidShowOnboarding = @"DidShowOnboarding5.0";
                 WMFExploreViewController* exploreViewController = (WMFExploreViewController*)[self exploreViewController];
                 [exploreViewController scrollToTop];
             }
-                break;
+            break;
             case WMFAppTabTypeSaved: {
-                WMFArticleListTableViewController *savedArticlesViewController = (WMFArticleListTableViewController *)[self savedArticlesViewController];
+                WMFArticleListTableViewController* savedArticlesViewController = (WMFArticleListTableViewController*)[self savedArticlesViewController];
                 [savedArticlesViewController scrollToTop:savedArticlesViewController.dataStore.userDataStore.savedPageList.countOfEntries > 0];
             }
-                break;
+            break;
             case WMFAppTabTypeRecent: {
-                WMFArticleListTableViewController *historyArticlesViewController = (WMFArticleListTableViewController *)[self recentArticlesViewController];
+                WMFArticleListTableViewController* historyArticlesViewController = (WMFArticleListTableViewController*)[self recentArticlesViewController];
                 [historyArticlesViewController scrollToTop:historyArticlesViewController.dataStore.userDataStore.historyList.countOfEntries > 0];
             }
-                break;
+            break;
         }
     }
-    
+
     return YES;
 }
 

--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -203,6 +203,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
         self.otherLanguagesButton.titleLabel.font = [UIFont wmf_subtitle];
 
         [self updateLanguageBarLanguages];
+        [self selectLanguageForURL:[self currentlySelectedSearchURL]];
     } else {
         [self.languageBarContainer removeFromSuperview];
         [self.searchContentContainer mas_makeConstraints:^(MASConstraintMaker* make) {
@@ -247,6 +248,9 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
         [self.view layoutIfNeeded];
         [self.searchField becomeFirstResponder];
     } completion:nil];
+    
+    
+    
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -573,8 +577,12 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
             }];
         }
     }];
+    
     NSString* query = self.searchField.text;
-    [self searchForSearchTerm:query];
+    
+    if(![url isEqual:[self.resultsListController.dataSource searchSiteURL]] || [query isEqualToString:[self.resultsListController.dataSource searchResults].searchTerm]){
+        [self searchForSearchTerm:query];
+    }
 }
 
 - (void)selectLanguageForButton:(UIButton*)button {

--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -565,18 +565,26 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 }
 
 - (void)selectLanguageForURL:(NSURL*)url {
+    __block BOOL foundLanguageInBar = NO;
     [[self languageBarLanguages] enumerateObjectsUsingBlock:^(MWKLanguageLink* _Nonnull language, NSUInteger idx, BOOL* _Nonnull stop) {
         if ([[language siteURL] isEqual:url]) {
             UIButton* buttonToSelect = self.languageButtons[idx];
             [self.languageButtons enumerateObjectsUsingBlock:^(UIButton* _Nonnull obj, NSUInteger idx, BOOL* _Nonnull stop) {
                 if (obj == buttonToSelect) {
                     [obj setSelected:YES];
+                    foundLanguageInBar = YES;
                 } else {
                     [obj setSelected:NO];
                 }
             }];
         }
     }];
+    
+    //If we didn't find the last selected Language, jsut select the first one
+    if(!foundLanguageInBar){
+        [self setSelectedLanguage:[[self languageBarLanguages] firstObject]];
+        return;
+    }
     
     NSString* query = self.searchField.text;
     

--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -635,7 +635,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
         [self updateLanguageBarLanguages];
     }
     
-    [self selectLanguageForURL:language.siteURL];
+    [self setSelectedLanguage:language];
     [controller dismissViewControllerAnimated:YES completion:NULL];
 }
 


### PR DESCRIPTION
…the search screen

https://phabricator.wikimedia.org/T139103

2 issues:
Didn't update the language bar when the search results re-appear
Didn't update the results weren't updated for the new language.

Now whenever the view comes back on screen, we reselect the last selected language
Then check to see if the language is different from the displayed results, and if it is we run the search again