### PR TITLE
Hierarchy issues on individual reading list views followup

### DIFF
--- a/WMF Framework/NavigationBar.swift
+++ b/WMF Framework/NavigationBar.swift
@@ -7,6 +7,8 @@ public class NavigationBar: SetupView {
     fileprivate let shadow: UIView = UIView()
     fileprivate let progressView: UIProgressView = UIProgressView()
     fileprivate let backgroundView: UIView = UIView()
+    public var extendedViewPercentHiddenForShowingTitle: CGFloat?
+    public var title: String?
     
     /// back button presses will be forwarded to this nav controller
     @objc public weak var delegate: UIViewController? {
@@ -170,6 +172,11 @@ public class NavigationBar: SetupView {
         _extendedViewPercentHidden = extendedViewPercentHidden
         setNeedsLayout()
         //print("nb: \(navigationBarPercentHidden) ev: \(extendedViewPercentHidden)")
+        if let extendedViewPercentHiddenForShowingTitle = self.extendedViewPercentHiddenForShowingTitle {
+            UIView.animate(withDuration: 0.2) {
+                self.delegate?.title = extendedViewPercentHidden >= extendedViewPercentHiddenForShowingTitle ? self.title : nil
+            }
+        }
         let changes = {
             self.layoutIfNeeded()
             additionalAnimations?()

--- a/Wikipedia/Code/ReadingListDetailViewController.swift
+++ b/Wikipedia/Code/ReadingListDetailViewController.swift
@@ -47,7 +47,9 @@ class ReadingListDetailViewController: ColumnarCollectionViewController, Editabl
 
         emptyViewType = .noSavedPages
 
+        navigationBar.title = readingList.name
         navigationBar.addExtendedNavigationBarView(readingListDetailExtendedViewController.view)
+        navigationBar.extendedViewPercentHiddenForShowingTitle = 0.4
         
         setupFetchedResultsController()
         setupCollectionViewUpdater()

--- a/Wikipedia/Code/SavedArticlesCollectionViewCell.swift
+++ b/Wikipedia/Code/SavedArticlesCollectionViewCell.swift
@@ -308,7 +308,7 @@ class SavedArticlesCollectionViewCell: ArticleCollectionViewCell {
         }
         
         if shouldShowSeparators {
-            topSeparator.isHidden = index > 0
+            topSeparator.isHidden = true
             bottomSeparator.isHidden = false
         } else {
             bottomSeparator.isHidden = true


### PR DESCRIPTION
https://phabricator.wikimedia.org/T191254#

- [x] make the HR between the search bar and the top list item the same thickness as the list items HRs
- [x] have the Title of the reading list move into the header after the user has scrolled past the large title (similar to the header in iOS settings)