### PR TITLE
[5.6.1] Fix edit pencils on iOS 9

### DIFF
--- a/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.m
+++ b/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.m
@@ -19,10 +19,10 @@ static int const kMinimumTextSelectionLength = 2;
 
 - (void)wmf_addEditPencilsForArticle:(MWKArticle *)article {
     if (!article.isMain) {
-        [self evaluateJavaScript: [NSString stringWithFormat:@""
-                                   "window.wmf.editButtons.add(document);"
-                                   "document.querySelectorAll('.pagelib_edit_section_link').forEach(anchor => {anchor.href = '%@'});"
-                                   , WMFEditPencil]
+        [self evaluateJavaScript:[NSString stringWithFormat:@""
+                                                             "window.wmf.editButtons.add(document);"
+                                                             "Array.from(document.querySelectorAll('.pagelib_edit_section_link')).forEach(function(anchor){anchor.href = '%@'});",
+                                                            WMFEditPencil]
                completionHandler:nil];
     }
 }

--- a/Wikipedia/assets/preview.html
+++ b/Wikipedia/assets/preview.html
@@ -6,6 +6,11 @@
     <meta name="viewport" id="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0">
     <link href="preview.css" rel="stylesheet" type="text/css"></link>
     <link href="styleoverrides.css" rel="stylesheet" type="text/css"></link>
+    <style>
+      A.edit-page {
+        display: none;
+      }
+    </style>
     %@
 	  <!-- %@ %@ %@ (needed for consistency with index.html) -->
     </head>

--- a/Wikipedia/assets/preview.js
+++ b/Wikipedia/assets/preview.js
@@ -2321,6 +2321,7 @@ wmf.compatibility = require('wikimedia-page-library').CompatibilityTransform
 wmf.themes = require('wikimedia-page-library').ThemeTransform
 wmf.utilities = require('./js/utilities')
 wmf.platform = require('wikimedia-page-library').PlatformTransform
+wmf.imageDimming = require('wikimedia-page-library').DimImagesTransform
 
 window.wmf = wmf
 },{"./js/utilities":1,"wikimedia-page-library":2}]},{},[3,1]);

--- a/www/preview-main.js
+++ b/www/preview-main.js
@@ -4,5 +4,6 @@ wmf.compatibility = require('wikimedia-page-library').CompatibilityTransform
 wmf.themes = require('wikimedia-page-library').ThemeTransform
 wmf.utilities = require('./js/utilities')
 wmf.platform = require('wikimedia-page-library').PlatformTransform
+wmf.imageDimming = require('wikimedia-page-library').DimImagesTransform
 
 window.wmf = wmf

--- a/www/preview.html
+++ b/www/preview.html
@@ -6,6 +6,11 @@
     <meta name="viewport" id="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0">
     <link href="preview.css" rel="stylesheet" type="text/css"></link>
     <link href="styleoverrides.css" rel="stylesheet" type="text/css"></link>
+    <style>
+      A.edit-page {
+        display: none;
+      }
+    </style>
     %@
 	  <!-- %@ %@ %@ (needed for consistency with index.html) -->
     </head>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T175777

- edit pencils now show correctly across iOS 9, 10 and 11
- "EDIT" link now hidden in edit previews
- fixed JS error on edit preview

(I did a project-wide search for "=>" in js, swift and obj-c files and looks like we finally got 'em all.)