### PR TITLE
Close the action pane if the user decides not to delete an item via swipe

### DIFF
--- a/WMF Framework/CollectionViewEditController.swift
+++ b/WMF Framework/CollectionViewEditController.swift
@@ -469,10 +469,14 @@ public class CollectionViewEditController: NSObject, UIGestureRecognizerDelegate
     }
     
     @objc public func close() {
-        guard editingState == .open else {
+        guard editingState == .open || editingState == .swiping else {
             return
         }
-        editingState = .closed
+        if editingState == .swiping {
+            editingState = .none
+        } else {
+            editingState = .closed
+        }
         closeActionPane()
     }
     


### PR DESCRIPTION
If the user sees an alert about whether they want to delete an article/reading list via swipe action and taps cancel, the action pane should close