### PR TITLE
More widget visual tweaks

### DIFF
--- a/ContinueReadingWidget/Base.lproj/MainInterface.storyboard
+++ b/ContinueReadingWidget/Base.lproj/MainInterface.storyboard
@@ -3,7 +3,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -22,8 +21,8 @@
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="af3-Uc-bMS">
                                 <constraints>
-                                    <constraint firstAttribute="width" priority="999" id="4Nd-ZK-qSB"/>
-                                    <constraint firstAttribute="width" secondItem="af3-Uc-bMS" secondAttribute="height" multiplier="1:1" id="7cr-os-XYp"/>
+                                    <constraint firstAttribute="height" constant="86" id="Nz9-5s-phP"/>
+                                    <constraint firstAttribute="width" constant="86" id="tPS-cg-OC1"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -105,7 +104,6 @@
                         <constraints>
                             <constraint firstItem="vq4-5M-Tnk" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" constant="10" id="2e4-f1-47H"/>
                             <constraint firstItem="3Uu-vI-59e" firstAttribute="top" relation="greaterThanOrEqual" secondItem="CwR-CM-SDN" secondAttribute="bottom" constant="5" id="4Lb-rh-iGP"/>
-                            <constraint firstItem="af3-Uc-bMS" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" constant="10" id="60z-FL-ImQ"/>
                             <constraint firstItem="ZR6-x7-9Of" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leadingMargin" id="65O-ga-KaL"/>
                             <constraint firstItem="FKl-LY-JtV" firstAttribute="top" secondItem="3Uu-vI-59e" secondAttribute="bottom" constant="10" id="9ub-W2-dPU"/>
                             <constraint firstItem="ZR6-x7-9Of" firstAttribute="centerY" secondItem="S3S-Oj-5AN" secondAttribute="centerY" id="BQN-qh-xVn"/>
@@ -116,12 +114,12 @@
                             <constraint firstItem="3Uu-vI-59e" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leadingMargin" id="YxV-va-6jY"/>
                             <constraint firstAttribute="trailing" secondItem="BSk-BH-jRq" secondAttribute="trailing" id="ZUD-Y6-aY4"/>
                             <constraint firstItem="CwR-CM-SDN" firstAttribute="width" secondItem="vq4-5M-Tnk" secondAttribute="width" id="dlu-4c-Js5"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="af3-Uc-bMS" secondAttribute="trailing" id="eXn-dd-RUF"/>
-                            <constraint firstItem="FKl-LY-JtV" firstAttribute="top" secondItem="af3-Uc-bMS" secondAttribute="bottom" constant="10" id="jeM-R7-CaC"/>
+                            <constraint firstAttribute="trailing" secondItem="af3-Uc-bMS" secondAttribute="trailing" constant="15" id="mWN-ky-uf3"/>
                             <constraint firstItem="vq4-5M-Tnk" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leadingMargin" id="n9q-aN-sgE"/>
                             <constraint firstItem="ZR6-x7-9Of" firstAttribute="trailing" secondItem="S3S-Oj-5AN" secondAttribute="trailingMargin" id="pFm-6j-Ldv"/>
-                            <constraint firstItem="af3-Uc-bMS" firstAttribute="leading" secondItem="vq4-5M-Tnk" secondAttribute="trailing" constant="10" id="pVG-3w-TAN"/>
+                            <constraint firstItem="af3-Uc-bMS" firstAttribute="leading" secondItem="vq4-5M-Tnk" secondAttribute="trailing" constant="8" id="pVG-3w-TAN"/>
                             <constraint firstItem="FKl-LY-JtV" firstAttribute="top" secondItem="BSk-BH-jRq" secondAttribute="bottom" id="qB8-lW-aTH"/>
+                            <constraint firstItem="af3-Uc-bMS" firstAttribute="centerY" secondItem="S3S-Oj-5AN" secondAttribute="centerY" id="raJ-27-DZf"/>
                             <constraint firstItem="BSk-BH-jRq" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" id="slu-kn-2dO"/>
                         </constraints>
                     </view>
@@ -137,9 +135,8 @@
                         <outlet property="emptyDescriptionLabel" destination="rMd-L0-hne" id="3kP-dD-tib"/>
                         <outlet property="emptyTitleLabel" destination="Ejf-xt-rvu" id="osb-La-67R"/>
                         <outlet property="emptyView" destination="ZR6-x7-9Of" id="p6Z-LW-3nv"/>
-                        <outlet property="imageAspectRatioConstraint" destination="7cr-os-XYp" id="lRN-bu-5ul"/>
                         <outlet property="imageView" destination="af3-Uc-bMS" id="91S-oM-RCp"/>
