### PR TITLE
Fix missing `Similar pages` footer menu items.

### DIFF
--- a/Wikipedia/Code/MWKSection.m
+++ b/Wikipedia/Code/MWKSection.m
@@ -244,7 +244,7 @@ static NSString *const WMFSectionSummaryXPathSelector = @"\
     }] componentsJoinedByString:@" "] wmf_summaryFromText];
 }
 
-static NSString *const WMFSectionDisambiguationTitlesXPathSelector = @"//div[@class='hatnote']//a/@href";
+static NSString *const WMFSectionDisambiguationTitlesXPathSelector = @"//div[contains(@class, 'hatnote')]//a/@href";
 
 - (nullable NSArray<NSURL *> *)disambiguationURLs {
     NSArray *textNodes = [self elementsInTextMatchingXPath:WMFSectionDisambiguationTitlesXPathSelector];


### PR DESCRIPTION
The upstream css changed adding an additional class and we were testing for an extact match.

https://phabricator.wikimedia.org/T167476

# Before
![before1 mov](https://user-images.githubusercontent.com/3143487/26954493-1a8d8e16-4c65-11e7-867b-573b5b2f3518.gif)

# After
![after2 mov](https://user-images.githubusercontent.com/3143487/26954495-1d780aac-4c65-11e7-9dae-667c7344824f.gif)
