### PR TITLE
Fix layout margins for top read lists

### DIFF
--- a/Wikipedia/Code/ArticleCollectionViewCell+WMFFeedContentDisplaying.swift
+++ b/Wikipedia/Code/ArticleCollectionViewCell+WMFFeedContentDisplaying.swift
@@ -2,15 +2,15 @@ import Foundation
 
 public extension ArticleCollectionViewCell {
     fileprivate func adjustMargins(for index: Int, count: Int) {
-        var newMargins = layoutMargins
+        var newMultipliers: UIEdgeInsets = ArticleCollectionViewCell.defaultMarginsMultipliers
         let maxIndex = count - 1
         if index < maxIndex {
-            newMargins.bottom = round(0.5*layoutMargins.bottom)
+            newMultipliers.bottom = 0.5
         }
         if index > 0 {
-            newMargins.top = round(0.5*layoutMargins.top)
+            newMultipliers.top = 0.5
         }
-        layoutMargins = newMargins
+        layoutMarginsMultipliers = newMultipliers
     }
     
     @objc(setTitleText:highlightingText:locale:)

--- a/Wikipedia/Code/ArticleCollectionViewCell.swift
+++ b/Wikipedia/Code/ArticleCollectionViewCell.swift
@@ -4,7 +4,8 @@ import UIKit
 
 @objc(WMFArticleCollectionViewCell)
 open class ArticleCollectionViewCell: CollectionViewCell, SwipeableCell {
-    static let defaultMargins = UIEdgeInsetsMake(15, 13, 15, 13)
+    static let defaultMargins: UIEdgeInsets = UIEdgeInsets(top: 15, left: 13, bottom: 15, right: 13)
+    static let defaultMarginsMultipliers: UIEdgeInsets = UIEdgeInsets(top: 1, left: 1, bottom: 1, right: 1)
     
     @objc public let titleLabel = UILabel()
     @objc public let descriptionLabel = UILabel()
@@ -12,6 +13,33 @@ open class ArticleCollectionViewCell: CollectionViewCell, SwipeableCell {
     @objc public let saveButton = SaveButton()
     @objc public var extractLabel: UILabel?
     public let actionsView = ActionsView()
+
+    func updateMargins() {
+        let margins = privateLayoutMargins
+        let multipliers = layoutMarginsMultipliers
+        super.layoutMargins = UIEdgeInsets(top: round(margins.top * multipliers.top), left: round(margins.left * multipliers.left), bottom: round(margins.bottom * multipliers.bottom), right: round(margins.right * multipliers.right))
+    }
+
+    fileprivate var privateLayoutMargins: UIEdgeInsets = ArticleCollectionViewCell.defaultMargins {
+        didSet {
+            updateMargins()
+        }
+    }
+
+    var layoutMarginsMultipliers: UIEdgeInsets = ArticleCollectionViewCell.defaultMarginsMultipliers {
+        didSet {
+            updateMargins()
+        }
+    }
+
+    open override var layoutMargins: UIEdgeInsets {
+        set {
+            privateLayoutMargins = newValue
+        }
+        get {
+            return super.layoutMargins
+        }
+    }
 
     public var actions: [Action] {
         set {
@@ -54,6 +82,7 @@ open class ArticleCollectionViewCell: CollectionViewCell, SwipeableCell {
     // This method is called to reset the cell to the default configuration. It is called on initial setup and prepareForReuse. Subclassers should call super.
     override open func reset() {
         super.reset()
+        layoutMarginsMultipliers = ArticleCollectionViewCell.defaultMarginsMultipliers
         titleFontFamily = .georgia
         titleTextStyle = .title1
         descriptionFontFamily = .system

--- a/Wikipedia/Code/ArticleCollectionViewCell.swift
+++ b/Wikipedia/Code/ArticleCollectionViewCell.swift
@@ -6,6 +6,7 @@ import UIKit
 open class ArticleCollectionViewCell: CollectionViewCell, SwipeableCell {
     static let defaultMargins: UIEdgeInsets = UIEdgeInsets(top: 15, left: 13, bottom: 15, right: 13)
     static let defaultMarginsMultipliers: UIEdgeInsets = UIEdgeInsets(top: 1, left: 1, bottom: 1, right: 1)
+    var layoutMarginsMultipliers: UIEdgeInsets = ArticleCollectionViewCell.defaultMarginsMultipliers
     
     @objc public let titleLabel = UILabel()
     @objc public let descriptionLabel = UILabel()
@@ -13,33 +14,6 @@ open class ArticleCollectionViewCell: CollectionViewCell, SwipeableCell {
     @objc public let saveButton = SaveButton()
     @objc public var extractLabel: UILabel?
     public let actionsView = ActionsView()
-
-    func updateMargins() {
-        let margins = privateLayoutMargins
-        let multipliers = layoutMarginsMultipliers
-        super.layoutMargins = UIEdgeInsets(top: round(margins.top * multipliers.top), left: round(margins.left * multipliers.left), bottom: round(margins.bottom * multipliers.bottom), right: round(margins.right * multipliers.right))
-    }
-
-    fileprivate var privateLayoutMargins: UIEdgeInsets = ArticleCollectionViewCell.defaultMargins {
-        didSet {
-            updateMargins()
-        }
-    }
-
-    var layoutMarginsMultipliers: UIEdgeInsets = ArticleCollectionViewCell.defaultMarginsMultipliers {
-        didSet {
-            updateMargins()
-        }
-    }
-
-    open override var layoutMargins: UIEdgeInsets {
-        set {
-            privateLayoutMargins = newValue
-        }
-        get {
-            return super.layoutMargins
-        }
-    }
 
     public var actions: [Action] {
         set {

--- a/Wikipedia/Code/ArticleCollectionViewController.swift
+++ b/Wikipedia/Code/ArticleCollectionViewController.swift
@@ -35,7 +35,7 @@ class ArticleCollectionViewController: ColumnarCollectionViewController {
         let numberOfItems = self.collectionView(collectionView, numberOfItemsInSection: indexPath.section)
         cell.configure(article: article, displayType: .compactList, index: indexPath.item, count: numberOfItems, shouldAdjustMargins: false, shouldShowSeparators: true, theme: theme, layoutOnly: layoutOnly)
         cell.actions = availableActions(at: indexPath)
-        cell.layoutMargins = layout.readableMargins
+        cell.insets = layout.readableMargins
     }
     
     open func articleURL(at indexPath: IndexPath) -> URL? {

--- a/Wikipedia/Code/ArticleCollectionViewController.swift
+++ b/Wikipedia/Code/ArticleCollectionViewController.swift
@@ -35,7 +35,7 @@ class ArticleCollectionViewController: ColumnarCollectionViewController {
         let numberOfItems = self.collectionView(collectionView, numberOfItemsInSection: indexPath.section)
         cell.configure(article: article, displayType: .compactList, index: indexPath.item, count: numberOfItems, shouldAdjustMargins: false, shouldShowSeparators: true, theme: theme, layoutOnly: layoutOnly)
         cell.actions = availableActions(at: indexPath)
-        cell.insets = layout.readableMargins
+        cell.layoutMargins = layout.readableMargins
     }
     
     open func articleURL(at indexPath: IndexPath) -> URL? {

--- a/Wikipedia/Code/ArticleRightAlignedImageCollectionViewCell.swift
+++ b/Wikipedia/Code/ArticleRightAlignedImageCollectionViewCell.swift
@@ -34,6 +34,10 @@ open class ArticleRightAlignedImageCollectionViewCell: ArticleCollectionViewCell
         let size = super.sizeThatFits(size, apply: apply)
         let isRTL = articleSemanticContentAttribute == .forceRightToLeft
 
+        let margins = self.layoutMargins
+        let multipliers = self.layoutMarginsMultipliers
+        let layoutMargins = UIEdgeInsets(top: round(margins.top * multipliers.top), left: round(margins.left * multipliers.left), bottom: round(margins.bottom * multipliers.bottom), right: round(margins.right * multipliers.right))
+
         var widthMinusMargins = size.width - layoutMargins.left - layoutMargins.right
         let minHeight = imageViewDimension + layoutMargins.top + layoutMargins.bottom
         let minHeightMinusMargins = minHeight - layoutMargins.top - layoutMargins.bottom


### PR DESCRIPTION
Before this fix, the margins on top read cells were wrong. Easiest to see by tapping and holding on the cell to see the selected background. The content should be centered for the middle cells, extra padding on the top for the first cell, bottom for the last cell.

After fix:
![simulator screen shot - iphone 6s - 2017-10-11 at 16 35 50](https://user-images.githubusercontent.com/741327/31469521-e559cea0-aeaf-11e7-843c-37fdd6c4f511.png)
