### PR TITLE
Non-edge swipe to show TOC.

### DIFF
--- a/Wikipedia/Code/WMFGeometry.c
+++ b/Wikipedia/Code/WMFGeometry.c
@@ -1,5 +1,6 @@
 #import "WMFGeometry.h"
-#include <CoreGraphics/CGAffineTransform.h>
+#import <CoreGraphics/CGAffineTransform.h>
+#import <math.h>
 
 #pragma mark - Aggregate Operations
 
@@ -61,4 +62,10 @@ CGAffineTransform WMFAffineCoreGraphicsToUIKitTransformMake(CGSize size) {
 
 CGAffineTransform WMFAffineUIKitToCoreGraphicsTransformMake(CGSize size) {
     return CGAffineTransformInvert(WMFAffineCoreGraphicsToUIKitTransformMake(size));
+}
+
+#pragma mark - Angle from velocity vector
+
+CGFloat WMFAbsoluteHorizontalAngleFromVelocityVector(CGPoint velocity) {
+    return (atan2(fabs(velocity.y), fabs(velocity.x)));
 }

--- a/Wikipedia/Code/WMFGeometry.h
+++ b/Wikipedia/Code/WMFGeometry.h
@@ -113,3 +113,9 @@ extern CGAffineTransform WMFAffineUIKitToCoreGraphicsTransformMake(CGSize size);
  * @note Inverse of `WMFAffineUIKitToCoreGraphicsTransformMake`
  */
 extern CGAffineTransform WMFAffineCoreGraphicsToUIKitTransformMake(CGSize size);
+
+/**
+ * @return Absolute angle from horizontal axis in radians.
+ *
+ */
+extern CGFloat WMFAbsoluteHorizontalAngleFromVelocityVector(CGPoint velocity);


### PR DESCRIPTION
https://phabricator.wikimedia.org/T145720

- Doesn't interfere with edge drag to go back or vertical article scrolling.
- Tuned to trigger if the swipe is fairly fast so as to not interfere with dragging horizontal overflow images from side-to-side.
- RTL ready.

Note: is not progressive drag.