### PR TITLE
Log WMF api warnings so we can catch and fix them.

### DIFF
--- a/Wikipedia/Code/WMFApiJsonResponseSerializer.m
+++ b/Wikipedia/Code/WMFApiJsonResponseSerializer.m
@@ -27,6 +27,14 @@
         }
         return nil;
     }
+
+#if DEBUG
+    NSDictionary *warnings = json[@"warnings"];
+    if (warnings) {
+        NSLog(@"\n\n\nWarnings for request:\n%@\n%@", response.URL.absoluteString, warnings);
+    }
+#endif
+
     return json;
 }
 

--- a/Wikipedia/Code/WMFApiJsonResponseSerializer.m
+++ b/Wikipedia/Code/WMFApiJsonResponseSerializer.m
@@ -1,5 +1,6 @@
 #import <WMF/WMFApiJsonResponseSerializer.h>
 #import <WMF/WMFNetworkUtilities.h>
+#import <WMF/WMFLogging.h>
 
 @implementation WMFApiJsonResponseSerializer
 
@@ -31,7 +32,7 @@
 #if DEBUG
     NSDictionary *warnings = json[@"warnings"];
     if (warnings) {
-        NSLog(@"\n\n\nWarnings for request:\n%@\n%@", response.URL.absoluteString, warnings);
+        DDLogWarn(@"\n\n\nWarnings for request:\n%@\n%@", response.URL.absoluteString, warnings);
     }
 #endif
 


### PR DESCRIPTION
I noticed a few different API warnings when playing with various feed requests. Figured we could catch these more easily in the future if we logged warnings.