### PR TITLE
Replace announcement "text" field break tags with newlines.

### DIFF
--- a/WMF Framework/WMFAnnouncement.m
+++ b/WMF Framework/WMFAnnouncement.m
@@ -46,6 +46,12 @@
         }];
 }
 
++ (MTLValueTransformer *)textJSONTransformer {
+    return [MTLValueTransformer transformerUsingForwardBlock:^id(NSString *text, BOOL *success, NSError *__autoreleasing *error) {
+        return [text stringByReplacingOccurrencesOfString:@"<br>" withString:@"\n"];
+    }];
+}
+
 + (NSValueTransformer *)startTimeJSONTransformer {
     return [MTLValueTransformer transformerUsingForwardBlock:^id(NSString *value, BOOL *success, NSError *__autoreleasing *error) {
         NSDate *date = [[NSDateFormatter wmf_iso8601Formatter] dateFromString:value];


### PR DESCRIPTION
https://phabricator.wikimedia.org/T166356

( Note: bearND was able to fix this upstream for this announcement, so hopefully the survey delivered to app store version will be fixed by the time you read this. See the phab ticket for details. )

# Before

![screen shot 2017-05-25 at 5 26 02 pm](https://cloud.githubusercontent.com/assets/3143487/26477667/10a5c3f8-417c-11e7-8aef-eebad79cffbb.png)

# After

![screen shot 2017-05-25 at 6 58 17 pm](https://cloud.githubusercontent.com/assets/3143487/26477678/2142c742-417c-11e7-8ab1-7f00348ab4e7.png)