### PR TITLE
Fixes T139980 - Voiceover Home button - extra "button"

### DIFF
--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -386,7 +386,7 @@
 "home-hide-suggestion-prompt" = "Hide this suggestion";
 "home-hide-suggestion-cancel" = "Cancel";
 "home-accessibility-label" = "Wikipedia, Explore";
-"home-button-accessibility-label" = "Home Button";
+"home-button-accessibility-label" = "Home";
 
 "potd-empty-error-description" = "Failed to retrieve picture of the day for $1";
 "potd-description-prefix" = "Picture of the day for $1";


### PR DESCRIPTION
 Remove the word "Button" from the Home button accessibility label.