### PR TITLE
Fix article image peek if file extension wasn't all lower case.

### DIFF
--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1632,7 +1632,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 }
 
 - (nullable UIViewController *)peekViewControllerForURL:(NSURL *)linkURL {
-    if ([self.peekableImageExtensions containsObject:[linkURL pathExtension]]) {
+    if ([self.peekableImageExtensions containsObject:[[linkURL pathExtension] lowercaseString]]) {
         return [self viewControllerForImageFilePageURL:linkURL];
     } else {
         return [self viewControllerForPreviewURL:linkURL];


### PR DESCRIPTION
https://phabricator.wikimedia.org/T167371

Noticed on first non-lead image on `enwiki > Freestyle swimming`.

# Before
![before mov](https://user-images.githubusercontent.com/3143487/26907433-9babad24-4ba8-11e7-9de1-4012273d1783.gif)

# After
![after mov](https://user-images.githubusercontent.com/3143487/26907440-9ff1e056-4ba8-11e7-81c4-7926e7095a7a.gif)