### PR TITLE
[T167298] Fix default localizations

### DIFF
--- a/WMF Framework/Localization.swift
+++ b/WMF Framework/Localization.swift
@@ -1,8 +1,5 @@
 import Foundation
 
 public func WMFLocalizedString(_ key: String, siteURL: URL? = nil, bundle: Bundle = Bundle.wmf_localization, value: String, comment: String) -> String {
-    guard let siteURL = siteURL else {
-        return NSLocalizedString(key, tableName: nil, bundle: bundle, value: value, comment: comment)
-    }
     return WMFLocalizedStringWithDefaultValue(key, siteURL, bundle, value, comment)
 }

--- a/WMF Framework/WMFLocalization.m
+++ b/WMF Framework/WMFLocalization.m
@@ -38,7 +38,7 @@ NSString *WMFLocalizedStringWithDefaultValue(NSString *key, NSURL * _Nullable ur
     }
     NSString *language = url.wmf_language;
     if (language == nil) {
-       return NSLocalizedStringWithDefaultValue(key, nil, bundle, value, comment);
+        return [bundle localizedStringForKey:key value:value table:nil];
     }
 
     NSBundle *languageBundle = [bundle wmf_languageBundleForLanguage:language];
@@ -47,7 +47,7 @@ NSString *WMFLocalizedStringWithDefaultValue(NSString *key, NSURL * _Nullable ur
         translation = [languageBundle localizedStringForKey:key value:@"" table:nil];
     }
     if (!translation || [translation isEqualToString:key] || (translation.length == 0)) {
-        return NSLocalizedStringWithDefaultValue(key, nil, bundle, value, comment);
+        return [bundle localizedStringForKey:key value:value table:nil];
     }
     return translation ? translation : @"";
 }


### PR DESCRIPTION
Default localizations weren't properly accessing the pluralized values from the `stringsdict` files. Using `[NSBundle localizedStringForKey` instead of the macro fixes this issue.