### PR TITLE
[Design bug] No quick way to exit focus search on the Saved tab

### DIFF
--- a/Wikipedia/Code/Saved.storyboard
+++ b/Wikipedia/Code/Saved.storyboard
@@ -35,13 +35,13 @@
                         <barButtonItem key="backBarButtonItem" title="Back" id="moe-WC-1c5"/>
                     </navigationItem>
                     <connections>
+                        <outlet property="actionButton" destination="269-0y-zMz" id="afs-tZ-Hwi"/>
                         <outlet property="allArticlesButton" destination="Euv-Dh-yK7" id="F0v-LU-kMw"/>
                         <outlet property="containerView" destination="hVp-Ga-oZr" id="ypl-2a-8uk"/>
                         <outlet property="extendedNavBarView" destination="eby-nN-6Yg" id="VN4-EM-xv8"/>
                         <outlet property="readingListsButton" destination="Kqc-qA-t3B" id="5IA-VI-xA7"/>
                         <outlet property="searchBar" destination="nj7-Fx-dME" id="N8j-eC-oeH"/>
                         <outlet property="separatorView" destination="YHx-oI-zV4" id="I7m-6y-sIv"/>
-                        <outlet property="sortButton" destination="269-0y-zMz" id="2EB-vW-bIH"/>
                         <outlet property="underBarView" destination="MOy-Ht-6zp" id="iln-NY-tBP"/>
                         <outletCollection property="toggleButtons" destination="Euv-Dh-yK7" collectionClass="NSMutableArray" id="D5f-8f-XtH"/>
                         <outletCollection property="toggleButtons" destination="Kqc-qA-t3B" collectionClass="NSMutableArray" id="CRS-iW-yxS"/>
@@ -115,12 +115,12 @@
                             </constraints>
                             <textInputTraits key="textInputTraits"/>
                         </searchBar>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="269-0y-zMz">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="269-0y-zMz" userLabel="Action Button">
                             <rect key="frame" x="317" y="11" width="30" height="30"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <state key="normal" title="Sort"/>
                             <connections>
-                                <action selector="sortButonPressed:" destination="DbA-ai-MSH" eventType="touchUpInside" id="1Fi-LP-Njx"/>
+                                <action selector="actionButonPressed:" destination="DbA-ai-MSH" eventType="touchUpInside" id="SqX-sp-EPM"/>
                             </connections>
                         </button>
                     </subviews>

--- a/Wikipedia/Code/SavedArticlesViewController.swift
+++ b/Wikipedia/Code/SavedArticlesViewController.swift
@@ -415,6 +415,18 @@ extension SavedArticlesViewController: SavedViewControllerDelegate {
     func savedWillShowSortAlert(_ saved: SavedViewController, from button: UIButton) {
         presentSortAlert(from: button)
     }
+    
+    func saved(_ saved: SavedViewController, searchBar: UISearchBar, textDidChange searchText: String) {
+        updateSearchString(searchText)
+        
+        if searchText.isEmpty {
+            searchBar.resignFirstResponder()
+        }
+    }
+    
+    func saved(_ saved: SavedViewController, searchBarSearchButtonClicked searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
+    }
 }
 
 // MARK: - AddArticlesToReadingListDelegate
@@ -445,22 +457,6 @@ extension SavedArticlesViewController {
     override func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
         viewControllerToCommit.wmf_removePeekableChildViewControllers()
         wmf_push(viewControllerToCommit, animated: true)
-    }
-}
-
-// MARK: - UISearchBarDelegate
-
-extension SavedArticlesViewController: UISearchBarDelegate {
-    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        updateSearchString(searchText)
-        
-        if searchText.isEmpty {
-            searchBar.resignFirstResponder()
-        }
-    }
-    
-    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        searchBar.resignFirstResponder()
     }
 }
 


### PR DESCRIPTION
feel free change/rename, couldn't think of a good name for what used to be a `sortButton` so ended up with `actionButton` ¯\_(ツ)_/¯