### PR TITLE
Remove margin from scrolling reference panels

### DIFF
--- a/Wikipedia/Code/WMFReferencePanels.storyboard
+++ b/Wikipedia/Code/WMFReferencePanels.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,14 +19,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m6z-cT-jig">
-                                <rect key="frame" x="16" y="20" width="343" height="647"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                             </containerView>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="m6z-cT-jig" firstAttribute="leading" secondItem="Ktd-hA-m9P" secondAttribute="leadingMargin" id="3I7-dq-RSV"/>
+                            <constraint firstItem="m6z-cT-jig" firstAttribute="trailing" secondItem="miW-no-4N3" secondAttribute="trailing" id="Hz8-Xh-W6Q"/>
                             <constraint firstItem="miW-no-4N3" firstAttribute="bottom" secondItem="m6z-cT-jig" secondAttribute="bottom" id="MsO-Sc-KJx"/>
                             <constraint firstItem="m6z-cT-jig" firstAttribute="top" secondItem="miW-no-4N3" secondAttribute="top" id="Riw-nd-7oN"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="m6z-cT-jig" secondAttribute="trailing" id="u3j-Ym-guB"/>
+                            <constraint firstItem="m6z-cT-jig" firstAttribute="leading" secondItem="miW-no-4N3" secondAttribute="leading" id="XdO-H5-RDi"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="miW-no-4N3"/>
                     </view>
@@ -37,7 +36,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ued-L4-yrg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-618" y="106"/>
+            <point key="canvasLocation" x="-618.39999999999998" y="105.69715142428787"/>
         </scene>
         <!--Reference Panel View Controller-->
         <scene sceneID="JXo-R8-waf">


### PR DESCRIPTION
This addresses bug https://phabricator.wikimedia.org/T185256

I solved this issue by removing the margins of the container view in WMFReferencePageViewController

![simulator screen shot - iphone x - 2018-04-05 at 08 04 53](https://user-images.githubusercontent.com/11032592/38349931-85cdf3ec-38a9-11e8-9c2b-b3c4c6ee49a2.png)

![simulator screen shot - iphone x - 2018-04-05 at 08 05 25](https://user-images.githubusercontent.com/11032592/38349932-85e703f0-38a9-11e8-81e6-4a1b0188c93f.png)