### PR TITLE
[5.4.1] Potential crash fixes, new debugging methods

### DIFF
--- a/WMF Framework/WMFExploreFeedContentController.h
+++ b/WMF Framework/WMFExploreFeedContentController.h
@@ -15,5 +15,6 @@
 - (void)updateBackgroundSourcesWithCompletion:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler;
 
 - (void)debugSendRandomInTheNewsNotification;
+- (void)debugChaos;
 
 @end

--- a/WMF Framework/WMFExploreFeedContentController.h
+++ b/WMF Framework/WMFExploreFeedContentController.h
@@ -14,7 +14,9 @@
 - (void)updateNearbyForce:(BOOL)force completion:(nullable dispatch_block_t)completion;
 - (void)updateBackgroundSourcesWithCompletion:(void (^_Nonnull)(UIBackgroundFetchResult))completionHandler;
 
+#if DEBUG
 - (void)debugSendRandomInTheNewsNotification;
 - (void)debugChaos;
+#endif
 
 @end

--- a/WMF Framework/WMFExploreFeedContentController.m
+++ b/WMF Framework/WMFExploreFeedContentController.m
@@ -145,9 +145,9 @@ static NSTimeInterval WMFFeedRefreshBackgroundTimeout = 30;
                                     if ([moc hasChanges] && ![moc save:&saveError]) {
                                         DDLogError(@"Error saving: %@", saveError);
                                     }
