### PR TITLE
Fix for tapping on grey area not dismissing ref panel on phone.

### DIFF
--- a/Wikipedia/Code/WMFReferencePanelViewController.swift
+++ b/Wikipedia/Code/WMFReferencePanelViewController.swift
@@ -1,6 +1,5 @@
 
 import Foundation
-import BlocksKitUIKitExtensions
 
 class WMFReferencePanelViewController: UIViewController {
     
@@ -10,11 +9,17 @@ class WMFReferencePanelViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        let tapRecognizer = UITapGestureRecognizer.bk_recognizer { (sender, state, location) in
-            self.presentingViewController?.dismiss(animated: true, completion: nil)
-        }
-        view.addGestureRecognizer(tapRecognizer)
+        view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.handleTapGestureRecognizer(_:))))
         embedContainerControllerView()
+    }
+
+    func handleTapGestureRecognizer(_ recognizer: UITapGestureRecognizer) {
+        switch recognizer.state {
+        case .ended:
+            self.presentingViewController?.dismiss(animated: true, completion: nil)
+        default:
+            break
+        }
     }
 
     fileprivate func panelHeight() -> CGFloat {

--- a/Wikipedia/Code/WMFReferencePanelViewController.swift
+++ b/Wikipedia/Code/WMFReferencePanelViewController.swift
@@ -11,9 +11,7 @@ class WMFReferencePanelViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         let tapRecognizer = UITapGestureRecognizer.bk_recognizer { (sender, state, location) in
-            if state == .ended {
-                self.presentingViewController?.dismiss(animated: true, completion: nil)
-            }
+            self.presentingViewController?.dismiss(animated: true, completion: nil)
         }
         view.addGestureRecognizer(tapRecognizer)
         embedContainerControllerView()


### PR DESCRIPTION
Unsure why state `.ended` is not seen when using bk_recognizer... (it's always `.possible` but never `.ended`)