### PR TITLE
[5.5.1] [T167958] Fix 5.5 explore feed crashes

### DIFF
--- a/Wikipedia/Code/WMFCVLInfo.h
+++ b/Wikipedia/Code/WMFCVLInfo.h
@@ -23,8 +23,8 @@
 - (void)enumerateSectionsWithBlock:(nonnull void (^)(WMFCVLSection *_Nonnull section, NSUInteger idx, BOOL *_Nonnull stop))block;
 - (void)enumerateColumnsWithBlock:(nonnull void (^)(WMFCVLColumn *_Nonnull column, NSUInteger idx, BOOL *_Nonnull stop))block;
 
-- (nullable WMFCVLAttributes *)layoutAttributesForItemAtIndexPath:(nonnull NSIndexPath *)indexPath;
-- (nullable WMFCVLAttributes *)layoutAttributesForSupplementaryViewOfKind:(nonnull NSString *)elementKind atIndexPath:(nonnull NSIndexPath *)indexPath;
+- (nonnull WMFCVLAttributes *)layoutAttributesForItemAtIndexPath:(nonnull NSIndexPath *)indexPath;
+- (nonnull WMFCVLAttributes *)layoutAttributesForSupplementaryViewOfKind:(nonnull NSString *)elementKind atIndexPath:(nonnull NSIndexPath *)indexPath;
 
 - (void)layoutWithMetrics:(nonnull WMFCVLMetrics *)metrics delegate:(nullable id<WMFColumnarCollectionViewLayoutDelegate>)delegate collectionView:(nullable UICollectionView *)collectionView invalidationContext:(nullable WMFCVLInvalidationContext *)context;
 

--- a/Wikipedia/Code/WMFCVLInfo.m
+++ b/Wikipedia/Code/WMFCVLInfo.m
@@ -53,17 +53,17 @@
     [self.columns enumerateObjectsUsingBlock:block];
 }
 
-- (nullable WMFCVLAttributes *)layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath {
+- (nonnull WMFCVLAttributes *)layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger sectionIndex = indexPath.section;
 
     if (sectionIndex < 0 || sectionIndex >= self.sections.count) {
-        return nil;
+        return [WMFCVLAttributes layoutAttributesForCellWithIndexPath:indexPath];
     }
 
     WMFCVLSection *section = self.sections[sectionIndex];
     NSInteger itemIndex = indexPath.item;
     if (itemIndex < 0 || itemIndex >= section.items.count) {
-        return nil;
+        return [WMFCVLAttributes layoutAttributesForCellWithIndexPath:indexPath];
     }
 
     WMFCVLAttributes *attributes = section.items[itemIndex];
@@ -71,10 +71,10 @@
     return attributes;
 }
 
