### PR TITLE
ensure assets are available when needed

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -507,7 +507,6 @@
 		BCD557BB1C45B1600060A51A /* UIApplication+VisualTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = BCD557BA1C45B1600060A51A /* UIApplication+VisualTestUtils.m */; };
 		BCE839591BF14DB900F5BBA4 /* TitlePreviewQuery.json in Resources */ = {isa = PBXBuildFile; fileRef = BCE839581BF14DB900F5BBA4 /* TitlePreviewQuery.json */; };
 		BCE839781BF3C9BB00F5BBA4 /* ObamaImageElement.html in Resources */ = {isa = PBXBuildFile; fileRef = BCE839771BF3C9BB00F5BBA4 /* ObamaImageElement.html */; };
-		BCF012331AD2FA38008D3675 /* assets in Resources */ = {isa = PBXBuildFile; fileRef = BCF012321AD2FA38008D3675 /* assets */; };
 		BCF4553E1BCC73DB007C748A /* mobileview-preview.json in Resources */ = {isa = PBXBuildFile; fileRef = BCF4553C1BCC73BB007C748A /* mobileview-preview.json */; };
 		BCF73DA71BD064AD000A13DB /* 4.1.7 in Resources */ = {isa = PBXBuildFile; fileRef = BCF73DA61BD064AD000A13DB /* 4.1.7 */; };
 		BCF8DCA81B7009B100149C26 /* MobileView in Resources */ = {isa = PBXBuildFile; fileRef = BCF8DCA71B7009B100149C26 /* MobileView */; };
@@ -839,6 +838,7 @@
 		D8DC17001D6F718300D6D9FB /* NSURL+WMFMainPage.h in Headers */ = {isa = PBXBuildFile; fileRef = D8DC16FE1D6F718300D6D9FB /* NSURL+WMFMainPage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D8DC17011D6F718300D6D9FB /* NSURL+WMFMainPage.m in Sources */ = {isa = PBXBuildFile; fileRef = D8DC16FF1D6F718300D6D9FB /* NSURL+WMFMainPage.m */; };
 		D8E2B0F31D6CC5DE006FFB24 /* WMFImageURLParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = B0E807331C0CED810065EBC0 /* WMFImageURLParsing.m */; };
+		D8E4CCAA1D931CE100EB6C61 /* assets in CopyFiles */ = {isa = PBXBuildFile; fileRef = BCF012321AD2FA38008D3675 /* assets */; };
 		D8EA02E11D6CC9F5008E8A47 /* WMFRelatedSectionBlackList.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E331BF41C49647600DDE02A /* WMFRelatedSectionBlackList.m */; };
 		D8EA02E21D6CC9F8008E8A47 /* WMFRelatedSectionBlackList.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E331BF31C49647600DDE02A /* WMFRelatedSectionBlackList.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D8EC64031D007B1F00C286EE /* WMFLinkParsingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D8EC64021D007B1F00C286EE /* WMFLinkParsingTests.m */; };
@@ -954,6 +954,16 @@
 				D8AC392C1D6F2480007E3C14 /* WMFUI.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D8E4CCA91D931CDA00EB6C61 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 7;
+			files = (
+				D8E4CCAA1D931CE100EB6C61 /* assets in CopyFiles */,
+			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -6004,6 +6014,7 @@
 				D844D9671D6CB2600042D692 /* Sources */,
 				D844D9681D6CB2600042D692 /* Frameworks */,
 				D844D9691D6CB2600042D692 /* Headers */,
+				D8E4CCA91D931CDA00EB6C61 /* CopyFiles */,
 				6C76A39E89C19E71FCF71E81 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -6377,7 +6388,6 @@
 				B0B4CF0C1CC0501B0051DF7A /* WMFArticleLanguagesSectionHeader.xib in Resources */,
 				D8D270371D75D45B00D093A8 /* WMFArticleListTableViewCell.xib in Resources */,
 				0E69CD5B1C8773410095918B /* Launch Screen.storyboard in Resources */,
-				BCF012331AD2FA38008D3675 /* assets in Resources */,
 				B0E804121C0CDE480065EBC0 /* PreviewAndSaveViewController.storyboard in Resources */,
 				B0E806E41C0CEB930065EBC0 /* PreviewLicenseView.xib in Resources */,
 				B0E806EC1C0CEBA40065EBC0 /* RecentSearchCell.xib in Resources */,

