### PR TITLE
Fix layout constraints on places

### DIFF
--- a/Wikipedia/Code/Places.storyboard
+++ b/Wikipedia/Code/Places.storyboard
@@ -28,7 +28,7 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mxh-CO-RQm">
-                                <rect key="frame" x="319" y="83" width="40" height="40"/>
+                                <rect key="frame" x="319" y="84.5" width="40" height="40"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="40" id="JR3-1A-AEQ"/>
@@ -368,7 +368,6 @@
                             <constraint firstAttribute="trailingMargin" secondItem="mxh-CO-RQm" secondAttribute="trailing" id="Jrj-Yh-h1b"/>
                             <constraint firstAttribute="trailing" secondItem="Pet-ct-8QU" secondAttribute="trailing" id="Lu5-NQ-Oca"/>
                             <constraint firstItem="EsT-De-Ary" firstAttribute="leading" secondItem="pBD-gM-dPf" secondAttribute="leading" id="N4z-kS-Lfj"/>
-                            <constraint firstItem="mxh-CO-RQm" firstAttribute="top" secondItem="Pet-ct-8QU" secondAttribute="top" constant="15" id="NpV-RO-Sui"/>
                             <constraint firstItem="hEe-dF-AFg" firstAttribute="top" secondItem="mxh-CO-RQm" secondAttribute="top" id="S5v-Rm-6Vf"/>
                             <constraint firstItem="CKz-f0-MZN" firstAttribute="top" secondItem="EsT-De-Ary" secondAttribute="bottom" id="Y57-cG-ifd"/>
                             <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" secondItem="z6h-da-ewO" secondAttribute="trailing" constant="15" id="bVF-HO-Onf"/>
@@ -381,6 +380,7 @@
                             <constraint firstItem="5Dc-Qk-ppi" firstAttribute="top" secondItem="Pet-ct-8QU" secondAttribute="bottom" constant="15" id="iGn-ip-sz8"/>
                             <constraint firstItem="Pet-ct-8QU" firstAttribute="leading" secondItem="pBD-gM-dPf" secondAttribute="leading" id="j1P-UH-ysO"/>
                             <constraint firstItem="z6h-da-ewO" firstAttribute="centerX" secondItem="pBD-gM-dPf" secondAttribute="centerX" priority="999" id="kJv-Kd-ffk"/>
+                            <constraint firstItem="mxh-CO-RQm" firstAttribute="top" secondItem="Pet-ct-8QU" secondAttribute="bottom" constant="15" id="ktL-e4-gOU"/>
                             <constraint firstItem="hEe-dF-AFg" firstAttribute="top" secondItem="qzd-3E-mH2" secondAttribute="bottom" id="mYf-kK-anz"/>
                             <constraint firstItem="5Dc-Qk-ppi" firstAttribute="centerX" secondItem="pBD-gM-dPf" secondAttribute="centerX" priority="999" id="mu2-bC-yEv"/>
                             <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="5Dc-Qk-ppi" secondAttribute="trailing" constant="15" id="ua0-k1-E4K"/>
@@ -410,8 +410,8 @@
                                 <exclude reference="fmp-aY-ndd"/>
                                 <exclude reference="Fqd-WF-erI"/>
                                 <include reference="S5v-Rm-6Vf"/>
-                                <exclude reference="kJv-Kd-ffk"/>
                                 <exclude reference="mu2-bC-yEv"/>
+                                <exclude reference="kJv-Kd-ffk"/>
                                 <exclude reference="FX1-9v-ZFx"/>
                                 <include reference="IFe-5L-9c3"/>
                                 <include reference="bVF-HO-Onf"/>

--- a/Wikipedia/Code/Places.storyboard
+++ b/Wikipedia/Code/Places.storyboard
@@ -359,7 +359,7 @@
                             </constraint>
                             <constraint firstAttribute="trailing" secondItem="EsT-De-Ary" secondAttribute="trailing" id="8Fb-x8-txL"/>
                             <constraint firstItem="qzd-3E-mH2" firstAttribute="leading" secondItem="pBD-gM-dPf" secondAttribute="leading" id="AfI-uU-yeg"/>
