### PR TITLE
[T170465] Fix search URL handling

### DIFF
--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.m
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.m
@@ -34,7 +34,7 @@ NSString *const WMFNavigateToActivityNotification = @"WMFNavigateToActivityNotif
 + (instancetype)wmf_pageActivityWithName:(NSString *)pageName {
     NSUserActivity *activity = [self wmf_activityWithType:[pageName lowercaseString]];
     activity.title = pageName;
-    activity.userInfo = @{ @"WMFPage": pageName };
+    activity.userInfo = @{@"WMFPage": pageName};
 
     if ([[NSProcessInfo processInfo] wmf_isOperatingSystemMajorVersionAtLeast:9]) {
         NSMutableSet *set = [activity.keywords mutableCopy];
@@ -47,7 +47,7 @@ NSString *const WMFNavigateToActivityNotification = @"WMFNavigateToActivityNotif
 
 + (instancetype)wmf_contentActivityWithURL:(NSURL *)url {
     NSUserActivity *activity = [self wmf_activityWithType:@"Content"];
-    activity.userInfo = @{ @"WMFURL": url };
+    activity.userInfo = @{@"WMFURL": url};
     return activity;
 }
 
@@ -158,7 +158,25 @@ NSString *const WMFNavigateToActivityNotification = @"WMFNavigateToActivityNotif
 + (instancetype)wmf_searchResultsActivitySearchSiteURL:(NSURL *)url searchTerm:(NSString *)searchTerm {
     NSURLComponents *components = [[NSURLComponents alloc] initWithURL:url resolvingAgainstBaseURL:NO];
     components.path = @"/w/index.php";
-    components.query = [NSString stringWithFormat:@"search=%@&title=Special:Search&fulltext=1", searchTerm];
+    NSMutableArray *queryItems = [NSMutableArray arrayWithCapacity:3];
+    NSURLQueryItem *queryItem = nil;
+    if (searchTerm) {
+        queryItem = [NSURLQueryItem queryItemWithName:@"search" value:searchTerm];
+        if (queryItem) {
+            [queryItems addObject:queryItem];
+        }
+    }
+    queryItem = [NSURLQueryItem queryItemWithName:@"title" value:@"Special:Search"];
+    if (queryItem) {
+        [queryItems addObject:queryItem];
+    }
+
+    queryItem = [NSURLQueryItem queryItemWithName:@"fulltext" value:@"1"];
+    if (queryItem) {
+        [queryItems addObject:queryItem];
+    }
+
+    components.queryItems = queryItems;
     url = [components URL];
 
     NSUserActivity *activity = [self wmf_activityWithType:@"Searchresults"];

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -585,7 +585,7 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreFeed = 2 * 60 * 60;
 
 #if WMF_TWEAKS_ENABLED
     if (FBTweakValue(@"Alerts", @"General", @"Show error on launch", NO)) {
-        [[WMFAlertManager sharedInstance] showErrorAlert:[NSError errorWithDomain:@"WMFTestDomain" code:0 userInfo:@{ NSLocalizedDescriptionKey: @"There was an error" }] sticky:NO dismissPreviousAlerts:NO tapCallBack:NULL];
+        [[WMFAlertManager sharedInstance] showErrorAlert:[NSError errorWithDomain:@"WMFTestDomain" code:0 userInfo:@{NSLocalizedDescriptionKey: @"There was an error"}] sticky:NO dismissPreviousAlerts:NO tapCallBack:NULL];
     }
     if (FBTweakValue(@"Alerts", @"General", @"Show warning on launch", NO)) {
         [[WMFAlertManager sharedInstance] showWarningAlert:@"You have been warned" sticky:NO dismissPreviousAlerts:NO tapCallBack:NULL];
@@ -839,6 +839,7 @@ static NSTimeInterval const WMFTimeBeforeRefreshingExploreFeed = 2 * 60 * 60;
         case WMFUserActivityTypeSearchResults:
             [self switchToExploreAndShowSearchAnimated:animated];
             [self.searchViewController setSearchTerm:[activity wmf_searchTerm]];
+            [self.searchViewController performSearchWithCurrentSearchTerm];
             break;
         case WMFUserActivityTypeArticle: {
             NSURL *URL = [activity wmf_articleURL];

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1113,7 +1113,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 #pragma mark - Show Search
 
 - (void)switchToExploreAndShowSearchAnimated:(BOOL)animated {
-    if (self.presentedViewController == self.searchViewController) {
+    if (self.presentedViewController && self.presentedViewController == self.searchViewController) {
         return;
     }
     [self dismissPresentedViewControllers];

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1113,6 +1113,9 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 #pragma mark - Show Search
 
 - (void)switchToExploreAndShowSearchAnimated:(BOOL)animated {
+    if (self.presentedViewController == self.searchViewController) {
+        return;
+    }
     [self dismissPresentedViewControllers];
     if (self.rootTabBarController.selectedIndex != WMFAppTabTypeExplore) {
         [self.rootTabBarController setSelectedIndex:WMFAppTabTypeExplore];

--- a/Wikipedia/Code/WMFSearchFetcher.m
+++ b/Wikipedia/Code/WMFSearchFetcher.m
@@ -60,15 +60,7 @@ NSUInteger const WMFMaxSearchResultLimit = 24;
                      useDesktopURL:(BOOL)useDeskTopURL
                            failure:(WMFErrorHandler)failure
                            success:(WMFSearchResultsHandler)success {
-    if (!siteURL) {
-        siteURL = [NSURL wmf_URLWithDefaultSiteAndCurrentLocale];
-    }
-
-    if (!siteURL) {
-        failure([NSError wmf_errorWithType:WMFErrorTypeInvalidRequestParameters userInfo:nil]);
-        return;
-    }
-
+    NSParameterAssert(siteURL);
     NSURL *url = useDeskTopURL ? [NSURL wmf_desktopAPIURLForURL:siteURL] : [NSURL wmf_mobileAPIURLForURL:siteURL];
 
     WMFSearchRequestParameters *params = [WMFSearchRequestParameters new];

--- a/Wikipedia/Code/WMFSearchFetcher.m
+++ b/Wikipedia/Code/WMFSearchFetcher.m
@@ -60,7 +60,15 @@ NSUInteger const WMFMaxSearchResultLimit = 24;
                      useDesktopURL:(BOOL)useDeskTopURL
                            failure:(WMFErrorHandler)failure
                            success:(WMFSearchResultsHandler)success {
-    NSParameterAssert(siteURL);
+    if (!siteURL) {
+        siteURL = [NSURL wmf_URLWithDefaultSiteAndCurrentLocale];
+    }
+
+    if (!siteURL) {
+        failure([NSError wmf_errorWithType:WMFErrorTypeInvalidRequestParameters userInfo:nil]);
+        return;
+    }
+
     NSURL *url = useDeskTopURL ? [NSURL wmf_desktopAPIURLForURL:siteURL] : [NSURL wmf_mobileAPIURLForURL:siteURL];
 
     WMFSearchRequestParameters *params = [WMFSearchRequestParameters new];

--- a/Wikipedia/Code/WMFSearchFetcher.m
+++ b/Wikipedia/Code/WMFSearchFetcher.m
@@ -60,7 +60,15 @@ NSUInteger const WMFMaxSearchResultLimit = 24;
                      useDesktopURL:(BOOL)useDeskTopURL
                            failure:(WMFErrorHandler)failure
                            success:(WMFSearchResultsHandler)success {
-    NSParameterAssert(siteURL);
+    if (!siteURL) {
+        siteURL = [NSURL wmf_URLWithDefaultSiteAndCurrentLocale];
+    }
+    
+    if (!siteURL) {
+        failure([NSError wmf_errorWithType:WMFErrorTypeInvalidRequestParameters userInfo:nil]);
+        return;
+    }
+    
     NSURL *url = useDeskTopURL ? [NSURL wmf_desktopAPIURLForURL:siteURL] : [NSURL wmf_mobileAPIURLForURL:siteURL];
 
     WMFSearchRequestParameters *params = [WMFSearchRequestParameters new];

--- a/Wikipedia/Code/WMFSearchViewController.h
+++ b/Wikipedia/Code/WMFSearchViewController.h
@@ -8,10 +8,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface WMFSearchViewController : UIViewController <WMFAnalyticsContextProviding, WMFAnalyticsViewNameProviding, WMFThemeable>
 
 @property (nonatomic, strong, readonly) MWKDataStore *dataStore;
+@property (nonatomic, copy, nullable) NSString *searchTerm;
 
 + (instancetype)searchViewControllerWithDataStore:(MWKDataStore *)dataStore;
 
-- (void)setSearchTerm:(NSString *)searchTerm;
+
 
 @end
 

--- a/Wikipedia/Code/WMFSearchViewController.h
+++ b/Wikipedia/Code/WMFSearchViewController.h
@@ -8,10 +8,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface WMFSearchViewController : UIViewController <WMFAnalyticsContextProviding, WMFAnalyticsViewNameProviding, WMFThemeable>
 
 @property (nonatomic, strong, readonly) MWKDataStore *dataStore;
+@property (nonatomic, copy) NSString *searchTerm;
+
+- (void)performSearchWithCurrentSearchTerm;
 
 + (instancetype)searchViewControllerWithDataStore:(MWKDataStore *)dataStore;
 
-- (void)setSearchTerm:(NSString *)searchTerm;
 
 @end
 

--- a/Wikipedia/Code/WMFSearchViewController.h
+++ b/Wikipedia/Code/WMFSearchViewController.h
@@ -8,11 +8,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface WMFSearchViewController : UIViewController <WMFAnalyticsContextProviding, WMFAnalyticsViewNameProviding, WMFThemeable>
 
 @property (nonatomic, strong, readonly) MWKDataStore *dataStore;
-@property (nonatomic, copy, nullable) NSString *searchTerm;
 
 + (instancetype)searchViewControllerWithDataStore:(MWKDataStore *)dataStore;
 
-
+- (void)setSearchTerm:(NSString *)searchTerm;
 
 @end
 

--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -180,10 +180,6 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 
     [self updateUIWithResults:nil];
     [self updateRecentSearchesVisibility:NO];
-    
-    if (self.searchTerm) {
-        self.searchTerm = self.searchTerm;
-    }
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
@@ -369,10 +365,6 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 #pragma mark - Search
 
 - (void)setSearchTerm:(NSString *)searchTerm {
-    _searchTerm = [searchTerm copy];
-    if (!self.viewIfLoaded) {
-        return;
-    }
     if (searchTerm.length == 0) {
         return;
     }
@@ -381,7 +373,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 }
 
 - (NSURL *)currentlySelectedSearchURL {
-    return self.searchLanguagesBarViewController.currentlySelectedSearchLanguage.siteURL ?: [NSURL wmf_URLWithDefaultSiteAndCurrentLocale];
+    return self.searchLanguagesBarViewController.currentlySelectedSearchLanguage.siteURL;
 }
 
 - (void)didCancelSearch {
@@ -441,7 +433,9 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
     [self.fetcher fetchArticlesForSearchTerm:searchTerm
         siteURL:url
         resultLimit:WMFMaxSearchResultLimit
-        failure:failure
+        failure:^(NSError *_Nonnull error) {
+
+        }
         success:^(WMFSearchResults *_Nonnull results) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 @strongify(self);

--- a/Wikipedia/Code/WMFSearchViewController.m
+++ b/Wikipedia/Code/WMFSearchViewController.m
@@ -180,6 +180,10 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 
     [self updateUIWithResults:nil];
     [self updateRecentSearchesVisibility:NO];
+    
+    if (self.searchTerm) {
+        self.searchTerm = self.searchTerm;
+    }
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
@@ -365,6 +369,10 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 #pragma mark - Search
 
 - (void)setSearchTerm:(NSString *)searchTerm {
+    _searchTerm = [searchTerm copy];
+    if (!self.viewIfLoaded) {
+        return;
+    }
     if (searchTerm.length == 0) {
         return;
     }
@@ -373,7 +381,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
 }
 
 - (NSURL *)currentlySelectedSearchURL {
-    return self.searchLanguagesBarViewController.currentlySelectedSearchLanguage.siteURL;
+    return self.searchLanguagesBarViewController.currentlySelectedSearchLanguage.siteURL ?: [NSURL wmf_URLWithDefaultSiteAndCurrentLocale];
 }
 
 - (void)didCancelSearch {
@@ -433,9 +441,7 @@ static NSUInteger const kWMFMinResultsBeforeAutoFullTextSearch = 12;
     [self.fetcher fetchArticlesForSearchTerm:searchTerm
         siteURL:url
         resultLimit:WMFMaxSearchResultLimit
-        failure:^(NSError *_Nonnull error) {
-
-        }
+        failure:failure
         success:^(WMFSearchResults *_Nonnull results) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 @strongify(self);


### PR DESCRIPTION
https://phabricator.wikimedia.org/T170465

Search URLs were being constructed using a format string rather than `NSURLQueryItem`s.

Also, setting a search term on a search VC that hadn't been presented wasn't triggering a search.