--- a/Wikipedia/Code/WKWebView+LoadAssetsHtml.m
+++ b/Wikipedia/Code/WKWebView+LoadAssetsHtml.m
@@ -51,8 +51,7 @@ static const NSTimeInterval WKWebViewLoadAssetsHTMLRequestTimeout = 60; //60s is
 }
 
 - (NSString *)getAssetsPath {
-    NSString *containerPath = [[NSFileManager defaultManager] wmf_containerPath];
-    return [containerPath stringByAppendingPathComponent:@"assets"];
+    return [WikipediaAppUtils assetsPath];
 }
 
 @end

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -216,8 +216,6 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreScreen = 24 * 60 * 60;
 }
 
 - (void)launchAppInWindow:(UIWindow *)window {
-    [WikipediaAppUtils copyAssetsFolderToAppDataDocuments];
-
     WMFStyleManager *manager = [WMFStyleManager new];
     [manager applyStyleToWindow:window];
     [WMFStyleManager setSharedStyleManager:manager];

--- a/Wikipedia/Code/WMFAssetsFile.m
+++ b/Wikipedia/Code/WMFAssetsFile.m
@@ -23,7 +23,7 @@
 }
 
 - (NSString *)documentsAssetsPath {
-    return [[[NSFileManager defaultManager] wmf_containerPath] stringByAppendingPathComponent:@"assets"];
+    return [WikipediaAppUtils assetsPath];
 }
 
 - (NSString *)path {

--- a/Wikipedia/Code/WMFProxyServer.m
+++ b/Wikipedia/Code/WMFProxyServer.m
@@ -54,9 +54,7 @@
     NSString *secret = [[NSUUID UUID] UUIDString];
     self.secret = secret;
 
-    NSURL *documentsURL = [[NSFileManager defaultManager] wmf_containerURL];
-    NSURL *assetsURL = [documentsURL URLByAppendingPathComponent:@"assets"];
-    self.hostedFolderPath = assetsURL.path;
+    self.hostedFolderPath = [WikipediaAppUtils assetsPath];
 
     self.webServer = [[GCDWebServer alloc] init];
 

--- a/Wikipedia/Code/WikipediaAppUtils.h
+++ b/Wikipedia/Code/WikipediaAppUtils.h
@@ -12,6 +12,7 @@ WMF_TECH_DEBT_DEPRECATED_MSG("This class is deprecated, its methods should be br
 + (NSString *)versionedUserAgent;
 + (NSString *)languageNameForCode:(NSString *)code;
 
++ (NSString *)assetsPath;
 + (void)copyAssetsFolderToAppDataDocuments;
 
 @end

--- a/Wikipedia/Code/WikipediaAppUtils.m
+++ b/Wikipedia/Code/WikipediaAppUtils.m
@@ -6,6 +6,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation WikipediaAppUtils
 
++ (void)initialize {
+    if (self == [WikipediaAppUtils class]) {
+        [self copyAssetsFolderToAppDataDocuments];
+    }
+}
+
 + (void)load {
     [[NSNotificationCenter defaultCenter] addObserver:[self class] selector:@selector(didReceiveMemoryWarningWithNotification:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
 }
@@ -61,6 +67,14 @@ static WMFAssetsFile *languageFile = nil;
     }][@"name"];
 }
 
++ (NSString *)assetsPath {
+    return [[[NSFileManager defaultManager] wmf_containerPath] stringByAppendingPathComponent:@"assets"];
+}
+
++ (NSString *)bundledAssetsPath {
+    return [[NSBundle bundleWithIdentifier:@"org.wikimedia.WMFModel"] pathForResource:@"assets" ofType:nil];
+}
+
 #pragma mark Copy bundled assets folder and contents to app "AppData/Documents/assets/"
 
 + (void)copyAssetsFolderToAppDataDocuments {
@@ -93,10 +107,8 @@ static WMFAssetsFile *languageFile = nil;
        bundled file is always newer.
      */
 
-    NSString *folderName = @"assets";
-    NSString *containerPath = [[NSFileManager defaultManager] wmf_containerPath];
-    NSString *documentsPath = [containerPath stringByAppendingPathComponent:folderName];
-    NSString *bundledPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:folderName];
+    NSString *documentsPath = [self assetsPath];
+    NSString *bundledPath = [self bundledAssetsPath];
 
     void (^copy)(NSString *, NSString *) = ^void(NSString *path1, NSString *path2) {
         NSError *error = nil;

--- a/Wikipedia/Code/main.m
+++ b/Wikipedia/Code/main.m
@@ -26,13 +26,6 @@
     return _window;
 }
 
-- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions {
-    // HAX: usually session singleton does this, but we need to do it manually before any tests run to ensure
-    // things like languages.json are available
-    [WikipediaAppUtils copyAssetsFolderToAppDataDocuments];
-    return YES;
-}
-
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions {
     self.window.rootViewController = [UIViewController new];
     [self.window makeKeyAndVisible];


### PR DESCRIPTION
- Move assets folder to the WMFModel framework
- Copy assets in the WikipediaAppUtils class initializer
- Ensure clients use the class to get the assets path so that the assets are copied before needed