### PR TITLE
Small edge title edge inset for sides of announcement cell action button.

### DIFF
--- a/Wikipedia/Code/AnnouncementCollectionViewCell.swift
+++ b/Wikipedia/Code/AnnouncementCollectionViewCell.swift
@@ -46,6 +46,8 @@ open class AnnouncementCollectionViewCell: CollectionViewCell {
         captionTextView.isEditable = false
         addSubview(captionTextView)
         
+        actionButton.titleEdgeInsets = UIEdgeInsets.init(top: 0, left: 6, bottom: 0, right: 6)
+        
         actionButton.titleLabel?.adjustsFontSizeToFitWidth = true
         dismissButton.titleLabel?.adjustsFontSizeToFitWidth = true
         


### PR DESCRIPTION
Screenshots are from iPhone 5 simulator. (on larger devices the button ends up being a bit wider)

# Before 
<img width="376" alt="screen shot 2018-03-01 at 4 12 03 pm" src="https://user-images.githubusercontent.com/3143487/36876832-d742dfe8-1d6b-11e8-8bd2-6a639e028c28.png">

# After
<img width="376" alt="screen shot 2018-03-01 at 4 12 37 pm" src="https://user-images.githubusercontent.com/3143487/36876833-d75a629e-1d6b-11e8-8243-cce024af5c00.png">
