### PR TITLE
Move disambig and page issues determination to the footer menu transform

### DIFF
--- a/Wikipedia/Code/MWKArticle.h
+++ b/Wikipedia/Code/MWKArticle.h
@@ -17,10 +17,10 @@ static const NSInteger kMWKArticleSectionNone = -1;
 @property (readonly, weak, nonatomic, nullable) MWKDataStore *dataStore;
 
 // Metadata
-@property (readonly, strong, nonatomic, nullable) NSURL *redirectedURL;    // optional
-@property (readonly, strong, nonatomic, nullable) NSDate *lastmodified;    // required
+@property (readonly, strong, nonatomic, nullable) NSURL *redirectedURL; // optional
+@property (readonly, strong, nonatomic, nullable) NSDate *lastmodified; // required
 @property (readonly, strong, nonatomic, nullable) MWKUser *lastmodifiedby; // required
-@property (readonly, assign, nonatomic) int articleId;                     // required; -> 'id'
+@property (readonly, assign, nonatomic) int articleId; // required; -> 'id'
 @property (readonly, strong, nonatomic, nullable) NSNumber *revisionId;
 
 @property (copy, nonatomic, nullable) NSString *acceptLanguageRequestHeader;
@@ -34,21 +34,21 @@ static const NSInteger kMWKArticleSectionNone = -1;
  */
 @property (readonly, assign, nonatomic) int languagecount;
 
-@property (readonly, copy, nonatomic, nullable) NSString *displaytitle;            // optional
+@property (readonly, copy, nonatomic, nullable) NSString *displaytitle; // optional
 @property (readonly, strong, nonatomic, nullable) MWKProtectionStatus *protection; // required
-@property (readonly, assign, nonatomic) BOOL editable;                             // required
+@property (readonly, assign, nonatomic) BOOL editable; // required
 @property (readonly, assign, nonatomic) BOOL hasMultipleLanguages;
 
 /// Whether or not the receiver is the main page for its @c site.
 @property (readonly, assign, nonatomic, getter=isMain) BOOL main;
 
 @property (readonly, copy, nonatomic, nullable) NSString *thumbnailURL; // optional; generated from imageURL
-@property (readwrite, copy, nonatomic, nullable) NSString *imageURL;    // optional; pulled in article request
+@property (readwrite, copy, nonatomic, nullable) NSString *imageURL; // optional; pulled in article request
 
 - (nullable NSString *)bestThumbnailImageURL;
 
 @property (readonly, copy, nonatomic, nullable) NSString *entityDescription; // optional; currently pulled separately via wikidata
-@property (readonly, copy, nonatomic, nullable) NSString *searchSnippet;     //Snippet returned from search results
+@property (readonly, copy, nonatomic, nullable) NSString *searchSnippet; //Snippet returned from search results
 
 @property (readonly, strong, nonatomic, nullable) MWKSectionList *sections;
 
@@ -111,10 +111,6 @@ static const NSInteger kMWKArticleSectionNone = -1;
  *  @return The HTML for the article (all of the sections)
  */
 - (NSString *)articleHTML;
-
-- (nullable NSArray<NSURL *> *)disambiguationURLs;
-
-- (nullable NSArray<NSString *> *)pageIssues;
 
 @end
 

--- a/Wikipedia/Code/MWKArticle.m
+++ b/Wikipedia/Code/MWKArticle.m
@@ -491,12 +491,4 @@ static MWKArticleSchemaVersion const MWKArticleCurrentSchemaVersion = MWKArticle
     return htmlStr;
 }
 
-- (nullable NSArray<NSURL *> *)disambiguationURLs {
-    return [[self.sections.entries firstObject] disambiguationURLs];
-}
-
-- (nullable NSArray<NSString *> *)pageIssues {
-    return [[self.sections.entries firstObject] pageIssues];
-}
-
 @end

--- a/Wikipedia/Code/MWKSection.h
+++ b/Wikipedia/Code/MWKSection.h
@@ -147,10 +147,6 @@ extern NSString *const MWKSectionShareSnippetXPath;
 
 - (nullable NSString *)summary;
 
-- (nullable NSArray<NSURL *> *)disambiguationURLs;
-
-- (nullable NSArray<NSString *> *)pageIssues;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/MWKSection.m
+++ b/Wikipedia/Code/MWKSection.m
@@ -244,48 +244,6 @@ static NSString *const WMFSectionSummaryXPathSelector = @"\
     }] componentsJoinedByString:@" "] wmf_summaryFromText];
 }
 
