### PR TITLE
Fix 2FA text boxes - hide close button and use center alignment.

### DIFF
--- a/Wikipedia/Code/WMFTwoFactorPasswordViewController.swift
+++ b/Wikipedia/Code/WMFTwoFactorPasswordViewController.swift
@@ -213,6 +213,11 @@ class WMFTwoFactorPasswordViewController: WMFScrollViewController, UITextFieldDe
 
         oathTokenFields.sort { $0.tag < $1.tag }
 
+        oathTokenFields.forEach {
+            $0.rightViewMode = .never
+            $0.textAlignment = .center
+        }
+        
         // Cast fields once here to set 'deleteBackwardDelegate' rather than casting everywhere else UITextField is expected.
         if let fields = oathTokenFields as? [WMFDeleteBackwardReportingTextField] {
             fields.forEach {$0.deleteBackwardDelegate = self}


### PR DESCRIPTION
Was changed by ThemeableTextField.

# Before #
<img width="431" alt="screen shot 2017-10-12 at 1 33 32 pm" src="https://user-images.githubusercontent.com/3143487/31517862-0fbbf4fa-af52-11e7-9275-9595373f0428.png">

# After #
<img width="431" alt="screen shot 2017-10-12 at 1 31 16 pm" src="https://user-images.githubusercontent.com/3143487/31517863-100f30b6-af52-11e7-9806-82f2c189ee38.png">