### PR TITLE
Small explore peek cleanup

### DIFF
--- a/Wikipedia/Code/ArticlePeekPreviewViewController.swift
+++ b/Wikipedia/Code/ArticlePeekPreviewViewController.swift
@@ -20,7 +20,7 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
         return nil
     }
     
-    func fetchArticle() {
+    fileprivate func fetchArticle() {
         guard let article = dataStore.fetchArticle(with: articleURL) else {
             dataStore.viewContext.wmf_updateOrCreateArticleSummariesForArticles(withURLs: [articleURL], completion: { (articles) in
                 guard let first = articles.first else {
@@ -33,7 +33,7 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
         updateView(with: article)
     }
     
-    func updateView(with article: WMFArticle) {
+    fileprivate func updateView(with article: WMFArticle) {
         expandedArticleView.configure(article: article, displayType: .pageWithPreview, index: 0, count: 1, theme: theme, layoutOnly: false)
         expandedArticleView.isSaveButtonHidden = true
         expandedArticleView.extractLabel?.numberOfLines = 5
@@ -43,7 +43,11 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
         expandedArticleView.isHidden = false
 
         activityIndicatorView.stopAnimating()
-
+        
+        updateSize()
+    }
+    
+    fileprivate func updateSize() {
         let preferredSize = self.view.systemLayoutSizeFitting(CGSize(width: self.view.bounds.size.width, height: UILayoutFittingCompressedSize.height), withHorizontalFittingPriority: UILayoutPriority.required, verticalFittingPriority: UILayoutPriority.fittingSizeLevel)
         self.preferredContentSize = expandedArticleView.sizeThatFits(preferredSize, apply: true)
         self.parent?.preferredContentSize = self.preferredContentSize
@@ -59,6 +63,7 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
         view.addSubview(activityIndicatorView)
         expandedArticleView.isHidden = true
         view.addSubview(expandedArticleView)
+        updateSize()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Wikipedia/Code/ArticlePeekPreviewViewController.swift
+++ b/Wikipedia/Code/ArticlePeekPreviewViewController.swift
@@ -44,10 +44,6 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
 
         activityIndicatorView.stopAnimating()
         
-        updateSize()
-    }
-    
-    fileprivate func updateSize() {
         let preferredSize = self.view.systemLayoutSizeFitting(CGSize(width: self.view.bounds.size.width, height: UILayoutFittingCompressedSize.height), withHorizontalFittingPriority: UILayoutPriority.required, verticalFittingPriority: UILayoutPriority.fittingSizeLevel)
         self.preferredContentSize = expandedArticleView.sizeThatFits(preferredSize, apply: true)
         self.parent?.preferredContentSize = self.preferredContentSize
@@ -63,7 +59,6 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
         view.addSubview(activityIndicatorView)
         expandedArticleView.isHidden = true
         view.addSubview(expandedArticleView)
-        updateSize()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -1373,7 +1373,7 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
         NSAssert(false, @"Missing VC for group: %@", group);
         return;
     }
-    if (group.detailType == WMFFeedDetailTypePageWithRandomButton) {
+    if (group.detailType == WMFFeedDetailTypePageWithRandomButton && self.nextRandomArticleURL) {
         vc = [[WMFRandomArticleViewController alloc] initWithArticleURL:self.nextRandomArticleURL dataStore:self.userStore theme:self.theme];
     }
     [self.navigationController pushViewController:vc animated:animated];

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -1386,10 +1386,9 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
 
 #pragma mark - Peek View Controller
 
-- (nullable UIViewController *)peekViewControllerForItemAtIndexPath:(NSIndexPath *)indexPath peekedHeaderOrFooter:(BOOL)peekedHeaderOrFooter {
-    WMFContentGroup *group = [self sectionAtIndex:indexPath.section];
+- (nullable UIViewController *)peekViewControllerForItemAtIndexPath:(NSIndexPath *)indexPath group:(WMFContentGroup *)group sectionCount:(NSInteger)sectionCount peekedHeader:(BOOL)peekedHeader peekedFooter:(BOOL)peekedFooter {
 
-    if (peekedHeaderOrFooter && [group detailType] != WMFFeedDetailTypePageWithRandomButton) {
+    if ((peekedHeader || peekedFooter) && sectionCount != 1) {
         return [group detailViewControllerWithDataStore:self.userStore siteURL:[self currentSiteURL] theme:self.theme];
     }
 
@@ -1399,7 +1398,7 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
     switch ([group detailType]) {
         case WMFFeedDetailTypePage:
         case WMFFeedDetailTypePageWithRandomButton: {
-            if (peekedHeaderOrFooter) {
+            if (peekedFooter) {
                 articleURL = self.nextRandomArticleURL;
             } else {
                 articleURL = [self contentURLForIndexPath:indexPath];
@@ -1638,16 +1637,8 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
     }
     self.groupForPreviewedCell = group;
 
-    BOOL peekedHeaderOrFooter;
-
-    if ([layoutAttributes.representedElementKind isEqualToString:UICollectionElementKindSectionFooter] && [group detailType] == WMFFeedDetailTypePageWithRandomButton) {
-        peekedHeaderOrFooter = YES;
-    }
-
-    if (([layoutAttributes.representedElementKind isEqualToString:UICollectionElementKindSectionFooter] || [layoutAttributes.representedElementKind isEqualToString:UICollectionElementKindSectionHeader]) && sectionCount != 1) {
-        //peek full list on the card headers & footers
-        peekedHeaderOrFooter = YES;
-    }
+    BOOL peekedHeader = [layoutAttributes.representedElementKind isEqualToString:UICollectionElementKindSectionHeader];
+    BOOL peekedFooter = [layoutAttributes.representedElementKind isEqualToString:UICollectionElementKindSectionFooter];
 
     UICollectionViewCell *cell = [self.collectionView cellForItemAtIndexPath:previewIndexPath];
     previewingContext.sourceRect = cell.frame;
@@ -1665,7 +1656,7 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
         }
     }
 
-    UIViewController *vc = [self peekViewControllerForItemAtIndexPath:previewIndexPath peekedHeaderOrFooter:peekedHeaderOrFooter];
+    UIViewController *vc = [self peekViewControllerForItemAtIndexPath:previewIndexPath group:group sectionCount:sectionCount peekedHeader:peekedHeader peekedFooter:peekedFooter];
     [[PiwikTracker sharedInstance] wmf_logActionPreviewInContext:self contentType:group];
 
     if ([vc isKindOfClass:[WMFArticleViewController class]]) {

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -646,17 +646,6 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
     }
 }
 
-- (void)fetchNextRandomArticle {
-    WMFRandomArticleFetcher *fetcher = [[WMFRandomArticleFetcher alloc] init];
-    [fetcher fetchRandomArticleWithSiteURL:[self currentSiteURL]
-        failure:^(NSError *_Nonnull error) {
-            DDLogError(@"Failed fetching next random article url: %@ ", error);
-        }
-        success:^(MWKSearchResult *_Nonnull result) {
-            self.nextRandomArticleURL = [[self currentSiteURL] wmf_URLWithTitle:result.displayTitle];
-        }];
-}
-
 - (nonnull UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath {
     if ([kind isEqualToString:UICollectionElementKindSectionHeader]) {
         return [self collectionView:collectionView viewForSectionHeaderAtIndexPath:indexPath];
@@ -877,10 +866,6 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
         } else {
             [self.locationManager stopMonitoringLocation];
         }
-    }
-
-    if ([section detailType] == WMFFeedDetailTypePageWithRandomButton) {
-        [self fetchNextRandomArticle];
     }
 }
 
@@ -1373,9 +1358,7 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
         NSAssert(false, @"Missing VC for group: %@", group);
         return;
     }
-    if (group.detailType == WMFFeedDetailTypePageWithRandomButton && self.nextRandomArticleURL) {
-        vc = [[WMFRandomArticleViewController alloc] initWithArticleURL:self.nextRandomArticleURL dataStore:self.userStore theme:self.theme];
-    }
+
     [self.navigationController pushViewController:vc animated:animated];
 }
 
@@ -1398,11 +1381,7 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
     switch ([group detailType]) {
         case WMFFeedDetailTypePage:
         case WMFFeedDetailTypePageWithRandomButton: {
-            if (peekedFooter) {
-                articleURL = self.nextRandomArticleURL;
-            } else {
-                articleURL = [self contentURLForIndexPath:indexPath];
-            }
+            articleURL = [self contentURLForIndexPath:indexPath];
         } break;
         case WMFFeedDetailTypeEvent: {
             articleURL = [self onThisDayArticleURLAtIndexPath:indexPath group:group];

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -65,8 +65,6 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
 @property (nonatomic, getter=isLoadingOlderContent) BOOL loadingOlderContent;
 @property (nonatomic, getter=isLoadingNewContent) BOOL loadingNewContent;
 
-@property (nonatomic, strong, nullable) NSURL *nextRandomArticleURL;
-
 @end
 
 @implementation WMFExploreViewController

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -1356,7 +1356,6 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
         NSAssert(false, @"Missing VC for group: %@", group);
         return;
     }
-
     [self.navigationController pushViewController:vc animated:animated];
 }
 

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -595,11 +595,11 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
     WMFArticle *article = [self articleForIndexPath:indexPath];
     WMFFeedDisplayType displayType = [contentGroup displayTypeForItemAtIndex:indexPath.item];
     switch (displayType) {
-        case WMFFeedDisplayTypeRandom:
         case WMFFeedDisplayTypeRanked:
         case WMFFeedDisplayTypePage:
         case WMFFeedDisplayTypeContinueReading:
         case WMFFeedDisplayTypeMainPage:
+        case WMFFeedDisplayTypeRandom:
         case WMFFeedDisplayTypePageWithPreview:
         case WMFFeedDisplayTypeRelatedPagesSourceArticle:
         case WMFFeedDisplayTypeRelatedPages: {
@@ -650,7 +650,6 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
     WMFRandomArticleFetcher *fetcher = [[WMFRandomArticleFetcher alloc] init];
     [fetcher fetchRandomArticleWithSiteURL:[self currentSiteURL]
         failure:^(NSError *_Nonnull error) {
-            NSLog(@"Failed here! %@", error);
             DDLogError(@"Failed fetching next random article url: %@ ", error);
         }
         success:^(MWKSearchResult *_Nonnull result) {


### PR DESCRIPTION
To make `peekViewControllerForItemAtIndexPath` and `previewingContext ` a bit cleaner 