### PR TITLE
Pull to refresh fix

### DIFF
--- a/Wikipedia/Code/ReadingListDetailViewController.swift
+++ b/Wikipedia/Code/ReadingListDetailViewController.swift
@@ -11,7 +11,6 @@ class ReadingListDetailViewController: ColumnarCollectionViewController, Editabl
     typealias T = ReadingListEntry
     var fetchedResultsController: NSFetchedResultsController<ReadingListEntry>?
     var collectionViewUpdater: CollectionViewUpdater<ReadingListEntry>?
-    private let pullToRefresh = UIRefreshControl()
     
     var basePredicate: NSPredicate {
         return NSPredicate(format: "list == %@ && isDeletedLocally != YES", readingList)
@@ -58,18 +57,17 @@ class ReadingListDetailViewController: ColumnarCollectionViewController, Editabl
         fetch()
         
         register(SavedArticlesCollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier, addPlaceholder: true)
-        
-        pullToRefresh.addTarget(self, action: #selector(pulledToRefresh), for: .valueChanged)
-        scrollView?.refreshControl = pullToRefresh
 
         if displayType == .modal {
             navigationItem.leftBarButtonItem = UIBarButtonItem.wmf_buttonType(WMFButtonType.X, target: self, action: #selector(dismissController))
         }
+        
+        isRefreshControlEnabled = true
     }
     
-    @objc private func pulledToRefresh() {
+    override func refresh() {
         dataStore.readingListsController.fullSync {
-            self.pullToRefresh.endRefreshing()
+            self.endRefreshing()
         }
     }
     

--- a/Wikipedia/Code/ReadingListsViewController.swift
+++ b/Wikipedia/Code/ReadingListsViewController.swift
@@ -120,7 +120,7 @@ class ReadingListsViewController: ColumnarCollectionViewController, EditableColl
     }
     
     override func refresh() {
-        dataStore.readingListsController.backgroundUpdate {
+        dataStore.readingListsController.fullSync {
             self.endRefreshing()
         }
     }

--- a/Wikipedia/Code/SavedArticlesViewController.swift
+++ b/Wikipedia/Code/SavedArticlesViewController.swift
@@ -36,16 +36,13 @@ class SavedArticlesViewController: ColumnarCollectionViewController, EditableCol
     override func viewDidLoad() {
         super.viewDidLoad()
         register(SavedArticlesCollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier, addPlaceholder: true)
-    
         setupEditController()
-        
         isRefreshControlEnabled = true
-        
         emptyViewType = .noSavedPages
     }
     
     override func refresh() {
-        dataStore.readingListsController.backgroundUpdate {
+        dataStore.readingListsController.fullSync {
             self.endRefreshing()
         }
     }

--- a/Wikipedia/Code/SavedViewController.swift
+++ b/Wikipedia/Code/SavedViewController.swift
@@ -95,7 +95,6 @@ class SavedViewController: ViewController {
                 isSearchBarHidden = true
                 activeEditableCollection = readingListsViewController
             }
-            scrollView?.refreshControl = pullToRefresh
         }
     }
     
@@ -174,7 +173,8 @@ class SavedViewController: ViewController {
         edgesForExtendedLayout = .all
         
         pullToRefresh.addTarget(self, action: #selector(pulledToRefresh), for: .valueChanged)
-        
+        scrollView?.refreshControl = pullToRefresh
+
         super.viewDidLoad()
     }
     

--- a/Wikipedia/Code/SavedViewController.swift
+++ b/Wikipedia/Code/SavedViewController.swift
@@ -30,7 +30,6 @@ class SavedViewController: ViewController {
     @IBOutlet weak var separatorView: UIView!
     @IBOutlet var toggleButtons: [UIButton]!
     @IBOutlet weak var progressContainerView: UIView!
-    private let pullToRefresh = UIRefreshControl()
 
     lazy var addReadingListBarButtonItem: UIBarButtonItem = {
         return UIBarButtonItem(barButtonSystemItem: .add, target: readingListsViewController.self, action: #selector(readingListsViewController?.presentCreateReadingListViewController))
@@ -172,16 +171,7 @@ class SavedViewController: ViewController {
         extendedLayoutIncludesOpaqueBars = true
         edgesForExtendedLayout = .all
         
-        pullToRefresh.addTarget(self, action: #selector(pulledToRefresh), for: .valueChanged)
-        scrollView?.refreshControl = pullToRefresh
-
         super.viewDidLoad()
-    }
-    
-    @objc private func pulledToRefresh() {
-        dataStore?.readingListsController.fullSync {
-            self.pullToRefresh.endRefreshing()
-        }
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T189171

Fixes the following bug:

On app clean start:

On iOS 10.3.1:
- tap "Saved" tab bar icon
- do pull to refresh on "All articles"
- tap "Reading lists"
- do pull to refresh
- switch back to "All articles"
- attempt pull to refresh again, which won't work

On iOS 11.2:
- tap "Saved" tab bar icon
- do pull to refresh on "All articles"
- tap "Reading lists"
- do pull to refresh, which won't work