### PR TITLE
[T166241] Update appearance of detail views based on design review

### DIFF
--- a/Wikipedia/Code/ArticleCollectionViewCell.swift
+++ b/Wikipedia/Code/ArticleCollectionViewCell.swift
@@ -30,7 +30,7 @@ open class ArticleCollectionViewCell: CollectionViewCell {
         super.setup()
     }
     
-    // This method is called to reset the cell to the default configuration. It is called on initial setup and prepareForReuse.
+    // This method is called to reset the cell to the default configuration. It is called on initial setup and prepareForReuse. Subclassers should call super.
     open func reset() {
         backgroundColor = .white
         titleFontFamily = .georgia
@@ -45,6 +45,8 @@ open class ArticleCollectionViewCell: CollectionViewCell {
         spacing = 6
         imageViewDimension = 70
         saveButtonTopSpacing = 10
+        imageView.wmf_reset()
+        imageView.wmf_showPlaceholder()
     }
     
     deinit {
@@ -56,8 +58,6 @@ open class ArticleCollectionViewCell: CollectionViewCell {
     open override func prepareForReuse() {
         super.prepareForReuse()
         reset()
-        imageView.wmf_reset()
-        imageView.wmf_showPlaceholder()
     }
     
     // MARK - View configuration

--- a/Wikipedia/Code/ArticleCollectionViewController.swift
+++ b/Wikipedia/Code/ArticleCollectionViewController.swift
@@ -80,7 +80,7 @@ extension ArticleCollectionViewController {
         return WMFLayoutEstimate(precalculated: false, height: 60)
     }
     override func metrics(withBoundsSize size: CGSize) -> WMFCVLMetrics {
-        return WMFCVLMetrics(boundsSize: size, firstColumnRatio: 1, secondColumnRatio: 1, collapseSectionSpacing:true)
+        return WMFCVLMetrics.singleColumnMetrics(withBoundsSize: size, collapseSectionSpacing:true)
  
     }
 }

--- a/Wikipedia/Code/ArticleCollectionViewController.swift
+++ b/Wikipedia/Code/ArticleCollectionViewController.swift
@@ -54,7 +54,7 @@ extension ArticleCollectionViewController {
 // MARK: - UICollectionViewDelegate
 extension ArticleCollectionViewController {
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        wmf_pushArticle(with: articleURLs[indexPath.item], dataStore: dataStore, animated: true)
+        wmf_pushArticle(with: articleURLs[indexPath.section], dataStore: dataStore, animated: true)
     }
 }
 

--- a/Wikipedia/Code/ArticleLocationCollectionViewController.swift
+++ b/Wikipedia/Code/ArticleLocationCollectionViewController.swift
@@ -130,7 +130,7 @@ extension ArticleLocationCollectionViewController {
         return WMFLayoutEstimate(precalculated: false, height: WMFNearbyArticleCollectionViewCell.estimatedRowHeight())
     }
     override func metrics(withBoundsSize size: CGSize) -> WMFCVLMetrics {
-        return WMFCVLMetrics(boundsSize: size, firstColumnRatio: 1, secondColumnRatio: 1, collapseSectionSpacing:true)
+        return WMFCVLMetrics.singleColumnMetrics(withBoundsSize: size, collapseSectionSpacing: true)
  
     }
 }

--- a/Wikipedia/Code/ArticleLocationCollectionViewController.swift
+++ b/Wikipedia/Code/ArticleLocationCollectionViewController.swift
@@ -104,7 +104,7 @@ extension ArticleLocationCollectionViewController: WMFLocationManagerDelegate {
 // MARK: - UICollectionViewDelegate
 extension ArticleLocationCollectionViewController {
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        wmf_pushArticle(with: articleURLs[indexPath.item], dataStore: dataStore, animated: true)
+        wmf_pushArticle(with: articleURLs[indexPath.section], dataStore: dataStore, animated: true)
     }
 }
 

--- a/Wikipedia/Code/ColumnarCollectionViewController.swift
+++ b/Wikipedia/Code/ColumnarCollectionViewController.swift
@@ -107,6 +107,6 @@ extension ColumnarCollectionViewController: WMFColumnarCollectionViewLayoutDeleg
     }
     
     func metrics(withBoundsSize size: CGSize) -> WMFCVLMetrics {
-        return WMFCVLMetrics(boundsSize: size, firstColumnRatio: 1, secondColumnRatio: 1, collapseSectionSpacing:false)
+        return WMFCVLMetrics.singleColumnMetrics(withBoundsSize: size, collapseSectionSpacing: false)
     }
 }