-                                    [self.dataStore teardownFeedImportContext];
-                                    [[NSUserDefaults wmf_userDefaults] wmf_setFeedRefreshDate:[NSDate date]];
                                     dispatch_async(dispatch_get_main_queue(), ^{
+                                        [self.dataStore teardownFeedImportContext];
+                                        [[NSUserDefaults wmf_userDefaults] wmf_setFeedRefreshDate:[NSDate date]];
                                         self.taskGroup = nil;
                                         if (completion) {
                                             completion();

--- a/Wikipedia/Code/BITHockeyManager+WMFExtensions.m
+++ b/Wikipedia/Code/BITHockeyManager+WMFExtensions.m
@@ -29,8 +29,6 @@ static NSString *const kHockeyAppDoNotSendStringsKey = @"hockeyapp-alert-do-not-
 
 - (void)wmf_setupAndStart {
     NSString *appID = [[NSBundle mainBundle] wmf_hockeyappIdentifier];
-    DDLogError(@"app ID: %@", appID);
-
     if ([appID length] == 0) {
         DDLogError(@"Not setting up hockey because no app ID was found");
         return;

--- a/Wikipedia/Code/MWKDataStore.h
+++ b/Wikipedia/Code/MWKDataStore.h
@@ -22,16 +22,6 @@ FOUNDATION_EXPORT NSString *const MWKDataStoreValidImageSitePrefix;
 extern NSString *MWKCreateImageURLWithPath(NSString *path);
 
 /**
- * Subscribe to get notifications when an article is saved to the store
- * The article saved is in the userInfo under the `MWKArticleKey`
- * Notificaton is dispatched on the main thread
- */
-extern NSString *const MWKArticleKey;
-
-extern NSString *const MWKSetupDataSourcesNotification;
-extern NSString *const MWKTeardownDataSourcesNotification;
-
-/**
  * Subscribe to get notifications when a WMFArticle is
  * added to saved pages, history, etc…
  */

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -289,11 +289,6 @@ static uint64_t bundleHash() {
         return;
     }
 
-    NSManagedObjectContext *feedImportContext = _feedImportContext;
-    [feedImportContext performBlockAndWait:^{
-         [NSManagedObjectContext mergeChangesFromRemoteContextSave:userInfo intoContexts:@[feedImportContext]];
-    }];
-
     uint64_t state = bundleHash();
 
     NSDictionary *archiveableUserInfo = [self archivableNotificationUserInfoForUserInfo:userInfo];

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -6,12 +6,7 @@
 
 @import CoreData;
 
-NSString *const MWKArticleKey = @"MWKArticleKey";
-
 NSString *const WMFArticleUpdatedNotification = @"WMFArticleUpdatedNotification";
-
-NSString *const MWKSetupDataSourcesNotification = @"MWKSetupDataSourcesNotification";
-NSString *const MWKTeardownDataSourcesNotification = @"MWKTeardownDataSourcesNotification";
 
 NSString *const MWKDataStoreValidImageSitePrefix = @"//upload.wikimedia.org/";
 

--- a/Wikipedia/Code/SavedArticlesFetcher.m
+++ b/Wikipedia/Code/SavedArticlesFetcher.m
@@ -112,7 +112,9 @@ static SavedArticlesFetcher *_articleFetcher = nil;
                                 completion:^{
                                 }];
             if (article.isDownloaded) {
-                [self removeArticleWithURL:articleURL completion:^{ }];
+                [self removeArticleWithURL:articleURL
+                                completion:^{
+                                }];
                 [self.spotlightManager removeFromIndexWithUrl:articleURL];
             }
         }
@@ -189,9 +191,10 @@ static SavedArticlesFetcher *_articleFetcher = nil;
                 [group enter];
                 [self cancelFetchForArticleURL:articleURL
                                     completion:^{
-                                        [self removeArticleWithURL:articleURL completion:^{
-                                            [group leave];
-                                        }];
+                                        [self removeArticleWithURL:articleURL
+                                                        completion:^{
+                                                            [group leave];
+                                                        }];
                                     }];
             }
         }
@@ -448,7 +451,8 @@ static SavedArticlesFetcher *_articleFetcher = nil;
 - (void)didFetchArticle:(MWKArticle *__nullable)fetchedArticle
                     url:(NSURL *)url
                   error:(NSError *__nullable)error {
-    dispatch_assert_queue_debug(self.accessQueue);
+    //Uncomment when dropping iOS 9
+    //dispatch_assert_queue_debug(self.accessQueue);
     if (error) {
         // store errors for later reporting
         DDLogError(@"Failed to download saved page %@ due to error: %@", url, error);
@@ -481,7 +485,8 @@ static SavedArticlesFetcher *_articleFetcher = nil;
 
 /// Only invoke within accessQueue
 - (void)notifyDelegateIfFinished {
-    dispatch_assert_queue_debug(self.accessQueue);
+    //Uncomment when dropping iOS 9
+    //dispatch_assert_queue_debug(self.accessQueue);
     if ([self.fetchOperationsByArticleTitle count] == 0) {
         NSError *reportedError;
         if ([self.errorsByArticleTitle count] > 0) {

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -236,7 +236,6 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreFeed = 2 * 60 * 60;
         return;
     }
 
-    [[NSNotificationCenter defaultCenter] postNotificationName:MWKSetupDataSourcesNotification object:nil];
 #if WMF_TWEAKS_ENABLED
     if (FBTweakValue(@"Notifications", @"In the news", @"Send on app open", NO)) {
         [self.dataStore.feedContentController debugSendRandomInTheNewsNotification];
@@ -255,8 +254,6 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreFeed = 2 * 60 * 60;
     if (![self.dataStore save:&saveError]) {
         DDLogError(@"Error saving dataStore: %@", saveError);
     }
-
-    [[NSNotificationCenter defaultCenter] postNotificationName:MWKTeardownDataSourcesNotification object:nil];
 }
 
 - (void)appDidEnterBackgroundWithNotification:(NSNotification *)note {

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -1738,6 +1738,18 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
                          }];
 }
 
+#if DEBUG
+- (void)motionEnded:(UIEventSubtype)motion withEvent:(nullable UIEvent *)event {
+    if ([super respondsToSelector:@selector(motionEnded:withEvent:)]) {
+        [super motionEnded:motion withEvent:event];
+    }
+    if (event.subtype != UIEventSubtypeMotionShake) {
+        return;
+    }
+    [self.userStore.feedContentController debugChaos];
+}
+#endif
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFLocationManager.m
+++ b/Wikipedia/Code/WMFLocationManager.m
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)isAuthorized {
     return [CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorizedWhenInUse || [CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorizedAlways;
 }
-    
+
 + (BOOL)isAuthorizationNotDetermined {
     return [CLLocationManager authorizationStatus] == kCLAuthorizationStatusNotDetermined;
 }
@@ -107,7 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)isAuthorizationDenied {
     return [CLLocationManager authorizationStatus] == kCLAuthorizationStatusDenied;
 }
-    
+
 + (BOOL)isAuthorizationRestricted {
     return [CLLocationManager authorizationStatus] == kCLAuthorizationStatusRestricted;
 }
@@ -146,7 +146,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSParameterAssert([WMFLocationManager isAuthorized]);
 
     self.updating = YES;
-    DDLogInfo(@"%@ starting monitoring location & heading updates.", self);
+    DDLogDebug(@"%@ starting monitoring location & heading updates.", self);
     [self startLocationUpdates];
     [self startHeadingUpdates];
 }
@@ -154,7 +154,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)stopMonitoringLocation {
     if (self.isUpdating) {
         self.updating = NO;
-        DDLogInfo(@"%@ stopping location & heading updates.", self);
+        DDLogDebug(@"%@ stopping location & heading updates.", self);
         [self stopLocationUpdates];
         [self stopHeadingUpdates];
     }

--- a/Wikipedia/Code/WMFNearbyContentSource.m
+++ b/Wikipedia/Code/WMFNearbyContentSource.m
@@ -73,19 +73,20 @@ const CLLocationDistance WMFNearbyForcedUpdateDistanceThresholdInMeters = 1000;
         if (![WMFLocationManager isAuthorized]) {
             [moc removeAllContentGroupsOfKind:WMFContentGroupKindLocation];
             if (![[NSUserDefaults wmf_userDefaults] wmf_exploreDidPromptForLocationAuthorization]) {
-                [self showAuthorizationPlaceholderInManagedObjectContext:moc completion:^{
-                    if (completion) {
-                        completion();
-                    }
-                }];
+                [self showAuthorizationPlaceholderInManagedObjectContext:moc
+                                                              completion:^{
+                                                                  if (completion) {
+                                                                      completion();
+                                                                  }
+                                                              }];
             } else if (completion) {
                 completion();
             }
             return;
         }
-        
+
         [moc removeAllContentGroupsOfKind:WMFContentGroupKindLocationPlaceholder];
-        
+
         if (self.currentLocationManager.location == nil) {
             self.isFetchingInitialLocation = YES;
             self.completion = completion;
@@ -97,31 +98,31 @@ const CLLocationDistance WMFNearbyForcedUpdateDistanceThresholdInMeters = 1000;
                 }
             };
             [self getGroupForLocation:self.currentLocationManager.location
-               inManagedObjectContext:moc
-                                force:force
-                           completion:^(WMFContentGroup *group, CLLocation *location, CLPlacemark *placemark) {
-                               if (group && [group.content isKindOfClass:[NSArray class]] && group.content.count > 0) {
-                                   NSDate *now = [NSDate date];
-                                   NSDate *todayMidnightUTC = [now wmf_midnightUTCDateFromLocalDate];
-                                   if (force || (![[NSUserDefaults wmf_userDefaults] wmf_placesHasAppeared] && [[NSCalendar wmf_utcGregorianCalendar] wmf_daysFromDate:group.midnightUTCDate toDate:todayMidnightUTC] >= WMFNearbyDaysBetweenForcedUpdates)) {
-                                       group.date = now;
-                                       group.midnightUTCDate = todayMidnightUTC;
-                                   }
-                                   done();
-                                   return;
-                               }
-                               [self fetchResultsForLocation:location
-                                                   placemark:placemark
-                                      inManagedObjectContext:moc
-                                                  completion:^{
-                                                      done();
-                                                  }];
-                           }
-                              failure:^(NSError *error) {
-                                  done();
-                              }];
+                inManagedObjectContext:moc
+                force:force
+                completion:^(WMFContentGroup *group, CLLocation *location, CLPlacemark *placemark) {
+                    if (group && [group.content isKindOfClass:[NSArray class]] && group.content.count > 0) {
+                        NSDate *now = [NSDate date];
+                        NSDate *todayMidnightUTC = [now wmf_midnightUTCDateFromLocalDate];
+                        if (force || (![[NSUserDefaults wmf_userDefaults] wmf_placesHasAppeared] && [[NSCalendar wmf_utcGregorianCalendar] wmf_daysFromDate:group.midnightUTCDate toDate:todayMidnightUTC] >= WMFNearbyDaysBetweenForcedUpdates)) {
+                            group.date = now;
+                            group.midnightUTCDate = todayMidnightUTC;
+                        }
+                        done();
+                        return;
+                    }
+                    [self fetchResultsForLocation:location
+                                        placemark:placemark
+                           inManagedObjectContext:moc
+                                       completion:^{
+                                           done();
+                                       }];
+                }
+                failure:^(NSError *error) {
+                    done();
+                }];
         }
