### PR TITLE
Design tweaks for peek previews

### DIFF
--- a/Wikipedia/Code/ArticlePeekPreviewViewController.swift
+++ b/Wikipedia/Code/ArticlePeekPreviewViewController.swift
@@ -15,6 +15,9 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
     @IBOutlet weak var textLabel: UILabel!
     @IBOutlet weak var textView: UIView!
     
+    @IBOutlet weak var headerViewTopConstraint: NSLayoutConstraint!
+    
+    
     @objc required init(articleURL: URL, dataStore: MWKDataStore, theme: Theme) {
         self.articleURL = articleURL
         self.dataStore = dataStore
@@ -43,12 +46,12 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
         
         if let imageURL = article.imageURL(forWidth: traitCollection.wmf_leadImageWidth) {
             self.leadImageView.wmf_setImage(with: imageURL, detectFaces: true, onGPU: true, failure: { (error) in
-                self.leadImageView.isHidden = true
+                self.leadImageViewHidden = true
             }, success: {
                 //handle success
             })
         } else {
-            leadImageView.isHidden = true
+            leadImageViewHidden = true
         }
 
         titleLabel.text = article.displayTitle
@@ -57,6 +60,16 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
         
         self.preferredContentSize = self.view.systemLayoutSizeFitting(CGSize(width: self.view.bounds.size.width, height: UILayoutFittingCompressedSize.height), withHorizontalFittingPriority: UILayoutPriority.required, verticalFittingPriority: UILayoutPriority.fittingSizeLevel)
         self.parent?.preferredContentSize = self.preferredContentSize
+    }
+    
+    fileprivate var leadImageViewHidden: Bool {
+        set {
+            leadImageView.isHidden = newValue
+            headerViewTopConstraint.constant = newValue ? 15 : 0
+        }
+        get {
+            return leadImageView.isHidden
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -76,7 +89,7 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
     func updateFonts() {
         titleLabel.setFont(with: .georgia, style: .title1, traitCollection: traitCollection)
         descriptionLabel.setFont(with: .system, style: .subheadline, traitCollection: traitCollection)
-        textLabel.setFont(with: .system, style: .body, traitCollection: traitCollection)
+        textLabel.setFont(with: .system, style: .subheadline, traitCollection: traitCollection)
         textLabel.lineBreakMode = .byTruncatingTail
         
         if #available(iOS 11.0, *) {

--- a/Wikipedia/Code/ArticlePeekPreviewViewController.xib
+++ b/Wikipedia/Code/ArticlePeekPreviewViewController.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13174"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -15,6 +15,7 @@
             <connections>
                 <outlet property="descriptionLabel" destination="cCB-wn-buP" id="o3i-U7-ys9"/>
                 <outlet property="headerView" destination="A2X-YE-PwK" id="Kf8-I9-h5J"/>
+                <outlet property="headerViewTopConstraint" destination="IIR-Nr-bRd" id="nOv-r0-5bQ"/>
                 <outlet property="leadImageView" destination="tMT-E4-kIC" id="9Vv-ey-fbN"/>
                 <outlet property="textLabel" destination="Ezb-Jj-MfF" id="XzA-dh-4bu"/>
                 <outlet property="textView" destination="MeE-uX-nNB" id="VEc-AH-b18"/>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T128650#3739182
https://phabricator.wikimedia.org/T179746

This PR addresses design review comments. It is using the original peek preview view controller. #1915 is using existing `ArticleFullWidthImageCollectionViewCell`. Opening 2 PRs so we can decide which approach is better.