-                        <outlet property="imageZeroWidthConstraint" destination="4Nd-ZK-qSB" id="pEv-kP-lYb"/>
+                        <outlet property="imageWidthConstraint" destination="tPS-cg-OC1" id="Kg2-hi-pfg"/>
                         <outlet property="textLabel" destination="CwR-CM-SDN" id="wXQ-Lk-zcc"/>
                         <outlet property="titleLabel" destination="vq4-5M-Tnk" id="zJ9-bC-g8G"/>
                         <outlet property="titleLabelTrailingConstraint" destination="pVG-3w-TAN" id="Ap3-Lq-h0z"/>

--- a/ContinueReadingWidget/WMFTodayContinueReadingWidgetViewController.swift
+++ b/ContinueReadingWidget/WMFTodayContinueReadingWidgetViewController.swift
@@ -14,8 +14,7 @@ class WMFTodayContinueReadingWidgetViewController: UIViewController, NCWidgetPro
     @IBOutlet weak var emptyTitleLabel: UILabel!
     @IBOutlet weak var emptyDescriptionLabel: UILabel!
 
-    @IBOutlet var imageAspectRatioConstraint: NSLayoutConstraint!
-    @IBOutlet var imageZeroWidthConstraint: NSLayoutConstraint!
+    @IBOutlet var imageWidthConstraint: NSLayoutConstraint!
     @IBOutlet var titleLabelTrailingConstraint: NSLayoutConstraint!
     
     var articleURL: NSURL?
