### PR TITLE
Ensure login button state is up to date when settings appears.

### DIFF
--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -87,6 +87,11 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
     [NSUserActivity wmf_makeActivityActive:[NSUserActivity wmf_settingsViewActivity]];
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self reloadVisibleCellOfType:WMFSettingsMenuItemType_Login];
+}
+
 - (void)configureBackButton {
     @weakify(self)
         UIBarButtonItem *xButton = [UIBarButtonItem wmf_buttonType:WMFButtonTypeX


### PR DESCRIPTION
https://phabricator.wikimedia.org/T145871

Wasn't able to repro after much testing. 

I based this fix on @josve05a's comment the phab ticket...

> I've encounterd that it says "log in" after an update (and if I press it, I get shown log in-screen). But if I just wait on the settings screen for a few seconds, or **_go back to explore and back to settings_**, it usually says "Logged in as Josve05a" again. So maybe just needs to be purged-ish....