### PR TITLE
Update LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2013–2017 Wikimedia Foundation
+Copyright (c) 2013–2018 Wikimedia Foundation et al.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updating to 2018, and changing from "Wikimedia Foundation" to "Wikimedia Foundation et al." since volunteer contributors still own their part of the code they created.