-                            <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="z6h-da-ewO" secondAttribute="trailing" priority="998" constant="15" id="FX1-9v-ZFx"/>
+                            <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="z6h-da-ewO" secondAttribute="trailing" constant="15" id="FX1-9v-ZFx"/>
                             <constraint firstAttribute="trailing" secondItem="hEe-dF-AFg" secondAttribute="trailing" id="Fqd-WF-erI"/>
                             <constraint firstItem="EsT-De-Ary" firstAttribute="top" secondItem="Cy7-2m-87u" secondAttribute="bottom" id="Gdw-I5-72V"/>
                             <constraint firstItem="qzd-3E-mH2" firstAttribute="top" secondItem="Cy7-2m-87u" secondAttribute="bottom" id="HuV-Vk-h3n"/>
@@ -383,7 +383,7 @@
                             <constraint firstItem="z6h-da-ewO" firstAttribute="centerX" secondItem="pBD-gM-dPf" secondAttribute="centerX" priority="999" id="kJv-Kd-ffk"/>
                             <constraint firstItem="hEe-dF-AFg" firstAttribute="top" secondItem="qzd-3E-mH2" secondAttribute="bottom" id="mYf-kK-anz"/>
                             <constraint firstItem="5Dc-Qk-ppi" firstAttribute="centerX" secondItem="pBD-gM-dPf" secondAttribute="centerX" priority="999" id="mu2-bC-yEv"/>
-                            <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="5Dc-Qk-ppi" secondAttribute="trailing" priority="998" constant="15" id="ua0-k1-E4K"/>
+                            <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="5Dc-Qk-ppi" secondAttribute="trailing" constant="15" id="ua0-k1-E4K"/>
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">

--- a/Wikipedia/Code/Places.storyboard
+++ b/Wikipedia/Code/Places.storyboard
@@ -58,13 +58,14 @@
                                 </connections>
                             </button>
                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="z6h-da-ewO">
-                                <rect key="frame" x="63.5" y="85" width="248" height="40"/>
+                                <rect key="frame" x="103.5" y="85" width="168" height="40"/>
                                 <color key="backgroundColor" red="0.2535856366" green="0.48979490999999997" blue="0.83848792309999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
+                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="235" id="Nes-Zp-3AQ"/>
                                     <constraint firstAttribute="height" constant="40" id="bl4-5f-ixX"/>
                                 </constraints>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <state key="normal" title="          Redo Search in this Area          "/>
+                                <state key="normal" title="Redo Search in this Area"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="masksToBounds" value="NO"/>
                                     <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -88,7 +89,7 @@
                                 </connections>
                             </button>
                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="5Dc-Qk-ppi">
-                                <rect key="frame" x="71" y="85" width="233" height="40"/>
+                                <rect key="frame" x="96.5" y="85" width="182" height="40"/>
                                 <color key="backgroundColor" red="0.2535856366" green="0.48979490999999997" blue="0.83848792309999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="235" id="DTV-bA-1bt"/>
@@ -358,9 +359,11 @@
                             </constraint>
                             <constraint firstAttribute="trailing" secondItem="EsT-De-Ary" secondAttribute="trailing" id="8Fb-x8-txL"/>
                             <constraint firstItem="qzd-3E-mH2" firstAttribute="leading" secondItem="pBD-gM-dPf" secondAttribute="leading" id="AfI-uU-yeg"/>
