### PR TITLE
add empty editing state

### DIFF
--- a/WMF Framework/CollectionViewEditController.swift
+++ b/WMF Framework/CollectionViewEditController.swift
@@ -417,12 +417,6 @@ public class CollectionViewEditController: NSObject, UIGestureRecognizerDelegate
             navigationDelegate?.didChangeEditingState(from: oldValue, to: editingState, rightBarButton: rightButton, leftBarButton: leftButton)
         }
         
-        guard !isCollectionViewEmpty && !hasDefaultCell else {
-            isBatchEditToolbarHidden = true
-            enabled = false
-            return
-        }
-        
         switch newValue {
         case .editing:
             areSwipeActionsDisabled = true
@@ -435,6 +429,9 @@ public class CollectionViewEditController: NSObject, UIGestureRecognizerDelegate
             fallthrough
         case .closed:
             transformBatchEditPane(for: editingState)
+        case .empty:
+            isBatchEditToolbarHidden = true
+            enabled = false
         default:
             break
         }
@@ -479,6 +476,8 @@ public class CollectionViewEditController: NSObject, UIGestureRecognizerDelegate
     
     private func emptyStateDidChange() {
         if isCollectionViewEmpty {
+            editingState = .empty
+        } else {
             editingState = .none
         }
         navigationDelegate?.emptyStateDidChange(isCollectionViewEmpty)
@@ -490,15 +489,6 @@ public class CollectionViewEditController: NSObject, UIGestureRecognizerDelegate
                 return
             }
             emptyStateDidChange()
-        }
-    }
-    
-    public var hasDefaultCell: Bool = false {
-        didSet {
-            guard hasDefaultCell else {
-                return
-            }
-            editingState = .none
         }
     }
     

--- a/WMF Framework/CollectionViewEditController.swift
+++ b/WMF Framework/CollectionViewEditController.swift
@@ -372,7 +372,7 @@ public class CollectionViewEditController: NSObject, UIGestureRecognizerDelegate
             if navigationDelegate == nil {
                 editingState = .unknown
             } else {
-                editingState = .none
+                editingState = isCollectionViewEmpty ? .empty : .none
             }
         }
     }

--- a/WMF Framework/CollectionViewEditController.swift
+++ b/WMF Framework/CollectionViewEditController.swift
@@ -443,7 +443,9 @@ public class CollectionViewEditController: NSObject, UIGestureRecognizerDelegate
         collectionView.allowsMultipleSelection = willOpen
         isBatchEditToolbarHidden = !willOpen
         for cell in editableCells {
-            cell.isBatchEditable = true
+            guard cell.isBatchEditable else {
+                continue
+            }
             if animated {
                 // ensure layout is in the start anim state
                 cell.isBatchEditing = !willOpen

--- a/Wikipedia/Code/ArticleCollectionViewCell.swift
+++ b/Wikipedia/Code/ArticleCollectionViewCell.swift
@@ -76,6 +76,8 @@ open class ArticleCollectionViewCell: CollectionViewCell, SwipeableCell, BatchEd
         imageView.wmf_reset()
         resetSwipeable()
         isBatchEditing = false
+        isBatchEditable = false
+        actions = []
         updateFonts(with: traitCollection)
     }
 

--- a/Wikipedia/Code/BatchEditSelectView.swift
+++ b/Wikipedia/Code/BatchEditSelectView.swift
@@ -65,6 +65,7 @@ public class BatchEditSelectView: SizeThatFitsView, Themeable {
 
 public enum EditingState: Int, EnumCollection {
     case unknown // pre-init state, nil delegate state
+    case empty // collection view is empty
     case none // initial state
     case open // batch editing pane is open
     case closed // batch editing pane is closed

--- a/Wikipedia/Code/ReadingListDetailViewController.swift
+++ b/Wikipedia/Code/ReadingListDetailViewController.swift
@@ -446,6 +446,7 @@ extension ReadingListDetailViewController {
         }
         
         cell.actions = availableActions(at: indexPath)
+        cell.isBatchEditable = true
         cell.layoutMargins = layout.readableMargins
         
         guard !layoutOnly, let translation = editController.swipeTranslationForItem(at: indexPath) else {

--- a/Wikipedia/Code/ReadingListsViewController.swift
+++ b/Wikipedia/Code/ReadingListsViewController.swift
@@ -173,7 +173,9 @@ class ReadingListsViewController: ColumnarCollectionViewController, EditableColl
             }
             cell.isBatchEditing = false
             cell.swipeTranslation = 0
+            cell.isBatchEditable = false
         } else {
+            cell.isBatchEditable = true
             cell.actions = availableActions(at: indexPath)
             if editController.isBatchEditing {
                 cell.isBatchEditing = editController.isBatchEditing

--- a/Wikipedia/Code/SavedArticlesViewController.swift
+++ b/Wikipedia/Code/SavedArticlesViewController.swift
@@ -278,6 +278,7 @@ extension SavedArticlesViewController {
         
         cell.configure(article: article, index: indexPath.item, count: numberOfItems, shouldAdjustMargins: false, shouldShowSeparators: true, theme: theme, layoutOnly: layoutOnly)
         cell.actions = availableActions(at: indexPath)
+        cell.isBatchEditable = true
         cell.tags = (readingLists: readingListsForArticle(at: indexPath), indexPath: indexPath)
         cell.delegate = self
         

--- a/Wikipedia/Code/SavedViewController.swift
+++ b/Wikipedia/Code/SavedViewController.swift
@@ -72,6 +72,7 @@ class SavedViewController: ViewController {
                 removeChild(readingListsViewController)
                 addChild(savedArticlesViewController)
                 savedArticlesViewController.editController.navigationDelegate = self
+                readingListsViewController?.editController.navigationDelegate = nil
                 savedDelegate = savedArticlesViewController
                 isAddButtonHidden = true
                 isSearchBarHidden = savedArticlesViewController.isEmpty
@@ -81,6 +82,7 @@ class SavedViewController: ViewController {
                 removeChild(savedArticlesViewController)
                 addChild(readingListsViewController)
                 readingListsViewController?.editController.navigationDelegate = self
+                savedArticlesViewController.editController.navigationDelegate = nil
                 isAddButtonHidden = false
                 scrollView = readingListsViewController?.collectionView
                 isSearchBarHidden = true


### PR DESCRIPTION
Fixes issue with "edit" button not being disabled when the collection view becomes empty.