### PR TITLE
build: Update PROD_CSS_PREFIX to wikipedia.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ exec-check:  ##Check that executable dependencies are installed
 web: ##Make web assets
 web: css grunt
 
-PROD_CSS_PREFIX="http://bits.wikimedia.org/en.wikipedia.org"
+PROD_CSS_PREFIX="https://en.wikipedia.org/w"
 LOCAL_CSS_PREFIX="http://127.0.0.1:8080/w"
 
 # Switch to LOCAL_CSS_PREFIX when testing CSS changes in a local MW instance (in vagrant).


### PR DESCRIPTION
The internal bits.wikimedia.org domain has been deprecated and is on its way to be decommissioned.

See https://phabricator.wikimedia.org/T107430 for more info.