### PR TITLE
Design review updates to saved icon badge 

### DIFF
--- a/Wikipedia/Code/SavedTabBarItemProgressBadgeManager.swift
+++ b/Wikipedia/Code/SavedTabBarItemProgressBadgeManager.swift
@@ -43,6 +43,6 @@
 
 private extension UITabBarItem {
     func showBadge(_ shouldShow: Bool) {
-        badgeValue = shouldShow ? "\u{25cf}" : nil
+        badgeValue = shouldShow ? "\u{2605}" : nil
     }
 }

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1618,12 +1618,19 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 
     // Tab bar items
 
+    NSMutableParagraphStyle *badgeParagraphStyle = [[NSMutableParagraphStyle alloc] init];
+    badgeParagraphStyle.firstLineHeadIndent = 0.4;
+    NSDictionary *badgeAttributes = @{
+                                      NSForegroundColorAttributeName: theme.colors.chromeBackground,
+                                      NSParagraphStyleAttributeName: badgeParagraphStyle
+                                      };
+    
     UIFont *tabBarItemFont = [UIFont systemFontOfSize:12];
     NSDictionary *tabBarTitleTextAttributes = @{NSForegroundColorAttributeName: theme.colors.secondaryText, NSFontAttributeName: tabBarItemFont};
     NSDictionary *tabBarSelectedTitleTextAttributes = @{NSForegroundColorAttributeName: theme.colors.link, NSFontAttributeName: tabBarItemFont};
     for (UITabBarItem *item in tabBarItems) {
-        [item setBadgeTextAttributes:@{NSForegroundColorAttributeName: theme.colors.accent} forState:UIControlStateNormal];
-        [item setBadgeColor:theme.colors.chromeBackground];
+        [item setBadgeTextAttributes:badgeAttributes forState:UIControlStateNormal];
+        [item setBadgeColor:theme.colors.accent];
         [item setTitleTextAttributes:tabBarTitleTextAttributes forState:UIControlStateNormal];
         [item setTitleTextAttributes:tabBarSelectedTitleTextAttributes forState:UIControlStateSelected];
     }


### PR DESCRIPTION
Follow-ups per Carolyn for:
https://phabricator.wikimedia.org/T187823

# Before
<img width="431" alt="screen shot 2018-04-10 at 2 41 51 pm" src="https://user-images.githubusercontent.com/3143487/38586537-f8ac2f3c-3cd2-11e8-9353-016ce23641e5.png">

# After
<img width="431" alt="screen shot 2018-04-10 at 3 19 47 pm" src="https://user-images.githubusercontent.com/3143487/38586538-f8c50ae8-3cd2-11e8-901f-de1125515b4d.png">

