### PR TITLE
Fix edit pencil peeking when they should not

### DIFF
--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -575,7 +575,6 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
     WKUserContentController *userContentController = [[WKUserContentController alloc] init];
 
     NSArray *handlerNames = @[
-        @"peek",
         @"linkClicked",
         @"imageClicked",
         @"referenceClicked",

--- a/Wikipedia/assets/index.js
+++ b/Wikipedia/assets/index.js
@@ -733,7 +733,7 @@ const applyTransformationsToFragment = (fragment, article, isLead) => {
       const heading = fragment.querySelector('.section_heading[data-id]')
       heading.appendChild(requirements.editTransform.newEditSectionButton(fragment, heading.getAttribute('data-id')))
     }
-    fragment.querySelectorAll('.pagelib_edit_section_link').forEach(anchor => {anchor.href = 'WMFEditPencil'});
+    fragment.querySelectorAll('a.pagelib_edit_section_link').forEach(anchor => {anchor.href = 'WMFEditPencil'});
   }
 
   const tableFooterDivClickCallback = container => {

--- a/Wikipedia/assets/index.js
+++ b/Wikipedia/assets/index.js
@@ -733,6 +733,7 @@ const applyTransformationsToFragment = (fragment, article, isLead) => {
       const heading = fragment.querySelector('.section_heading[data-id]')
       heading.appendChild(requirements.editTransform.newEditSectionButton(fragment, heading.getAttribute('data-id')))
     }
+    fragment.querySelectorAll('.pagelib_edit_section_link').forEach(anchor => {anchor.href = 'WMFEditPencil'});
   }
 
   const tableFooterDivClickCallback = container => {

--- a/www/js/sections.js
+++ b/www/js/sections.js
@@ -152,6 +152,7 @@ const applyTransformationsToFragment = (fragment, article, isLead) => {
       const heading = fragment.querySelector('.section_heading[data-id]')
       heading.appendChild(requirements.editTransform.newEditSectionButton(fragment, heading.getAttribute('data-id')))
     }
+    fragment.querySelectorAll('.pagelib_edit_section_link').forEach(anchor => {anchor.href = 'WMFEditPencil'});
   }
 
   const tableFooterDivClickCallback = container => {

--- a/www/js/sections.js
+++ b/www/js/sections.js
@@ -152,7 +152,7 @@ const applyTransformationsToFragment = (fragment, article, isLead) => {
       const heading = fragment.querySelector('.section_heading[data-id]')
       heading.appendChild(requirements.editTransform.newEditSectionButton(fragment, heading.getAttribute('data-id')))
     }
-    fragment.querySelectorAll('.pagelib_edit_section_link').forEach(anchor => {anchor.href = 'WMFEditPencil'});
+    fragment.querySelectorAll('a.pagelib_edit_section_link').forEach(anchor => {anchor.href = 'WMFEditPencil'});
   }
 
   const tableFooterDivClickCallback = container => {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T182902

I forgot to carry this over when doing the headless document fragment bits.

Note, there is a regression which causes edit pencil taps to not work correctly (the edit VC appears for a second and disappears). I added a note to https://phabricator.wikimedia.org/T182618 about that regression.