@@ -57,8 +56,7 @@ class WMFTodayContinueReadingWidgetViewController: UIViewController, NCWidgetPro
 
     var collapseImageAndWidenLabels: Bool = true {
         didSet {
-            imageAspectRatioConstraint.active = !collapseImageAndWidenLabels
-            imageZeroWidthConstraint.active = collapseImageAndWidenLabels
+            imageWidthConstraint.constant = collapseImageAndWidenLabels ? 0 : 86
             titleLabelTrailingConstraint.constant = collapseImageAndWidenLabels ? 0 : 10
             self.imageView.alpha = self.collapseImageAndWidenLabels ? 0 : 1
             self.view.layoutIfNeeded()

--- a/Wikipedia/Code/WMFArticlePreviewViewController.swift
+++ b/Wikipedia/Code/WMFArticlePreviewViewController.swift
@@ -12,7 +12,7 @@ public class WMFArticlePreviewViewController: UIViewController {
     @IBOutlet weak public var sparklineView: WMFSparklineView!
     
     @IBOutlet var imageWidthConstraint: NSLayoutConstraint!
-    @IBOutlet var subtitleLabelTrailingConstraint: NSLayoutConstraint!
+    @IBOutlet var titleLabelTrailingConstraint: NSLayoutConstraint!
 
     public required init() {
         let bundle = NSBundle(identifier: "org.wikimedia.WMFUI")
@@ -33,10 +33,11 @@ public class WMFArticlePreviewViewController: UIViewController {
         collapseImageAndWidenLabels = true
     }
     
+    
     public var collapseImageAndWidenLabels: Bool = true {
         didSet {
-            imageWidthConstraint.constant = collapseImageAndWidenLabels ? 0 : 80
-            subtitleLabelTrailingConstraint.constant = collapseImageAndWidenLabels ? 0 : 8
+            imageWidthConstraint.constant = collapseImageAndWidenLabels ? 0 : 86
+            titleLabelTrailingConstraint.constant = collapseImageAndWidenLabels ? 0 : 8
             self.imageView.alpha = self.collapseImageAndWidenLabels ? 0 : 1
             self.view.layoutIfNeeded()
         }

--- a/Wikipedia/Code/WMFArticlePreviewViewController.xib
+++ b/Wikipedia/Code/WMFArticlePreviewViewController.xib
@@ -13,8 +13,8 @@
                 <outlet property="separatorView" destination="xnh-wl-RXW" id="7Cd-KF-RX3"/>
                 <outlet property="sparklineView" destination="vap-0K-H1T" id="qNY-da-Zzw"/>
                 <outlet property="subtitleLabel" destination="tGB-R2-1JO" id="3cy-Z7-BNS"/>
-                <outlet property="subtitleLabelTrailingConstraint" destination="dq3-MQ-cPm" id="JQ8-mq-XMv"/>
                 <outlet property="titleLabel" destination="3sD-Qs-JfB" id="cDK-az-uMN"/>
+                <outlet property="titleLabelTrailingConstraint" destination="0Dc-eJ-A6M" id="f2o-S0-sU9"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
                 <outlet property="viewCountAndSparklineContainerView" destination="6G4-5v-LNq" id="AH7-gc-8zC"/>
                 <outlet property="viewCountLabel" destination="Hxu-Xo-JQO" id="eFE-M3-Tea"/>
@@ -25,7 +25,7 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="136"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="sBV-nz-BRl">
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="sBV-nz-BRl">
                     <constraints>
                         <constraint firstAttribute="width" constant="86" id="8QF-Lg-cIG"/>
                         <constraint firstAttribute="height" constant="86" id="gwp-Md-Ur5"/>
@@ -91,10 +91,10 @@
             </subviews>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             <constraints>
+                <constraint firstItem="sBV-nz-BRl" firstAttribute="leading" secondItem="3sD-Qs-JfB" secondAttribute="trailing" constant="8" id="0Dc-eJ-A6M"/>
                 <constraint firstItem="sBV-nz-BRl" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="0uS-mw-tlE"/>
                 <constraint firstItem="3sD-Qs-JfB" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="35" id="4f9-jk-UAA" userLabel="ArticleVC Title Label Leading"/>
                 <constraint firstItem="8p9-Hg-81S" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="14" id="9A8-U2-H3W" userLabel="ArticleVC Rank Label Leading"/>
-                <constraint firstItem="sBV-nz-BRl" firstAttribute="top" relation="greaterThanOrEqual" secondItem="i5M-Pr-FkT" secondAttribute="top" priority="750" constant="14" id="Cr9-82-itP"/>
                 <constraint firstItem="xnh-wl-RXW" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="14" id="EWj-3S-e96"/>
                 <constraint firstItem="6G4-5v-LNq" firstAttribute="top" relation="greaterThanOrEqual" secondItem="tGB-R2-1JO" secondAttribute="bottom" constant="8" id="F5c-Pq-5GL"/>
                 <constraint firstItem="xnh-wl-RXW" firstAttribute="top" secondItem="6G4-5v-LNq" secondAttribute="bottom" constant="17" id="J1n-5m-vHU"/>
@@ -102,13 +102,11 @@
                 <constraint firstAttribute="bottom" secondItem="xnh-wl-RXW" secondAttribute="bottom" id="P8p-Ma-M5h"/>
                 <constraint firstItem="tGB-R2-1JO" firstAttribute="top" secondItem="3sD-Qs-JfB" secondAttribute="bottom" constant="2" id="TIt-oc-VCe" userLabel="ArticleVC Subtitle Label Top"/>
                 <constraint firstItem="8p9-Hg-81S" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="14" id="UcO-e5-K5U" userLabel="ArticleVC Rank Label Top"/>
-                <constraint firstItem="sBV-nz-BRl" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3sD-Qs-JfB" secondAttribute="trailing" priority="750" constant="14" id="cEs-2z-GxT"/>
-                <constraint firstAttribute="trailing" secondItem="sBV-nz-BRl" secondAttribute="trailing" constant="14" id="dDa-n0-3wG"/>
-                <constraint firstItem="sBV-nz-BRl" firstAttribute="leading" secondItem="tGB-R2-1JO" secondAttribute="trailing" constant="8" id="dq3-MQ-cPm"/>
+                <constraint firstAttribute="trailing" secondItem="sBV-nz-BRl" secondAttribute="trailing" constant="15" id="dDa-n0-3wG"/>
+                <constraint firstItem="tGB-R2-1JO" firstAttribute="trailing" secondItem="3sD-Qs-JfB" secondAttribute="trailing" id="dnp-xQ-THx"/>
                 <constraint firstItem="3sD-Qs-JfB" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="14" id="eKF-om-e13" userLabel="ArticleVC Title Label Top"/>
                 <constraint firstAttribute="trailing" secondItem="xnh-wl-RXW" secondAttribute="trailing" id="hZ1-Qp-sRR"/>
                 <constraint firstItem="tGB-R2-1JO" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="35" id="pcI-zM-erP"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="sBV-nz-BRl" secondAttribute="bottom" priority="750" constant="14" id="vIx-aM-iiu"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T142762#2625348

-----

- [x] Size of the Continue reading image should be the same as Top read articles' images. At the moment it is slightly bigger.

- [x] Continue reading image should be in the same position as the Top read articles' images. Actual: It is slightly closer to the left (ie., greater padding on the RHS).

- [x] Top read article images should be a square 86x86pt size. At the moment they are slightly narrower.

- [ ] <strike>Title of the expanded Top read widget (ie., where it says the Wikipedia language) should be in font type SF UI Display with the heavier font-weight Black (but still in the same color #555A5F)</strike> 
_For some reason IB won't let me pick SF... can figure this out later_

- [x] Sparkline should move to always be below the last line of text rather than being locked in the bottom LHS corner of each list item.

-----

![screen shot 2016-09-10 at 2 12 55 pm](https://cloud.githubusercontent.com/assets/3143487/18413586/b3c6067e-7760-11e6-9b35-81a9cdcb5cc9.png)