### PR TITLE
Dismissing reading themes controls popover when tapping on other toolbar item

### DIFF
--- a/Wikipedia/Code/ReadingThemesControlsViewController.swift
+++ b/Wikipedia/Code/ReadingThemesControlsViewController.swift
@@ -164,12 +164,7 @@ open class ReadingThemesControlsViewController: UIViewController {
     
     func makeImageDimmingSwitchMoreProminentForDisabledState(_ isEnabled: Bool) {
         imageDimmingSwitch.layer.cornerRadius = imageDimmingSwitch.frame.height / 2
-        if isEnabled {
-            imageDimmingSwitch.backgroundColor = nil
-        } else {
-        imageDimmingSwitch.tintColor = UIColor.wmf_lighterGray
-        imageDimmingSwitch.backgroundColor = UIColor.wmf_lighterGray
-        }
+        imageDimmingSwitch.backgroundColor = isEnabled ? nil : UIColor.wmf_lighterGray
     }
     
     func screenBrightnessChangedInApp(notification: Notification){

--- a/Wikipedia/Code/ReadingThemesControlsViewController.swift
+++ b/Wikipedia/Code/ReadingThemesControlsViewController.swift
@@ -137,6 +137,7 @@ open class ReadingThemesControlsViewController: UIViewController {
         removeBorderFrom(darkThemeButton)
         removeBorderFrom(sepiaThemeButton)
         imageDimmingSwitch.isEnabled = false
+        makeImageDimmingSwitchMoreProminentForDisabledState(imageDimmingSwitch.isEnabled)
         imageDimmingSwitch.isOn = UserDefaults.wmf_userDefaults().wmf_isImageDimmingEnabled
         switch theme.name {
         case Theme.sepia.name:
@@ -147,9 +148,20 @@ open class ReadingThemesControlsViewController: UIViewController {
             fallthrough
         case Theme.dark.name:
             imageDimmingSwitch.isEnabled = true
+            makeImageDimmingSwitchMoreProminentForDisabledState(imageDimmingSwitch.isEnabled)
             applyBorder(to: darkThemeButton)
         default:
             break
+        }
+    }
+    
+    func makeImageDimmingSwitchMoreProminentForDisabledState(_ isEnabled: Bool) {
+        imageDimmingSwitch.layer.cornerRadius = imageDimmingSwitch.frame.height / 2
+        if isEnabled {
+            imageDimmingSwitch.backgroundColor = nil
+        } else {
+        imageDimmingSwitch.tintColor = UIColor.wmf_lighterGray
+        imageDimmingSwitch.backgroundColor = UIColor.wmf_lighterGray
         }
     }
     

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -559,9 +559,12 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 }
 
 - (void)findInPageButtonPressed {
-    [self.presentedViewController dismissViewControllerAnimated:YES completion:^{
+    [CATransaction begin];
+    [CATransaction setCompletionBlock:^{
         [self.webViewController showFindInPage];
     }];
+    [self dismissReadingThemesPopoverIfActive];
+    [CATransaction commit];
 }
 
 - (UIBarButtonItem *)languagesToolbarItem {
@@ -1247,9 +1250,6 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
         self.shareArticleOnLoad = YES;
     }
 }
-
-#pragma mark - Find-in-page
-
 
 #pragma mark - Save
 

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -559,9 +559,9 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 }
 
 - (void)findInPageButtonPressed {
-    if ([self canFindInPage]) { // Needed so you can't tap find icon when text size adjuster is onscreen.
-        [self showFindInPage];
-    }
+    [self.presentedViewController dismissViewControllerAnimated:YES completion:^{
+        [self.webViewController showFindInPage];
+    }];
 }
 
 - (UIBarButtonItem *)languagesToolbarItem {
@@ -577,6 +577,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 #pragma mark - Article languages
 
 - (void)showLanguagePicker {
+    [self dismissReadingThemesPopoverIfActive];
     WMFArticleLanguagesViewController *languagesVC = [WMFArticleLanguagesViewController articleLanguagesViewControllerWithArticleURL:self.articleURL];
     languagesVC.delegate = self;
     [self presentViewControllerEmbeddedInNavigationController:languagesVC];
@@ -974,6 +975,8 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 }
 
 - (void)showTableOfContents:(id)sender {
+    [self dismissReadingThemesPopoverIfActive];
+    
     if (self.tableOfContentsViewController == nil) {
         return;
     }
@@ -1230,6 +1233,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 }
 
 - (void)shareArticle {
+    [self dismissReadingThemesPopoverIfActive];
     UIActivityViewController *vc = [self.article sharingActivityViewControllerWithTextSnippet:nil fromButton:self->_shareToolbarItem shareFunnel:self.shareFunnel];
     if (vc) {
         [self presentViewController:vc animated:YES completion:NULL];
@@ -1246,17 +1250,11 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 
 #pragma mark - Find-in-page
 
-- (void)showFindInPage {
-    if (self.presentedViewController != nil) {
-        return;
-    }
-
-    [self.webViewController showFindInPage];
-}
 
 #pragma mark - Save
 
 - (void)toggleSave:(id)sender {
+    [self dismissReadingThemesPopoverIfActive];
     BOOL isSaved = [self.savedPages toggleSavedPageForURL:self.articleURL];
     if (isSaved) {
         [self.savedPagesFunnel logSaveNew];
@@ -1305,6 +1303,12 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
     self.readingThemesPopoverPresenter.backgroundColor = self.theme.colors.popoverBackground;
 
     [self presentViewController:self.readingThemesViewController animated:YES completion:nil];
+}
+
+- (void)dismissReadingThemesPopoverIfActive {
+    if ([self.presentedViewController isKindOfClass:[WMFReadingThemesControlsViewController class]]) {
+        [self.presentedViewController dismissViewControllerAnimated:YES completion:nil];
+    }
 }
 
 - (UIModalPresentationStyle)adaptivePresentationStyleForPresentationController:(UIPresentationController *)controller {


### PR DESCRIPTION
- Reading Themes Controls Popover is dismissed when other `UIBarButtonItem` is tapped
-  Dim images switch in Reading Controls Popover is more prominent for disabled & off state (Default, Sepia)

Awaiting other design review tweaks

