### PR TITLE
Fix Explore status bar tap "scroll to top" after 3D-peek

### DIFF
--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -55,10 +55,8 @@
 
 #import "WMFCVLAttributes.h"
 #import "NSCalendar+WMFCommonCalendars.h"
-
 #import "UIImageView+WMFFaceDetectionBasedOnUIApplicationSharedApplication.h"
 #import "UIScrollView+WMFScrollsToTop.h"
-
 @import WMF;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -613,6 +611,7 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
 - (void)viewDidAppear:(BOOL)animated {
     NSParameterAssert(self.userStore);
     [super viewDidAppear:animated];
+
     [self.collectionView wmf_shouldScrollToTopOnStatusBarTap:YES];
     [[PiwikTracker sharedInstance] wmf_logView:self];
     [NSUserActivity wmf_makeActivityActive:[NSUserActivity wmf_exploreViewActivity]];

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -55,7 +55,10 @@
 
 #import "WMFCVLAttributes.h"
 #import "NSCalendar+WMFCommonCalendars.h"
+
 #import "UIImageView+WMFFaceDetectionBasedOnUIApplicationSharedApplication.h"
+#import "UIScrollView+WMFScrollsToTop.h"
+
 @import WMF;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -523,7 +526,6 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
 - (void)viewDidLoad {
     [super viewDidLoad];
     [self registerCellsAndViews];
-    self.collectionView.scrollsToTop = YES;
     self.collectionView.dataSource = self;
     self.collectionView.delegate = self;
     if ([self.collectionView respondsToSelector:@selector(setPrefetchDataSource:)]) {
@@ -611,7 +613,7 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
 - (void)viewDidAppear:(BOOL)animated {
     NSParameterAssert(self.userStore);
     [super viewDidAppear:animated];
-
+    [self.collectionView wmf_shouldScrollToTopOnStatusBarTap:YES];
     [[PiwikTracker sharedInstance] wmf_logView:self];
     [NSUserActivity wmf_makeActivityActive:[NSUserActivity wmf_exploreViewActivity]];
     [self startMonitoringReachabilityIfNeeded];

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -1590,7 +1590,7 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
     return vc;
 }
 
-static const NSString *kvo_WMFExploreViewController_peek_gesture_recognizer_for_failure_relationship = nil;
+static const NSString *kvo_WMFExploreViewController_peek_gesture_recognizer_for_failure_relationship = @"kvo_WMFExploreViewController_peek_gesture_recognizer_for_failure_relationship";
 NSString *const kvo_WMFExploreViewController_peek_state_keypath = @"state";
 
 - (void)observeValueForKeyPath:(nullable NSString *)keyPath ofObject:(nullable id)object change:(nullable NSDictionary<NSKeyValueChangeKey, id> *)change context:(nullable void *)context {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T128688

Fix Explore status bar tap "scroll to top" when:
- [x] coming back to Explore after peeking AND popping to an article
- [x] coming back to Explore after peeking but NOT popping to an article

The two cases above are now working properly:
![title mov](https://cloud.githubusercontent.com/assets/3143487/25926957/769d93ce-35a7-11e7-8f98-fa7b7e33b4e1.gif)

@joewalsh @amrox This fixes both cases but the [latter fix](https://github.com/wikimedia/wikipedia-ios/pull/1422/commits/fa48a882d2afb5048055da545ac28680a4cda736) seems more complicated than it should be :/
Perhaps there's an easier way to know when [a peek has ended without popping](http://stackoverflow.com/a/33778293/135557)? (`viewDidAppear` doesn't seem to re-fire if you peek but then don't pop)