### PR TITLE
Use iOS 11+ recommended API change, fix iOS 10 bottom inset bug

### DIFF
--- a/Wikipedia/Code/ViewController.swift
+++ b/Wikipedia/Code/ViewController.swift
@@ -89,7 +89,7 @@ class ViewController: UIViewController, Themeable {
         if #available(iOS 11.0, *) {
             safeInsets = view.safeAreaInsets
         } else {
-            safeInsets = UIEdgeInsets(top: topLayoutGuide.length, left: 0, bottom: bottomLayoutGuide.length, right: 0)
+            safeInsets = UIEdgeInsets(top: topLayoutGuide.length, left: 0, bottom: min(44, bottomLayoutGuide.length), right: 0) // MIN 44 is a workaround for an iOS 10 only issue where the bottom layout guide is too tall when pushing from explore
         }
         
         let bottom = safeInsets.bottom

--- a/Wikipedia/Code/ViewController.swift
+++ b/Wikipedia/Code/ViewController.swift
@@ -88,8 +88,11 @@ class ViewController: UIViewController, Themeable {
         var safeInsets = UIEdgeInsets.zero
         if #available(iOS 11.0, *) {
             safeInsets = view.safeAreaInsets
+        } else {
+            safeInsets = UIEdgeInsets(top: topLayoutGuide.length, left: 0, bottom: bottomLayoutGuide.length, right: 0)
         }
-        let bottom = bottomLayoutGuide.length
+        
+        let bottom = safeInsets.bottom
         let scrollIndicatorInsets = UIEdgeInsets(top: top, left: safeInsets.left, bottom: bottom, right: safeInsets.right)
         if let rc = scrollView.refreshControl, rc.isRefreshing {
             top += rc.frame.height

--- a/Wikipedia/Code/WMFViewController.m
+++ b/Wikipedia/Code/WMFViewController.m
@@ -104,7 +104,7 @@
     if (@available(iOS 11.0, *)) {
         safeInsets = self.view.safeAreaInsets;
     } else {
-        safeInsets = UIEdgeInsetsMake(self.topLayoutGuide.length, 0, self.bottomLayoutGuide.length, 0);
+        safeInsets = UIEdgeInsetsMake(self.topLayoutGuide.length, 0, MIN(44, self.bottomLayoutGuide.length), 0); // MIN 44 is a workaround for an iOS 10 only issue where the bottom layout guide is too tall when pushing from explore
     }
     CGFloat bottom = safeInsets.bottom;
     UIEdgeInsets scrollIndicatorInsets = UIEdgeInsetsMake(top, safeInsets.left, bottom, safeInsets.right);

--- a/Wikipedia/Code/WMFViewController.m
+++ b/Wikipedia/Code/WMFViewController.m
@@ -103,8 +103,10 @@
     UIEdgeInsets safeInsets = UIEdgeInsetsZero;
     if (@available(iOS 11.0, *)) {
         safeInsets = self.view.safeAreaInsets;
+    } else {
+        safeInsets = UIEdgeInsetsMake(self.topLayoutGuide.length, 0, self.bottomLayoutGuide.length, 0);
     }
-    CGFloat bottom = self.bottomLayoutGuide.length;
+    CGFloat bottom = safeInsets.bottom;
     UIEdgeInsets scrollIndicatorInsets = UIEdgeInsetsMake(top, safeInsets.left, bottom, safeInsets.right);
     if (scrollView.refreshControl.isRefreshing) {
         top += scrollView.refreshControl.frame.size.height;

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -673,6 +673,11 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
                                              selector:@selector(articleUpdatedWithNotification:)
                                                  name:WMFArticleUpdatedNotification
                                                object:nil];
+
+    UIGestureRecognizer *interactivePopGR = self.navigationController.interactivePopGestureRecognizer;
+    if (interactivePopGR) {
+        [self.webView.scrollView.panGestureRecognizer requireGestureRecognizerToFail:interactivePopGR];
+    }
 }
 
 - (void)viewWillDisappear:(BOOL)animated {


### PR DESCRIPTION
Fix issue where bottom inset is too tall on iOS 10 in some situations.

Repro steps:

From explore, search for "North Korea" and tap the article. Scroll sideways and observe the location of the horizontal scroll indicator.

https://phabricator.wikimedia.org/T182901

Also fixes issue where swipe to back would fail on articles with side scrolling.

Repro steps:

From explore, search for "North Korea" and tap the article. Attempt to swipe to go back to explore.

https://phabricator.wikimedia.org/T182900