### PR TITLE
Fix premature location permission request

### DIFF
--- a/Wikipedia/Code/ArticleLocationCollectionViewController.swift
+++ b/Wikipedia/Code/ArticleLocationCollectionViewController.swift
@@ -30,7 +30,9 @@ class ArticleLocationCollectionViewController: ColumnarCollectionViewController 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         locationManager.delegate = self
-        locationManager.startMonitoringLocation()
+        if WMFLocationManager.isAuthorized() {
+            locationManager.startMonitoringLocation()
+        }
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -105,6 +107,12 @@ extension ArticleLocationCollectionViewController: WMFLocationManagerDelegate {
     
     func locationManager(_ controller: WMFLocationManager, didUpdate heading: CLHeading) {
         updateLocationOnVisibleCells()
+    }
+
+    func locationManager(_ controller: WMFLocationManager, didChangeEnabledState enabled: Bool) {
+        if enabled {
+            locationManager.startMonitoringLocation()
+        }
     }
 }
 

--- a/Wikipedia/Code/EnableLocationViewController.xib
+++ b/Wikipedia/Code/EnableLocationViewController.xib
@@ -40,7 +40,6 @@
                             <rect key="frame" x="0.0" y="0.0" width="268" height="95"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="95" id="jWo-IS-JDh"/>
-                                <constraint firstAttribute="width" constant="95" id="rz1-ZG-dlE"/>
                             </constraints>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Explore articles near your location by enabling Location Access " textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cta-dZ-grZ">


### PR DESCRIPTION
`ArticleLocationCollectionViewController` would trigger a location permission request automatically - we should only trigger requests after the user taps an in-app prompt.

Also removes the auth arrow width constraint on the location auth popover - there shouldn't need to be a width constraint in a vertical stack view and it was causing unsatisfiable constraint errors.