+                            <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="z6h-da-ewO" secondAttribute="trailing" priority="998" constant="15" id="FX1-9v-ZFx"/>
                             <constraint firstAttribute="trailing" secondItem="hEe-dF-AFg" secondAttribute="trailing" id="Fqd-WF-erI"/>
                             <constraint firstItem="EsT-De-Ary" firstAttribute="top" secondItem="Cy7-2m-87u" secondAttribute="bottom" id="Gdw-I5-72V"/>
                             <constraint firstItem="qzd-3E-mH2" firstAttribute="top" secondItem="Cy7-2m-87u" secondAttribute="bottom" id="HuV-Vk-h3n"/>
+                            <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" secondItem="5Dc-Qk-ppi" secondAttribute="trailing" constant="15" id="IFe-5L-9c3"/>
                             <constraint firstItem="Pet-ct-8QU" firstAttribute="top" secondItem="qzd-3E-mH2" secondAttribute="bottom" id="Jc5-dx-3Pw"/>
                             <constraint firstAttribute="trailingMargin" secondItem="mxh-CO-RQm" secondAttribute="trailing" id="Jrj-Yh-h1b"/>
                             <constraint firstAttribute="trailing" secondItem="Pet-ct-8QU" secondAttribute="trailing" id="Lu5-NQ-Oca"/>
@@ -380,13 +383,14 @@
                             <constraint firstItem="z6h-da-ewO" firstAttribute="centerX" secondItem="pBD-gM-dPf" secondAttribute="centerX" priority="999" id="kJv-Kd-ffk"/>
                             <constraint firstItem="hEe-dF-AFg" firstAttribute="top" secondItem="qzd-3E-mH2" secondAttribute="bottom" id="mYf-kK-anz"/>
                             <constraint firstItem="5Dc-Qk-ppi" firstAttribute="centerX" secondItem="pBD-gM-dPf" secondAttribute="centerX" priority="999" id="mu2-bC-yEv"/>
-                            <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" secondItem="5Dc-Qk-ppi" secondAttribute="trailing" priority="998" constant="15" id="ua0-k1-E4K"/>
+                            <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="5Dc-Qk-ppi" secondAttribute="trailing" priority="998" constant="15" id="ua0-k1-E4K"/>
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">
                                 <exclude reference="Gdw-I5-72V"/>
                                 <exclude reference="S5v-Rm-6Vf"/>
                                 <exclude reference="mYf-kK-anz"/>
+                                <exclude reference="IFe-5L-9c3"/>
                                 <exclude reference="bVF-HO-Onf"/>
                             </mask>
                         </variation>
@@ -408,7 +412,10 @@
                                 <include reference="S5v-Rm-6Vf"/>
                                 <exclude reference="kJv-Kd-ffk"/>
                                 <exclude reference="mu2-bC-yEv"/>
+                                <exclude reference="FX1-9v-ZFx"/>
+                                <include reference="IFe-5L-9c3"/>
                                 <include reference="bVF-HO-Onf"/>
+                                <exclude reference="ua0-k1-E4K"/>
                                 <exclude reference="1PC-H2-U7d"/>
                             </mask>
                         </variation>

--- a/Wikipedia/Code/Places.storyboard
+++ b/Wikipedia/Code/Places.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -88,7 +88,7 @@
                                 </connections>
                             </button>
                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="5Dc-Qk-ppi">
-                                <rect key="frame" x="71" y="84" width="233" height="40"/>
+                                <rect key="frame" x="96.5" y="84" width="182" height="40"/>
                                 <color key="backgroundColor" red="0.2535856366" green="0.48979490999999997" blue="0.83848792309999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="235" id="DTV-bA-1bt"/>
@@ -380,8 +380,8 @@
                             <constraint firstItem="Pet-ct-8QU" firstAttribute="leading" secondItem="pBD-gM-dPf" secondAttribute="leading" id="j1P-UH-ysO"/>
                             <constraint firstItem="z6h-da-ewO" firstAttribute="centerX" secondItem="pBD-gM-dPf" secondAttribute="centerX" id="kJv-Kd-ffk"/>
                             <constraint firstItem="hEe-dF-AFg" firstAttribute="top" secondItem="qzd-3E-mH2" secondAttribute="bottom" id="mYf-kK-anz"/>
