### PR TITLE
Fix for find in page matches on small screen in landscape.

### DIFF
--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -521,7 +521,17 @@ NSString *const WMFCCBySALicenseURL =
                                              completion:^(CGRect rect) {
                                                  @strongify(self);
                                                  self.disableMinimizeFindInPage = YES;
-                                                 [self.webView.scrollView wmf_safeSetContentOffset:CGPointMake(self.webView.scrollView.contentOffset.x, fmaxf(rect.origin.y - 80.f, 0.f))
+                                                 
+                                                 CGFloat halfSpaceAboveKeyboardBar = [self.findInPageKeyboardBar convertPoint:CGPointZero toView:self.webView].y / 2.f;
+                                                 CGFloat halfMatchHeight = rect.size.height / 2.f;
+                                                 CGFloat yCenteringMatchAboveKeyboardBar = halfSpaceAboveKeyboardBar - halfMatchHeight;
+                                                 CGPoint offsetCenteringMatchAboveKeyboardBar =
+                                                 CGPointMake(
+                                                             self.webView.scrollView.contentOffset.x,
+                                                             fmaxf(rect.origin.y - yCenteringMatchAboveKeyboardBar, 0.f)
+                                                             );
+                                                 
+                                                 [self.webView.scrollView wmf_safeSetContentOffset:offsetCenteringMatchAboveKeyboardBar
                                                                                           animated:YES
                                                                                         completion:^(BOOL done) {
                                                                                             self.disableMinimizeFindInPage = NO;


### PR DESCRIPTION
https://phabricator.wikimedia.org/T143565

# Landscape on iPhone 4s

## Before 
![before mov](https://cloud.githubusercontent.com/assets/3143487/26182353/ab6372ba-3b2c-11e7-9792-4416d45eef96.gif)

## After
![after mov](https://cloud.githubusercontent.com/assets/3143487/26182349/a7fd2d50-3b2c-11e7-9d13-acaeaedb5b8c.gif)