### PR TITLE
[T166615] Fix search filter dropdown layout inconsistency

### DIFF
--- a/Wikipedia/Code/PlaceSearchFilterListController.swift
+++ b/Wikipedia/Code/PlaceSearchFilterListController.swift
@@ -19,6 +19,10 @@ class PlaceSearchFilterListController: UITableViewController {
         }
     }
     
+    public func preferredHeight(for width: CGFloat) -> CGFloat {
+        return 128 // this should be dynamically calculated if/when this view supports dynamic type
+    }
+    
     init(delegate: PlaceSearchFilterListDelegate) {
         super.init(style: .plain)
         self.delegate = delegate

--- a/Wikipedia/Code/PlacesViewController.swift
+++ b/Wikipedia/Code/PlacesViewController.swift
@@ -1776,6 +1776,9 @@ class PlacesViewController: UIViewController, MKMapViewDelegate, UISearchBarDele
                 let annotationView = self.selectedArticleAnnotationView {
                 self.adjustLayout(ofPopover: popover, withSize: popover.preferredContentSize, viewSize: size, forAnnotationView: annotationView)
             }
+            if self.isSearchFilterDropDownShowing {
+                self.isSearchFilterDropDownShowing = false
+            }
             self.updateTraitBasedViewMode()
         }, completion: nil)
     }
@@ -1976,7 +1979,8 @@ class PlacesViewController: UIViewController, MKMapViewDelegate, UISearchBarDele
             return
         }
         
-        let origHeight = filterDropDownContainerView.bounds.height
+        let origHeight = searchFilterListController.preferredHeight(for: view.bounds.size.width)
+        
         
         let frame: CGRect
         if (isSearchBarInNavigationBar) {
@@ -2016,7 +2020,7 @@ class PlacesViewController: UIViewController, MKMapViewDelegate, UISearchBarDele
     
     private func hideSearchFilterDropdown(completion: @escaping ((Bool) -> Void)) {
         
-        let origHeight = filterDropDownContainerView.bounds.height
+        let origHeight = searchFilterListController.preferredHeight(for: view.bounds.size.width)
         
         self.touchOutsideOverlayView.removeFromSuperview()
         


### PR DESCRIPTION
https://phabricator.wikimedia.org/T166615

The container view bounds would be adjusted on rotate. This change allows the filter view controller to dictate the height it needs. It also hides the filter dropdown on rotate to prevent the automatic resize from being visible.