--- a/Wikipedia/Code/NewsCollectionViewCell.swift
+++ b/Wikipedia/Code/NewsCollectionViewCell.swift
@@ -88,8 +88,7 @@ class NewsCollectionViewCell: CollectionViewCell {
         let collectionViewSpacing: CGFloat = 10
         let height = prototypeCell.wmf_preferredHeight(at: origin, fitting: widthToFit, alignedBy: newsSemanticContentAttribute, spacing: 2*collectionViewSpacing, apply: false)
         if (apply) {
-            flowLayout?.itemSize = CGSize(width: 250, height: height - 2*collectionViewSpacing)
-
+            flowLayout?.itemSize = CGSize(width: max(250, round(0.45*size.width)), height: height - 2*collectionViewSpacing)
             flowLayout?.minimumInteritemSpacing = collectionViewSpacing
             flowLayout?.sectionInset = UIEdgeInsets(top: collectionViewSpacing, left: collectionViewSpacing, bottom: collectionViewSpacing, right: collectionViewSpacing)
             collectionView.frame = CGRect(x: 0, y: origin.y, width: size.width, height: height)

--- a/Wikipedia/Code/WMFCVLMetrics.h
+++ b/Wikipedia/Code/WMFCVLMetrics.h
@@ -46,11 +46,12 @@
  The weight for each column's width - must add up to the total number of colums.
  @discussion @[ @1.25, @0.75, @1.0 ] is valid but @[ @1.25, @0.80, @1.0 ] is not
  */
-@property (nonnull, nonatomic, copy, readonly) NSArray *columnWeights;
+@property (nonnull, nonatomic, copy, readonly) NSArray<NSNumber *> *columnWeights;
 
 @property (nonatomic) BOOL shouldMatchColumnHeights;
 
 + (nonnull WMFCVLMetrics *)metricsWithBoundsSize:(CGSize)boundsSize;
 + (nonnull WMFCVLMetrics *)metricsWithBoundsSize:(CGSize)boundsSize firstColumnRatio:(CGFloat)firstColumnRatio secondColumnRatio:(CGFloat)secondColumnRatio collapseSectionSpacing:(BOOL)collapseSectionSpacing; // ratios should add up to 2
++ (nonnull WMFCVLMetrics *)singleColumnMetricsWithBoundsSize:(CGSize)boundsSize collapseSectionSpacing:(BOOL)collapseSectionSpacing;
 
 @end

--- a/Wikipedia/Code/WMFCVLMetrics.m
+++ b/Wikipedia/Code/WMFCVLMetrics.m
@@ -8,7 +8,7 @@
 @property (nonatomic) CGFloat interColumnSpacing;
 @property (nonatomic) CGFloat interSectionSpacing;
 @property (nonatomic) CGFloat interItemSpacing;
-@property (nonatomic, copy) NSArray *columnWeights;
+@property (nonatomic, copy) NSArray<NSNumber *> *columnWeights;
 @end
 
 @implementation WMFCVLMetrics
@@ -49,4 +49,21 @@
     return metrics;
 }
 
++ (nonnull WMFCVLMetrics *)singleColumnMetricsWithBoundsSize:(CGSize)boundsSize collapseSectionSpacing:(BOOL)collapseSectionSpacing {
+    WMFCVLMetrics *metrics = [[WMFCVLMetrics alloc] init];
+    metrics.boundsSize = boundsSize;
+    BOOL hasMargins = boundsSize.width > 600;
+    CGFloat fixedWidth = MIN(600, boundsSize.width);
+    metrics.numberOfColumns = 1;
+    metrics.columnWeights = @[@1];
+    metrics.interColumnSpacing = 0;
+    metrics.interItemSpacing = 0;
+    metrics.interSectionSpacing = collapseSectionSpacing ? 0 : 50;
+    CGFloat insetLeftAndRight = MAX(0, floor(0.5*(boundsSize.width - fixedWidth)));
+    CGFloat insetTopAndBottom = hasMargins ? 20 : 0;
+    metrics.contentInsets = UIEdgeInsetsMake(insetTopAndBottom, insetLeftAndRight, insetTopAndBottom, insetLeftAndRight);
+    metrics.sectionInsets = UIEdgeInsetsZero;
+    metrics.shouldMatchColumnHeights = YES;
+    return metrics;
+}
 @end


### PR DESCRIPTION
https://phabricator.wikimedia.org/T166241
Detail views are always 1 column now - full width for widths under 600, fixed width of 600 otherwise.

Also fixes selecting items in the detail view & initial image view setup and loading for article cells

![simulator screen shot may 30 2017 1 30 26 pm](https://cloud.githubusercontent.com/assets/741327/26596390/8ddf8cdc-453c-11e7-948c-bd3a61e59fa0.png)
![simulator screen shot may 30 2017 1 30 23 pm](https://cloud.githubusercontent.com/assets/741327/26596392/8de34b2e-453c-11e7-9d93-908090b6ef88.png)
![simulator screen shot may 30 2017 1 30 10 pm](https://cloud.githubusercontent.com/assets/741327/26596389/8ddd2528-453c-11e7-976e-935e7afeb0e2.png)
![simulator screen shot may 30 2017 1 30 08 pm](https://cloud.githubusercontent.com/assets/741327/26596391/8de281e4-453c-11e7-96f1-5ffe3140a1eb.png)
![simulator screen shot may 30 2017 1 07 54 pm](https://cloud.githubusercontent.com/assets/741327/26596403/974be48c-453c-11e7-8647-0d52dd248aff.png)
![simulator screen shot may 30 2017 1 07 52 pm](https://cloud.githubusercontent.com/assets/741327/26596402/97459046-453c-11e7-8381-cede0cd599c0.png)
