### PR TITLE
[T172019] Don't show older news stories at the end of newer feed content

### DIFF
--- a/Wikipedia/Code/WMFExploreCollectionViewController.m
+++ b/Wikipedia/Code/WMFExploreCollectionViewController.m
@@ -1814,11 +1814,6 @@ NSString *const kvo_WMFExploreViewController_peek_state_keypath = @"state";
 
     WMFContentGroup *lastGroup = [self.fetchedResultsController objectAtIndexPath:[NSIndexPath indexPathForItem:lastGroupIndex inSection:0]];
 
-    while (lastGroupIndex > 0 && lastGroup != nil && (lastGroup.contentGroupKind == WMFContentGroupKindNews || lastGroup.contentGroupKind == WMFContentGroupKindOnThisDay || lastGroup.contentGroupKind == WMFContentGroupKindNotification) && lastGroupIndex > 0) { // News or On This Day can be added further back in the timeline, so don't use them as the date for this
-        lastGroupIndex--;
-        lastGroup = [self.fetchedResultsController objectAtIndexPath:[NSIndexPath indexPathForItem:lastGroupIndex inSection:0]];
-    }
-
     NSDate *now = [NSDate date];
     NSDate *midnightUTC = [now wmf_midnightUTCDateFromLocalDate];
     NSDate *lastGroupMidnightUTC = lastGroup.midnightUTCDate;


### PR DESCRIPTION
Only add or show a news card that matches the feed date being loaded.

https://phabricator.wikimedia.org/T172019