### PR TITLE
Add common actions to article peek

### DIFF
--- a/Wikipedia/Code/WMFArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFArticleListTableViewController.m
@@ -114,8 +114,8 @@
     UIViewController *vc = self.delegate ?
         [self.delegate listViewController:self viewControllerForPreviewingArticleURL:url] : [[WMFArticleViewController alloc] initWithArticleURL:url dataStore:self.dataStore];
     
-    if ([[vc class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsProviding)]){
-        ((id< WMFArticlePreviewingActionsProviding >)vc).articlePreviewingActionsDelegate = self;
+    if ([[vc class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsDelegate)]){
+        ((WMFArticleViewController*)vc).articlePreviewingActionsDelegate = self;
     }
     return vc;
 }

--- a/Wikipedia/Code/WMFArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFArticleListTableViewController.m
@@ -136,12 +136,12 @@
 
 #pragma mark - WMFArticlePreviewingActionsDelegate
 
-- (void)articleReadMorePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleViewController:(WMFArticleViewController *)articleViewController {
-    [self commitViewController:articleViewController];
+- (void)readMoreArticlePreviewActionSelectedWithArticleController:(WMFArticleViewController *)articleController {
+    [self commitViewController:articleController];
 }
 
-- (void)articleSharePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController {
-    [self presentViewController:shareActivityViewController animated:YES completion:NULL];
+- (void)shareArticlePreviewActionSelectedWithArticleShareActivityController:(UIActivityViewController*)shareActivityController {
+    [self presentViewController:shareActivityController animated:YES completion:NULL];
 }
 
 #pragma mark - Delete Button

--- a/Wikipedia/Code/WMFArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFArticleListTableViewController.m
@@ -140,10 +140,8 @@
     [self commitViewController:articleViewController];
 }
 
-- (void)presentPreviewedArticleShareActivityViewController:(nullable UIActivityViewController*)shareActivityViewController {
-    if (shareActivityViewController){
-        [self presentViewController:shareActivityViewController animated:YES completion:NULL];
-    }
+- (void)presentPreviewedArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController {
+    [self presentViewController:shareActivityViewController animated:YES completion:NULL];
 }
 
 #pragma mark - Delete Button

--- a/Wikipedia/Code/WMFArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFArticleListTableViewController.m
@@ -114,7 +114,7 @@
     UIViewController *vc = self.delegate ?
         [self.delegate listViewController:self viewControllerForPreviewingArticleURL:url] : [[WMFArticleViewController alloc] initWithArticleURL:url dataStore:self.dataStore];
     
-    if ([[vc class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsDelegate)]){
+    if ([vc isKindOfClass:[WMFArticleViewController class]]){
         ((WMFArticleViewController*)vc).articlePreviewingActionsDelegate = self;
     }
     return vc;

--- a/Wikipedia/Code/WMFArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFArticleListTableViewController.m
@@ -140,7 +140,8 @@
     [self commitViewController:articleController];
 }
 
-- (void)shareArticlePreviewActionSelectedWithArticleShareActivityController:(UIActivityViewController*)shareActivityController {
+- (void)shareArticlePreviewActionSelectedWithArticleController:(WMFArticleViewController *)articleController
+                                       shareActivityController:(UIActivityViewController*)shareActivityController {
     [self presentViewController:shareActivityController animated:YES completion:NULL];
 }
 

--- a/Wikipedia/Code/WMFArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFArticleListTableViewController.m
@@ -114,8 +114,8 @@
     UIViewController *vc = self.delegate ?
         [self.delegate listViewController:self viewControllerForPreviewingArticleURL:url] : [[WMFArticleViewController alloc] initWithArticleURL:url dataStore:self.dataStore];
     
-    if ([[vc class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsDelegate)]){
-        ((WMFArticleViewController*)vc).articlePreviewingActionsDelegate = self;
+    if ([[vc class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsProviding)]){
+        ((id< WMFArticlePreviewingActionsProviding >)vc).articlePreviewingActionsDelegate = self;
     }
     return vc;
 }

--- a/Wikipedia/Code/WMFArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFArticleListTableViewController.m
@@ -136,11 +136,11 @@
 
 #pragma mark - WMFArticlePreviewingActionsDelegate
 
-- (void)pushPreviewedArticleViewController:(WMFArticleViewController *)articleViewController {
+- (void)articleReadMorePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleViewController:(WMFArticleViewController *)articleViewController {
     [self commitViewController:articleViewController];
 }
 
-- (void)presentPreviewedArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController {
+- (void)articleSharePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController {
     [self presentViewController:shareActivityViewController animated:YES completion:NULL];
 }
 

--- a/Wikipedia/Code/WMFArticleListTableViewController.m
+++ b/Wikipedia/Code/WMFArticleListTableViewController.m
@@ -140,8 +140,10 @@
     [self commitViewController:articleViewController];
 }
 
-- (void)sharePreviewedArticle:(MWKArticle*)article {
-    
+- (void)presentPreviewedArticleShareActivityViewController:(nullable UIActivityViewController*)shareActivityViewController {
+    if (shareActivityViewController){
+        [self presentViewController:shareActivityViewController animated:YES completion:NULL];
+    }
 }
 
 #pragma mark - Delete Button

--- a/Wikipedia/Code/WMFArticleViewController.h
+++ b/Wikipedia/Code/WMFArticleViewController.h
@@ -39,9 +39,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol WMFArticlePreviewingActionsDelegate <NSObject>
 
-- (void)articleReadMorePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleViewController:(WMFArticleViewController *)articleViewController;
+- (void)readMoreArticlePreviewActionSelectedWithArticleController:(WMFArticleViewController *)articleController;
 
-- (void)articleSharePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController;
+- (void)shareArticlePreviewActionSelectedWithArticleShareActivityController:(UIActivityViewController*)shareActivityController;
 
 @end
 

--- a/Wikipedia/Code/WMFArticleViewController.h
+++ b/Wikipedia/Code/WMFArticleViewController.h
@@ -41,7 +41,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readMoreArticlePreviewActionSelectedWithArticleController:(WMFArticleViewController *)articleController;
 
-- (void)shareArticlePreviewActionSelectedWithArticleShareActivityController:(UIActivityViewController*)shareActivityController;
+- (void)shareArticlePreviewActionSelectedWithArticleController:(WMFArticleViewController *)articleController
+                                       shareActivityController:(UIActivityViewController*)shareActivityController;
 
 @end
 

--- a/Wikipedia/Code/WMFArticleViewController.h
+++ b/Wikipedia/Code/WMFArticleViewController.h
@@ -46,12 +46,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@protocol WMFArticlePreviewingActionsProviding <NSObject>
-
-@property (weak, nonatomic, nullable) id<WMFArticlePreviewingActionsDelegate> articlePreviewingActionsDelegate;
-
-@end
-
 /**
  *  View controller responsible for displaying article content.
  */

--- a/Wikipedia/Code/WMFArticleViewController.h
+++ b/Wikipedia/Code/WMFArticleViewController.h
@@ -46,6 +46,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@protocol WMFArticlePreviewingActionsProviding <NSObject>
+
+@property (weak, nonatomic, nullable) id<WMFArticlePreviewingActionsDelegate> articlePreviewingActionsDelegate;
+
+@end
+
 /**
  *  View controller responsible for displaying article content.
  */

--- a/Wikipedia/Code/WMFArticleViewController.h
+++ b/Wikipedia/Code/WMFArticleViewController.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)pushPreviewedArticleViewController:(WMFArticleViewController *)articleViewController;
 
-- (void)sharePreviewedArticle:(MWKArticle*)article;
+- (void)presentPreviewedArticleShareActivityViewController:(nullable UIActivityViewController*)shareActivityViewController;
 
 @end
 
@@ -86,8 +86,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)hasAboutThisArticle;
 
 - (void)fetchArticleIfNeeded;
-
-- (void)shareArticleFromButton:(nullable UIBarButtonItem *)button;
 
 @end
 

--- a/Wikipedia/Code/WMFArticleViewController.h
+++ b/Wikipedia/Code/WMFArticleViewController.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)pushPreviewedArticleViewController:(WMFArticleViewController *)articleViewController;
 
-- (void)presentPreviewedArticleShareActivityViewController:(nullable UIActivityViewController*)shareActivityViewController;
+- (void)presentPreviewedArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController;
 
 @end
 

--- a/Wikipedia/Code/WMFArticleViewController.h
+++ b/Wikipedia/Code/WMFArticleViewController.h
@@ -37,6 +37,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@protocol WMFArticlePreviewingActionsDelegate <NSObject>
+
+- (void)pushPreviewedArticleViewController:(WMFArticleViewController *)articleViewController;
+
+- (void)sharePreviewedArticle:(MWKArticle*)article;
+
+@end
+
 /**
  *  View controller responsible for displaying article content.
  */
@@ -61,6 +69,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) MWKSection *sectionToRestoreScrollOffset; //doesn't actually update the view, only here for access from Swift category
 @property (nonatomic) NSInteger currentFooterIndex;                               //doesn't actually update the view, only here for access from Swift category
 @property (nonatomic) NSInteger footerIndexToRestoreScrollOffset;                 //doesn't actually update the view, only here for access from Swift category
+
+@property (weak, nonatomic, nullable) id<WMFArticlePreviewingActionsDelegate> articlePreviewingActionsDelegate;
 
 @end
 

--- a/Wikipedia/Code/WMFArticleViewController.h
+++ b/Wikipedia/Code/WMFArticleViewController.h
@@ -39,9 +39,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol WMFArticlePreviewingActionsDelegate <NSObject>
 
-- (void)pushPreviewedArticleViewController:(WMFArticleViewController *)articleViewController;
+- (void)articleReadMorePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleViewController:(WMFArticleViewController *)articleViewController;
 
-- (void)presentPreviewedArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController;
+- (void)articleSharePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController;
 
 @end
 

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1652,7 +1652,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                              }];
 
     UIPreviewAction *saveAction =
