### PR TITLE
Change "iOS" to "device" in a message

### DIFF
--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -121,7 +121,7 @@
 "settings-help-and-feedback" = "Help and feedback";
 "settings-primary-language" = "Primary";
 "settings-primary-language-details" = "The first language in this list is used as the primary language for the app. Changing this language will change daily content (such as Featured Article) shown on Explore.";
-"settings-notifications-system-off" = "Notifications are currently turned off for Wikipedia. Go to your iOS Settings to turn on notifications";
+"settings-notifications-system-off" = "Notifications are currently turned off for Wikipedia. Go to your device's Settings to turn on notifications";
 "settings-notifications-system-turn-on" = "Turn on Notifications";
 "settings-notifications-info" = "Be alerted to trending and top read articles on Wikipedia with our push notifications. All provided with respect to privacy and up to the minute data.";
 "settings-notifications-learn-more" = "Learn more about notifications";


### PR DESCRIPTION
"iOS" might be too advanced for a lot of people,
and "device" is more generic and easy to understand.