### PR TITLE
Minor TOC style updates

### DIFF
--- a/Wikipedia/Code/UIColor+WMFStyle.m
+++ b/Wikipedia/Code/UIColor+WMFStyle.m
@@ -149,7 +149,7 @@
 
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        c = [UIColor colorWithRed:0.4 green:0.4 blue:0.4 alpha:1];
+        c = [UIColor colorWithRed:85.0/255.0 green:90.0/255.0 blue:95.0/255.0 alpha:1];
     });
     return c;
 }

--- a/Wikipedia/Code/WMFTableOfContentsHeader.xib
+++ b/Wikipedia/Code/WMFTableOfContentsHeader.xib
@@ -22,7 +22,7 @@
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="oF1-jo-N7w" secondAttribute="trailing" id="S5z-Bd-dAa"/>
                 <constraint firstItem="oF1-jo-N7w" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="V9E-eY-960"/>
-                <constraint firstAttribute="bottom" secondItem="oF1-jo-N7w" secondAttribute="bottom" constant="12" id="ayl-SF-Uiv"/>
+                <constraint firstAttribute="bottom" secondItem="oF1-jo-N7w" secondAttribute="bottom" constant="5" id="ayl-SF-Uiv"/>
                 <constraint firstItem="oF1-jo-N7w" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="30" id="j0J-ho-Jo4"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>


### PR DESCRIPTION
- reduced space between “CONTENTS” heading and first section header
- updated color of the subsection text to rub (85,90,95)