### PR TITLE
Adding “IMAGE_DIFF_DIR” env variable for reference

### DIFF
--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
@@ -120,19 +120,24 @@
       </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
+            key = "WMF_FIXTURE_DIRECTORY"
+            value = "$(SOURCE_ROOT)/WikipediaUnitTests/Fixtures"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "FB_REFERENCE_IMAGE_DIR"
             value = "$(SOURCE_ROOT)/WikipediaUnitTests/ReferenceImages"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "DYLD_PRINT_STATISTICS"
-            value = "1"
+            key = "IMAGE_DIFF_DIR"
+            value = "$(SOURCE_ROOT)/WikipediaUnitTests/FailureDiffs"
             isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "WMF_FIXTURE_DIRECTORY"
-            value = "$(SOURCE_ROOT)/WikipediaUnitTests/Fixtures"
-            isEnabled = "YES">
+            key = "DYLD_PRINT_STATISTICS"
+            value = "1"
+            isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>


### PR DESCRIPTION
[For FBSnapshotTestCase](https://github.com/facebook/ios-snapshot-test-case)

Defaults to NO