### PR TITLE
Only use two columns if the readableWidth is greater than 500

### DIFF
--- a/Wikipedia/Code/WMFCVLMetrics.m
+++ b/Wikipedia/Code/WMFCVLMetrics.m
@@ -43,7 +43,7 @@
 
     BOOL isRTL = layoutDirection == UIUserInterfaceLayoutDirectionRightToLeft;
     BOOL isPad = boundsSize.width >= 600;
-    BOOL useTwoColumns = isPad || boundsSize.width > boundsSize.height;
+    BOOL useTwoColumns = isPad || (boundsSize.width > boundsSize.height && readableWidth >= 500);
 
     metrics.numberOfColumns = useTwoColumns ? 2 : 1;
     metrics.columnWeights = useTwoColumns ? isRTL ? @[@(secondColumnRatio), @(firstColumnRatio)] : @[@(firstColumnRatio), @(secondColumnRatio)] : @[@1];


### PR DESCRIPTION
Fixes this:

![simulator screen shot - iphone 4s - 2017-10-02 at 12 34 04](https://user-images.githubusercontent.com/741327/31088710-a584a904-a76f-11e7-95f7-06368a5c4387.png)
