### PR TITLE
Fix reference page vc not being dismissed when ref link tapped.

### DIFF
--- a/Wikipedia/Code/WebViewController+WMFReferencePopover.m
+++ b/Wikipedia/Code/WebViewController+WMFReferencePopover.m
@@ -75,7 +75,7 @@ typedef void (^WMFReferencePopoverPresentationHandler)(UIPopoverPresentationCont
 }
 
 - (void)wmf_dismissReferencePopoverAnimated:(BOOL)flag completion:(void (^__nullable)(void))completion {
-    if ([self.presentedViewController isMemberOfClass:[WMFReferencePopoverMessageViewController class]]) {
+    if ([self.presentedViewController isMemberOfClass:[WMFReferencePopoverMessageViewController class]] || [self.presentedViewController isMemberOfClass:[WMFReferencePageViewController class]]) {
         [self dismissViewControllerAnimated:flag completion:completion];
     } else {
         if (completion) {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T116857

Fixes issue where tapping a reference link on phone wouldn't cause the ref page vc to hidden properly:

![img_0021](https://cloud.githubusercontent.com/assets/3143487/19872603/e6e6ff92-9f77-11e6-9482-970d518d18bd.PNG)

Note: the page not existing issue from the screenshot is a separate issue ( https://phabricator.wikimedia.org/T103914 ) because the tapped link was an ISBN link.