### PR TITLE
Collapsed table footer tap should not scroll table to top if top of table is onscreen.

### DIFF
--- a/Wikipedia/assets/index.js
+++ b/Wikipedia/assets/index.js
@@ -62,7 +62,7 @@ exports.getElementFromPoint = function(x, y){
     return document.elementFromPoint(x - window.pageXOffset, y - window.pageYOffset);
 };
 
-exports.isTopOfElementAboveTopOfScreen = function(element){
+exports.isElementTopOnscreen = function(element){
   return (element.getBoundingClientRect().top < 0);
 };
 
@@ -439,10 +439,10 @@ exports.sendNearbyReferences = sendNearbyReferences;
 
 },{"./elementLocation":2}],6:[function(require,module,exports){
 const tableCollapser = require('wikimedia-page-library').CollapseTable;
-var elementLocation = require("../elementLocation");
+var location = require("../elementLocation");
 
 function footerDivClickCallback(container) {
-  if(elementLocation.isTopOfElementAboveTopOfScreen(container)){
+  if(location.isElementTopOnscreen(container)){
     window.scrollTo( 0, container.offsetTop - 10 );
   }
 }

--- a/Wikipedia/assets/index.js
+++ b/Wikipedia/assets/index.js
@@ -62,6 +62,10 @@ exports.getElementFromPoint = function(x, y){
     return document.elementFromPoint(x - window.pageXOffset, y - window.pageYOffset);
 };
 
+exports.isTopOfElementAboveTopOfScreen = function(element){
+  return (element.getBoundingClientRect().top < 0);
+};
+
 },{}],3:[function(require,module,exports){
 // Based on the excellent blog post:
 // http://www.icab.de/blog/2010/01/12/search-and-highlight-text-in-uiwebview/
@@ -435,9 +439,12 @@ exports.sendNearbyReferences = sendNearbyReferences;
 
 },{"./elementLocation":2}],6:[function(require,module,exports){
 const tableCollapser = require('wikimedia-page-library').CollapseTable;
+var elementLocation = require("../elementLocation");
 
 function footerDivClickCallback(container) {
-  window.scrollTo( 0, container.offsetTop - 10 );
+  if(elementLocation.isTopOfElementAboveTopOfScreen(container)){
+    window.scrollTo( 0, container.offsetTop - 10 );
+  }
 }
 
 function hideTables(content, isMainPage, pageTitle, infoboxTitle, otherTitle, footerTitle) {
@@ -445,7 +452,7 @@ function hideTables(content, isMainPage, pageTitle, infoboxTitle, otherTitle, fo
 }
 
 exports.hideTables = hideTables;
-},{"wikimedia-page-library":16}],7:[function(require,module,exports){
+},{"../elementLocation":2,"wikimedia-page-library":16}],7:[function(require,module,exports){
 
 function disableFilePageEdit( content ) {
     var filetoc = content.querySelector( '#filetoc' );

--- a/www/js/elementLocation.js
+++ b/www/js/elementLocation.js
@@ -45,6 +45,6 @@ exports.getElementFromPoint = function(x, y){
     return document.elementFromPoint(x - window.pageXOffset, y - window.pageYOffset);
 };
 
-exports.isTopOfElementAboveTopOfScreen = function(element){
+exports.isElementTopOnscreen = function(element){
   return (element.getBoundingClientRect().top < 0);
 };

--- a/www/js/elementLocation.js
+++ b/www/js/elementLocation.js
@@ -44,3 +44,7 @@ exports.getIndexOfFirstOnScreenElement = function(elementPrefix, elementCount){
 exports.getElementFromPoint = function(x, y){
     return document.elementFromPoint(x - window.pageXOffset, y - window.pageYOffset);
 };
+
+exports.isTopOfElementAboveTopOfScreen = function(element){
+  return (element.getBoundingClientRect().top < 0);
+};

--- a/www/js/transforms/collapseTables.js
+++ b/www/js/transforms/collapseTables.js
@@ -1,8 +1,8 @@
 const tableCollapser = require('wikimedia-page-library').CollapseTable;
-var elementLocation = require("../elementLocation");
+var location = require("../elementLocation");
 
 function footerDivClickCallback(container) {
-  if(elementLocation.isTopOfElementAboveTopOfScreen(container)){
+  if(location.isElementTopOnscreen(container)){
     window.scrollTo( 0, container.offsetTop - 10 );
   }
 }

--- a/www/js/transforms/collapseTables.js
+++ b/www/js/transforms/collapseTables.js
@@ -1,7 +1,10 @@
 const tableCollapser = require('wikimedia-page-library').CollapseTable;
+var elementLocation = require("../elementLocation");
 
 function footerDivClickCallback(container) {
-  window.scrollTo( 0, container.offsetTop - 10 );
+  if(elementLocation.isTopOfElementAboveTopOfScreen(container)){
+    window.scrollTo( 0, container.offsetTop - 10 );
+  }
 }
 
 function hideTables(content, isMainPage, pageTitle, infoboxTitle, otherTitle, footerTitle) {


### PR DESCRIPTION
As noted by Anthony here:
https://phabricator.wikimedia.org/T164324#3252500

Keep in mind when looking at the animations below that the first (largest) table still collapses and expands in the same way before and after this fix.

The changed behavior is on the second smaller collapsed table. 

The code in question scrolls the table to the top of the screen when you tap the expanded table's footer (to re-collapse it). 

The reason we needed this scroll-table-to-top-on-re-collapse behavior in the first place was otherwise, on large tables, you'd be left in some random-ish place in the article text after you collapsed a large table whose top was scrolled _above the top of the screen_.

This PR simply adds a check to not auto-scroll the table to the top if its top was still onscreen when you re-collapse it. Again, you can see the different behaviors with the _smaller table_ in the two animations below: 

# Before
Note the larger table jumps to the top of the screen when collapsing it, but the smaller one does too:
![before mov](https://cloud.githubusercontent.com/assets/3143487/26076986/802151f8-396f-11e7-8a31-76ead3e97385.gif)


# After
Note the larger table jumps to the top of the screen when collapsing it, but the smaller one doesn't (the auto-scroll-top top now only engages if the top of the expanded table is above the top of the screen):
![after mov](https://cloud.githubusercontent.com/assets/3143487/26077002/828dc5e8-396f-11e7-8979-84afa5b955c3.gif)
