### PR TITLE
# 2169 followup: put the 2nd nav bar animation in a completion block

### DIFF
--- a/WMF Framework/NavigationBar.swift
+++ b/WMF Framework/NavigationBar.swift
@@ -172,19 +172,25 @@ public class NavigationBar: SetupView {
         _extendedViewPercentHidden = extendedViewPercentHidden
         setNeedsLayout()
         //print("nb: \(navigationBarPercentHidden) ev: \(extendedViewPercentHidden)")
-        if let extendedViewPercentHiddenForShowingTitle = self.extendedViewPercentHiddenForShowingTitle {
-            UIView.animate(withDuration: 0.2) {
-                self.delegate?.title = extendedViewPercentHidden >= extendedViewPercentHiddenForShowingTitle ? self.title : nil
+        let applyChanges = {
+            let changes = {
+                self.layoutIfNeeded()
+                additionalAnimations?()
+            }
+            if animated {
+                UIView.animate(withDuration: 0.2, animations: changes)
+            } else {
+                changes()
             }
         }
-        let changes = {
-            self.layoutIfNeeded()
-            additionalAnimations?()
-        }
-        if animated {
-            UIView.animate(withDuration: 0.2, animations: changes)
+        if let extendedViewPercentHiddenForShowingTitle = self.extendedViewPercentHiddenForShowingTitle {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.delegate?.title = extendedViewPercentHidden >= extendedViewPercentHiddenForShowingTitle ? self.title : nil
+            }, completion: { (_) in
+                applyChanges()
+            })
         } else {
-            changes()
+            applyChanges()
         }
     }
     


### PR DESCRIPTION
We talked about putting the 2nd nav bar animation in a completion block (https://github.com/wikimedia/wikipedia-ios/pull/2169) but I forgot to update the code

It's to make sure that animations don't fight with each other as pointed out by @montehurd 👍