-    [UIPreviewAction actionWithTitle:[self.savedPages isSaved:self.articleURL] ? MWLocalizedString(@"button-saved-for-later", nil) : MWLocalizedString(@"button-save-for-later", nil)
+    [UIPreviewAction actionWithTitle:[self.savedPages isSaved:self.articleURL] ? MWLocalizedString(@"button-saved-remove", nil) : MWLocalizedString(@"button-save-for-later", nil)
                                style:UIPreviewActionStyleDefault
                              handler:^(UIPreviewAction * _Nonnull action,
                                        UIViewController * _Nonnull previewViewController) {

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1645,7 +1645,11 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                              handler:^(UIPreviewAction * _Nonnull action,
                                        UIViewController * _Nonnull previewViewController) {
                                  // No need to have articlePreviewingActionsDelegate method for saving since saving doesn't require presenting anything.
-                                 [self.savedPages addSavedPageWithURL:self.articleURL];
+                                 if([self.savedPages isSaved:self.articleURL]){
+                                     [self.savedPages removeEntryWithURL:self.articleURL];
+                                 }else{
+                                     [self.savedPages addSavedPageWithURL:self.articleURL];
+                                 }
                              }];
     
     UIPreviewAction *shareAction =

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1636,7 +1636,8 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                              handler:^(UIPreviewAction * _Nonnull action,
                                        UIViewController * _Nonnull previewViewController) {
                                  NSAssert([previewViewController isKindOfClass:[WMFArticleViewController class]], @"Unexpected view controller type");
-                                 [self.articlePreviewingActionsDelegate pushPreviewedArticleViewController:(WMFArticleViewController*)previewViewController];
+                                 [self.articlePreviewingActionsDelegate articleReadMorePreviewAction:action
+                                                                   selectedWithArticleViewController:(WMFArticleViewController*)previewViewController];
                              }];
 
     UIPreviewAction *saveAction =
@@ -1666,7 +1667,8 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                                        UIViewController * _Nonnull previewViewController) {
                                  UIActivityViewController *vc = [self activityViewControllerForSharingArticle:self.article withTextSnippet:nil fromButton:self.shareToolbarItem shareFunnel:self.shareFunnel];
                                  if (vc){
-                                     [self.articlePreviewingActionsDelegate presentPreviewedArticleShareActivityViewController:vc];
+                                     [self.articlePreviewingActionsDelegate articleSharePreviewAction:action
+                                                       selectedWithArticleShareActivityViewController:vc];
                                  }
                              }];
     
