### PR TITLE
Fix notification scheduling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8
+osx_image: xcode8.1
 env:
     - IOS_VER="10.0" FL_ARGS="verify" FASTLANE_XCODE_LIST_TIMEOUT=120
     # - IOS_VER="9.3" FL_ARGS="verify" FASTLANE_XCODE_LIST_TIMEOUT=120

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.1
+osx_image: xcode8
 env:
     - IOS_VER="10.0" FL_ARGS="verify" FASTLANE_XCODE_LIST_TIMEOUT=120
     # - IOS_VER="9.3" FL_ARGS="verify" FASTLANE_XCODE_LIST_TIMEOUT=120

--- a/Wikipedia/Code/WMFFeedContentSource.m
+++ b/Wikipedia/Code/WMFFeedContentSource.m
@@ -71,7 +71,12 @@ static NSInteger WMFFeedInTheNewsNotificationViewCountDays = 5;
 #pragma mark - WMFContentSource
 
 - (void)loadNewContentForce:(BOOL)force completion:(nullable dispatch_block_t)completion {
-    [self loadContentForDate:[NSDate date] completion:completion];
+    NSDate *date = [NSDate date];
+    NSCalendar *calendar = [NSCalendar autoupdatingCurrentCalendar];
+    NSDateComponents *dateComponents = [calendar components:NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear fromDate:date];
+    NSCalendar *UTCCalendar = [NSCalendar wmf_utcGregorianCalendar];
+    NSDate *dateUTC = [UTCCalendar dateFromComponents:dateComponents];
+    [self loadContentForDate:dateUTC completion:completion];
 }
 
 - (void)loadContentFromDate:(NSDate *)fromDate forwardForDays:(NSInteger)days completion:(nullable dispatch_block_t)completion {
@@ -90,8 +95,12 @@ static NSInteger WMFFeedInTheNewsNotificationViewCountDays = 5;
 }
 
 - (void)preloadContentForNumberOfDays:(NSInteger)days completion:(nullable dispatch_block_t)completion {
-    NSCalendar *calendar = [NSCalendar wmf_utcGregorianCalendar];
-    NSDate *fromDate = [calendar dateByAddingUnit:NSCalendarUnitDay value:-days toDate:[NSDate date] options:NSCalendarMatchStrictly];
+    NSDate *date = [NSDate date];
+    NSCalendar *calendar = [NSCalendar autoupdatingCurrentCalendar];
+    NSDateComponents *dateComponents = [calendar components:NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear fromDate:date];
+    NSCalendar *UTCCalendar = [NSCalendar wmf_utcGregorianCalendar];
+    NSDate *dateUTC = [UTCCalendar dateFromComponents:dateComponents];
+    NSDate *fromDate = [UTCCalendar dateByAddingUnit:NSCalendarUnitDay value:-days toDate:dateUTC options:NSCalendarMatchStrictly];
     [self loadContentFromDate:fromDate forwardForDays:days completion:completion];
 }
 

--- a/Wikipedia/Code/WMFFeedContentSource.m
+++ b/Wikipedia/Code/WMFFeedContentSource.m
@@ -197,11 +197,13 @@ static NSInteger WMFFeedInTheNewsNotificationViewCountDays = 5;
         [self saveGroupForNews:feedDay.newsStories pageViews:pageViews date:date];
     }
     [self.contentStore notifyWhenWriteTransactionsComplete:^{
-        [self scheduleNotificationsForFeedDay:feedDay onDate:date];
-        if (!completion) {
-            return;
-        }
-        completion();
+        [self.previewStore notifyWhenWriteTransactionsComplete:^{
+            [self scheduleNotificationsForFeedDay:feedDay onDate:date];
+            if (!completion) {
+                return;
+            }
+            completion();
+        }];
     }];
 }
 

--- a/Wikipedia/Code/WMFFeedContentSource.m
+++ b/Wikipedia/Code/WMFFeedContentSource.m
@@ -112,7 +112,7 @@ static NSInteger WMFFeedInTheNewsNotificationViewCountDays = 5;
             NSMutableDictionary<NSURL *, NSDictionary<NSDate *, NSNumber *> *> *pageViews = [NSMutableDictionary dictionary];
 
             NSDate *startDate = [self startDateForPageViewsForDate:date];
-            NSDate *endDate = [self endDateForPreviewsForDate:date];
+            NSDate *endDate = [self endDateForPageViewsForDate:date];
 
             WMFTaskGroup *group = [WMFTaskGroup new];
 
