### PR TITLE
Update fastlane, disable the change log

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.1)
-    fastlane (2.70.0)
+    fastlane (2.70.1)
       CFPropertyList (>= 2.3, < 3.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -250,11 +250,12 @@ platform :ios do
       build_number: build_number
     )
     
-    changelog_from_git_commits(
-      pretty: '- (%ae) %s', # Optional, lets you provide a custom format to apply to each commit when generating the changelog text
-      tag_match_pattern: "#{tag_prefix}/*", # Optional, lets you search for a tag name that matches a glob(7) pattern
-      include_merges: false # Optional, lets you filter out merge commits
-    )
+    # the changelog was overwriting whatever custom test notes we added
+    # changelog_from_git_commits(
+    #   pretty: '- (%ae) %s', # Optional, lets you provide a custom format to apply to each commit when generating the changelog text
+    #   tag_match_pattern: "#{tag_prefix}/*", # Optional, lets you search for a tag name that matches a glob(7) pattern
+    #   include_merges: false # Optional, lets you filter out merge commits
+    # )
 
     build(
       product_name: product_name,


### PR DESCRIPTION
The change log was overwriting our public beta test notes.