-- (nullable WMFCVLAttributes *)layoutAttributesForSupplementaryViewOfKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath {
+- (nonnull WMFCVLAttributes *)layoutAttributesForSupplementaryViewOfKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath {
     NSInteger sectionIndex = indexPath.section;
     if (sectionIndex < 0 || sectionIndex >= self.sections.count) {
-        return nil;
+        return [WMFCVLAttributes layoutAttributesForSupplementaryViewOfKind:elementKind withIndexPath:indexPath];;
     }
 
     WMFCVLSection *section = self.sections[sectionIndex];
@@ -83,13 +83,13 @@
     if ([elementKind isEqualToString:UICollectionElementKindSectionHeader]) {
         NSInteger itemIndex = indexPath.item;
         if (itemIndex < 0 || itemIndex >= section.headers.count) {
-            return nil;
+            return [WMFCVLAttributes layoutAttributesForSupplementaryViewOfKind:elementKind withIndexPath:indexPath];;
         }
         attributes = section.headers[itemIndex];
     } else if ([elementKind isEqualToString:UICollectionElementKindSectionFooter]) {
         NSInteger itemIndex = indexPath.item;
         if (itemIndex < 0 || itemIndex >= section.footers.count) {
-            return nil;
+            return [WMFCVLAttributes layoutAttributesForSupplementaryViewOfKind:elementKind withIndexPath:indexPath];
         }
         attributes = section.footers[itemIndex];
     }

--- a/Wikipedia/Code/WMFCVLInfo.m
+++ b/Wikipedia/Code/WMFCVLInfo.m
@@ -83,7 +83,7 @@
     if ([elementKind isEqualToString:UICollectionElementKindSectionHeader]) {
         NSInteger itemIndex = indexPath.item;
         if (itemIndex < 0 || itemIndex >= section.headers.count) {
-            return [WMFCVLAttributes layoutAttributesForSupplementaryViewOfKind:elementKind withIndexPath:indexPath];;
+            return [WMFCVLAttributes layoutAttributesForSupplementaryViewOfKind:elementKind withIndexPath:indexPath];
         }
         attributes = section.headers[itemIndex];
     } else if ([elementKind isEqualToString:UICollectionElementKindSectionFooter]) {
@@ -92,6 +92,8 @@
             return [WMFCVLAttributes layoutAttributesForSupplementaryViewOfKind:elementKind withIndexPath:indexPath];
         }
         attributes = section.footers[itemIndex];
+    } else {
+        attributes = [WMFCVLAttributes layoutAttributesForSupplementaryViewOfKind:elementKind withIndexPath:indexPath];
     }
 
     assert(attributes != nil);

--- a/Wikipedia/Code/WMFCVLInfo.m
+++ b/Wikipedia/Code/WMFCVLInfo.m
@@ -74,7 +74,7 @@
 - (nonnull WMFCVLAttributes *)layoutAttributesForSupplementaryViewOfKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath {
     NSInteger sectionIndex = indexPath.section;
     if (sectionIndex < 0 || sectionIndex >= self.sections.count) {
-        return [WMFCVLAttributes layoutAttributesForSupplementaryViewOfKind:elementKind withIndexPath:indexPath];;
+        return [WMFCVLAttributes layoutAttributesForSupplementaryViewOfKind:elementKind withIndexPath:indexPath];
     }
 
     WMFCVLSection *section = self.sections[sectionIndex];

--- a/Wikipedia/Code/WMFExploreCollectionViewController.m
+++ b/Wikipedia/Code/WMFExploreCollectionViewController.m
@@ -280,23 +280,16 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
     WMFContentGroup *section = [self sectionAtIndex:indexPath.section];
     NSURL *articleURL = nil;
     NSInteger width = 0;
-    if ([section contentType] == WMFContentTypeTopReadPreview) {
-
-        NSArray<WMFFeedTopReadArticlePreview *> *content = [self contentForSectionAtIndex:indexPath.section];
-
-        if (indexPath.row >= [content count]) {
-            articleURL = nil;
-        }
-
-        articleURL = [content[indexPath.row] articleURL];
+    NSArray<NSCoding> *content = [self contentForSectionAtIndex:indexPath.section];
+    if (indexPath.row >= [content count]) {
+        return nil;
+    }
+    NSObject *object = content[indexPath.row];
+    if ([section contentType] == WMFContentTypeTopReadPreview  && [object isKindOfClass:[WMFFeedTopReadArticlePreview class]]) {
+        articleURL = [(WMFFeedTopReadArticlePreview *)object articleURL];
         width = self.traitCollection.wmf_listThumbnailWidth;
-    } else if ([section contentType] == WMFContentTypeURL) {
-
-        NSArray<NSURL *> *content = [self contentForSectionAtIndex:indexPath.section];
-        if (indexPath.row >= [content count]) {
-            articleURL = nil;
-        }
-        articleURL = content[indexPath.row];
+    } else if ([section contentType] == WMFContentTypeURL  && [object isKindOfClass:[NSURL class]]) {
+        articleURL = (NSURL *)object;
         switch (section.contentGroupKind) {
             case WMFContentGroupKindRelatedPages:
             case WMFContentGroupKindPictureOfTheDay:
@@ -309,12 +302,9 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
                 break;
         }
 
-    } else if ([section contentType] == WMFContentTypeStory) {
-        NSArray<WMFFeedNewsStory *> *content = [self contentForSectionAtIndex:indexPath.section];
-        if (indexPath.row >= [content count]) {
-            articleURL = nil;
-        }
-        articleURL = [[content[indexPath.row] featuredArticlePreview] articleURL] ?: [[[content[indexPath.row] articlePreviews] firstObject] articleURL];
+    } else if ([section contentType] == WMFContentTypeStory && [object isKindOfClass:[WMFFeedNewsStory class]]) {
+        WMFFeedNewsStory *newsStory = (WMFFeedNewsStory *)object;
+        articleURL = [[newsStory featuredArticlePreview] articleURL] ?: [[[newsStory articlePreviews] firstObject] articleURL];
         width = self.traitCollection.wmf_nearbyThumbnailWidth;
     } else {
         return nil;


### PR DESCRIPTION
https://phabricator.wikimedia.org/T167958

- Returns empty layout attributes instead of nil
- Adds a range check on `WMFContentGroup` contents array