### PR TITLE
[5.4.1] Crash Fix - Maintain a background task for migration

### DIFF
--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -49,12 +49,6 @@
 #import "WMFNotificationsController.h"
 #import "UIViewController+WMFOpenExternalUrl.h"
 
-#define TEST_SHARED_CONTAINER_MIGRATION DEBUG && 0
-
-#if TEST_SHARED_CONTAINER_MIGRATION
-#import "YapDatabase+WMFExtensions.h"
-#endif
-
 #import "WMFArticleNavigationController.h"
 
 /**
@@ -110,14 +104,16 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreFeed = 2 * 60 * 60;
 @property (nonatomic, strong) NSUserActivity *unprocessedUserActivity;
 @property (nonatomic, strong) UIApplicationShortcutItem *unprocessedShortcutItem;
 
-@property (nonatomic) UIBackgroundTaskIdentifier backgroundTaskIdentifier;
+@property (nonatomic) UIBackgroundTaskIdentifier housekeepingBackgroundTaskIdentifier;
+@property (nonatomic) UIBackgroundTaskIdentifier migrationBackgroundTaskIdentifier;
 
 @property (nonatomic, strong) WMFDailyStatsLoggingFunnel *statsFunnel;
 
 @property (nonatomic, strong) WMFNotificationsController *notificationsController;
 
 @property (nonatomic, getter=isWaitingToResumeApp) BOOL waitingToResumeApp;
-@property (nonatomic, getter=areLaunchMigrationsComplete) BOOL launchMigrationsComplete;
+@property (nonatomic, getter=isMigrationComplete) BOOL migrationComplete;
+@property (nonatomic, getter=isMigrationActive) BOOL migrationActive;
 
 @property (nonatomic, strong) WMFLocationManager *showNearbyLocationManager;
 
@@ -136,7 +132,8 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreFeed = 2 * 60 * 60;
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    self.housekeepingBackgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    self.migrationBackgroundTaskIdentifier = UIBackgroundTaskInvalid;
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(isZeroRatedChanged:)
                                                  name:WMFZeroRatingChanged
@@ -227,6 +224,9 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreFeed = 2 * 60 * 60;
 - (void)appWillEnterForegroundWithNotification:(NSNotification *)note {
     self.unprocessedUserActivity = nil;
     self.unprocessedShortcutItem = nil;
+
+    // Retry migration if it was terminated by a background task ending
+    [self migrateIfNecessary];
 }
 
 - (void)appDidBecomeActiveWithNotification:(NSNotification *)note {
@@ -260,7 +260,7 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreFeed = 2 * 60 * 60;
     if (![self uiIsLoaded]) {
         return;
     }
-    [self startBackgroundTask];
+    [self startHousekeepingBackgroundTask];
     dispatch_async(dispatch_get_main_queue(), ^{
 #if WMF_TWEAKS_ENABLED
         if (FBTweakValue(@"Notifications", @"In the news", @"Send on app exit", NO)) {
@@ -280,7 +280,7 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreFeed = 2 * 60 * 60;
 
 - (void)performBackgroundFetchWithCompletion:(void (^)(UIBackgroundFetchResult))completion {
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (!self.areLaunchMigrationsComplete) {
+        if (!self.isMigrationComplete) {
             completion(UIBackgroundFetchResultNoData);
             return;
         }
@@ -290,24 +290,45 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreFeed = 2 * 60 * 60;
 
 #pragma mark - Background Tasks
 
-- (void)startBackgroundTask {
-    if (self.backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+- (void)startHousekeepingBackgroundTask {
+    if (self.housekeepingBackgroundTaskIdentifier != UIBackgroundTaskInvalid) {
         return;
     }
-    self.backgroundTaskIdentifier = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+    self.housekeepingBackgroundTaskIdentifier = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
         [self.dataStore stopCacheRemoval];
         [self.savedArticlesFetcher cancelFetchForSavedPages];
-        [self endBackgroundTask];
+        [self endHousekeepingBackgroundTask];
     }];
 }
 
-- (void)endBackgroundTask {
-    if (self.backgroundTaskIdentifier == UIBackgroundTaskInvalid) {
+- (void)endHousekeepingBackgroundTask {
+    if (self.housekeepingBackgroundTaskIdentifier == UIBackgroundTaskInvalid) {
         return;
     }
 
-    UIBackgroundTaskIdentifier backgroundTaskToStop = self.backgroundTaskIdentifier;
-    self.backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    UIBackgroundTaskIdentifier backgroundTaskToStop = self.housekeepingBackgroundTaskIdentifier;
+    self.housekeepingBackgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    [[UIApplication sharedApplication] endBackgroundTask:backgroundTaskToStop];
+}
+
+- (void)startMigrationBackgroundTask:(dispatch_block_t)expirationHandler {
+    if (self.migrationBackgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+        return;
+    }
+    self.migrationBackgroundTaskIdentifier = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+        if (expirationHandler) {
+            expirationHandler();
+        }
+    }];
+}
+
+- (void)endMigrationBackgroundTask {
+    if (self.migrationBackgroundTaskIdentifier == UIBackgroundTaskInvalid) {
+        return;
+    }
+
+    UIBackgroundTaskIdentifier backgroundTaskToStop = self.migrationBackgroundTaskIdentifier;
+    self.migrationBackgroundTaskIdentifier = UIBackgroundTaskInvalid;
     [[UIApplication sharedApplication] endBackgroundTask:backgroundTaskToStop];
 }
 
@@ -334,22 +355,49 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreFeed = 2 * 60 * 60;
 
     [self showSplashView];
 
-#if TEST_SHARED_CONTAINER_MIGRATION
-    NSFileManager *fm = [NSFileManager defaultManager];
-    [fm removeItemAtPath:[YapDatabase wmf_databasePath] error:nil];
-    [fm removeItemAtPath:[MWKDataStore mainDataStorePath] error:nil];
-    [fm removeItemAtPath:[SDImageCache wmf_imageCacheDirectory] error:nil];
-    [[NSUserDefaults wmf_userDefaults] wmf_setDidMigrateToSharedContainer:NO];
-#endif
+    [self migrateIfNecessary];
+}
+
+- (void)migrateIfNecessary {
+    if (self.isMigrationComplete || self.isMigrationActive) {
+        return;
+    }
+
+    __block BOOL migrationsAllowed = YES;
+    [self startMigrationBackgroundTask:^{
+        migrationsAllowed = NO;
+    }];
+    dispatch_block_t bail = ^{
+        [self endMigrationBackgroundTask];
+        self.migrationActive = NO;
+    };
     [self migrateToSharedContainerIfNecessaryWithCompletion:^{
+        if (!migrationsAllowed) {
+            bail();
+            return;
+        }
         [self migrateToNewFeedIfNecessaryWithCompletion:^{
+            if (!migrationsAllowed) {
+                bail();
+                return;
+            }
             [self.dataStore performCoreDataMigrations:^{
+                if (!migrationsAllowed) {
+                    bail();
+                    return;
+                }
                 [self migrateToQuadKeyLocationIfNecessaryWithCompletion:^{
+                    if (!migrationsAllowed) {
+                        bail();
+                        return;
+                    }
                     [self migrateToRemoveUnreferencedArticlesIfNecessaryWithCompletion:^{
                         dispatch_async(dispatch_get_main_queue(), ^{
+                            [self endMigrationBackgroundTask];
                             [self presentOnboardingIfNeededWithCompletion:^(BOOL didShowOnboarding) {
                                 [self loadMainUI];
-                                self.launchMigrationsComplete = YES;
+                                self.migrationComplete = YES;
+                                self.migrationActive = NO;
                                 if (!self.isWaitingToResumeApp) {
                                     [self resumeApp:^{
                                         [self hideSplashViewAnimated:!didShowOnboarding];
@@ -424,7 +472,7 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreFeed = 2 * 60 * 60;
 
 - (void)hideSplashScreenAndResumeApp {
     self.waitingToResumeApp = NO;
-    if (self.areLaunchMigrationsComplete) {
+    if (self.isMigrationComplete) {
         [self resumeApp:^{
             [self hideSplashViewAnimated:true];
         }];
@@ -543,28 +591,28 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreFeed = 2 * 60 * 60;
     if (deletedArticleURLs.count > 0) {
         [self.dataStore removeArticlesWithURLsFromCache:deletedArticleURLs];
     }
-    
+
     if (self.backgroundTaskGroup) {
         return;
     }
-    
+
     WMFTaskGroup *taskGroup = [WMFTaskGroup new];
     self.backgroundTaskGroup = taskGroup;
-    
+
     [taskGroup enter];
     [self.dataStore startCacheRemoval:^{
         [taskGroup leave];
     }];
-    
+
     [taskGroup enter];
     [self.savedArticlesFetcher fetchUncachedArticlesInSavedPages:^{
         [taskGroup leave];
     }];
-    
+
     [taskGroup waitInBackgroundWithCompletion:^{
         WMFAssertMainThread(@"Completion assumed to be called on the main queue.");
         self.backgroundTaskGroup = nil;
-        [self endBackgroundTask];
+        [self endHousekeepingBackgroundTask];
     }];
 }
 


### PR DESCRIPTION
> The exception code 0xdead10cc indicates that an application has been terminated by the OS because it held on to a file lock or sqlite database lock during suspension. If your application is performing operations on a locked file or sqlite database at suspension time, it must request additional background execution time to complete those operations and relinquish the lock before suspending.

```objc
Exception Type:  EXC_CRASH (SIGKILL)
Exception Codes: 0x0000000000000000, 0x0000000000000000
Exception Note:  EXC_CORPSE_NOTIFY
Termination Reason: Namespace SPRINGBOARD, Code 0xdead10cc
Triggered by Thread:  0

Thread 0 name:
Thread 0 Crashed:
0   libsystem_kernel.dylib        	0x0000000191b3d4dc fsync + 8
1   libsqlite3.dylib              	0x00000001930bb04c unixSync + 220 (sqlite3.c:33772)
2   libsqlite3.dylib              	0x00000001930f0c14 pagerWalFrames + 1180 (sqlite3.c:18932)
3   libsqlite3.dylib              	0x00000001930ba648 sqlite3PagerCommitPhaseOne + 384 (sqlite3.c:57510)
4   libsqlite3.dylib              	0x00000001930a75a0 sqlite3BtreeCommitPhaseOne + 180 (sqlite3.c:66409)
5   libsqlite3.dylib              	0x0000000193076d68 sqlite3VdbeHalt + 2508 (sqlite3.c:77161)
6   libsqlite3.dylib              	0x00000001930a05f4 sqlite3VdbeExec + 54876 (sqlite3.c:84989)
7   libsqlite3.dylib              	0x00000001930920e0 sqlite3_step + 528 (sqlite3.c:80263)
8   CoreData                      	0x0000000194e31194 _execute + 164 (NSSQLiteConnection.m:3792)
9   CoreData                      	0x0000000194e65fd8 -[NSSQLiteConnection commitTransaction] + 312 (NSSQLiteConnection.m:2654)
10  CoreData                      	0x0000000194ffaa30 _commitTransactionForSaveRequest + 468 (NSSQLCore_Functions.m:1658)
11  CoreData                      	0x0000000194ffadcc _commitChangesForSaveRequest + 136 (NSSQLCore_Functions.m:1696)
12  CoreData                      	0x0000000194ffb5a8 _executeSaveChangesRequest + 424 (NSSQLCore_Functions.m:1801)
13  CoreData                      	0x0000000194ff15f0 -[NSSQLSaveChangesRequestContext executeRequestUsingConnection:] + 44 (NSSQLSaveChangesRequestContext.m:103)
14  CoreData                      	0x0000000194f090c4 __52-[NSSQLDefaultConnectionManager handleStoreRequest:]_block_invoke + 256 (NSSQLConnectionManager.m:305)
15  libdispatch.dylib             	0x0000000191a169a0 _dispatch_client_callout + 16 (object.m:473)
16  libdispatch.dylib             	0x0000000191a23ee0 _dispatch_barrier_sync_f_invoke + 84 (queue.c:3446)
17  CoreData                      	0x0000000194f08f64 -[NSSQLDefaultConnectionManager handleStoreRequest:] + 208 (NSSQLConnectionManager.m:290)
18  CoreData                      	0x0000000194fcb824 -[NSSQLCoreDispatchManager routeStoreRequest:] + 272 (NSSQLCoreDispatchManager.m:56)
19  CoreData                      	0x0000000194f3675c -[NSSQLCore dispatchRequest:withRetries:] + 236 (NSSQLCore.m:2726)
20  CoreData                      	0x0000000194f32578 -[NSSQLCore processSaveChanges:forContext:] + 200 (NSSQLCore.m:1569)
21  CoreData                      	0x0000000194e36f10 -[NSSQLCore executeRequest:withContext:error:] + 724 (NSSQLCore.m:1923)
22  CoreData                      	0x0000000194f1584c __65-[NSPersistentStoreCoordinator executeRequest:withContext:error:]_block_invoke + 3492 (NSPersistentStoreCoordinator.m:2820)
23  CoreData                      	0x0000000194f0e0f0 -[NSPersistentStoreCoordinator _routeHeavyweightBlock:] + 276 (NSPersistentStoreCoordinator.m:586)
24  CoreData                      	0x0000000194e36adc -[NSPersistentStoreCoordinator executeRequest:withContext:error:] + 408 (NSPersistentStoreCoordinator.m:2706)
25  CoreData                      	0x0000000194e5797c -[NSManagedObjectContext save:] + 2548 (NSManagedObjectContext.m:1419)
26  WMF                           	0x00000001004be78c __41-[MWKDataStore backgroundContextDidSave:]_block_invoke + 64 (MWKDataStore.m:465)
27  CoreData                      	0x0000000194eda214 developerSubmittedBlockToNSManagedObjectContextPerform + 152 (NSManagedObjectContext.m:3549)
28  libdispatch.dylib             	0x0000000191a169a0 _dispatch_client_callout + 16 (object.m:473)
29  libdispatch.dylib             	0x0000000191a277a8 _dispatch_barrier_sync_f_slow_invoke + 304 (queue.c:3585)
30  libdispatch.dylib             	0x0000000191a169a0 _dispatch_client_callout + 16 (object.m:473)
31  libdispatch.dylib             	0x0000000191a1b5e8 _dispatch_main_queue_callback_4CF + 996 (inline_internal.h:2431)
32  CoreFoundation                	0x0000000192b0d0c0 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12 (CFRunLoop.c:1793)
33  CoreFoundation                	0x0000000192b0acdc __CFRunLoopRun + 1572 (CFRunLoop.c:3004)
34  CoreFoundation                	0x0000000192a3ad94 CFRunLoopRunSpecific + 424 (CFRunLoop.c:3113)
35  GraphicsServices              	0x00000001944a4074 GSEventRunModal + 100 (GSEvent.c:2245)
36  UIKit                         	0x0000000198cf3130 UIApplicationMain + 208 (UIApplication.m:4089)
37  Wikipedia                     	0x000000010011a400 main + 88 (main.m:46)
38  libdyld.dylib                 	0x0000000191a4959c start + 4
```