### PR TITLE
Fix for T158484: Font-size change is not reflected in previous articles

### DIFF
--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -855,6 +855,10 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
+    
+    NSUInteger index = self.indexOfCurrentFontSize;
+    NSNumber *multiplier = self.fontSizeMultipliers[index];
+    [self.webViewController setFontSizeMultiplier:multiplier];
 
     [self updateTableOfContentsDisplayModeWithTraitCollection:self.traitCollection];
 


### PR DESCRIPTION
Fix for bug - https://phabricator.wikimedia.org/T158484

> Font-size change is not reflected in previous articles.

Updating font-size in `WMFArticleViewController` method `viewWillAppear`.