### PR TITLE
Fix TOC crash

### DIFF
--- a/Wikipedia/Code/WMFTableOfContentsViewController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsViewController.swift
@@ -128,6 +128,10 @@ open class WMFTableOfContentsViewController: UIViewController, UITableViewDelega
             assertionFailure("No indexPath known for TOC item \(item)")
             return
         }
+
+        guard indexPath.section < tableView.numberOfSections && indexPath.row < tableView.numberOfRows(inSection: indexPath.section) else {
+            return
+        }
         
         if let selectedIndexPath = tableView.indexPathForSelectedRow {
             if selectedIndexPath != indexPath {

--- a/Wikipedia/Code/WMFTableOfContentsViewController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsViewController.swift
@@ -130,6 +130,7 @@ open class WMFTableOfContentsViewController: UIViewController, UITableViewDelega
         }
 
         guard indexPath.section < tableView.numberOfSections && indexPath.row < tableView.numberOfRows(inSection: indexPath.section) else {
+            assertionFailure("Attempted to select out of range item \(item)")
             return
         }
         


### PR DESCRIPTION
Check the range when selecting an item. Perhaps this is also missing a reload data earlier that would allow the item to be selected?

iPad/iPhone Plus only, so far unable to repro

https://rink.hockeyapp.net/manage/apps/152731/app_versions/444/crash_reasons/203086087.html?page=1&per_page=10&type=crashes