### PR TITLE
Fix all iOS 9 articles being broken on 5.6.1. (release blocker!)

### DIFF
--- a/Wikipedia/assets/index.js
+++ b/Wikipedia/assets/index.js
@@ -511,8 +511,8 @@ function hideTables(content, isMainPage, pageTitle, infoboxTitle, otherTitle, fo
 
   // Prevents some collapsed tables from scrolling side-to-side.
   // May want to move this to wikimedia-page-library if there are no issues.
-  document.querySelectorAll('.app_table_container *[class~="nowrap"]')
-    .forEach(el => el.classList.remove('nowrap'))
+  Array.from(document.querySelectorAll('.app_table_container *[class~="nowrap"]'))
+    .forEach(function(el) {el.classList.remove('nowrap')})
 }
 
 exports.hideTables = hideTables

--- a/www/js/transforms/collapseTables.js
+++ b/www/js/transforms/collapseTables.js
@@ -12,8 +12,8 @@ function hideTables(content, isMainPage, pageTitle, infoboxTitle, otherTitle, fo
 
   // Prevents some collapsed tables from scrolling side-to-side.
   // May want to move this to wikimedia-page-library if there are no issues.
-  document.querySelectorAll('.app_table_container *[class~="nowrap"]')
-    .forEach(el => el.classList.remove('nowrap'))
+  Array.from(document.querySelectorAll('.app_table_container *[class~="nowrap"]'))
+    .forEach(function(el) {el.classList.remove('nowrap')})
 }
 
 exports.hideTables = hideTables


### PR DESCRIPTION
https://phabricator.wikimedia.org/T175434

Caused by [this fix](https://phabricator.wikimedia.org/T174722) of mine which accidentally used more modern JS syntax not supported by iOS 9.


We'll also need to merge this into 5.7 so iOS 9 is fixed there too.

(may want to take the time to hook up babel trans-pile so we don't get bitten by this yet again, but may not be worth the effort if iOS 9 is dropped relatively soon...)

# Before
![screen shot 2017-09-08 at 3 32 30 pm](https://user-images.githubusercontent.com/3143487/30234502-8b493638-94b2-11e7-8a70-926679bce336.png)

# After
![screen shot 2017-09-08 at 4 26 27 pm](https://user-images.githubusercontent.com/3143487/30234503-9087bc46-94b2-11e7-8628-7e83e9e71988.png)