@@ -1677,11 +1679,11 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 
 #pragma mark - WMFArticlePreviewingActionsDelegate methods
 
-- (void)pushPreviewedArticleViewController:(UIViewController *)articleViewController {
+- (void)articleReadMorePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleViewController:(UIViewController *)articleViewController {
     [self commitViewController:articleViewController];
 }
 
-- (void)presentPreviewedArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController {
+- (void)articleSharePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController {
     [self presentViewController:shareActivityViewController animated:YES completion:NULL];
 }
 

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -118,7 +118,8 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                                         WMFFontSliderViewControllerDelegate,
                                         UIPopoverPresentationControllerDelegate,
                                         WKUIDelegate,
-                                        WMFArticlePreviewingActionsDelegate>
+                                        WMFArticlePreviewingActionsDelegate,
+                                        WMFArticlePreviewingActionsProviding>
 
 // Data
 @property (nonatomic, strong, readwrite, nullable) MWKArticle *article;
@@ -1526,8 +1527,8 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
         [[PiwikTracker wmf_configuredInstance] wmf_logActionPreviewInContext:self contentType:nil];
         [self.webViewController hideFindInPageWithCompletion:nil];
 
-        if ([[peekVC class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsDelegate)]){
-            ((WMFArticleViewController*)peekVC).articlePreviewingActionsDelegate = self;
+        if ([[peekVC class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsProviding)]){
+            ((id< WMFArticlePreviewingActionsProviding >)peekVC).articlePreviewingActionsDelegate = self;
         }
         
         return peekVC;

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1631,7 +1631,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 
 - (NSArray<id<UIPreviewActionItem>> *)previewActions {
     UIPreviewAction *readAction =
-    [UIPreviewAction actionWithTitle:@"Read now"
+    [UIPreviewAction actionWithTitle:MWLocalizedString(@"button-read-now", nil)
                                style:UIPreviewActionStyleDefault
                              handler:^(UIPreviewAction * _Nonnull action,
                                        UIViewController * _Nonnull previewViewController) {
@@ -1640,7 +1640,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                              }];
 
     UIPreviewAction *saveAction =
-    [UIPreviewAction actionWithTitle:@"Save for later"
+    [UIPreviewAction actionWithTitle:[self.savedPages isSaved:self.articleURL] ? MWLocalizedString(@"button-saved-for-later", nil) : MWLocalizedString(@"button-save-for-later", nil)
                                style:UIPreviewActionStyleDefault
                              handler:^(UIPreviewAction * _Nonnull action,
                                        UIViewController * _Nonnull previewViewController) {
@@ -1649,7 +1649,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                              }];
     
     UIPreviewAction *shareAction =
-    [UIPreviewAction actionWithTitle:@"Share"
+    [UIPreviewAction actionWithTitle:MWLocalizedString(@"share-custom-menu-item", nil)
                                style:UIPreviewActionStyleDefault
                              handler:^(UIPreviewAction * _Nonnull action,
                                        UIViewController * _Nonnull previewViewController) {

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1526,7 +1526,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
         [[PiwikTracker wmf_configuredInstance] wmf_logActionPreviewInContext:self contentType:nil];
         [self.webViewController hideFindInPageWithCompletion:nil];
 
-        if ([[peekVC class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsDelegate)]){
+        if ([peekVC isKindOfClass:[WMFArticleViewController class]]){
             ((WMFArticleViewController*)peekVC).articlePreviewingActionsDelegate = self;
         }
         

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1654,8 +1654,9 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                              handler:^(UIPreviewAction * _Nonnull action,
                                        UIViewController * _Nonnull previewViewController) {
                                  UIActivityViewController *vc = [self activityViewControllerForSharingArticle:self.article withTextSnippet:nil fromButton:self.shareToolbarItem shareFunnel:self.shareFunnel];
-
-                                 [self.articlePreviewingActionsDelegate presentPreviewedArticleShareActivityViewController:vc];
+                                 if (vc){
+                                     [self.articlePreviewingActionsDelegate presentPreviewedArticleShareActivityViewController:vc];
+                                 }
                              }];
     
     return @[readAction, saveAction, shareAction];
@@ -1667,10 +1668,8 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
     [self commitViewController:articleViewController];
 }
 
-- (void)presentPreviewedArticleShareActivityViewController:(nullable UIActivityViewController*)shareActivityViewController {
-    if (shareActivityViewController){
-        [self presentViewController:shareActivityViewController animated:YES completion:NULL];
-    }
+- (void)presentPreviewedArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController {
+    [self presentViewController:shareActivityViewController animated:YES completion:NULL];
 }
 
 #pragma mark - Article Navigation

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1658,17 +1658,10 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                              handler:^(UIPreviewAction * _Nonnull action,
                                        UIViewController * _Nonnull previewViewController) {
                                  // No need to have articlePreviewingActionsDelegate method for saving since saving doesn't require presenting anything.
-                                 
-                                 // HAX: since we only have self.articleURL below when we return the array of actions, we're only checking
-                                 // the URL for the enwiki main page suffix "Main_page". For other language wikis with different main page
-                                 // names the save button will appear when peeking their main pages, but we don't want to save main pages
-                                 // since they change. Fix this later, but for now just never save if main page.
-                                 if(!self.article.isMain){
-                                     if([self.savedPages isSaved:self.articleURL]){
-                                         [self.savedPages removeEntryWithURL:self.articleURL];
-                                     }else{
-                                         [self.savedPages addSavedPageWithURL:self.articleURL];
-                                     }
+                                 if([self.savedPages isSaved:self.articleURL]){
+                                     [self.savedPages removeEntryWithURL:self.articleURL];
+                                 }else{
+                                     [self.savedPages addSavedPageWithURL:self.articleURL];
                                  }
                              }];
     
@@ -1684,9 +1677,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                                  }
                              }];
     
-    // HAX: check for enwiki main page suffix... not ideal, but we don't have full MWKArticle at this
-    // point (or we could check its "isMain" property). See related HAX note in the "saveAction" above.
-    return [self.articleURL.absoluteString hasSuffix:@"Main_Page"] ? @[readAction, shareAction]: @[readAction, saveAction, shareAction];
+    return @[readAction, saveAction, shareAction];
 }
 
 #pragma mark - WMFArticlePreviewingActionsDelegate methods

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1669,11 +1669,11 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                                style:UIPreviewActionStyleDefault
                              handler:^(UIPreviewAction * _Nonnull action,
                                        UIViewController * _Nonnull previewViewController) {
-                                 UIActivityViewController *vc = [self.article sharingActivityViewControllerWithTextSnippet:nil fromButton:self.shareToolbarItem shareFunnel:self.shareFunnel];
-                                 if (vc){
+                                 UIActivityViewController *shareActivityController = [self.article sharingActivityViewControllerWithTextSnippet:nil fromButton:self.shareToolbarItem shareFunnel:self.shareFunnel];
+                                 if (shareActivityController){
                                      NSAssert([previewViewController isKindOfClass:[WMFArticleViewController class]], @"Unexpected view controller type");
                                      [self.articlePreviewingActionsDelegate shareArticlePreviewActionSelectedWithArticleController:(WMFArticleViewController*)previewViewController
-                                                                                                           shareActivityController:vc];
+                                                                                                           shareActivityController:shareActivityController];
                                  }
                              }];
     

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -69,7 +69,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSeparatorWidth = 1;
 static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollDistance = 10;
 
 
-@interface MWKArticle (WMFSharingActivityViewController) // TODO: move this to WMFModel
+@interface MWKArticle (WMFSharingActivityViewController)
 
 - (nullable UIActivityViewController*)sharingActivityViewControllerWithTextSnippet:(nullable NSString *)text
                                                                         fromButton:(UIBarButtonItem *)button
@@ -1648,8 +1648,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                              handler:^(UIPreviewAction * _Nonnull action,
                                        UIViewController * _Nonnull previewViewController) {
                                  NSAssert([previewViewController isKindOfClass:[WMFArticleViewController class]], @"Unexpected view controller type");
-                                 [self.articlePreviewingActionsDelegate articleReadMorePreviewAction:action
-                                                                   selectedWithArticleViewController:(WMFArticleViewController*)previewViewController];
+                                 [self.articlePreviewingActionsDelegate readMoreArticlePreviewActionSelectedWithArticleController:(WMFArticleViewController*)previewViewController];
                              }];
 
     UIPreviewAction *saveAction =
@@ -1672,8 +1671,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                                        UIViewController * _Nonnull previewViewController) {
                                  UIActivityViewController *vc = [self.article sharingActivityViewControllerWithTextSnippet:nil fromButton:self.shareToolbarItem shareFunnel:self.shareFunnel];
                                  if (vc){
-                                     [self.articlePreviewingActionsDelegate articleSharePreviewAction:action
-                                                       selectedWithArticleShareActivityViewController:vc];
+                                     [self.articlePreviewingActionsDelegate shareArticlePreviewActionSelectedWithArticleShareActivityController:vc];
                                  }
                              }];
     
@@ -1682,12 +1680,12 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 
 #pragma mark - WMFArticlePreviewingActionsDelegate methods
 
-- (void)articleReadMorePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleViewController:(UIViewController *)articleViewController {
-    [self commitViewController:articleViewController];
+- (void)readMoreArticlePreviewActionSelectedWithArticleController:(UIViewController *)articleController {
+    [self commitViewController:articleController];
 }
 
-- (void)articleSharePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController {
-    [self presentViewController:shareActivityViewController animated:YES completion:NULL];
+- (void)shareArticlePreviewActionSelectedWithArticleShareActivityController:(UIActivityViewController*)shareActivityController {
+    [self presentViewController:shareActivityController animated:YES completion:NULL];
 }
 
 #pragma mark - Article Navigation

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -118,8 +118,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                                         WMFFontSliderViewControllerDelegate,
                                         UIPopoverPresentationControllerDelegate,
                                         WKUIDelegate,
-                                        WMFArticlePreviewingActionsDelegate,
-                                        WMFArticlePreviewingActionsProviding>
+                                        WMFArticlePreviewingActionsDelegate>
 
 // Data
 @property (nonatomic, strong, readwrite, nullable) MWKArticle *article;
@@ -1527,8 +1526,8 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
         [[PiwikTracker wmf_configuredInstance] wmf_logActionPreviewInContext:self contentType:nil];
         [self.webViewController hideFindInPageWithCompletion:nil];
 
-        if ([[peekVC class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsProviding)]){
-            ((id< WMFArticlePreviewingActionsProviding >)peekVC).articlePreviewingActionsDelegate = self;
+        if ([[peekVC class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsDelegate)]){
+            ((WMFArticleViewController*)peekVC).articlePreviewingActionsDelegate = self;
         }
         
         return peekVC;

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1671,7 +1671,9 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                                        UIViewController * _Nonnull previewViewController) {
                                  UIActivityViewController *vc = [self.article sharingActivityViewControllerWithTextSnippet:nil fromButton:self.shareToolbarItem shareFunnel:self.shareFunnel];
                                  if (vc){
-                                     [self.articlePreviewingActionsDelegate shareArticlePreviewActionSelectedWithArticleShareActivityController:vc];
+                                     NSAssert([previewViewController isKindOfClass:[WMFArticleViewController class]], @"Unexpected view controller type");
+                                     [self.articlePreviewingActionsDelegate shareArticlePreviewActionSelectedWithArticleController:(WMFArticleViewController*)previewViewController
+                                                                                                           shareActivityController:vc];
                                  }
                              }];
     
@@ -1684,7 +1686,8 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
     [self commitViewController:articleController];
 }
 
-- (void)shareArticlePreviewActionSelectedWithArticleShareActivityController:(UIActivityViewController*)shareActivityController {
+- (void)shareArticlePreviewActionSelectedWithArticleController:(WMFArticleViewController *)articleController
+                                       shareActivityController:(UIActivityViewController*)shareActivityController {
     [self presentViewController:shareActivityController animated:YES completion:NULL];
 }
 

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -988,12 +988,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - WMFArticlePreviewingActionsDelegate
 
-- (void)articleReadMorePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleViewController:(WMFArticleViewController *)articleViewController {
-    [self wmf_pushArticleViewController:articleViewController animated:YES];
+- (void)readMoreArticlePreviewActionSelectedWithArticleController:(WMFArticleViewController *)articleController {
+    [self wmf_pushArticleViewController:articleController animated:YES];
 }
 
-- (void)articleSharePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController {
-    [self presentViewController:shareActivityViewController animated:YES completion:NULL];
+- (void)shareArticlePreviewActionSelectedWithArticleShareActivityController:(UIActivityViewController*)shareActivityController {
+    [self presentViewController:shareActivityController animated:YES completion:NULL];
 }
 
 #pragma mark - UIRefreshControl

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -64,7 +64,8 @@ NS_ASSUME_NONNULL_BEGIN
                                         UIViewControllerPreviewingDelegate,
                                         WMFAnalyticsContextProviding,
                                         WMFAnalyticsViewNameProviding,
-                                        WMFColumnarCollectionViewLayoutDelegate>
+                                        WMFColumnarCollectionViewLayoutDelegate,
+                                        WMFArticlePreviewingActionsDelegate>
 
 @property (nonatomic, strong, readonly) MWKSavedPageList *savedPages;
 @property (nonatomic, strong, readonly) MWKHistoryList *recentPages;
@@ -957,6 +958,11 @@ NS_ASSUME_NONNULL_BEGIN
     UIViewController *vc = [sectionController detailViewControllerForItemAtIndexPath:previewIndexPath];
     self.sectionOfPreviewingTitle = sectionController;
     [[PiwikTracker wmf_configuredInstance] wmf_logActionPreviewInContext:self contentType:sectionController];
+    
+    if ([[vc class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsDelegate)]){
+        ((WMFArticleViewController*)vc).articlePreviewingActionsDelegate = self;
+    }
+
     return vc;
 }
 
@@ -978,6 +984,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)analyticsName {
     return [self analyticsContext];
+}
+
+#pragma mark - WMFArticlePreviewingActionsDelegate
+
+- (void)pushPreviewedArticleViewController:(WMFArticleViewController *)articleViewController {
+    [self wmf_pushArticleViewController:articleViewController animated:YES];
+}
+
+- (void)sharePreviewedArticle:(MWKArticle*)article {
+    
 }
 
 #pragma mark - UIRefreshControl

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -992,7 +992,8 @@ NS_ASSUME_NONNULL_BEGIN
     [self wmf_pushArticleViewController:articleController animated:YES];
 }
 
-- (void)shareArticlePreviewActionSelectedWithArticleShareActivityController:(UIActivityViewController*)shareActivityController {
+- (void)shareArticlePreviewActionSelectedWithArticleController:(WMFArticleViewController *)articleController
+                                       shareActivityController:(UIActivityViewController*)shareActivityController {
     [self presentViewController:shareActivityController animated:YES completion:NULL];
 }
 

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -992,8 +992,10 @@ NS_ASSUME_NONNULL_BEGIN
     [self wmf_pushArticleViewController:articleViewController animated:YES];
 }
 
-- (void)sharePreviewedArticle:(MWKArticle*)article {
-    
+- (void)presentPreviewedArticleShareActivityViewController:(nullable UIActivityViewController*)shareActivityViewController {
+    if (shareActivityViewController){
+        [self presentViewController:shareActivityViewController animated:YES completion:NULL];
+    }
 }
 
 #pragma mark - UIRefreshControl

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -988,11 +988,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - WMFArticlePreviewingActionsDelegate
 
-- (void)pushPreviewedArticleViewController:(WMFArticleViewController *)articleViewController {
+- (void)articleReadMorePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleViewController:(WMFArticleViewController *)articleViewController {
     [self wmf_pushArticleViewController:articleViewController animated:YES];
 }
 
-- (void)presentPreviewedArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController {
+- (void)articleSharePreviewAction:(UIPreviewAction*)previewAction selectedWithArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController {
     [self presentViewController:shareActivityViewController animated:YES completion:NULL];
 }
 

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -959,8 +959,8 @@ NS_ASSUME_NONNULL_BEGIN
     self.sectionOfPreviewingTitle = sectionController;
     [[PiwikTracker wmf_configuredInstance] wmf_logActionPreviewInContext:self contentType:sectionController];
     
-    if ([[vc class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsDelegate)]){
-        ((WMFArticleViewController*)vc).articlePreviewingActionsDelegate = self;
+    if ([[vc class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsProviding)]){
+        ((id< WMFArticlePreviewingActionsProviding >)vc).articlePreviewingActionsDelegate = self;
     }
 
     return vc;

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -992,10 +992,8 @@ NS_ASSUME_NONNULL_BEGIN
     [self wmf_pushArticleViewController:articleViewController animated:YES];
 }
 
-- (void)presentPreviewedArticleShareActivityViewController:(nullable UIActivityViewController*)shareActivityViewController {
-    if (shareActivityViewController){
-        [self presentViewController:shareActivityViewController animated:YES completion:NULL];
-    }
+- (void)presentPreviewedArticleShareActivityViewController:(UIActivityViewController*)shareActivityViewController {
+    [self presentViewController:shareActivityViewController animated:YES completion:NULL];
 }
 
 #pragma mark - UIRefreshControl

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -959,8 +959,8 @@ NS_ASSUME_NONNULL_BEGIN
     self.sectionOfPreviewingTitle = sectionController;
     [[PiwikTracker wmf_configuredInstance] wmf_logActionPreviewInContext:self contentType:sectionController];
     
-    if ([[vc class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsProviding)]){
-        ((id< WMFArticlePreviewingActionsProviding >)vc).articlePreviewingActionsDelegate = self;
+    if ([[vc class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsDelegate)]){
+        ((WMFArticleViewController*)vc).articlePreviewingActionsDelegate = self;
     }
 
     return vc;

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -959,7 +959,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.sectionOfPreviewingTitle = sectionController;
     [[PiwikTracker wmf_configuredInstance] wmf_logActionPreviewInContext:self contentType:sectionController];
     
-    if ([[vc class] conformsToProtocol:@protocol(WMFArticlePreviewingActionsDelegate)]){
+    if ([vc isKindOfClass:[WMFArticleViewController class]]){
         ((WMFArticleViewController*)vc).articlePreviewingActionsDelegate = self;
     }
 

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -265,6 +265,7 @@
 "button-ok" = "OK";
 "button-save-for-later" = "Save for later";
 "button-saved-for-later" = "Saved for later";
+"button-read-now" = "Read now";
 
 "button-report-a-bug" = "Report a bug";
 

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -265,6 +265,7 @@
 "button-ok" = "OK";
 "button-save-for-later" = "Save for later";
 "button-saved-for-later" = "Saved for later";
+"button-saved-remove" = "Remove from saved";
 "button-read-now" = "Read now";
 
 "button-report-a-bug" = "Report a bug";

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -251,6 +251,7 @@
 "button-ok" = "Button text for ok button used in various places\n{{Identical|OK}}";
 "button-save-for-later" = "Longer button text for save button used in various places.";
 "button-saved-for-later" = "Longer button text for already saved button used in various places.";
+"button-read-now" = "Button text for read now button used in various plaes.";
 "button-report-a-bug" = "Button text for reporting a bug";
 "onboarding-create-account" = "Button text prompting first time users to create an account";
 "onboarding-login" = "{{Identical|Log in}}";

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -251,7 +251,8 @@
 "button-ok" = "Button text for ok button used in various places\n{{Identical|OK}}";
 "button-save-for-later" = "Longer button text for save button used in various places.";
 "button-saved-for-later" = "Longer button text for already saved button used in various places.";
-"button-read-now" = "Button text for read now button used in various plaes.";
+"button-saved-remove" = "Remove from saved button text used in various places.";
+"button-read-now" = "Read now button text used in various places.";
 "button-report-a-bug" = "Button text for reporting a bug";
 "onboarding-create-account" = "Button text prompting first time users to create an account";
 "onboarding-login" = "{{Identical|Log in}}";


### PR DESCRIPTION
https://phabricator.wikimedia.org/T116944


**Add "Read now", "Save for later" and "Share" peek actions when peeking:**
- [x] Article links
- [x] Explore cards
- [x] List items (top read, search, saved, history, read more at bottom of article, etc)

**Other:**
- [x] Don't add actions for image or external url peeks
- [x] i18n strings
- [x] If the peeked article is already saved the save for later button should say "Saved for later" and tapping it should un-save it (same text and functionality as explore card save buttons)
- [x] Hide save item if peeking main page
- [x] Test everything on ipad including old article share functionality