-                            <constraint firstItem="5Dc-Qk-ppi" firstAttribute="centerX" secondItem="pBD-gM-dPf" secondAttribute="centerX" id="mu2-bC-yEv"/>
-                            <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" secondItem="5Dc-Qk-ppi" secondAttribute="trailing" constant="15" id="ua0-k1-E4K"/>
+                            <constraint firstItem="5Dc-Qk-ppi" firstAttribute="centerX" secondItem="pBD-gM-dPf" secondAttribute="centerX" priority="999" id="mu2-bC-yEv"/>
+                            <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="5Dc-Qk-ppi" secondAttribute="trailing" priority="998" constant="15" id="ua0-k1-E4K"/>
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">
@@ -644,7 +644,7 @@
                 <navigationController storyboardIdentifier="Places" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" navigationBarHidden="YES" id="fC7-UI-Knm" userLabel="Places" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Places" image="tabbar-nearby" selectedImage="tabbar-nearby-selected" id="qMU-9n-S42"/>
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="HFz-Jz-Pn5">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="HFz-Jz-Pn5">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>

--- a/Wikipedia/Code/Places.storyboard
+++ b/Wikipedia/Code/Places.storyboard
@@ -58,7 +58,7 @@
                                 </connections>
                             </button>
                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="z6h-da-ewO">
-                                <rect key="frame" x="63.5" y="84" width="248" height="40"/>
+                                <rect key="frame" x="63.5" y="85" width="248" height="40"/>
                                 <color key="backgroundColor" red="0.2535856366" green="0.48979490999999997" blue="0.83848792309999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="bl4-5f-ixX"/>
@@ -88,7 +88,7 @@
                                 </connections>
                             </button>
                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="5Dc-Qk-ppi">
-                                <rect key="frame" x="96.5" y="84" width="182" height="40"/>
+                                <rect key="frame" x="71" y="85" width="233" height="40"/>
                                 <color key="backgroundColor" red="0.2535856366" green="0.48979490999999997" blue="0.83848792309999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="235" id="DTV-bA-1bt"/>
@@ -375,13 +375,12 @@
                             </constraint>
                             <constraint firstItem="z6h-da-ewO" firstAttribute="top" secondItem="Pet-ct-8QU" secondAttribute="bottom" constant="15" id="fgS-zA-xVL"/>
                             <constraint firstItem="EsT-De-Ary" firstAttribute="top" secondItem="qzd-3E-mH2" secondAttribute="bottom" id="fmp-aY-ndd"/>
-                            <constraint firstAttribute="trailing" secondItem="mxh-CO-RQm" secondAttribute="trailing" constant="15" id="gRy-yz-tGe"/>
                             <constraint firstItem="5Dc-Qk-ppi" firstAttribute="top" secondItem="Pet-ct-8QU" secondAttribute="bottom" constant="15" id="iGn-ip-sz8"/>
                             <constraint firstItem="Pet-ct-8QU" firstAttribute="leading" secondItem="pBD-gM-dPf" secondAttribute="leading" id="j1P-UH-ysO"/>
-                            <constraint firstItem="z6h-da-ewO" firstAttribute="centerX" secondItem="pBD-gM-dPf" secondAttribute="centerX" id="kJv-Kd-ffk"/>
+                            <constraint firstItem="z6h-da-ewO" firstAttribute="centerX" secondItem="pBD-gM-dPf" secondAttribute="centerX" priority="999" id="kJv-Kd-ffk"/>
                             <constraint firstItem="hEe-dF-AFg" firstAttribute="top" secondItem="qzd-3E-mH2" secondAttribute="bottom" id="mYf-kK-anz"/>
                             <constraint firstItem="5Dc-Qk-ppi" firstAttribute="centerX" secondItem="pBD-gM-dPf" secondAttribute="centerX" priority="999" id="mu2-bC-yEv"/>