-static NSString *const WMFSectionDisambiguationTitlesXPathSelector = @"//div[contains(@class, 'hatnote')]//a/@href";
-
-- (nullable NSArray<NSURL *> *)disambiguationURLs {
-    NSArray *textNodes = [self elementsInTextMatchingXPath:WMFSectionDisambiguationTitlesXPathSelector];
-    return [textNodes wmf_mapAndRejectNil:^id(TFHppleElement *node) {
-        if (node.text.length == 0 || [node.text containsString:@"redlink=1"] || ![node.text containsString:WMFInternalLinkPathPrefix]) {
-            return nil;
-        }
-        return [NSURL wmf_URLWithSiteURL:self.url escapedDenormalizedInternalLink:node.text];
-    }];
-}
-
-/*
-   TODO: Add tests for issues from:
-    enwiki > biocoenosis
-        - "This article does not cite any references (sources). (July 2015)"
-    enwiki > toleration
-        - "This article possibly contains original research. (May 2011)",
-        - "The examples and perspective in this article or section might have an extensive bias or disproportional coverage towards one or more specific regions. (May 2011)"
- */
-static NSString *const WMFSectionPageIssuesXPathSelector =
-    @"//td[(contains(@class,'mbox-text') or contains(@class,'ambox-text')) and not(count(descendant::td) > 0)]";
-
-static NSString *const WMFSectionPageIssueUnhiddenXPathSelector =
-    @"//*[not(ancestor-or-self::*[@class = 'hide-when-compact' or contains(@class, 'collapsed')])]/text()";
-
-- (nullable NSArray<NSString *> *)pageIssues {
-    NSArray *issueNodes = [self elementsInTextMatchingXPath:WMFSectionPageIssuesXPathSelector];
-    return [issueNodes wmf_mapAndRejectNil:^id(TFHppleElement *node) {
-        if (node.raw.length == 0) {
-            return nil;
-        }
-        NSArray *unhiddenIssueNodes = [[TFHpple hppleWithHTMLData:[node.raw dataUsingEncoding:NSUTF8StringEncoding]] searchWithXPathQuery:WMFSectionPageIssueUnhiddenXPathSelector];
-
-        NSArray *issuesStrings = [unhiddenIssueNodes wmf_mapAndRejectNil:^id(TFHppleElement *node) {
-            return ([[node.content stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] length] == 0) ? nil : node.content;
-        }];
-
-        return issuesStrings.count > 0 ? [issuesStrings componentsJoinedByString:@""] : nil;
-    }];
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WKScriptMessage+WMFScriptMessage.swift
+++ b/Wikipedia/Code/WKScriptMessage+WMFScriptMessage.swift
@@ -62,7 +62,6 @@ extension WKScriptMessage {
             }
         case .lateJavascriptTransform,
              .articleState,
-             .footerMenuItemClicked,
              .footerLegalLicenseLinkClicked:
             if body is String {
                 return body
@@ -71,6 +70,21 @@ extension WKScriptMessage {
              .footerReadMoreTitlesShown:
             if body is Array<Any>{
                 return body
+            }
+        case .footerMenuItemClicked:
+            if
+                let body = body as? Dictionary<String, Any>,
+                let safeBody = (body as NSDictionary).wmf_dictionaryByRemovingNullObjects(),
+                let selection = safeBody["selection"] as? String,
+                let payload = safeBody["payload"] as? [String]
+            {
+                if selection == "disambiguation" {
+                    // WKScriptMessage's body doesn't auto-convert url strings to URL, so manually do so for
+                    // the disambiguation payload.
+                    return ["selection": selection, "payload": payload.flatMap{URL(string: $0)}]
+                }else{
+                    return safeBody
+                }
             }
         case .unknown:
             if body is NSNull{

--- a/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
+++ b/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
@@ -86,7 +86,7 @@ import WebKit
             "window.webkit.messageHandlers.footerMenuItemClicked.postMessage({'selection': '\(footerMenuJSTransformEnumString)', 'payload': payload});" +
         "}"
         
-        return "window.wmf.footerMenu.addItem('\(title)', '\(subtitle)', \(self.footerMenuTransformJSEnumPath), 'footer_container_menu_items', \(itemSelectionHandler));"
+        return "window.wmf.footerMenu.maybeAddItem('\(title)', '\(subtitle)', \(self.footerMenuTransformJSEnumPath), 'footer_container_menu_items', \(itemSelectionHandler));"
     }
 }
 

--- a/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
+++ b/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
@@ -17,7 +17,7 @@ import WebKit
     }
     
     private var footerMenuTransformJSEnumPath: String {
-        return "window.wmf.footerMenu.IconTypeEnum.\(footerMenuJSTransformEnumString)"
+        return "window.wmf.footerMenu.ItemTypeEnum.\(footerMenuJSTransformEnumString)"
     }
     
     private func localizedTitle(with article: MWKArticle) -> String {

--- a/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
+++ b/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
@@ -82,8 +82,8 @@ import WebKit
         let subtitle = self.localizedSubtitle(with: article)
         
         let itemSelectionHandler =
-        "function(){" +
-            "window.webkit.messageHandlers.footerMenuItemClicked.postMessage('\(footerMenuJSTransformEnumString)');" +
+        "function(payload){" +
+            "window.webkit.messageHandlers.footerMenuItemClicked.postMessage({'selection': '\(footerMenuJSTransformEnumString)', 'payload': payload});" +
         "}"
         
         return "window.wmf.footerMenu.addItem('\(title)', '\(subtitle)', \(self.footerMenuTransformJSEnumPath), 'footer_container_menu_items', \(itemSelectionHandler));"

--- a/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
+++ b/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
@@ -6,7 +6,7 @@ import WebKit
     case languages, lastEdited, pageIssues, disambiguation, coordinate
     
     // Reminder: These are the strings used by the footerMenu JS transform:
-    private var footerMenuJSTransformEnumString: String {
+    private var menuItemTypeString: String {
         switch self {
         case .languages: return "languages"
         case .lastEdited: return "lastEdited"
@@ -16,8 +16,8 @@ import WebKit
         }
     }
     
-    private var footerMenuTransformJSEnumPath: String {
-        return "window.wmf.footerMenu.MenuItemType.\(footerMenuJSTransformEnumString)"
+    private var menuItemTypeJSPath: String {
+        return "window.wmf.footerMenu.MenuItemType.\(menuItemTypeString)"
     }
     
     private func localizedTitle(with article: MWKArticle) -> String {
@@ -83,10 +83,10 @@ import WebKit
         
         let itemSelectionHandler =
         "function(payload){" +
-            "window.webkit.messageHandlers.footerMenuItemClicked.postMessage({'selection': '\(footerMenuJSTransformEnumString)', 'payload': payload});" +
+            "window.webkit.messageHandlers.footerMenuItemClicked.postMessage({'selection': '\(menuItemTypeString)', 'payload': payload});" +
         "}"
         
-        return "window.wmf.footerMenu.maybeAddItem('\(title)', '\(subtitle)', \(self.footerMenuTransformJSEnumPath), 'footer_container_menu_items', \(itemSelectionHandler));"
+        return "window.wmf.footerMenu.maybeAddItem('\(title)', '\(subtitle)', \(self.menuItemTypeJSPath), 'footer_container_menu_items', \(itemSelectionHandler));"
     }
 }
 

--- a/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
+++ b/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
@@ -60,13 +60,11 @@ import WebKit
         case .languages where !article.hasMultipleLanguages:
             return false
         case .pageIssues:
-            guard let issues = article.pageIssues(), issues.count > 0 else {
-                return false
-            }
+            // Always try to add - footer menu JS will hide this if no page issues found.
+            return true
         case .disambiguation:
-            guard let issues = article.disambiguationURLs(), issues.count > 0 else {
-                return false
-            }
+            // Always try to add - footer menu JS will hide this if no disambiguation titles found.
+            return true
         case .coordinate where !CLLocationCoordinate2DIsValid(article.coordinate):
             return false
         default:

--- a/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
+++ b/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
@@ -17,7 +17,7 @@ import WebKit
     }
     
     private var footerMenuTransformJSEnumPath: String {
-        return "window.wmf.footerMenu.ItemTypeEnum.\(footerMenuJSTransformEnumString)"
+        return "window.wmf.footerMenu.MenuItemType.\(footerMenuJSTransformEnumString)"
     }
     
     private func localizedTitle(with article: MWKArticle) -> String {

--- a/Wikipedia/Code/WMFArticlePreviewDataSource.m
+++ b/Wikipedia/Code/WMFArticlePreviewDataSource.m
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
             NSURL *URL = [self urlForIndexPath:indexPath];
             NSParameterAssert([URL.wmf_domain isEqual:siteURL.wmf_domain]);
             cell.titleText = URL.wmf_title;
-            cell.descriptionText = searchResult.wikidataDescription;
+            cell.descriptionText = [searchResult.wikidataDescription wmf_stringByCapitalizingFirstCharacterUsingWikipediaLanguage:self.siteURL.wmf_language];
             [cell setImageURL:searchResult.thumbnailURL];
         };
     }

--- a/Wikipedia/Code/WMFArticlePreviewFetcher.m
+++ b/Wikipedia/Code/WMFArticlePreviewFetcher.m
@@ -129,9 +129,10 @@ NS_ASSUME_NONNULL_BEGIN
     [baseParams setValuesForKeysWithDictionary:@{
         @"titles": [self barSeparatedTitlesStringFromURLs:params.articleURLs],
         @"pilimit": @(params.articleURLs.count),
-        //@"pilicense": @"any",
-        @"prop": @"coordinates"
     }];
+    
+    baseParams[@"prop"] = [baseParams[@"prop"] stringByAppendingString:@"|coordinates"];
+    
     if (params.extractLength > 0) {
         baseParams[@"exlimit"] = @(params.articleURLs.count);
     }

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1489,7 +1489,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 
 #pragma mark - Footer menu
 
-- (void)webViewController:(WebViewController *)controller didTapFooterMenuItem:(WMFArticleFooterMenuItem)item payload:(NSArray*)payload {
+- (void)webViewController:(WebViewController *)controller didTapFooterMenuItem:(WMFArticleFooterMenuItem)item payload:(NSArray *)payload {
     switch (item) {
         case WMFArticleFooterMenuItemLanguages:
             [self showLanguages];
@@ -1498,10 +1498,10 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
             [self showEditHistory];
             break;
         case WMFArticleFooterMenuItemPageIssues:
-            [self showPageIssues];
+            [self showPageIssues:payload];
             break;
         case WMFArticleFooterMenuItemDisambiguation:
-            [self showDisambiguationItems];
+            [self showDisambiguationPages:payload];
             break;
         case WMFArticleFooterMenuItemCoordinate:
             [self showLocation];
@@ -1519,8 +1519,8 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
     [self presentViewController:navC animated:YES completion:nil];
 }
 
-- (void)showDisambiguationItems {
-    WMFDisambiguationPagesViewController *articleListVC = [[WMFDisambiguationPagesViewController alloc] initWithArticle:self.article dataStore:self.dataStore];
+- (void)showDisambiguationPages:(NSArray<NSURL *> *)pageURLs {
+    WMFDisambiguationPagesViewController *articleListVC = [[WMFDisambiguationPagesViewController alloc] initWithURLs:pageURLs siteURL:self.article.url dataStore:self.dataStore];
     [articleListVC applyTheme:self.theme];
     articleListVC.delegate = self;
     articleListVC.title = WMFLocalizedStringWithDefaultValue(@"page-similar-titles", nil, nil, @"Similar pages", @"Label for button that shows a list of similar titles (disambiguation) for the current page");
@@ -1539,9 +1539,9 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
     [self presentViewControllerEmbeddedInNavigationController:languagesVC];
 }
 
-- (void)showPageIssues {
+- (void)showPageIssues:(NSArray<NSString *> *)issueStrings {
     WMFPageIssuesViewController *issuesVC = [[WMFPageIssuesViewController alloc] initWithStyle:UITableViewStyleGrouped];
-    issuesVC.dataSource = [[SSArrayDataSource alloc] initWithItems:self.article.pageIssues];
+    issuesVC.dataSource = [[SSArrayDataSource alloc] initWithItems:issueStrings];
     [self presentViewControllerEmbeddedInNavigationController:issuesVC];
 }
 

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1489,7 +1489,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 
 #pragma mark - Footer menu
 
-- (void)webViewController:(WebViewController *)controller didTapFooterMenuItem:(WMFArticleFooterMenuItem)item {
+- (void)webViewController:(WebViewController *)controller didTapFooterMenuItem:(WMFArticleFooterMenuItem)item payload:(NSArray*)payload {
     switch (item) {
         case WMFArticleFooterMenuItemLanguages:
             [self showLanguages];

--- a/Wikipedia/Code/WebViewController.h
+++ b/Wikipedia/Code/WebViewController.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)webViewController:(WebViewController *)controller didTapImageWithSourceURL:(NSURL *)imageSourceURL;
 - (void)webViewController:(WebViewController *)controller scrollViewDidScroll:(UIScrollView *)scrollView;
 - (void)webViewController:(WebViewController *)controller scrollViewDidScrollToTop:(UIScrollView *)scrollView;
-- (void)webViewController:(WebViewController *)controller didTapFooterMenuItem:(WMFArticleFooterMenuItem)item;
+- (void)webViewController:(WebViewController *)controller didTapFooterMenuItem:(WMFArticleFooterMenuItem)item payload:(NSArray*)payload;
 
 @end
 

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -160,7 +160,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
         NSAssert(false, @"Unhandled footer item type encountered");
         return;
     }
-    [self.delegate webViewController:self didTapFooterMenuItem:item];
+    [self.delegate webViewController:self didTapFooterMenuItem:item payload:payload];
 }
 
 - (void)handleFooterLegalLicenseLinkClickedScriptMessage:(NSString *)messageString {

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -141,7 +141,10 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
     }
 }
 
-- (void)handleFooterMenuItemClickedScriptMessage:(NSString *)messageString {
+- (void)handleFooterMenuItemClickedScriptMessage:(NSDictionary *)messageDict {
+    NSString *messageString = messageDict[@"selection"];
+    NSArray *payload = messageDict[@"payload"];
+
     WMFArticleFooterMenuItem item;
     if ([messageString isEqualToString:@"languages"]) {
         item = WMFArticleFooterMenuItemLanguages;

--- a/Wikipedia/assets/index.js
+++ b/Wikipedia/assets/index.js
@@ -568,7 +568,7 @@ function disambiguationTitlesArray() {
   return Array.from(document.querySelectorAll('div#content_block_0 div.hatnote a[href]:not([href=""]):not([redlink="1"])')).map(el => el.href)
 }
 
-var ItemTypeEnum = {
+var MenuItemType = {
   languages: 1,
   lastEdited: 2,
   pageIssues: 3,
@@ -586,29 +586,29 @@ class WMFMenuItem {
   }
   iconClass(){
     switch(this.itemType){
-    case ItemTypeEnum.languages:
+    case MenuItemType.languages:
       return 'footer_menu_icon_languages'
-    case ItemTypeEnum.lastEdited:
+    case MenuItemType.lastEdited:
       return 'footer_menu_icon_last_edited'
-    case ItemTypeEnum.pageIssues:
+    case MenuItemType.pageIssues:
       return 'footer_menu_icon_page_issues'
-    case ItemTypeEnum.disambiguation:
+    case MenuItemType.disambiguation:
       return 'footer_menu_icon_disambiguation'
-    case ItemTypeEnum.coordinate:
+    case MenuItemType.coordinate:
       return 'footer_menu_icon_coordinate'
     }
   }
   payloadExtractor(){
     switch(this.itemType){
-    case ItemTypeEnum.languages:
+    case MenuItemType.languages:
       return null
-    case ItemTypeEnum.lastEdited:
+    case MenuItemType.lastEdited:
       return null
-    case ItemTypeEnum.pageIssues:
+    case MenuItemType.pageIssues:
       return pageIssuesStringsArray
-    case ItemTypeEnum.disambiguation:
+    case MenuItemType.disambiguation:
       return disambiguationTitlesArray
-    case ItemTypeEnum.coordinate:
+    case MenuItemType.coordinate:
       return null
     }
   }
@@ -675,7 +675,7 @@ function setHeading(headingString, headingID) {
   headingElement.title = headingString
 }
 
-exports.ItemTypeEnum = ItemTypeEnum
+exports.MenuItemType = MenuItemType
 exports.setHeading = setHeading
 exports.maybeAddItem = maybeAddItem
 },{}],11:[function(require,module,exports){

--- a/Wikipedia/assets/index.js
+++ b/Wikipedia/assets/index.js
@@ -551,30 +551,61 @@ function add(licenseString, licenseSubstitutionString, containerID, licenceLinkC
 exports.add = add
 },{}],10:[function(require,module,exports){
 
+function pageIssuesStringsArray() {
+  const tables = document.querySelectorAll( 'div#content_block_0 table.ambox:not(.ambox-multiple_issues):not(.ambox-notice)' )
+  // Get the tables into a fragment so we can remove some elements without triggering a layout
+  var fragment = document.createDocumentFragment()
+  for (var i = 0; i < tables.length; i++) {
+    fragment.appendChild(tables[i].cloneNode(true))
+  }
+  // Remove some element so their text doesn't appear when we use "innerText"
+  Array.from(fragment.querySelectorAll( '.hide-when-compact, .collapsed' )).forEach(el => el.remove())
+  // Get the innerText
+  return Array.from(fragment.querySelectorAll( 'td[class$=mbox-text]' )).map(el => el.innerText)
+}
+
+function disambiguationTitlesArray() {
+  return Array.from(document.querySelectorAll('div#content_block_0 div.hatnote a[href]:not([href=""]):not([redlink="1"])')).map(el => el.href)
+}
+
 // var thisType = IconTypeEnum.languages;
 // var iconClass = IconTypeEnum.properties[thisType].iconClass;
 // iconClass is 'footer_menu_icon_languages'
-var IconTypeEnum = {
+var ItemTypeEnum = {
   languages: 1,
   lastEdited: 2,
   pageIssues: 3,
   disambiguation: 4,
   coordinate: 5,
-  properties: {
-    1: {iconClass: 'footer_menu_icon_languages'},
-    2: {iconClass: 'footer_menu_icon_last_edited'},
-    3: {iconClass: 'footer_menu_icon_page_issues'},
-    4: {iconClass: 'footer_menu_icon_disambiguation'},
-    5: {iconClass: 'footer_menu_icon_coordinate'}
+  iconClass: {
+    1: 'footer_menu_icon_languages',
+    2: 'footer_menu_icon_last_edited',
+    3: 'footer_menu_icon_page_issues',
+    4: 'footer_menu_icon_disambiguation',
+    5: 'footer_menu_icon_coordinate'
+  },
+  payloadExtractor: {
+    1: null,
+    2: null,
+    3: pageIssuesStringsArray,
+    4: disambiguationTitlesArray,
+    5: null
   }
 }
 
 class WMFMenuItem {
-  constructor(title, subtitle, iconType, clickHandler) {
+  constructor(title, subtitle, itemType, clickHandler) {
     this.title = title
     this.subtitle = subtitle
-    this.iconType = iconType
+    this.itemType = itemType
     this.clickHandler = clickHandler
+    this.payload = []
+  }
+  iconClass(){
+    return ItemTypeEnum.iconClass[this.itemType]
+  }
+  payloadExtractor(){
+    return ItemTypeEnum.payloadExtractor[this.itemType]
   }
 }
 
@@ -585,7 +616,7 @@ class WMFMenuItemFragment {
 
     var containerAnchor = document.createElement('a')
     containerAnchor.addEventListener('click', function(){
-      wmfMenuItem.clickHandler()
+      wmfMenuItem.clickHandler(wmfMenuItem.payload)
     }, false)
 
     item.appendChild(containerAnchor)
@@ -605,8 +636,8 @@ class WMFMenuItemFragment {
       containerAnchor.appendChild(subtitle)
     }
 
-    if(wmfMenuItem.iconType){
-      var iconClass = IconTypeEnum.properties[wmfMenuItem.iconType].iconClass
+    var iconClass = wmfMenuItem.iconClass()
+    if(iconClass){
       item.classList.add(iconClass)
     }
 
@@ -614,10 +645,23 @@ class WMFMenuItemFragment {
   }
 }
 
-function addItem(title, subtitle, iconType, containerID, clickHandler) {
-  const itemModel = new WMFMenuItem(title, subtitle, iconType, clickHandler)
-  const itemFragment = new WMFMenuItemFragment(itemModel)
-  document.getElementById(containerID).appendChild(itemFragment)
+function maybeAddItem(title, subtitle, itemType, containerID, clickHandler) {
+  const item = new WMFMenuItem(title, subtitle, itemType, clickHandler)
+
+  // Items are not added if they have a payload extractor which fails to extract anything.
+  if (item.payloadExtractor() !== null){
+    item.payload = item.payloadExtractor()()
+    if(item.payload.length === 0){
+      return
+    }
+  }
+
+  addItem(item, containerID)
+}
+
+function addItem(wmfMenuItem, containerID) {
+  const fragment = new WMFMenuItemFragment(wmfMenuItem)
+  document.getElementById(containerID).appendChild(fragment)
 }
 
 function setHeading(headingString, headingID) {
@@ -626,9 +670,9 @@ function setHeading(headingString, headingID) {
   headingElement.title = headingString
 }
 
-exports.IconTypeEnum = IconTypeEnum
+exports.ItemTypeEnum = ItemTypeEnum
 exports.setHeading = setHeading
-exports.addItem = addItem
+exports.maybeAddItem = maybeAddItem
 },{}],11:[function(require,module,exports){
 
 var _saveButtonClickHandler = null

--- a/Wikipedia/assets/index.js
+++ b/Wikipedia/assets/index.js
@@ -568,29 +568,12 @@ function disambiguationTitlesArray() {
   return Array.from(document.querySelectorAll('div#content_block_0 div.hatnote a[href]:not([href=""]):not([redlink="1"])')).map(el => el.href)
 }
 
-// var thisType = IconTypeEnum.languages;
-// var iconClass = IconTypeEnum.properties[thisType].iconClass;
-// iconClass is 'footer_menu_icon_languages'
 var ItemTypeEnum = {
   languages: 1,
   lastEdited: 2,
   pageIssues: 3,
   disambiguation: 4,
-  coordinate: 5,
-  iconClass: {
-    1: 'footer_menu_icon_languages',
-    2: 'footer_menu_icon_last_edited',
-    3: 'footer_menu_icon_page_issues',
-    4: 'footer_menu_icon_disambiguation',
-    5: 'footer_menu_icon_coordinate'
-  },
-  payloadExtractor: {
-    1: null,
-    2: null,
-    3: pageIssuesStringsArray,
-    4: disambiguationTitlesArray,
-    5: null
-  }
+  coordinate: 5
 }
 
 class WMFMenuItem {
@@ -602,10 +585,32 @@ class WMFMenuItem {
     this.payload = []
   }
   iconClass(){
-    return ItemTypeEnum.iconClass[this.itemType]
+    switch(this.itemType){
+    case ItemTypeEnum.languages:
+      return 'footer_menu_icon_languages'
+    case ItemTypeEnum.lastEdited:
+      return 'footer_menu_icon_last_edited'
+    case ItemTypeEnum.pageIssues:
+      return 'footer_menu_icon_page_issues'
+    case ItemTypeEnum.disambiguation:
+      return 'footer_menu_icon_disambiguation'
+    case ItemTypeEnum.coordinate:
+      return 'footer_menu_icon_coordinate'
+    }
   }
   payloadExtractor(){
-    return ItemTypeEnum.payloadExtractor[this.itemType]
+    switch(this.itemType){
+    case ItemTypeEnum.languages:
+      return null
+    case ItemTypeEnum.lastEdited:
+      return null
+    case ItemTypeEnum.pageIssues:
+      return pageIssuesStringsArray
+    case ItemTypeEnum.disambiguation:
+      return disambiguationTitlesArray
+    case ItemTypeEnum.coordinate:
+      return null
+    }
   }
 }
 

--- a/WikipediaUnitTests/Code/WMFDisambiguationPagesViewController.h
+++ b/WikipediaUnitTests/Code/WMFDisambiguationPagesViewController.h
@@ -1,10 +1,10 @@
 #import "WMFArticleListDataSourceTableViewController.h"
-@class MWKArticle;
 
 @interface WMFDisambiguationPagesViewController : WMFArticleListDataSourceTableViewController
 
-@property (nonatomic, strong, readonly) MWKArticle *article;
+@property (nonatomic, strong, readonly) NSArray *URLs;
+@property (nonatomic, strong, readonly) NSURL *siteURL;
 
-- (instancetype)initWithArticle:(MWKArticle *)article dataStore:(MWKDataStore *)dataStore;
+- (instancetype)initWithURLs:(NSArray *)URLs siteURL:(NSURL*)siteURL dataStore:(MWKDataStore *)dataStore;
 
 @end

--- a/WikipediaUnitTests/Code/WMFDisambiguationPagesViewController.m
+++ b/WikipediaUnitTests/Code/WMFDisambiguationPagesViewController.m
@@ -3,25 +3,25 @@
 #import "WMFArticleFetcher.h"
 #import "UIBarButtonItem+WMFButtonConvenience.h"
 @import WMF.MWKDataStore;
-@import WMF.MWKArticle;
 @import WMF.WMFArticlePreviewFetcher;
 
 @interface WMFDisambiguationPagesViewController ()
 
-@property (nonatomic, strong, readwrite) MWKArticle *article;
+@property (nonatomic, strong, readwrite) NSArray *URLs;
+@property (nonatomic, strong, readwrite) NSURL *siteURL;
 
 @end
 
 @implementation WMFDisambiguationPagesViewController
 
-- (instancetype)initWithArticle:(MWKArticle *)article dataStore:(MWKDataStore *)dataStore {
+- (instancetype)initWithURLs:(NSArray *)URLs siteURL:(NSURL*)siteURL  dataStore:(MWKDataStore *)dataStore {
     self = [super init];
     if (self) {
-        self.article = article;
+        self.URLs = URLs;
         self.userDataStore = dataStore;
         self.dataSource =
-            [[WMFArticlePreviewDataSource alloc] initWithArticleURLs:self.article.disambiguationURLs
-                                                             siteURL:self.article.url
+            [[WMFArticlePreviewDataSource alloc] initWithArticleURLs:self.URLs
+                                                             siteURL:siteURL
                                                            dataStore:dataStore
                                                              fetcher:[[WMFArticlePreviewFetcher alloc] init]];
         self.dataSource.tableView = self.tableView;

--- a/www/js/transforms/footerMenu.js
+++ b/www/js/transforms/footerMenu.js
@@ -16,30 +16,41 @@ function disambiguationTitlesArray() {
   return Array.from(document.querySelectorAll('div#content_block_0 div.hatnote a[href]:not([href=""]):not([redlink="1"])')).map(el => el.href)
 }
 
-// var thisType = IconTypeEnum.languages;
-// var iconClass = IconTypeEnum.properties[thisType].iconClass;
-// iconClass is 'footer_menu_icon_languages'
-var IconTypeEnum = {
+var ItemTypeEnum = {
   languages: 1,
   lastEdited: 2,
   pageIssues: 3,
   disambiguation: 4,
   coordinate: 5,
-  properties: {
-    1: {iconClass: 'footer_menu_icon_languages'},
-    2: {iconClass: 'footer_menu_icon_last_edited'},
-    3: {iconClass: 'footer_menu_icon_page_issues'},
-    4: {iconClass: 'footer_menu_icon_disambiguation'},
-    5: {iconClass: 'footer_menu_icon_coordinate'}
+  iconClass: {
+    1: 'footer_menu_icon_languages',
+    2: 'footer_menu_icon_last_edited',
+    3: 'footer_menu_icon_page_issues',
+    4: 'footer_menu_icon_disambiguation',
+    5: 'footer_menu_icon_coordinate'
+  },
+  payloadExtractor: {
+    1: null,
+    2: null,
+    3: pageIssuesStringsArray,
+    4: disambiguationTitlesArray,
+    5: null
   }
 }
 
 class WMFMenuItem {
-  constructor(title, subtitle, iconType, clickHandler) {
+  constructor(title, subtitle, itemType, clickHandler) {
     this.title = title
     this.subtitle = subtitle
-    this.iconType = iconType
+    this.itemType = itemType
     this.clickHandler = clickHandler
+    this.payload = []
+  }
+  iconClass(){
+    return ItemTypeEnum.iconClass[this.itemType]
+  }
+  payloadExtractor(){
+    return ItemTypeEnum.payloadExtractor[this.itemType]
   }
 }
 
@@ -70,8 +81,8 @@ class WMFMenuItemFragment {
       containerAnchor.appendChild(subtitle)
     }
 
-    if(wmfMenuItem.iconType){
-      var iconClass = IconTypeEnum.properties[wmfMenuItem.iconType].iconClass
+    var iconClass = wmfMenuItem.iconClass()
+    if(iconClass){
       item.classList.add(iconClass)
     }
 
@@ -91,6 +102,6 @@ function setHeading(headingString, headingID) {
   headingElement.title = headingString
 }
 
-exports.IconTypeEnum = IconTypeEnum
+exports.ItemTypeEnum = ItemTypeEnum
 exports.setHeading = setHeading
 exports.addItem = addItem

--- a/www/js/transforms/footerMenu.js
+++ b/www/js/transforms/footerMenu.js
@@ -16,7 +16,7 @@ function disambiguationTitlesArray() {
   return Array.from(document.querySelectorAll('div#content_block_0 div.hatnote a[href]:not([href=""]):not([redlink="1"])')).map(el => el.href)
 }
 
-var ItemTypeEnum = {
+var MenuItemType = {
   languages: 1,
   lastEdited: 2,
   pageIssues: 3,
@@ -34,29 +34,29 @@ class WMFMenuItem {
   }
   iconClass(){
     switch(this.itemType){
-    case ItemTypeEnum.languages:
+    case MenuItemType.languages:
       return 'footer_menu_icon_languages'
-    case ItemTypeEnum.lastEdited:
+    case MenuItemType.lastEdited:
       return 'footer_menu_icon_last_edited'
-    case ItemTypeEnum.pageIssues:
+    case MenuItemType.pageIssues:
       return 'footer_menu_icon_page_issues'
-    case ItemTypeEnum.disambiguation:
+    case MenuItemType.disambiguation:
       return 'footer_menu_icon_disambiguation'
-    case ItemTypeEnum.coordinate:
+    case MenuItemType.coordinate:
       return 'footer_menu_icon_coordinate'
     }
   }
   payloadExtractor(){
     switch(this.itemType){
-    case ItemTypeEnum.languages:
+    case MenuItemType.languages:
       return null
-    case ItemTypeEnum.lastEdited:
+    case MenuItemType.lastEdited:
       return null
-    case ItemTypeEnum.pageIssues:
+    case MenuItemType.pageIssues:
       return pageIssuesStringsArray
-    case ItemTypeEnum.disambiguation:
+    case MenuItemType.disambiguation:
       return disambiguationTitlesArray
-    case ItemTypeEnum.coordinate:
+    case MenuItemType.coordinate:
       return null
     }
   }
@@ -123,6 +123,6 @@ function setHeading(headingString, headingID) {
   headingElement.title = headingString
 }
 
-exports.ItemTypeEnum = ItemTypeEnum
+exports.MenuItemType = MenuItemType
 exports.setHeading = setHeading
 exports.maybeAddItem = maybeAddItem

--- a/www/js/transforms/footerMenu.js
+++ b/www/js/transforms/footerMenu.js
@@ -21,21 +21,7 @@ var ItemTypeEnum = {
   lastEdited: 2,
   pageIssues: 3,
   disambiguation: 4,
-  coordinate: 5,
-  iconClass: {
-    1: 'footer_menu_icon_languages',
-    2: 'footer_menu_icon_last_edited',
-    3: 'footer_menu_icon_page_issues',
-    4: 'footer_menu_icon_disambiguation',
-    5: 'footer_menu_icon_coordinate'
-  },
-  payloadExtractor: {
-    1: null,
-    2: null,
-    3: pageIssuesStringsArray,
-    4: disambiguationTitlesArray,
-    5: null
-  }
+  coordinate: 5
 }
 
 class WMFMenuItem {
@@ -47,10 +33,32 @@ class WMFMenuItem {
     this.payload = []
   }
   iconClass(){
-    return ItemTypeEnum.iconClass[this.itemType]
+    switch(this.itemType){
+    case ItemTypeEnum.languages:
+      return 'footer_menu_icon_languages'
+    case ItemTypeEnum.lastEdited:
+      return 'footer_menu_icon_last_edited'
+    case ItemTypeEnum.pageIssues:
+      return 'footer_menu_icon_page_issues'
+    case ItemTypeEnum.disambiguation:
+      return 'footer_menu_icon_disambiguation'
+    case ItemTypeEnum.coordinate:
+      return 'footer_menu_icon_coordinate'
+    }
   }
   payloadExtractor(){
-    return ItemTypeEnum.payloadExtractor[this.itemType]
+    switch(this.itemType){
+    case ItemTypeEnum.languages:
+      return null
+    case ItemTypeEnum.lastEdited:
+      return null
+    case ItemTypeEnum.pageIssues:
+      return pageIssuesStringsArray
+    case ItemTypeEnum.disambiguation:
+      return disambiguationTitlesArray
+    case ItemTypeEnum.coordinate:
+      return null
+    }
   }
 }
 

--- a/www/js/transforms/footerMenu.js
+++ b/www/js/transforms/footerMenu.js
@@ -1,4 +1,21 @@
 
+function pageIssuesStringsArray() {
+  const tables = document.querySelectorAll( 'div#content_block_0 table.ambox:not(.ambox-multiple_issues):not(.ambox-notice)' )
+  // Get the tables into a fragment so we can remove some elements without triggering a layout
+  var fragment = document.createDocumentFragment()
+  for (var i = 0; i < tables.length; i++) {
+    fragment.appendChild(tables[i].cloneNode(true))
+  }
+  // Remove some element so their text doesn't appear when we use "innerText"
+  Array.from(fragment.querySelectorAll( '.hide-when-compact, .collapsed' )).forEach(el => el.remove())
+  // Get the innerText
+  return Array.from(fragment.querySelectorAll( 'td[class$=mbox-text]' )).map(el => el.innerText)
+}
+
+function disambiguationTitlesArray() {
+  return Array.from(document.querySelectorAll('div#content_block_0 div.hatnote a[href]:not([href=""]):not([redlink="1"])')).map(el => el.href)
+}
+
 // var thisType = IconTypeEnum.languages;
 // var iconClass = IconTypeEnum.properties[thisType].iconClass;
 // iconClass is 'footer_menu_icon_languages'

--- a/www/js/transforms/footerMenu.js
+++ b/www/js/transforms/footerMenu.js
@@ -90,10 +90,23 @@ class WMFMenuItemFragment {
   }
 }
 
-function addItem(title, subtitle, iconType, containerID, clickHandler) {
-  const itemModel = new WMFMenuItem(title, subtitle, iconType, clickHandler)
-  const itemFragment = new WMFMenuItemFragment(itemModel)
-  document.getElementById(containerID).appendChild(itemFragment)
+function maybeAddItem(title, subtitle, itemType, containerID, clickHandler) {
+  const item = new WMFMenuItem(title, subtitle, itemType, clickHandler)
+
+  // Items are not added if they have a payload extractor which fails to extract anything.
+  if (item.payloadExtractor() !== null){
+    item.payload = item.payloadExtractor()()
+    if(item.payload.length === 0){
+      return
+    }
+  }
+
+  addItem(item, containerID)
+}
+
+function addItem(wmfMenuItem, containerID) {
+  const fragment = new WMFMenuItemFragment(wmfMenuItem)
+  document.getElementById(containerID).appendChild(fragment)
 }
 
 function setHeading(headingString, headingID) {
@@ -104,4 +117,4 @@ function setHeading(headingString, headingID) {
 
 exports.ItemTypeEnum = ItemTypeEnum
 exports.setHeading = setHeading
-exports.addItem = addItem
+exports.maybeAddItem = maybeAddItem

--- a/www/js/transforms/footerMenu.js
+++ b/www/js/transforms/footerMenu.js
@@ -61,7 +61,7 @@ class WMFMenuItemFragment {
 
     var containerAnchor = document.createElement('a')
     containerAnchor.addEventListener('click', function(){
-      wmfMenuItem.clickHandler()
+      wmfMenuItem.clickHandler(wmfMenuItem.payload)
     }, false)
 
     item.appendChild(containerAnchor)


### PR DESCRIPTION
Phase one of https://phabricator.wikimedia.org/T164137

The footer menu JS now extracts the disambiguation URLs and the page issues strings and relays them to native land. Formerly these were extracted by parsing the article HTML in native land.

Consolidating this to the footer menu transform so both platforms can use same code.

(Next phase will start moving the transform JS to the page lib.)

![woooo mov](https://user-images.githubusercontent.com/3143487/28099293-640d6474-6670-11e7-9cea-ea8af7fe710e.gif)