-        
+
     }];
 }
 
@@ -179,7 +180,9 @@ const CLLocationDistance WMFNearbyForcedUpdateDistanceThresholdInMeters = 1000;
     }
     self.isFetchingInitialLocation = NO;
     NSManagedObjectContext *moc = self.dataStore.viewContext;
-    [self getGroupForLocation:location inManagedObjectContext:moc force:NO
+    [self getGroupForLocation:location
+        inManagedObjectContext:moc
+        force:NO
         completion:^(WMFContentGroup *group, CLLocation *location, CLPlacemark *placemark) {
             if (group && [group.content isKindOfClass:[NSArray class]] && group.content.count > 0) {
                 if (self.completion) {
@@ -217,7 +220,7 @@ const CLLocationDistance WMFNearbyForcedUpdateDistanceThresholdInMeters = 1000;
     if (!force) {
         WMFContentGroup *newestContentGroup = [moc newestGroupOfKind:WMFContentGroupKindLocation];
         NSDate *newestMidnightUTCDate = newestContentGroup.midnightUTCDate;
-        if (newestMidnightUTCDate &&[[NSCalendar wmf_utcGregorianCalendar] wmf_daysFromDate:newestMidnightUTCDate toDate:todayMidnightUTC] >= daysUntilForcedUpdate) {
+        if (newestMidnightUTCDate && [[NSCalendar wmf_utcGregorianCalendar] wmf_daysFromDate:newestMidnightUTCDate toDate:todayMidnightUTC] >= daysUntilForcedUpdate) {
             distanceThreshold = WMFNearbyForcedUpdateDistanceThresholdInMeters;
         }
     }
@@ -233,7 +236,7 @@ const CLLocationDistance WMFNearbyForcedUpdateDistanceThresholdInMeters = 1000;
         return;
     }
     self.isProcessingLocation = YES;
-    
+
     [moc performBlock:^{
         WMFContentGroup *group = [self contentGroupCloseToLocation:location inManagedObjectContext:moc force:force];
         if (group) {
@@ -241,16 +244,16 @@ const CLLocationDistance WMFNearbyForcedUpdateDistanceThresholdInMeters = 1000;
             completion(group, group.location, group.placemark);
             return;
         }
-        
+
         [self.currentLocationManager reverseGeocodeLocation:location
-                                                 completion:^(CLPlacemark *_Nonnull placemark) {
-                                                     completion(nil, location, placemark);
-                                                     self.isProcessingLocation = NO;
-                                                 }
-                                                    failure:^(NSError *_Nonnull error) {
-                                                        self.isProcessingLocation = NO;
-                                                        failure(error);
-                                                    }];
+            completion:^(CLPlacemark *_Nonnull placemark) {
+                completion(nil, location, placemark);
+                self.isProcessingLocation = NO;
+            }
+            failure:^(NSError *_Nonnull error) {
+                self.isProcessingLocation = NO;
+                failure(error);
+            }];
     }];
 }
 
@@ -271,31 +274,36 @@ const CLLocationDistance WMFNearbyForcedUpdateDistanceThresholdInMeters = 1000;
                 return;
             }
 
-            NSArray<NSURL *> *urls = [results.results wmf_map:^id(id obj) {
-                return [results urlForResult:obj];
-            }];
-            
+            NSArray<MWKLocationSearchResult *> *locationSearchResults = results.results;
+            NSMutableDictionary<NSURL *, MWKLocationSearchResult *> *resultsByURL = [NSMutableDictionary dictionaryWithCapacity:locationSearchResults.count];
+            NSMutableArray<NSURL *> *orderedURLs = [NSMutableArray arrayWithCapacity:locationSearchResults.count];
+            for (MWKLocationSearchResult *result in locationSearchResults) {
+                NSURL *articleURL = [results urlForResult:result];
+                if (articleURL) {
+                    resultsByURL[articleURL] = result;
+                    [orderedURLs addObject:articleURL];
+                }
+            }
+
             [moc performBlock:^{
-                [results.results enumerateObjectsUsingBlock:^(MWKLocationSearchResult *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-                    [moc fetchOrCreateArticleWithURL:urls[idx] updatedWithSearchResult:obj];
+                [resultsByURL enumerateKeysAndObjectsUsingBlock:^(NSURL *_Nonnull articleURL, MWKLocationSearchResult *_Nonnull result, BOOL *_Nonnull stop) {
+                    [moc fetchOrCreateArticleWithURL:articleURL updatedWithSearchResult:result];
                 }];
-                
                 WMFContentGroup *group = [moc createGroupOfKind:WMFContentGroupKindLocation
-                                                                      forDate:date
-                                                                  withSiteURL:self.siteURL
-                                                            associatedContent:nil
-                                                           customizationBlock:^(WMFContentGroup *_Nonnull group) {
-                                                               group.location = location;
-                                                               group.placemark = placemark;
-                                                           }];
+                                                        forDate:date
+                                                    withSiteURL:self.siteURL
+                                              associatedContent:nil
+                                             customizationBlock:^(WMFContentGroup *_Nonnull group) {
+                                                 group.location = location;
+                                                 group.placemark = placemark;
+                                             }];
                 [self removeSectionsForMidnightUTCDate:group.midnightUTCDate withKeyNotEqualToKey:group.key inManagedObjectContext:moc];
-                group.content = urls;
+                group.content = orderedURLs;
                 if (completion) {
                     completion();
                 }
             }];
 
-            
         }
         failure:^(NSError *_Nonnull error) {
             self.isProcessingLocation = NO;

--- a/Wikipedia/Code/WMFNearbyContentSource.m
+++ b/Wikipedia/Code/WMFNearbyContentSource.m
@@ -292,13 +292,12 @@ const CLLocationDistance WMFNearbyForcedUpdateDistanceThresholdInMeters = 1000;
                 WMFContentGroup *group = [moc createGroupOfKind:WMFContentGroupKindLocation
                                                         forDate:date
                                                     withSiteURL:self.siteURL
-                                              associatedContent:nil
+                                              associatedContent:orderedURLs
                                              customizationBlock:^(WMFContentGroup *_Nonnull group) {
                                                  group.location = location;
                                                  group.placemark = placemark;
                                              }];
                 [self removeSectionsForMidnightUTCDate:group.midnightUTCDate withKeyNotEqualToKey:group.key inManagedObjectContext:moc];
-                group.content = orderedURLs;
                 if (completion) {
                     completion();
                 }


### PR DESCRIPTION
- Ensure `feedImportContext` is created and torn down on the main thread
- Save the main context after any `feedImportContext` save (previously would hold changes in memory until saving on app exit)
- Fixes iOS 9 crashes by removing unsupported `automaticallyMergesChangesFromParent` and `dispatch_assert_queue_debug`
- Ensure feed imports on any context are saved & the callback occurs on the main thread
- `debugChaos` for randomly moving, inserting, deleting feed sections