### PR TITLE
Enable edit summary "Done" button even if no summary text.

### DIFF
--- a/Wikipedia/Code/EditSummaryViewController.m
+++ b/Wikipedia/Code/EditSummaryViewController.m
@@ -64,16 +64,11 @@
 }
 
 - (void)textFieldDidChange:(NSNotification *)notification {
-    [self updateDoneButtonState];
     [self updatePlaceholderLabelState];
 }
 
 - (void)updatePlaceholderLabelState {
     self.placeholderLabel.hidden = ([self.summaryTextField.text length] == 0) ? NO : YES;
-}
-
-- (void)updateDoneButtonState {
-    self.buttonDone.enabled = (self.summaryTextField.text.length > 0) ? YES : NO;
 }
 
 // From: http://stackoverflow.com/a/1773257
@@ -91,7 +86,6 @@
     [super viewWillAppear:animated];
     self.summaryTextField.text = self.summaryText;
 
-    [self updateDoneButtonState];
     [self updatePlaceholderLabelState];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textFieldDidChange:) name:@"UITextFieldTextDidChangeNotification" object:self.summaryTextField];


### PR DESCRIPTION
https://phabricator.wikimedia.org/T149439

With this PR the "Done" button can now be tapped even when there is no edit summary:

![button mov](https://cloud.githubusercontent.com/assets/3143487/24883089/468deba0-1df8-11e7-8fff-5d94f6153040.gif)
