### PR TITLE
Expand continue reading and top read widget text fields if no image.

### DIFF
--- a/ContinueReadingWidget/Base.lproj/MainInterface.storyboard
+++ b/ContinueReadingWidget/Base.lproj/MainInterface.storyboard
@@ -22,6 +22,7 @@
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="af3-Uc-bMS">
                                 <constraints>
+                                    <constraint firstAttribute="width" priority="999" id="4Nd-ZK-qSB"/>
                                     <constraint firstAttribute="width" secondItem="af3-Uc-bMS" secondAttribute="height" multiplier="1:1" id="7cr-os-XYp"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
@@ -114,10 +115,10 @@
                             <constraint firstItem="CwR-CM-SDN" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leadingMargin" id="Yqs-Mz-SgU"/>
                             <constraint firstItem="3Uu-vI-59e" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leadingMargin" id="YxV-va-6jY"/>
                             <constraint firstAttribute="trailing" secondItem="BSk-BH-jRq" secondAttribute="trailing" id="ZUD-Y6-aY4"/>
+                            <constraint firstItem="CwR-CM-SDN" firstAttribute="width" secondItem="vq4-5M-Tnk" secondAttribute="width" id="dlu-4c-Js5"/>
                             <constraint firstAttribute="trailingMargin" secondItem="af3-Uc-bMS" secondAttribute="trailing" id="eXn-dd-RUF"/>
                             <constraint firstItem="FKl-LY-JtV" firstAttribute="top" secondItem="af3-Uc-bMS" secondAttribute="bottom" constant="10" id="jeM-R7-CaC"/>
                             <constraint firstItem="vq4-5M-Tnk" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leadingMargin" id="n9q-aN-sgE"/>
-                            <constraint firstItem="af3-Uc-bMS" firstAttribute="leading" secondItem="CwR-CM-SDN" secondAttribute="trailing" constant="10" id="oxe-BC-EHi"/>
                             <constraint firstItem="ZR6-x7-9Of" firstAttribute="trailing" secondItem="S3S-Oj-5AN" secondAttribute="trailingMargin" id="pFm-6j-Ldv"/>
                             <constraint firstItem="af3-Uc-bMS" firstAttribute="leading" secondItem="vq4-5M-Tnk" secondAttribute="trailing" constant="10" id="pVG-3w-TAN"/>
                             <constraint firstItem="FKl-LY-JtV" firstAttribute="top" secondItem="BSk-BH-jRq" secondAttribute="bottom" id="qB8-lW-aTH"/>
@@ -136,9 +137,12 @@
                         <outlet property="emptyDescriptionLabel" destination="rMd-L0-hne" id="3kP-dD-tib"/>
                         <outlet property="emptyTitleLabel" destination="Ejf-xt-rvu" id="osb-La-67R"/>
                         <outlet property="emptyView" destination="ZR6-x7-9Of" id="p6Z-LW-3nv"/>
+                        <outlet property="imageAspectRatioConstraint" destination="7cr-os-XYp" id="lRN-bu-5ul"/>
                         <outlet property="imageView" destination="af3-Uc-bMS" id="91S-oM-RCp"/>
+                        <outlet property="imageZeroWidthConstraint" destination="4Nd-ZK-qSB" id="pEv-kP-lYb"/>
                         <outlet property="textLabel" destination="CwR-CM-SDN" id="wXQ-Lk-zcc"/>
                         <outlet property="titleLabel" destination="vq4-5M-Tnk" id="zJ9-bC-g8G"/>
+                        <outlet property="titleLabelTrailingConstraint" destination="pVG-3w-TAN" id="Ap3-Lq-h0z"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/ContinueReadingWidget/WMFTodayContinueReadingWidgetViewController.swift
+++ b/ContinueReadingWidget/WMFTodayContinueReadingWidgetViewController.swift
@@ -14,6 +14,10 @@ class WMFTodayContinueReadingWidgetViewController: UIViewController, NCWidgetPro
     @IBOutlet weak var emptyTitleLabel: UILabel!
     @IBOutlet weak var emptyDescriptionLabel: UILabel!
 
+    @IBOutlet var imageAspectRatioConstraint: NSLayoutConstraint!
+    @IBOutlet var imageZeroWidthConstraint: NSLayoutConstraint!
+    @IBOutlet var titleLabelTrailingConstraint: NSLayoutConstraint!
+    
     var articleURL: NSURL?
     
     override func viewDidLoad() {
@@ -50,6 +54,16 @@ class WMFTodayContinueReadingWidgetViewController: UIViewController, NCWidgetPro
             daysAgoView.hidden = !emptyViewHidden
         }
     }
