### PR TITLE
Minor 5.4.1 bug fixes

### DIFF
--- a/Wikipedia/Code/WMFArticleFetcher.m
+++ b/Wikipedia/Code/WMFArticleFetcher.m
@@ -148,7 +148,7 @@ NSString *const WMFArticleFetcherErrorCachedFallbackArticleKey = @"WMFArticleFet
     operation.priority = NSURLSessionTaskPriorityHigh;
     [self trackOperation:operation forArticleURL:articleURL];
 
-    [taskGroup waitInBackgroundAndNotifyOnQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)
+    [taskGroup waitInBackgroundAndNotifyOnQueue:dispatch_get_main_queue()
                                       withBlock:^{
                                           [[MWNetworkActivityIndicatorManager sharedManager] pop];
                                           if (articleResponse && [articleResponse isKindOfClass:[NSDictionary class]]) {
@@ -159,17 +159,13 @@ NSString *const WMFArticleFetcherErrorCachedFallbackArticleKey = @"WMFArticleFet
                                               }
                                               MWKArticle *article = [self serializedArticleWithURL:articleURL response:articleResponse];
                                               [self.dataStore asynchronouslyCacheArticle:article];
-                                              dispatch_async(dispatch_get_main_queue(), ^{
-                                                  [self.previewStore addPreviewWithURL:articleURL updatedWithArticle:article];
-                                                  success(article);
-                                              });
+                                              [self.previewStore addPreviewWithURL:articleURL updatedWithArticle:article];
+                                              success(article);
                                           } else {
                                               if (!articleError) {
                                                   articleError = [NSError wmf_errorWithType:WMFErrorTypeUnexpectedResponseType userInfo:@{}];
                                               }
-                                              dispatch_async(dispatch_get_main_queue(), ^{
-                                                  failure(articleError);
-                                              });
+                                              failure(articleError);
                                           }
                                       }];
 

--- a/Wikipedia/Code/WMFRelatedPagesContentSource.m
+++ b/Wikipedia/Code/WMFRelatedPagesContentSource.m
@@ -110,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
     fetchRequest.predicate = [NSPredicate predicateWithFormat:@"contentGroupKindInteger == %@", @(WMFContentGroupKindRelatedPages)];
     NSError *fetchError = nil;
     NSArray<WMFContentGroup *> *relatedPagesContentGroups = [self.userDataStore.viewContext executeFetchRequest:fetchRequest error:&fetchError];
-    if (fetchError || !relatedPagesContentGroups.count) {
+    if (fetchError) {
         DDLogError(@"Error fetching content groups: %@", fetchError);
     }
 


### PR DESCRIPTION
- Revert change in 5.4 that moved article read to a concurrent queue
- Remove unnecessary error logging when there are no related page content groups