### PR TITLE
Increase max random items in explore to 10.

### DIFF
--- a/Wikipedia/Code/WMFExploreSection.m
+++ b/Wikipedia/Code/WMFExploreSection.m
@@ -238,10 +238,10 @@ NS_ASSUME_NONNULL_BEGIN
         case WMFExploreSectionTypeMostRead:
         case WMFExploreSectionTypeNearby:
         case WMFExploreSectionTypePictureOfTheDay:
+        case WMFExploreSectionTypeRandom:
             return 10;
             break;
         case WMFExploreSectionTypeContinueReading:
-        case WMFExploreSectionTypeRandom:
         case WMFExploreSectionTypeMainPage:
             return 1;
             break;

--- a/Wikipedia/Code/WMFExploreSectionSchema.m
+++ b/Wikipedia/Code/WMFExploreSectionSchema.m
@@ -205,6 +205,9 @@ static CLLocationDistance const WMFMinimumDistanceBeforeUpdatingNearby = 500.0;
     NSMutableArray<WMFExploreSection*>* sections = [[self staticSections] mutableCopy];
 
     [sections addObjectsFromArray:[self featuredSections]];
+
+    [sections addObjectsFromArray:[self randomSections]];
+
     [sections addObjectsFromArray:[self mostReadSectionsWithUpdateIfNeeded]];
     [sections addObjectsFromArray:[self nearbySections]];
 
@@ -326,7 +329,6 @@ static CLLocationDistance const WMFMinimumDistanceBeforeUpdatingNearby = 500.0;
 - (NSArray<WMFExploreSection*>*)staticSections {
     NSMutableArray<WMFExploreSection*>* sections = [NSMutableArray array];
 
-    [sections wmf_safeAddObject:[self randomSection]];
     [sections addObject:[self mainPageSection]];
     [sections wmf_safeAddObject:[self continueReadingSection]];
 
@@ -352,6 +354,34 @@ static CLLocationDistance const WMFMinimumDistanceBeforeUpdatingNearby = 500.0;
     }
 
     return random;
+}
+
+- (NSArray<WMFExploreSection*>*)randomSections {
+    NSArray* existingRandomArticleSections = [self.sections bk_select:^BOOL (WMFExploreSection* obj) {
+        return obj.type == WMFExploreSectionTypeRandom;
+    }];
+    
+    NSMutableArray* randomArray = [existingRandomArticleSections mutableCopy];
+    
+    BOOL const containsTodaysRandomArticle = [randomArray bk_any:^BOOL (WMFExploreSection* obj) {
+        NSAssert(obj.type == WMFExploreSectionTypeRandom,
+                 @"List should only contain random sections, got %@", randomArray);
+        return [obj.dateCreated isToday];
+    }];
+    
+    if (!containsTodaysRandomArticle) {
+        [randomArray wmf_safeAddObject:[self randomSection]];
+    }
+    
+    NSUInteger max = FBTweakValue(@"Explore", @"Sections", @"Max number of random", [WMFExploreSection maxNumberOfSectionsForType:WMFExploreSectionTypeRandom]);
+    
+    //Sort by date
+    [randomArray sortWithOptions:NSSortStable
+              usingComparator:^NSComparisonResult (WMFExploreSection* _Nonnull obj1, WMFExploreSection* _Nonnull obj2) {
+                  return -[obj1.dateCreated compare:obj2.dateCreated];
+              }];
+    
+    return [randomArray wmf_arrayByTrimmingToLength:max];
 }
 
 - (NSArray<WMFExploreSection*>*)nearbySections {

--- a/Wikipedia/Code/WMFExploreSectionSchema.m
+++ b/Wikipedia/Code/WMFExploreSectionSchema.m
@@ -335,27 +335,6 @@ static CLLocationDistance const WMFMinimumDistanceBeforeUpdatingNearby = 500.0;
     return sections;
 }
 
-- (WMFExploreSection*)randomSection {
-    WMFExploreSection* random = [self.sections bk_match:^BOOL (WMFExploreSection* obj) {
-        if (obj.type == WMFExploreSectionTypeRandom && [obj.siteURL isEqual:self.siteURL]) {
-            return YES;
-        }
-        return NO;
-    }];
-
-    MWKHistoryEntry* lastEntry = [self.historyPages mostRecentEntry];
-    if (lastEntry && [[NSDate date] timeIntervalSinceDate:lastEntry.dateViewed] > WMFTimeBeforeRefreshingRandom) {
-        random = [WMFExploreSection randomSectionWithSiteURL:self.siteURL];
-    }
-
-    //Always return a random section
-    if (!random) {
-        random = [WMFExploreSection randomSectionWithSiteURL:self.siteURL];
-    }
-
-    return random;
-}
-
 - (NSArray<WMFExploreSection*>*)randomSections {
     NSArray* existingRandomArticleSections = [self.sections bk_select:^BOOL (WMFExploreSection* obj) {
         return obj.type == WMFExploreSectionTypeRandom;
@@ -370,7 +349,7 @@ static CLLocationDistance const WMFMinimumDistanceBeforeUpdatingNearby = 500.0;
     }];
     
     if (!containsTodaysRandomArticle) {
-        [randomArray wmf_safeAddObject:[self randomSection]];
+        [randomArray wmf_safeAddObject:[WMFExploreSection randomSectionWithSiteURL:self.siteURL]];
     }
     
     NSUInteger max = FBTweakValue(@"Explore", @"Sections", @"Max number of random", [WMFExploreSection maxNumberOfSectionsForType:WMFExploreSectionTypeRandom]);

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -290,6 +290,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)viewDidLoad {
     [super viewDidLoad];
 
+//TEMP for testing...
+    self.view.layer.affineTransform = CGAffineTransformMakeScale(0.5, 0.5);
+    
     self.refreshControl = [[UIRefreshControl alloc] init];
     [self.refreshControl bk_addEventHandler:^(id sender) {
         [self updateSectionSchemaForce:YES];

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -290,9 +290,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-//TEMP for testing...
-    self.view.layer.affineTransform = CGAffineTransformMakeScale(0.5, 0.5);
-    
     self.refreshControl = [[UIRefreshControl alloc] init];
     [self.refreshControl bk_addEventHandler:^(id sender) {
         [self updateSectionSchemaForce:YES];


### PR DESCRIPTION
https://phabricator.wikimedia.org/T140779

I've been testing this by setting the explore VC's view layer scale to 0.5 so I can see more items onscreen at once.

I set my laptop's calendar back a few days, then restarted the app. Then moved the calendar one day forward and restarted the app, then repeated this step a few times. 

Problems I need to fix yet:
- [x] even though multiple random entries are now appearing in the feed they all show the same article after restart and this article is different after each restart (individual articles are not being remembered)
- [x] tapping refresh on any one of the random items only causes the 1st random item to refresh (even if that's not the one you tapped refresh on)

^ these shouldn't be to tricky to fix, but I'll need more time Monday.