### PR TITLE
Create lists using canonical name

### DIFF
--- a/WMF Framework/ReadingListsSyncOperation.swift
+++ b/WMF Framework/ReadingListsSyncOperation.swift
@@ -442,7 +442,7 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
         }
         
         let listNamesAndDescriptionsToCreate: [(name: String, description: String?)] = listsToCreate.flatMap {
-            guard let name = $0.name else {
+            guard let name = $0.canonicalName else {
                 return nil;
             }
             return (name: name, description: $0.readingListDescription)


### PR DESCRIPTION
Uses "default" instead of "Bookmarks" for default list. Helps prevent accidentally creating the default list on the server.