### PR TITLE
forcing blue in search filter bar

### DIFF
--- a/Wikipedia/Code/PlacesViewController.swift
+++ b/Wikipedia/Code/PlacesViewController.swift
@@ -1994,6 +1994,7 @@ class PlacesViewController: UIViewController, MKMapViewDelegate, UISearchBarDele
             let paragraphStyle = NSMutableParagraphStyle()
             paragraphStyle.alignment = .center
             attributedTitle.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: NSMakeRange(0, attributedTitle.length))
+            attributedTitle.addAttribute(NSForegroundColorAttributeName, value: UIColor.wmf_blueTitleColor, range: NSMakeRange(0, attributedTitle.length))
 
         } else {
             attributedTitle = NSMutableAttributedString(string: title)

--- a/Wikipedia/Code/PlacesViewController.swift
+++ b/Wikipedia/Code/PlacesViewController.swift
@@ -1994,7 +1994,7 @@ class PlacesViewController: UIViewController, MKMapViewDelegate, UISearchBarDele
             let paragraphStyle = NSMutableParagraphStyle()
             paragraphStyle.alignment = .center
             attributedTitle.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: NSMakeRange(0, attributedTitle.length))
-            attributedTitle.addAttribute(NSForegroundColorAttributeName, value: UIColor.wmf_blueTitleColor, range: NSMakeRange(0, attributedTitle.length))
+            attributedTitle.addAttribute(NSForegroundColorAttributeName, value: UIColor.wmf_blueTint, range: NSMakeRange(0, attributedTitle.length))
 
         } else {
             attributedTitle = NSMutableAttributedString(string: title)

--- a/Wikipedia/Code/UIColor+WMFStyle.swift
+++ b/Wikipedia/Code/UIColor+WMFStyle.swift
@@ -51,6 +51,5 @@ public extension UIColor {
     public static let wmf_orange: UIColor = .wmf_color(withHex: 0xff5b00, alpha: 1.0)
     public static let wmf_authTitle: UIColor = .wmf_color(withHex: 0x72777d, alpha: 1.0)
     public static let wmf_filterDropDownBackground: UIColor = .wmf_color(withHex: 0xf6f6f6, alpha: 1.0)
-    public static let wmf_blueTitleColor: UIColor = .wmf_color(withHex: 0x274ec0, alpha: 1.0)
 
 }

--- a/Wikipedia/Code/UIColor+WMFStyle.swift
+++ b/Wikipedia/Code/UIColor+WMFStyle.swift
@@ -51,5 +51,6 @@ public extension UIColor {
     public static let wmf_orange: UIColor = .wmf_color(withHex: 0xff5b00, alpha: 1.0)
     public static let wmf_authTitle: UIColor = .wmf_color(withHex: 0x72777d, alpha: 1.0)
     public static let wmf_filterDropDownBackground: UIColor = .wmf_color(withHex: 0xf6f6f6, alpha: 1.0)
+    public static let wmf_blueTitleColor: UIColor = .wmf_color(withHex: 0x274ec0, alpha: 1.0)
 
 }


### PR DESCRIPTION
Looks like the default tint color wasn't reliable

see https://github.com/wikimedia/wikipedia-ios/pull/1398/files