+
+    var collapseImageAndWidenLabels: Bool = true {
+        didSet {
+            imageAspectRatioConstraint.active = !collapseImageAndWidenLabels
+            imageZeroWidthConstraint.active = collapseImageAndWidenLabels
+            titleLabelTrailingConstraint.constant = collapseImageAndWidenLabels ? 0 : 10
+            self.imageView.alpha = self.collapseImageAndWidenLabels ? 0 : 1
+            self.view.layoutIfNeeded()
+        }
+    }
     
     func hasNewData() -> Bool{
         
@@ -82,6 +96,7 @@ class WMFTodayContinueReadingWidgetViewController: UIViewController, NCWidgetPro
         textLabel.text = nil
         titleLabel.text = nil
         imageView.image = nil
+        collapseImageAndWidenLabels = true
         imageView.hidden = true
         daysAgoLabel.text = nil
         daysAgoView.hidden = true
@@ -130,9 +145,9 @@ class WMFTodayContinueReadingWidgetViewController: UIViewController, NCWidgetPro
         if let string = article.imageURL, let imageURL = NSURL(string: string) {
             self.imageView.hidden = false
             self.imageView.wmf_setImageWithURL(imageURL, detectFaces: true, onGPU: true, failure: { (error) in
-                
+                self.collapseImageAndWidenLabels = true
             }) {
-                
+                self.collapseImageAndWidenLabels = false
             }
         }
         

--- a/TopReadWidget/WMFTodayTopReadWidgetViewController.swift
+++ b/TopReadWidget/WMFTodayTopReadWidgetViewController.swift
@@ -206,7 +206,11 @@ class WMFTodayTopReadWidgetViewController: UIViewController, NCWidgetProviding {
                 vc.viewCountAndSparklineContainerView.hidden = true
             }
             if let imageURL = result.thumbnailURL {
-                vc.imageView.wmf_setImageWithURL(imageURL, detectFaces: true, onGPU: true, failure: WMFIgnoreErrorHandler, success: WMFIgnoreSuccessHandler)
+                vc.imageView.wmf_setImageWithURL(imageURL, detectFaces: true, onGPU: true, failure: { (error) in
+                    vc.collapseImageAndWidenLabels = true
+                }) {
+                    vc.collapseImageAndWidenLabels = false
+                }
             }
             if i == (count - 1) {
                 vc.separatorView.hidden = true

--- a/Wikipedia/Code/WMFArticlePreviewViewController.swift
+++ b/Wikipedia/Code/WMFArticlePreviewViewController.swift
@@ -11,6 +11,9 @@ public class WMFArticlePreviewViewController: UIViewController {
     @IBOutlet weak public var viewCountLabel: UILabel!
     @IBOutlet weak public var sparklineView: WMFSparklineView!
     
+    @IBOutlet var imageWidthConstraint: NSLayoutConstraint!
+    @IBOutlet var subtitleLabelTrailingConstraint: NSLayoutConstraint!
+
     public required init() {
         let bundle = NSBundle(identifier: "org.wikimedia.WMFUI")
         super.init(nibName: "WMFArticlePreviewViewController", bundle: bundle)
@@ -26,4 +29,16 @@ public class WMFArticlePreviewViewController: UIViewController {
         separatorView.backgroundColor = UIColor.wmf_darkGray()
     }
 
+    public override func awakeFromNib() {
+        collapseImageAndWidenLabels = true
+    }
+    
+    public var collapseImageAndWidenLabels: Bool = true {
+        didSet {
+            imageWidthConstraint.constant = collapseImageAndWidenLabels ? 0 : 80
+            subtitleLabelTrailingConstraint.constant = collapseImageAndWidenLabels ? 0 : 8
+            self.imageView.alpha = self.collapseImageAndWidenLabels ? 0 : 1
+            self.view.layoutIfNeeded()
+        }
+    }
 }

--- a/Wikipedia/Code/WMFArticlePreviewViewController.xib
+++ b/Wikipedia/Code/WMFArticlePreviewViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11198.2" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -8,10 +8,12 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="WMFArticlePreviewViewController">
             <connections>
                 <outlet property="imageView" destination="sBV-nz-BRl" id="wNL-uY-r8g"/>
+                <outlet property="imageWidthConstraint" destination="8QF-Lg-cIG" id="4sW-WV-Szz"/>
                 <outlet property="rankLabel" destination="8p9-Hg-81S" id="EA6-S9-EwZ"/>
                 <outlet property="separatorView" destination="xnh-wl-RXW" id="7Cd-KF-RX3"/>
                 <outlet property="sparklineView" destination="vap-0K-H1T" id="qNY-da-Zzw"/>
                 <outlet property="subtitleLabel" destination="tGB-R2-1JO" id="3cy-Z7-BNS"/>
+                <outlet property="subtitleLabelTrailingConstraint" destination="dq3-MQ-cPm" id="JQ8-mq-XMv"/>
                 <outlet property="titleLabel" destination="3sD-Qs-JfB" id="cDK-az-uMN"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
                 <outlet property="viewCountAndSparklineContainerView" destination="6G4-5v-LNq" id="AH7-gc-8zC"/>


### PR DESCRIPTION
-----
The `continue reading` and `top read` cells are a bit different - I tried to keep this diff as minimal as possible. Can DRY up things in the future.

-----

# Top Read and Continue Reading with images
![screen shot 2016-09-09 at 11 43 29 pm](https://cloud.githubusercontent.com/assets/3143487/18408576/57a4bdea-76e8-11e6-8b3f-e084e2ccf354.png)

# Continue Reading without image with text fields extending to right edge
![screen shot 2016-09-09 at 11 44 43 pm](https://cloud.githubusercontent.com/assets/3143487/18408577/57d4e68c-76e8-11e6-94e1-7ae48c4731be.png)

# Top Read without image with text fields extending to right edge (see the last item - I faked out not having an image url for that cell)
![screen shot 2016-09-09 at 11 50 58 pm](https://cloud.githubusercontent.com/assets/3143487/18408578/57d8c66c-76e8-11e6-9781-b00cb3e98b64.png)