### PR TITLE
[5.6.1] Eliminate unnecessary updates to label background colors

### DIFF
--- a/Wikipedia/Code/CollectionViewCell.swift
+++ b/Wikipedia/Code/CollectionViewCell.swift
@@ -36,7 +36,8 @@ open class CollectionViewCell: UICollectionViewCell {
         
     }
 
-    fileprivate var isSelectedOrHighlighted = false
+    fileprivate var isSelectedOrHighlighted: Bool?
+    
     public final func updateSelectedOrHighlighted() {
         let newIsSelectedOrHighlighted = isSelected || isHighlighted
         guard newIsSelectedOrHighlighted != isSelectedOrHighlighted else {

--- a/Wikipedia/Code/CollectionViewCell.swift
+++ b/Wikipedia/Code/CollectionViewCell.swift
@@ -36,7 +36,15 @@ open class CollectionViewCell: UICollectionViewCell {
         
     }
 
+    fileprivate var isSelectedOrHighlighted = false
     public final func updateSelectedOrHighlighted() {
+        let newIsSelectedOrHighlighted = isSelected || isHighlighted
+        guard newIsSelectedOrHighlighted != isSelectedOrHighlighted else {
+            return
+        }
+
+        isSelectedOrHighlighted = newIsSelectedOrHighlighted
+
         // It appears that background color changes aren't properly animated when set within the animation block around isHighlighted/isSelected state changes
         // https://phabricator.wikimedia.org/T174341
 
@@ -51,7 +59,7 @@ open class CollectionViewCell: UICollectionViewCell {
             if let block = existingCompletionBlock {
                 block()
             }
-            self.labelBackgroundColor = self.isSelected || self.isHighlighted ? self.selectedBackgroundView?.backgroundColor : self.backgroundView?.backgroundColor
+            self.labelBackgroundColor =  newIsSelectedOrHighlighted ? self.selectedBackgroundView?.backgroundColor : self.backgroundView?.backgroundColor
         }
     }
 


### PR DESCRIPTION
The Core Data fetch and inflation of Mantle objects still causes some hang, but this helps mitigate https://phabricator.wikimedia.org/T175543

Before:
<img width="897" alt="screen shot 2017-09-11 at 7 31 28 am" src="https://user-images.githubusercontent.com/741327/30272735-f2592096-96c3-11e7-9f49-e2b09bb3453e.png">


After:
<img width="999" alt="screen shot 2017-09-11 at 7 35 15 am" src="https://user-images.githubusercontent.com/741327/30272711-d59f3f12-96c3-11e7-979f-ec20c72160f0.png">
