### PR TITLE
Process local updates after remote on full sync

### DIFF
--- a/WMF Framework/ReadingListsSyncOperation.swift
+++ b/WMF Framework/ReadingListsSyncOperation.swift
@@ -222,11 +222,6 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
     }
     
     func executeFullSync(on moc: NSManagedObjectContext) throws {
-        try processLocalUpdates(in: moc)
-        if moc.hasChanges {
-            try moc.save()
-        }
-        
         let taskGroup = WMFTaskGroup()
         var allAPIReadingLists: [APIReadingList] = []
         var getAllAPIReadingListsError: Error?
@@ -278,6 +273,12 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
         if let since = nextSince {
             moc.wmf_setValue(since as NSString, forKey: WMFReadingListUpdateKey)
         }
+        
+        if moc.hasChanges {
+            try moc.save()
+        }
+        
+        try processLocalUpdates(in: moc)
         
         guard moc.hasChanges else {
             return


### PR DESCRIPTION
Should mitigate the duplicate reading list issue until backend changes are implemented.

Local before remote is advantageous in the case the user cleared all articles or deleted all lists, but those cases are secondary to preventing dupes.