### PR TITLE
Fix empty reference panel for specific article reference.

### DIFF
--- a/Wikipedia/assets/index.js
+++ b/Wikipedia/assets/index.js
@@ -495,6 +495,11 @@ function collectRefText( sourceNode ) {
   var href = sourceNode.getAttribute( 'href' )
   var targetId = href.slice(1)
   var targetNode = document.getElementById( targetId )
+
+  if ( targetNode === null ) {
+    targetNode = document.getElementById( decodeURIComponent( targetId ) )
+  }
+  
   if ( targetNode === null ) {
     /*global console */
     console.log('reference target not found: ' + targetId)

--- a/www/js/refs.js
+++ b/www/js/refs.js
@@ -59,6 +59,11 @@ function collectRefText( sourceNode ) {
   var href = sourceNode.getAttribute( 'href' )
   var targetId = href.slice(1)
   var targetNode = document.getElementById( targetId )
+
+  if ( targetNode === null ) {
+    targetNode = document.getElementById( decodeURIComponent( targetId ) )
+  }
+  
   if ( targetNode === null ) {
     /*global console */
     console.log('reference target not found: ' + targetId)


### PR DESCRIPTION
https://phabricator.wikimedia.org/T183048

Reference `[7]` on `enwiki > Nights: Journey of Dreams`.

# Before
<img width="431" alt="screen shot 2017-12-15 at 4 11 46 pm" src="https://user-images.githubusercontent.com/3143487/34065088-810e3620-e1b3-11e7-94aa-c71f364f94ee.png">

# After
<img width="431" alt="screen shot 2017-12-15 at 4 10 43 pm" src="https://user-images.githubusercontent.com/3143487/34065086-7d5fe870-e1b3-11e7-8add-444546eab0a8.png">

