### PR TITLE
set GCDWebServer log level to warning

### DIFF
--- a/Wikipedia/Code/WMFProxyServer.m
+++ b/Wikipedia/Code/WMFProxyServer.m
@@ -34,6 +34,7 @@
     static dispatch_once_t onceToken;
     static WMFProxyServer* sharedProxyServer;
     dispatch_once(&onceToken, ^{
+        [GCDWebServer setLogLevel:3]; // 3 = Warning
         sharedProxyServer = [[WMFProxyServer alloc] init];
     });
     return sharedProxyServer;


### PR DESCRIPTION
to reduce log spam, make debugging on older devices more tolerable