### PR TITLE
Make saved progress background view extend to screen edge on iPhoneX.

### DIFF
--- a/Wikipedia/Code/Saved.storyboard
+++ b/Wikipedia/Code/Saved.storyboard
@@ -30,13 +30,13 @@
                             </containerView>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="gPn-7Q-j2P" firstAttribute="leading" secondItem="GCG-ME-1AZ" secondAttribute="leading" id="0M7-0H-eu1"/>
                             <constraint firstItem="hVp-Ga-oZr" firstAttribute="leading" secondItem="GCG-ME-1AZ" secondAttribute="leading" id="7h6-U1-pjA"/>
-                            <constraint firstItem="SMV-D9-nEr" firstAttribute="trailing" secondItem="gPn-7Q-j2P" secondAttribute="trailing" id="MVz-ZF-wM8"/>
                             <constraint firstItem="hVp-Ga-oZr" firstAttribute="top" secondItem="GCG-ME-1AZ" secondAttribute="top" id="MpS-JC-IqE"/>
                             <constraint firstItem="hVp-Ga-oZr" firstAttribute="bottom" secondItem="GCG-ME-1AZ" secondAttribute="bottom" id="TG1-Qj-s0g"/>
                             <constraint firstItem="hVp-Ga-oZr" firstAttribute="trailing" secondItem="GCG-ME-1AZ" secondAttribute="trailing" id="bM8-Ed-1rk"/>
                             <constraint firstItem="SMV-D9-nEr" firstAttribute="bottom" secondItem="gPn-7Q-j2P" secondAttribute="bottom" id="eiv-L8-05c"/>
-                            <constraint firstItem="gPn-7Q-j2P" firstAttribute="leading" secondItem="SMV-D9-nEr" secondAttribute="leading" id="u24-nI-9xL"/>
+                            <constraint firstAttribute="trailing" secondItem="gPn-7Q-j2P" secondAttribute="trailing" id="tsd-9o-tNl"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="SMV-D9-nEr"/>
                     </view>


### PR DESCRIPTION
Follow-up for https://phabricator.wikimedia.org/T187823

Should merge #2132 first since it fixes the iPhoneX save button tap crash.

<strike>I'm pinging Carolyn before removing the question tag to double-check this is wanted.</strike> (She said it's cool)

Before:
<img width="626" alt="screen shot 2018-03-23 at 7 46 29 pm" src="https://user-images.githubusercontent.com/3143487/37859569-edee2c0c-2ed2-11e8-876c-7f1163595f42.png">


After:
<img width="626" alt="screen shot 2018-03-23 at 7 39 18 pm" src="https://user-images.githubusercontent.com/3143487/37859547-9610bf9a-2ed2-11e8-8281-5c25c985de4a.png">