### PR TITLE
Fix extra padding at top of settings on iOS 9 and 10.

### DIFF
--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -109,6 +109,7 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
     [super viewWillAppear:animated];
     self.navigationController.toolbarHidden = YES;
     [self loadSections];
+    self.tableView.contentOffset = CGPointZero;
 }
 
 - (void)configureBackButton {

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -82,6 +82,12 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
     self.authManager = [WMFAuthenticationManager sharedInstance];
 
     [self applyTheme:self.theme];
+
+    if (@available(iOS 11.0, *)) {
+    } else {
+        // Before iOS 11
+        self.automaticallyAdjustsScrollViewInsets = NO;
+    }
 }
 
 - (void)dealloc {
@@ -109,7 +115,6 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
     [super viewWillAppear:animated];
     self.navigationController.toolbarHidden = YES;
     [self loadSections];
-    self.tableView.contentOffset = CGPointZero;
 }
 
 - (void)configureBackButton {


### PR DESCRIPTION
Not sure where the extra content offset is coming from...

<strike>I double-checked this fix on iPhone X sim and seems ok, but would rather find out what's causing the offset... ideas? (tried symbolic breakpoint tagged to this tableview and none of our code seems to be setting it...)</strike>

Turning off `automaticallyAdjustsScrollViewInsets` for iOS 9 and 10 fixed it... still uncertain why it gets added - unless maybe it's related to the nav controller we're using for pushing the appearance vc?

# Before #
<img width="431" alt="screen shot 2017-10-12 at 2 36 03 pm" src="https://user-images.githubusercontent.com/3143487/31520479-ced56436-af5a-11e7-9ce5-f744bcd4dcf3.png">


# After #
<img width="431" alt="screen shot 2017-10-12 at 2 34 39 pm" src="https://user-images.githubusercontent.com/3143487/31520429-b00277d8-af5a-11e7-9953-2f0ed7a6274d.png">