-                            <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="5Dc-Qk-ppi" secondAttribute="trailing" priority="998" constant="15" id="ua0-k1-E4K"/>
+                            <constraint firstItem="mxh-CO-RQm" firstAttribute="leading" secondItem="5Dc-Qk-ppi" secondAttribute="trailing" priority="998" constant="15" id="ua0-k1-E4K"/>
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">
@@ -389,7 +388,6 @@
                                 <exclude reference="S5v-Rm-6Vf"/>
                                 <exclude reference="mYf-kK-anz"/>
                                 <exclude reference="bVF-HO-Onf"/>
-                                <exclude reference="gRy-yz-tGe"/>
                             </mask>
                         </variation>
                         <variation key="heightClass=compact">
@@ -411,7 +409,6 @@
                                 <exclude reference="kJv-Kd-ffk"/>
                                 <exclude reference="mu2-bC-yEv"/>
                                 <include reference="bVF-HO-Onf"/>
-                                <include reference="gRy-yz-tGe"/>
                                 <exclude reference="1PC-H2-U7d"/>
                             </mask>
                         </variation>
@@ -457,7 +454,7 @@
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3Ik-kL-6c1">
-                            <rect key="frame" x="0.0" y="59" width="305" height="282.5"/>
+                            <rect key="frame" x="0.0" y="59.5" width="305" height="282.5"/>
                             <subviews>
                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" image="places-search-empty-state-overlay" translatesAutoresizingMaskIntoConstraints="NO" id="g1Q-tu-jmG">
                                     <rect key="frame" x="68.5" y="8" width="168" height="150"/>
@@ -468,7 +465,7 @@
                                     </constraints>
                                 </imageView>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Search for Wikipedia articles with geographic locations" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oYN-g3-07L">
-                                    <rect key="frame" x="14.5" y="166" width="276" height="50"/>
+                                    <rect key="frame" x="15" y="166" width="275" height="50"/>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="4s2-GM-K7d"/>
                                     </constraints>
@@ -477,7 +474,7 @@
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Explore cities, countries, continents, natural landmarks, historical events, buildings and more." textAlignment="center" lineBreakMode="wordWrap" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vm1-d9-7Ne">
-                                    <rect key="frame" x="14.5" y="224" width="276" height="50.5"/>
+                                    <rect key="frame" x="15" y="224" width="275" height="50.5"/>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="750" constant="40" id="97Q-bU-Bot"/>
                                     </constraints>


### PR DESCRIPTION
The "Did you mean" & "Recenter on my location" button constraints were unsatisfiable - made the space between them >= 15 at 998 priority and the centerX constraint 999 priority. Also removed a duplicate trailing constraint for the "Recenter on my location" button on iPad, updated the ""Redo search" constraints to match the "Did you mean" constraints, and fixed the vertical alignment of the "Recenter on my location button" (it was 1.5pt too high due to being constrained to 15pt from the top of the progress bar rather than the bottom)

```
Wikipedia[33120:10206405] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x608000690e50 UIButton:0x7f9b66136db0.width == 40>",
    "<NSLayoutConstraint:0x608000690ae0 UIButton:0x7f9b66136510.width <= 235>",
    "<NSLayoutConstraint:0x610000682120 UIButton:0x7f9b66136510.centerX == UIView:0x7f9b6613c450.centerX>",
    "<NSLayoutConstraint:0x6100006820d0 UIView:0x7f9b6613c450.trailingMargin == UIButton:0x7f9b66136db0.trailing>",
    "<NSLayoutConstraint:0x610000682080 UIButton:0x7f9b66136db0.leading == UIButton:0x7f9b66136510.trailing + 15>",
    "<NSLayoutConstraint:0x610000480910 UIView:0x7f9b6613c450.width == 375>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x608000690ae0 UIButton:0x7f9b66136510.width <= 235>
```