### PR TITLE
Fix crash when accessing toc cells before the view is loaded

### DIFF
--- a/Wikipedia/Code/WMFTableOfContentsViewController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsViewController.swift
@@ -42,6 +42,10 @@ public class WMFTableOfContentsViewController: UIViewController,
         tv.delegate = self
         tv.dataSource = self
         tv.backgroundView = nil
+
+        //add to the view now to ensure view did load is kicked off
+        self.view.addSubview(tv)
+
         return tv
     }()
 
@@ -171,7 +175,6 @@ public class WMFTableOfContentsViewController: UIViewController,
     public override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.view.addSubview(tableView)
         tableView.mas_makeConstraints { make in
             make.top.bottom().leading().and().trailing().equalTo()(self.view)
         }


### PR DESCRIPTION
Not able to repro, but the crash is due to asking the table view for cells before we registered
This is a side affect of the toc tableview not being self.vew
Since its not, accessing the table view does NOT automatically load the view and trigger viewDidLoad
The fix is making sure we access self.view when we create the table view

https://phabricator.wikimedia.org/T145277
https://rink.hockeyapp.net/manage/apps/152731/app_versions/79/crash_reasons/134953367?type=crashes