@@ -504,13 +504,18 @@ static NSInteger WMFFeedInTheNewsNotificationViewCountDays = 5;
 #pragma mark - Utility
 
 - (NSDate *)startDateForPageViewsForDate:(NSDate *)date {
-    NSDate *startDate = [[NSCalendar wmf_utcGregorianCalendar] dateByAddingUnit:NSCalendarUnitDay value:0 - WMFFeedInTheNewsNotificationViewCountDays toDate:date options:NSCalendarMatchStrictly];
+    NSCalendar *calendar = [NSCalendar wmf_utcGregorianCalendar];
+    NSDateComponents *dateComponents = [calendar components:NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear fromDate:date];
+    NSDate *dateUTC = [calendar dateFromComponents:dateComponents];
+    NSDate *startDate = [calendar dateByAddingUnit:NSCalendarUnitDay value:0 - WMFFeedInTheNewsNotificationViewCountDays toDate:dateUTC options:NSCalendarMatchStrictly];
     return startDate;
 }
 
-- (NSDate *)endDateForPreviewsForDate:(NSDate *)date {
-    NSDate *endDate = [[NSCalendar wmf_utcGregorianCalendar] dateByAddingUnit:NSCalendarUnitDay value:0 toDate:date options:NSCalendarMatchStrictly];
-    return endDate;
+- (NSDate *)endDateForPageViewsForDate:(NSDate *)date {
+    NSCalendar *calendar = [NSCalendar wmf_utcGregorianCalendar];
+    NSDateComponents *dateComponents = [calendar components:NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear fromDate:date];
+    NSDate *dateUTC = [calendar dateFromComponents:dateComponents];
+    return dateUTC;
 }
 
 @end

--- a/Wikipedia/Code/WMFFeedContentSource.m
+++ b/Wikipedia/Code/WMFFeedContentSource.m
@@ -401,10 +401,6 @@ static NSInteger WMFFeedInTheNewsNotificationViewCountDays = 5;
 - (BOOL)scheduleNotificationForNewsStory:(WMFFeedNewsStory *)newsStory
                           articlePreview:(WMFArticlePreview *)articlePreview
                                    force:(BOOL)force {
-    if (!force && (![[NSUserDefaults wmf_userDefaults] wmf_inTheNewsNotificationsEnabled])) {
-        return NO;
-    }
-
     if (!newsStory.featuredArticlePreview) {
         NSString *articlePreviewKey = articlePreview.url.wmf_databaseKey;
         if (!articlePreviewKey) {

--- a/Wikipedia/Code/WMFFeedContentSource.m
+++ b/Wikipedia/Code/WMFFeedContentSource.m
@@ -196,9 +196,13 @@ static NSInteger WMFFeedInTheNewsNotificationViewCountDays = 5;
     if ([date wmf_isTodayUTC]) {
         [self saveGroupForNews:feedDay.newsStories pageViews:pageViews date:date];
     }
-    [self scheduleNotificationsForFeedDay:feedDay onDate:date];
-
-    [self.contentStore notifyWhenWriteTransactionsComplete:completion];
+    [self.contentStore notifyWhenWriteTransactionsComplete:^{
+        [self scheduleNotificationsForFeedDay:feedDay onDate:date];
+        if (!completion) {
+            return;
+        }
+        completion();
+    }];
 }
 
 - (void)saveGroupForFeaturedPreview:(WMFFeedArticlePreview *)preview date:(NSDate *)date {

--- a/Wikipedia/Code/WMFFeedContentSource.m
+++ b/Wikipedia/Code/WMFFeedContentSource.m
@@ -484,7 +484,7 @@ static NSInteger WMFFeedInTheNewsNotificationViewCountDays = 5;
         if ([userCalendar daysFromDate:notificationDate toDate:mostRecentDate] > 0) { // don't send if we have a notification scheduled for tomorrow already
             return NO;
         }
-        if ([userCalendar isDate:mostRecentDate inSameDayAsDate:notificationDate]) {
+        if (mostRecentDate && [userCalendar isDate:mostRecentDate inSameDayAsDate:notificationDate]) {
             NSInteger count = [defaults wmf_inTheNewsMostRecentDateNotificationCount];
             if (count >= WMFFeedNotificationMaxPerDay) {
                 return NO;


### PR DESCRIPTION
Two things 1- non-UTC dates were being passed into UTC logic so fixed everything to standardize on UTC (except for notification scheduling which should be on user time) 2- notification scheduling wouldn't wait for db writes to complete - since there were no previews to notify about, notifications weren't scheduled