### PR TITLE
[T167308] Add translations to enable location explore feed card & add missing wmf_configureSubviewsForDynamicType

### DIFF
--- a/Wikipedia/Code/EnableLocationViewController.swift
+++ b/Wikipedia/Code/EnableLocationViewController.swift
@@ -3,8 +3,12 @@ import UIKit
 protocol EnableLocationViewControllerDelegate: NSObjectProtocol {
     func enableLocationViewController(_ enableLocationViewController: EnableLocationViewController, didFinishWithShouldPromptForLocationAccess  shouldPromptForLocationAccess: Bool)
 }
-class EnableLocationViewController: UIViewController {
 
+class EnableLocationViewController: UIViewController {
+    static let localizedEnableLocationTitle = WMFLocalizedString("places-enable-location-title", value:"Explore articles near your location by enabling Location Access", comment:"Explains that you can explore articles near you by enabling location access. \"Location\" should be the same term, which is used in the device settings, under \"Privacy\".")
+    static let localizedEnableLocationDescription = WMFLocalizedString("places-enable-location-description", value:"Access to your location is available only when the app or one of its features is visible on your screen.", comment:"Describes that access to your location is only used when the app or one of its features is on the screen")
+    static let localizedEnableLocationButtonTitle = WMFLocalizedString("places-enable-location-action-button-title", value:"Enable location", comment:"Button title to enable location access")
+    
     weak var delegate: EnableLocationViewControllerDelegate?
     
     @IBOutlet weak var enableLocationAccessButton: UIButton!
@@ -15,9 +19,9 @@ class EnableLocationViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        titleLabel.text = WMFLocalizedString("places-enable-location-title", value:"Explore articles near your location by enabling Location Access", comment:"Explains that you can explore articles near you by enabling location access. \"Location\" should be the same term, which is used in the device settings, under \"Privacy\".")
-        descriptionLabel.text = WMFLocalizedString("places-enable-location-description", value:"Access to your location is available only when the app or one of its features is visible on your screen.", comment:"Describes that access to your location is only used when the app or one of its features is on the screen")
-        enableLocationAccessButton.setTitle(WMFLocalizedString("places-enable-location-action-button-title", value:"Enable location", comment:"Button title to enable location access"), for: .normal)
+        titleLabel.text = EnableLocationViewController.localizedEnableLocationTitle
+        descriptionLabel.text = EnableLocationViewController.localizedEnableLocationDescription
+        enableLocationAccessButton.setTitle(EnableLocationViewController.localizedEnableLocationButtonTitle, for: .normal)
     }
     
     @IBAction func close(_ sender: Any) {

--- a/Wikipedia/Code/WMFDynamicTypeExtentions.swift
+++ b/Wikipedia/Code/WMFDynamicTypeExtentions.swift
@@ -1,7 +1,17 @@
 import Foundation
 
+extension UIView {
+    open func wmf_configureSubviewsForDynamicType() {
+        if #available(iOS 10.0, *) {
+            for subview in subviews {
+                subview.wmf_configureSubviewsForDynamicType()
+            }
+        }
+    }
+}
+
 extension UIButton {
-    fileprivate func wmf_configureForDynamicType(){
+    override open func wmf_configureSubviewsForDynamicType(){
         if #available(iOS 10.0, *) {
             guard let titleLabel = titleLabel else {
                 return
@@ -14,38 +24,25 @@ extension UIButton {
             titleLabel.minimumScaleFactor = 0.25
             titleLabel.adjustsFontSizeToFitWidth = true
         }
+        super.wmf_configureSubviewsForDynamicType()
     }
 }
 
 extension UILabel {
-    fileprivate func wmf_configureForDynamicType(){
+    override open func wmf_configureSubviewsForDynamicType(){
         if #available(iOS 10.0, *) {
             adjustsFontForContentSizeCategory = true
         }
+        super.wmf_configureSubviewsForDynamicType()
     }
 }
 
 extension UITextField {
-    fileprivate func wmf_configureForDynamicType(){
+    override open func wmf_configureSubviewsForDynamicType(){
         if #available(iOS 10.0, *) {
             adjustsFontForContentSizeCategory = true
         }
+        super.wmf_configureSubviewsForDynamicType()
     }
 }
 
-extension UIView {
-    func wmf_configureSubviewsForDynamicType() {
-        if #available(iOS 10.0, *) {
-            if isKind(of: UIButton.self) {
-                (self as! UIButton).wmf_configureForDynamicType()
-            }else if isKind(of: UILabel.self) {
-                (self as! UILabel).wmf_configureForDynamicType()
-            }else if isKind(of: UITextField.self) {
-                (self as! UITextField).wmf_configureForDynamicType()
-            }
-            for subview in subviews {
-                subview.wmf_configureSubviewsForDynamicType()
-            }
-        }
-    }
-}

--- a/Wikipedia/Code/WMFExploreCollectionViewController.m
+++ b/Wikipedia/Code/WMFExploreCollectionViewController.m
@@ -1081,7 +1081,9 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
             return [collectionView dequeueReusableSupplementaryViewOfKind:UICollectionElementKindSectionFooter withReuseIdentifier:WMFFeedEmptyHeaderFooterReuseIdentifier forIndexPath:indexPath];
         case WMFFeedMoreTypeLocationAuthorization: {
             WMFTitledExploreSectionFooter *footer = (id)[collectionView dequeueReusableSupplementaryViewOfKind:UICollectionElementKindSectionFooter withReuseIdentifier:[WMFTitledExploreSectionFooter wmf_nibName] forIndexPath:indexPath];
-            
+            footer.titleLabel.text = [EnableLocationViewController localizedEnableLocationTitle];
+            footer.descriptionLabel.text = [EnableLocationViewController localizedEnableLocationDescription];
+            [footer.enableLocationButton setTitle:[EnableLocationViewController localizedEnableLocationButtonTitle] forState: UIControlStateNormal];
             [footer.enableLocationButton removeTarget:self action:@selector(enableLocationButtonPressed:) forControlEvents:UIControlEventTouchUpInside]; // ensures the view controller isn't duplicated in the target list, causing duplicate actions to be sent
             footer.enableLocationButton.tag = indexPath.section;
             [footer.enableLocationButton addTarget:self action:@selector(enableLocationButtonPressed:) forControlEvents:UIControlEventTouchUpInside];

--- a/Wikipedia/Code/WMFTitledExploreSectionFooter.swift
+++ b/Wikipedia/Code/WMFTitledExploreSectionFooter.swift
@@ -1,5 +1,7 @@
 import UIKit
 
 class WMFTitledExploreSectionFooter: WMFExploreCollectionReusableView {
-    
+    override func awakeFromNib() {
+        wmf_configureSubviewsForDynamicType()
+    }
 }

--- a/Wikipedia/Code/WMFTitledExploreSectionFooter.swift
+++ b/Wikipedia/Code/WMFTitledExploreSectionFooter.swift
@@ -1,8 +1,11 @@
 import UIKit
 
 class WMFTitledExploreSectionFooter: WMFExploreCollectionReusableView {
-	@IBOutlet weak var enableLocationButton: UIButton!
-	
+
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var enableLocationButton: UIButton!
+    @IBOutlet weak var descriptionLabel: UILabel!
+    
     override func awakeFromNib() {
         wmf_configureSubviewsForDynamicType()
     }

--- a/Wikipedia/Code/WMFTitledExploreSectionFooter.xib
+++ b/Wikipedia/Code/WMFTitledExploreSectionFooter.xib
@@ -63,7 +63,9 @@
                 <constraint firstItem="FLN-Qn-RlX" firstAttribute="top" secondItem="Jze-hP-209" secondAttribute="bottom" constant="10.5" id="osJ-fz-5QS"/>
             </constraints>
             <connections>
+                <outlet property="descriptionLabel" destination="kUc-RJ-UHk" id="jFh-eD-8Di"/>
                 <outlet property="enableLocationButton" destination="FLN-Qn-RlX" id="lat-If-LkC"/>
+                <outlet property="titleLabel" destination="Jze-hP-209" id="Vo7-xT-YDG"/>
             </connections>
             <point key="canvasLocation" x="33.5" y="112.5"/>
         </collectionReusableView>


### PR DESCRIPTION
- Adds the same translations used in places
- Adds missing `wmf_configureSubviewsForDynamicType`
- Uses the ability to override extension functions to eliminate the need for the type check in `wmf_configureSubviewsForDynamicType`

![simulator screen shot jun 7 2017 11 20 36 am](https://user-images.githubusercontent.com/741327/26886490-83df2f2a-4b73-11e7-9190-ad5d3bc58d5f.png)
