### PR TITLE
[5.5.1] Remaining crash fixes & minor bug fixes

### DIFF
--- a/WMF Framework/WMFExploreFeedContentController.m
+++ b/WMF Framework/WMFExploreFeedContentController.m
@@ -311,9 +311,9 @@ static const NSString *kvo_WMFExploreFeedContentController_operationQueue_operat
 #pragma mark - Debug
 
 - (void)debugChaos {
+    BOOL needsTeardown = arc4random_uniform(2) > 0;
+    NSManagedObjectContext *moc = needsTeardown ? self.dataStore.feedImportContext : self.dataStore.viewContext;
     WMFAsyncBlockOperation *op = [[WMFAsyncBlockOperation alloc] initWithAsyncBlock:^(WMFAsyncBlockOperation * _Nonnull op) {
-        BOOL needsTeardown = arc4random_uniform(2) > 0;
-        NSManagedObjectContext *moc = needsTeardown ? self.dataStore.feedImportContext : self.dataStore.viewContext;
         [moc performBlock:^{
             NSFetchRequest *request = [WMFContentGroup fetchRequest];
             NSInteger count = [moc countForFetchRequest:request error:nil];
@@ -325,23 +325,14 @@ static const NSString *kvo_WMFExploreFeedContentController_operationQueue_operat
                 int32_t random = (15 - (int32_t)arc4random_uniform(30));
                 switch (seed) {
                     case 0:
-                        group.dailySortPriority = group.dailySortPriority + random;
-                        break;
-                    case 1:
                         group.midnightUTCDate = [group.midnightUTCDate dateByAddingTimeInterval:86400*random];
                         group.contentMidnightUTCDate = [group.contentMidnightUTCDate dateByAddingTimeInterval:86400*random];
                         group.date = [group.date dateByAddingTimeInterval:86400*random];
                         break;
-                    case 2:
+                    case 1:
                         [moc deleteObject:group];
                     default:
-                    {
-                        [moc createGroupOfKind:group.contentGroupKind forDate:[group.date dateByAddingTimeInterval:86400*random] withSiteURL:group.siteURL associatedContent:group.content customizationBlock:^(WMFContentGroup * _Nonnull newGroup) {
-                            newGroup.location = group.location;
-                            newGroup.placemark = group.placemark;
-                            newGroup.contentMidnightUTCDate = [group.contentMidnightUTCDate dateByAddingTimeInterval:86400*random];
-                        }];
-                    }
+                        group.dailySortPriority = group.dailySortPriority + random;
                         break;
                 }
             }

--- a/WMF Framework/WMFExploreFeedContentController.m
+++ b/WMF Framework/WMFExploreFeedContentController.m
@@ -331,8 +331,9 @@ static const NSString *kvo_WMFExploreFeedContentController_operationQueue_operat
                         break;
                     case 1:
                         [moc deleteObject:group];
-                    default:
+                    case 2:
                         group.dailySortPriority = group.dailySortPriority + random;
+                    default:
                         break;
                 }
             }

--- a/Wikipedia/Code/WMFCVLInfo.m
+++ b/Wikipedia/Code/WMFCVLInfo.m
@@ -238,7 +238,7 @@
         for (NSInteger columnIndex = 0; columnIndex < numberOfColumns; columnIndex++) {
             WMFCVLColumn *column = self.columns[columnIndex];
             CGFloat columnHeight = column.frame.size.height;
-            if (columnHeight < shortestColumnHeight) {
+            if (columnHeight <= shortestColumnHeight) { // <= to defer to the narrower column if it's equally short
                 shortestColumn = column;
                 shortestColumnHeight = columnHeight;
             }

--- a/Wikipedia/Code/WMFChange.m
+++ b/Wikipedia/Code/WMFChange.m
@@ -2,12 +2,33 @@
 
 @implementation WMFChange
 
+- (NSString *)debugDescription {
+    switch (self.type) {
+        case NSFetchedResultsChangeInsert:
+            return @"insert";
+        case NSFetchedResultsChangeDelete:
+            return @"delete";
+        case NSFetchedResultsChangeMove:
+            return @"move";
+        default:
+            return @"update";
+    }
+}
+
 @end
 
 @implementation WMFSectionChange
 
+- (NSString *)debugDescription {
+    return [NSString stringWithFormat:@"%@ section %li", [super debugDescription], self.sectionIndex];
+}
+
 @end
 
 @implementation WMFObjectChange
+
+- (NSString *)debugDescription {
+    return [NSString stringWithFormat:@"%@ object %@ to %@", [super debugDescription], self.fromIndexPath, self.toIndexPath];
+}
 
 @end

--- a/Wikipedia/Code/WMFChange.m
+++ b/Wikipedia/Code/WMFChange.m
@@ -2,33 +2,39 @@
 
 @implementation WMFChange
 
-- (NSString *)debugDescription {
+- (NSString *)description {
+    NSString *superDescription = [super description];
+    NSString *changeTypeString = nil;
     switch (self.type) {
         case NSFetchedResultsChangeInsert:
-            return @"insert";
+            changeTypeString = @"insert";
+            break;
         case NSFetchedResultsChangeDelete:
-            return @"delete";
+            changeTypeString = @"delete";
+            break;
         case NSFetchedResultsChangeMove:
-            return @"move";
+            changeTypeString = @"move";
+            break;
         default:
-            return @"update";
+            changeTypeString = @"update";
     }
+    return [NSString stringWithFormat:@"%@ %@", superDescription, changeTypeString];
 }
 
 @end
 
 @implementation WMFSectionChange
 
-- (NSString *)debugDescription {
-    return [NSString stringWithFormat:@"%@ section %li", [super debugDescription], self.sectionIndex];
+- (NSString *)description {
+    return [NSString stringWithFormat:@"%@ section %li", [super description], self.sectionIndex];
 }
 
 @end
 
 @implementation WMFObjectChange
 
-- (NSString *)debugDescription {
-    return [NSString stringWithFormat:@"%@ object %@ to %@", [super debugDescription], self.fromIndexPath, self.toIndexPath];
+- (NSString *)description {
+    return [NSString stringWithFormat:@"%@ object %@ to %@", [super description], self.fromIndexPath, self.toIndexPath];
 }
 
 @end

--- a/Wikipedia/Code/WMFContentGroup+WMFFeedContentDisplaying.m
+++ b/Wikipedia/Code/WMFContentGroup+WMFFeedContentDisplaying.m
@@ -428,7 +428,7 @@ NS_ASSUME_NONNULL_BEGIN
         case WMFContentGroupKindNews:
             return YES;
         case WMFContentGroupKindNotification:
-            break;
+            return YES;
         case WMFContentGroupKindAnnouncement:
             return YES;
         case WMFContentGroupKindUnknown:

--- a/Wikipedia/Code/WMFExploreCollectionViewController.m
+++ b/Wikipedia/Code/WMFExploreCollectionViewController.m
@@ -1563,43 +1563,12 @@ NSString *const kvo_WMFExploreViewController_peek_state_keypath = @"state";
                     [self.collectionView deleteSections:[NSIndexSet indexSetWithIndex:deletedIndex]];
                     [deletedSections addIndex:deletedIndex];
                 } break;
-                case NSFetchedResultsChangeUpdate: {
-                    if (change.toIndexPath && change.fromIndexPath && ![change.toIndexPath isEqual:change.fromIndexPath]) {
-                        if ([deletedSections containsIndex:change.fromIndexPath.row]) {
-                            [self.collectionView insertSections:[NSIndexSet indexSetWithIndex:change.toIndexPath.row]];
-                        } else {
-                            [self.collectionView deleteSections:[NSIndexSet indexSetWithIndex:change.fromIndexPath.row]];
-                            [self.collectionView insertSections:[NSIndexSet indexSetWithIndex:change.toIndexPath.row]];
-                        }
-                    } else {
-                        NSIndexPath *updatedIndexPath = change.toIndexPath ?: change.fromIndexPath;
-                        NSInteger sectionIndex = updatedIndexPath.row;
-                        if ([insertedSections containsIndex:updatedIndexPath.row]) {
-                            [self.collectionView insertSections:[NSIndexSet indexSetWithIndex:sectionIndex]];
-                        } else {
-                            NSInteger previousCount = [previousSectionCounts[sectionIndex] integerValue];
-                            NSInteger currentCount = [self.sectionCounts[sectionIndex] integerValue];
-                            if (previousCount == currentCount) {
-                                [self.collectionView reloadSections:[NSIndexSet indexSetWithIndex:sectionIndex]];
-                                continue;
-                            }
-
-                            while (previousCount > currentCount) {
-                                [self.collectionView deleteItemsAtIndexPaths:@[[NSIndexPath indexPathForItem:previousCount - 1 inSection:sectionIndex]]];
-                                previousCount--;
-                            }
-
-                            while (previousCount < currentCount) {
-                                [self.collectionView insertItemsAtIndexPaths:@[[NSIndexPath indexPathForItem:previousCount inSection:sectionIndex]]];
-                                previousCount++;
-                            }
-
-                            [self.collectionView reloadSections:[NSIndexSet indexSetWithIndex:sectionIndex]];
-                        }
-                    }
-                } break;
                 case NSFetchedResultsChangeMove:
                     [self.collectionView moveSection:change.fromIndexPath.row toSection:change.toIndexPath.row];
+                    break;
+                case NSFetchedResultsChangeUpdate:
+                default:
+                    NSAssert(false, @"Update should trigger a reload");
                     break;
             }
         }
@@ -1628,6 +1597,7 @@ NSString *const kvo_WMFExploreViewController_peek_state_keypath = @"state";
                 sectionDelta--;
                 break;
             case NSFetchedResultsChangeUpdate:
+                shouldReload = YES;
                 break;
             case NSFetchedResultsChangeMove:
                 break;

--- a/Wikipedia/Code/WMFFeedNotificationCell.xib
+++ b/Wikipedia/Code/WMFFeedNotificationCell.xib
@@ -42,6 +42,9 @@
                                     <constraint firstAttribute="width" constant="200" placeholder="YES" id="4jM-mc-wYS"/>
                                     <constraint firstAttribute="height" constant="36" id="hXc-15-Js6"/>
                                 </constraints>
+                                <connections>
+                                    <action selector="enableNotifications:" destination="20F-Cl-zlX" eventType="touchUpInside" id="VI7-pp-Mwl"/>
+                                </connections>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7uy-b7-3tZ">
                                 <rect key="frame" x="70" y="28" width="237" height="16"/>


### PR DESCRIPTION
- Fixes collection view change debugging method
- Adds better debug printing to collection view change model objects
- Fixes collection view update crashes observed while using collection view update debugging method  (any updated section triggers a complete reload)
- Fix issue where the main page would occupy the wider column on iPad
- Fix notification button not firing
- Update "enable notification" section to prefer the wider column on iPad