### PR TITLE
Allow reading list hint views to expand vertically for long strings

### DIFF
--- a/WMF Framework/UIStackView+SubviewVerification.swift
+++ b/WMF Framework/UIStackView+SubviewVerification.swift
@@ -1,6 +1,6 @@
 
-extension UIStackView {
-    public func wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint() -> UIView? {
+public extension UIStackView {
+    func wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint() -> UIView? {
         return arrangedSubviews.first(where: {arrangedSubview in
             let requiredHeightConstraint = arrangedSubview.constraints.first(where: {constraint in
                 guard
@@ -15,5 +15,8 @@ extension UIStackView {
             })
             return (requiredHeightConstraint != nil)
         })
+    }
+    func wmf_anArrangedSubviewHasRequiredNonZeroHeightConstraintAssertString() -> String {
+        return "\n\nAll stackview arrangedSubview height constraints need to have a priority of < 1000 so the stackview can collapse the 'cell' if the arrangedSubview's isHidden property is set to true. This arrangedSubview was determined to have a required height: \(String(describing: wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint())). To fix reduce the priority of its height constraint to < 1000.\n\n"
     }
 }

--- a/WMF Framework/WMFCaptchaViewController.swift
+++ b/WMF Framework/WMFCaptchaViewController.swift
@@ -166,7 +166,7 @@ class WMFCaptchaViewController: UIViewController, UITextFieldDelegate, Themeable
             return
         }
         
-        assert(stackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint() == nil, "\n\nAll stackview arrangedSubview height constraints need to have a priority of < 1000 so the stackview can collapse the 'cell' if the arrangedSubview's isHidden property is set to true. This arrangedSubview was determined to have a required height: \(String(describing: stackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint())). To fix reduce the priority of its height constraint to < 1000.\n\n")
+        assert(stackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint() == nil, stackView.wmf_anArrangedSubviewHasRequiredNonZeroHeightConstraintAssertString())
         
         
 

--- a/Wikipedia/Code/ReadingListHintController.swift
+++ b/Wikipedia/Code/ReadingListHintController.swift
@@ -14,7 +14,7 @@ public class ReadingListHintController: NSObject, ReadingListHintViewControllerD
 
     private let dataStore: MWKDataStore
     private weak var presenter: UIViewController?
-    private let hint: ReadingListHintViewController
+    private let hintVC: ReadingListHintViewController
     private let hintHeight: CGFloat = 50
     private var theme: Theme = Theme.standard
     private var didSaveArticle: Bool = false
@@ -36,26 +36,26 @@ public class ReadingListHintController: NSObject, ReadingListHintViewControllerD
     @objc init(dataStore: MWKDataStore, presenter: UIViewController) {
         self.dataStore = dataStore
         self.presenter = presenter
-        self.hint = ReadingListHintViewController()
-        self.hint.dataStore = dataStore
+        self.hintVC = ReadingListHintViewController()
+        self.hintVC.dataStore = dataStore
         super.init()
-        self.hint.delegate = self
+        self.hintVC.delegate = self
     }
     
     func removeHint() {
         task?.cancel()
-        hint.willMove(toParentViewController: nil)
-        hint.view.removeFromSuperview()
-        hint.removeFromParentViewController()
+        hintVC.willMove(toParentViewController: nil)
+        hintVC.view.removeFromSuperview()
+        hintVC.removeFromParentViewController()
         resetHint()
     }
     
     func addHint() {
-        hint.apply(theme: theme)
-        presenter?.addChildViewController(hint)
-        hint.view.autoresizingMask = [.flexibleTopMargin, .flexibleWidth]
-        presenter?.view.addSubview(hint.view)
-        hint.didMove(toParentViewController: presenter)
+        hintVC.apply(theme: theme)
+        presenter?.addChildViewController(hintVC)
+        hintVC.view.autoresizingMask = [.flexibleTopMargin, .flexibleWidth]
+        presenter?.view.addSubview(hintVC.view)
+        hintVC.didMove(toParentViewController: presenter)
     }
     
     var hintVisibilityTime: TimeInterval = 13 {
@@ -91,16 +91,16 @@ public class ReadingListHintController: NSObject, ReadingListHintViewControllerD
             // add hint before animation starts
             addHint()
             // set initial frame
-            if hint.view.frame.origin.y == 0 {
-                hint.view.frame = hintFrame.hidden
+            if hintVC.view.frame.origin.y == 0 {
+                hintVC.view.frame = hintFrame.hidden
             }
         }
         
         updateRandom(hintHidden)
         
         UIView.animate(withDuration: 0.4, delay: 0, options: [.curveEaseInOut, .beginFromCurrentState], animations: {
-            self.hint.view.frame = frame
-            self.hint.view.setNeedsLayout()
+            self.hintVC.view.frame = frame
+            self.hintVC.view.setNeedsLayout()
         }, completion: { (_) in
             // remove hint after animation is completed
             self.isHintHidden = hintHidden
@@ -127,8 +127,8 @@ public class ReadingListHintController: NSObject, ReadingListHintViewControllerD
         didSaveArticle = didSave
         self.theme = theme
         
-        let didSaveOtherArticle = didSave && !isHintHidden && article != hint.article
-        let didUnsaveOtherArticle = !didSave && !isHintHidden && article != hint.article
+        let didSaveOtherArticle = didSave && !isHintHidden && article != hintVC.article
+        let didUnsaveOtherArticle = !didSave && !isHintHidden && article != hintVC.article
         
         guard !didUnsaveOtherArticle else {
             return
@@ -137,18 +137,18 @@ public class ReadingListHintController: NSObject, ReadingListHintViewControllerD
         guard !didSaveOtherArticle else {
             resetHint()
             dismissHint()
-            hint.article = article
+            hintVC.article = article
             return
         }
         
-        hint.article = article
+        hintVC.article = article
         setHintHidden(!didSave)
     }
     
     private func resetHint() {
         didSaveArticle = false
         hintVisibilityTime = 13
-        hint.reset()
+        hintVC.reset()
     }
     
     @objc func didSave(_ saved: Bool, articleURL: URL, theme: Theme) {

--- a/Wikipedia/Code/ReadingListHintController.swift
+++ b/Wikipedia/Code/ReadingListHintController.swift
@@ -124,7 +124,7 @@ public class ReadingListHintController: NSObject, ReadingListHintViewControllerD
         
         updateRandom(hintHidden)
         
-        UIView.animate(withDuration: 0.4, delay: 0, options: [.curveEaseInOut], animations: {
+        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseInOut], animations: {
             if hintHidden {
                 self.containerBottomConstraint?.isActive = false
                 self.containerTopConstraint?.isActive = true

--- a/Wikipedia/Code/ReadingListHintController.swift
+++ b/Wikipedia/Code/ReadingListHintController.swift
@@ -7,7 +7,7 @@ public protocol ReadingListHintPresenter: class {
 
 protocol ReadingListHintViewControllerDelegate: class {
     func readingListHint(_ readingListHint: ReadingListHintViewController, shouldBeHidden: Bool)
-    func readingListHintRotated()
+    func readingListHintHeightChanged()
 }
 
 @objc(WMFReadingListHintController)
@@ -195,10 +195,8 @@ public class ReadingListHintController: NSObject, ReadingListHintViewControllerD
         setHintHidden(shouldBeHidden)
     }
     
-    func readingListHintRotated() {
-        dispatchOnMainQueueAfterDelayInSeconds(0.1) { [weak self] in
-            self?.updateRandom(self?.isHintHidden() ?? true)
-        }
+    func readingListHintHeightChanged(){
+        updateRandom(isHintHidden())
     }
 }
 

--- a/Wikipedia/Code/ReadingListHintController.swift
+++ b/Wikipedia/Code/ReadingListHintController.swift
@@ -33,7 +33,7 @@ public class ReadingListHintController: NSObject, ReadingListHintViewControllerD
         self.hintVC.delegate = self
     }
     
-    func removeHint() {
+    private func removeHint() {
         task?.cancel()
         hintVC.willMove(toParentViewController: nil)
         hintVC.view.removeFromSuperview()
@@ -42,10 +42,10 @@ public class ReadingListHintController: NSObject, ReadingListHintViewControllerD
         resetHint()
     }
     
-    var containerBottomConstraint:NSLayoutConstraint?
-    var containerTopConstraint:NSLayoutConstraint?
+    private var containerBottomConstraint:NSLayoutConstraint?
+    private var containerTopConstraint:NSLayoutConstraint?
     
-    func addHint() {
+    private func addHint() {
         guard isHintHidden() else {
             return
         }
@@ -82,7 +82,7 @@ public class ReadingListHintController: NSObject, ReadingListHintViewControllerD
         presenter?.wmf_add(childController: hintVC, andConstrainToEdgesOfContainerView: containerView)
     }
     
-    var hintVisibilityTime: TimeInterval = 13 {
+    private var hintVisibilityTime: TimeInterval = 13 {
         didSet {
             guard hintVisibilityTime != oldValue else {
                 return
@@ -93,14 +93,14 @@ public class ReadingListHintController: NSObject, ReadingListHintViewControllerD
     
     private var task: DispatchWorkItem?
     
-    func updateRandom(_ hintHidden: Bool) {
+    private func updateRandom(_ hintHidden: Bool) {
         if let navigationController = (presenter as? WMFRandomArticleViewController)?.navigationController as? WMFArticleNavigationController {
             navigationController.readingListHintHeight = containerView.frame.size.height
             navigationController.readingListHintHidden = hintHidden
         }
     }
     
-    func dismissHint() {
+    private func dismissHint() {
         self.task?.cancel()
         let task = DispatchWorkItem { [weak self] in
             self?.setHintHidden(true)

--- a/Wikipedia/Code/ReadingListHintController.swift
+++ b/Wikipedia/Code/ReadingListHintController.swift
@@ -16,7 +16,6 @@ public class ReadingListHintController: NSObject, ReadingListHintViewControllerD
     private let dataStore: MWKDataStore
     private weak var presenter: UIViewController?
     private let hintVC: ReadingListHintViewController
-    private let hintHeight: CGFloat = 50
     private var theme: Theme = Theme.standard
     private var didSaveArticle: Bool = false
     private var containerView = UIView()

--- a/Wikipedia/Code/ReadingListHintViewController.swift
+++ b/Wikipedia/Code/ReadingListHintViewController.swift
@@ -41,21 +41,9 @@ class ReadingListHintViewController: UIViewController {
         }
     }
     
-    private var tapHintGestureRecognizer: UIGestureRecognizer?
-    private var tapConfirmationGestureRecognizer: UIGestureRecognizer?
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         isHintViewHidden = false
-        
-        tapHintGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(addArticleToReadingList(_:)))
-        tapConfirmationGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(openReadingList))
-        if let tapHintGestureRecognizer = tapHintGestureRecognizer {
-            hintView?.addGestureRecognizer(tapHintGestureRecognizer)
-        }
-        if let tapConfirmationGestureRecognizer = tapConfirmationGestureRecognizer {
-            confirmationView?.addGestureRecognizer(tapConfirmationGestureRecognizer)
-        }
         
         confirmationImageView.layer.cornerRadius = 3
         confirmationImageView.clipsToBounds = true
@@ -76,12 +64,6 @@ class ReadingListHintViewController: UIViewController {
     
     deinit {
         NotificationCenter.default.removeObserver(self)
-        if let tapHintGestureRecognizer = tapHintGestureRecognizer {
-            hintView?.removeGestureRecognizer(tapHintGestureRecognizer)
-        }
-        if let tapConfirmationGestureRecognizer = tapConfirmationGestureRecognizer {
-            confirmationView?.removeGestureRecognizer(tapConfirmationGestureRecognizer)
-        }
     }
     
     func reset() {

--- a/Wikipedia/Code/ReadingListHintViewController.swift
+++ b/Wikipedia/Code/ReadingListHintViewController.swift
@@ -19,11 +19,13 @@ class ReadingListHintViewController: UIViewController {
     
     @IBOutlet weak var hintView: UIView?
     @IBOutlet weak var hintLabel: UILabel?
-    @IBOutlet weak var confirmationView: UIView?
+    @IBOutlet weak var confirmationContainerView: UIView?
     @IBOutlet weak var confirmationImageView: UIImageView!
     @IBOutlet weak var confirmationLabel: UILabel!
     @IBOutlet weak var confirmationChevron: UIButton!
-    
+    @IBOutlet weak var outerStackView: UIStackView!
+    @IBOutlet weak var confirmationStackView: UIStackView!
+
     private var isConfirmationImageViewHidden: Bool = false {
         didSet {
             confirmationImageView.isHidden = isConfirmationImageViewHidden
@@ -33,7 +35,7 @@ class ReadingListHintViewController: UIViewController {
     private var isHintViewHidden: Bool = false {
         didSet {
             hintView?.isHidden = isHintViewHidden
-            confirmationView?.isHidden = !isHintViewHidden
+            confirmationContainerView?.isHidden = !isHintViewHidden
         }
     }
     
@@ -46,6 +48,10 @@ class ReadingListHintViewController: UIViewController {
         setHintButtonTitle()
         apply(theme: theme)
         NotificationCenter.default.addObserver(self, selector: #selector(themeChanged), name: Notification.Name(ReadingThemesControlsViewController.WMFUserDidSelectThemeNotification), object: nil)
+    
+        assert(outerStackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint() == nil, "\n\nAll stackview arrangedSubview height constraints need to have a priority of < 1000 so the stackview can collapse the 'cell' if the arrangedSubview's isHidden property is set to true. This arrangedSubview was determined to have a required height: \(String(describing: outerStackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint())). To fix reduce the priority of its height constraint to < 1000.\n\n")
+
+        assert(confirmationStackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint() == nil, "\n\nAll stackview arrangedSubview height constraints need to have a priority of < 1000 so the stackview can collapse the 'cell' if the arrangedSubview's isHidden property is set to true. This arrangedSubview was determined to have a required height: \(String(describing: confirmationStackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint())). To fix reduce the priority of its height constraint to < 1000.\n\n")
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/Wikipedia/Code/ReadingListHintViewController.swift
+++ b/Wikipedia/Code/ReadingListHintViewController.swift
@@ -73,9 +73,15 @@ class ReadingListHintViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         hintLabel?.setFont(with: .systemMedium, style: .subheadline, traitCollection: traitCollection)
         confirmationLabel?.setFont(with: .systemMedium, style: .subheadline, traitCollection: traitCollection)
-        if (traitCollection.verticalSizeClass != previousTraitCollection?.verticalSizeClass) {
-            delegate?.readingListHintRotated()
+    }
+    
+    private var previousHeight:CGFloat = 0.0
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if previousHeight != view.frame.size.height {
+            delegate?.readingListHintHeightChanged()
         }
+        previousHeight = view.frame.size.height
     }
     
     public weak var delegate: ReadingListHintViewControllerDelegate?

--- a/Wikipedia/Code/ReadingListHintViewController.swift
+++ b/Wikipedia/Code/ReadingListHintViewController.swift
@@ -49,9 +49,8 @@ class ReadingListHintViewController: UIViewController {
         apply(theme: theme)
         NotificationCenter.default.addObserver(self, selector: #selector(themeChanged), name: Notification.Name(ReadingThemesControlsViewController.WMFUserDidSelectThemeNotification), object: nil)
     
-        assert(outerStackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint() == nil, "\n\nAll stackview arrangedSubview height constraints need to have a priority of < 1000 so the stackview can collapse the 'cell' if the arrangedSubview's isHidden property is set to true. This arrangedSubview was determined to have a required height: \(String(describing: outerStackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint())). To fix reduce the priority of its height constraint to < 1000.\n\n")
-
-        assert(confirmationStackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint() == nil, "\n\nAll stackview arrangedSubview height constraints need to have a priority of < 1000 so the stackview can collapse the 'cell' if the arrangedSubview's isHidden property is set to true. This arrangedSubview was determined to have a required height: \(String(describing: confirmationStackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint())). To fix reduce the priority of its height constraint to < 1000.\n\n")
+        assert(outerStackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint() == nil, outerStackView.wmf_anArrangedSubviewHasRequiredNonZeroHeightConstraintAssertString())
+        assert(confirmationStackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint() == nil, confirmationStackView.wmf_anArrangedSubviewHasRequiredNonZeroHeightConstraintAssertString())
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/Wikipedia/Code/ReadingListHintViewController.swift
+++ b/Wikipedia/Code/ReadingListHintViewController.swift
@@ -136,9 +136,9 @@ extension ReadingListHintViewController: AddArticlesToReadingListDelegate {
             isConfirmationImageViewHidden = true
         }
         self.readingList = readingList
-        isHintViewHidden = true
         let title = String.localizedStringWithFormat(WMFLocalizedString("reading-lists-article-added-confirmation", value: "Article added to “%1$@”", comment: "Confirmation shown after the user adds an article to a list"), name)
         confirmationLabel.text = title
+        isHintViewHidden = true
         delegate?.readingListHint(self, shouldBeHidden: false)
     }
     

--- a/Wikipedia/Code/ReadingListHintViewController.swift
+++ b/Wikipedia/Code/ReadingListHintViewController.swift
@@ -1,7 +1,7 @@
 class ReadingListHintViewController: UIViewController {
     
     var dataStore: MWKDataStore?
-    fileprivate var theme: Theme = Theme.standard
+    private var theme: Theme = Theme.standard
     
     var article: WMFArticle? {
         didSet {
@@ -17,14 +17,14 @@ class ReadingListHintViewController: UIViewController {
         return String.localizedStringWithFormat(WMFLocalizedString("reading-list-add-hint-title", value: "Add “%1$@” to a reading list?", comment: "Title of the reading list hint that appears after an article is saved"), "\(articleTitle)")
     }
     
-    @IBOutlet weak var hintView: UIView?
-    @IBOutlet weak var hintLabel: UILabel?
-    @IBOutlet weak var confirmationContainerView: UIView?
-    @IBOutlet weak var confirmationImageView: UIImageView!
-    @IBOutlet weak var confirmationLabel: UILabel!
-    @IBOutlet weak var confirmationChevron: UIButton!
-    @IBOutlet weak var outerStackView: UIStackView!
-    @IBOutlet weak var confirmationStackView: UIStackView!
+    @IBOutlet private weak var hintView: UIView?
+    @IBOutlet private weak var hintLabel: UILabel?
+    @IBOutlet private weak var confirmationContainerView: UIView?
+    @IBOutlet private weak var confirmationImageView: UIImageView!
+    @IBOutlet private weak var confirmationLabel: UILabel!
+    @IBOutlet private weak var confirmationChevron: UIButton!
+    @IBOutlet private weak var outerStackView: UIStackView!
+    @IBOutlet private weak var confirmationStackView: UIStackView!
 
     private var isConfirmationImageViewHidden: Bool = false {
         didSet {
@@ -95,8 +95,8 @@ class ReadingListHintViewController: UIViewController {
         present(addArticlesToReadingListViewController, animated: true, completion: nil)
     }
     
-    fileprivate var readingList: ReadingList?
-    fileprivate var themeableNavigationController: WMFThemeableNavigationController?
+    private var readingList: ReadingList?
+    private var themeableNavigationController: WMFThemeableNavigationController?
     
     @IBAction func openReadingList() {
         guard let readingList = readingList, let dataStore = dataStore else {

--- a/Wikipedia/Code/ReadingListHintViewController.swift
+++ b/Wikipedia/Code/ReadingListHintViewController.swift
@@ -18,19 +18,15 @@ class ReadingListHintViewController: UIViewController {
     }
     
     @IBOutlet weak var hintView: UIView?
-    @IBOutlet weak var hintButton: AlignedImageButton?
+    @IBOutlet weak var hintLabel: UILabel?
     @IBOutlet weak var confirmationView: UIView?
     @IBOutlet weak var confirmationImageView: UIImageView!
-    @IBOutlet weak var confirmationButton: UIButton!
+    @IBOutlet weak var confirmationLabel: UILabel!
     @IBOutlet weak var confirmationChevron: UIButton!
-    private var confirmationButtonLeadingConstraint: (toImageView: NSLayoutConstraint?, toView: NSLayoutConstraint?)
     
     private var isConfirmationImageViewHidden: Bool = false {
         didSet {
             confirmationImageView.isHidden = isConfirmationImageViewHidden
-            confirmationButtonLeadingConstraint.toImageView?.isActive = !isConfirmationImageViewHidden
-            confirmationButtonLeadingConstraint.toView?.isActive = isConfirmationImageViewHidden
-            view.setNeedsLayout()
         }
     }
     
@@ -47,11 +43,6 @@ class ReadingListHintViewController: UIViewController {
         
         confirmationImageView.layer.cornerRadius = 3
         confirmationImageView.clipsToBounds = true
-        confirmationButtonLeadingConstraint.toImageView = confirmationButton.leadingAnchor.constraint(equalTo: confirmationImageView.trailingAnchor, constant: 12)
-        confirmationButtonLeadingConstraint.toView = confirmationButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12)
-        hintButton?.verticalPadding = 5
-        hintButton?.titleLabel?.wmf_configureToAutoAdjustFontSize()
-        confirmationButton?.titleLabel?.wmf_configureToAutoAdjustFontSize()
         setHintButtonTitle()
         apply(theme: theme)
         NotificationCenter.default.addObserver(self, selector: #selector(themeChanged), name: Notification.Name(ReadingThemesControlsViewController.WMFUserDidSelectThemeNotification), object: nil)
@@ -71,12 +62,15 @@ class ReadingListHintViewController: UIViewController {
     }
     
     private func setHintButtonTitle() {
-        hintButton?.setTitle(hintButtonTitle, for: .normal)
+        hintLabel?.text = hintButtonTitle
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        hintButton?.titleLabel?.setFont(with: .systemMedium, style: .subheadline, traitCollection: traitCollection)
-        confirmationButton?.titleLabel?.setFont(with: .systemMedium, style: .subheadline, traitCollection: traitCollection)
+        hintLabel?.setFont(with: .systemMedium, style: .subheadline, traitCollection: traitCollection)
+        confirmationLabel?.setFont(with: .systemMedium, style: .subheadline, traitCollection: traitCollection)
+        if (traitCollection.verticalSizeClass != previousTraitCollection?.verticalSizeClass) {
+            delegate?.readingListHintRotated()
+        }
     }
     
     public weak var delegate: ReadingListHintViewControllerDelegate?
@@ -133,7 +127,7 @@ extension ReadingListHintViewController: AddArticlesToReadingListDelegate {
         self.readingList = readingList
         isHintViewHidden = true
         let title = String.localizedStringWithFormat(WMFLocalizedString("reading-lists-article-added-confirmation", value: "Article added to “%1$@”", comment: "Confirmation shown after the user adds an article to a list"), name)
-        confirmationButton.setTitle(title, for: .normal)
+        confirmationLabel.text = title
         delegate?.readingListHint(self, shouldBeHidden: false)
     }
     
@@ -148,10 +142,10 @@ extension ReadingListHintViewController: Themeable {
         guard viewIfLoaded != nil else {
             return
         }
-        view.backgroundColor = theme.colors.hintBackground 
-        hintButton?.setTitleColor(theme.colors.link, for: .normal)
-        hintButton?.tintColor = theme.colors.link
-        confirmationButton.setTitleColor(theme.colors.link, for: .normal)
+        view.backgroundColor = theme.colors.hintBackground
+        hintLabel?.textColor = theme.colors.link
+        hintLabel?.tintColor = theme.colors.link
+        confirmationLabel?.textColor = theme.colors.link        
         confirmationChevron.tintColor = theme.colors.link
     }
 }

--- a/Wikipedia/Code/ReadingListHintViewController.xib
+++ b/Wikipedia/Code/ReadingListHintViewController.xib
@@ -38,12 +38,16 @@
                             </connections>
                         </button>
                     </subviews>
+                    <gestureRecognizers/>
                     <constraints>
                         <constraint firstItem="cDy-Kw-ATH" firstAttribute="leading" secondItem="f2T-xz-pPZ" secondAttribute="leading" constant="12" id="63q-oq-wI0"/>
                         <constraint firstItem="cDy-Kw-ATH" firstAttribute="centerY" secondItem="f2T-xz-pPZ" secondAttribute="centerY" id="Btc-d4-WOK"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cDy-Kw-ATH" secondAttribute="trailing" constant="12" id="yRl-B4-i4c"/>
                     </constraints>
                     <viewLayoutGuide key="safeArea" id="sA1-Du-pXz"/>
+                    <connections>
+                        <outletCollection property="gestureRecognizers" destination="3D2-Ih-XyP" appends="YES" id="5R9-gq-LMx"/>
+                    </connections>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Mi-lB-pMN" userLabel="Confirmation View">
                     <rect key="frame" x="0.0" y="0.0" width="529" height="109"/>
@@ -70,6 +74,7 @@
                             </connections>
                         </button>
                     </subviews>
+                    <gestureRecognizers/>
                     <constraints>
                         <constraint firstItem="rVc-9B-yHX" firstAttribute="leading" secondItem="Q55-Ot-WJE" secondAttribute="trailing" constant="12" placeholder="YES" id="1RW-7g-g8G"/>
                         <constraint firstItem="zkX-4T-Nfr" firstAttribute="trailing" secondItem="wCS-DM-ckl" secondAttribute="trailing" constant="12" id="7S1-d7-lM6"/>
@@ -80,6 +85,9 @@
                         <constraint firstItem="Q55-Ot-WJE" firstAttribute="centerY" secondItem="9Mi-lB-pMN" secondAttribute="centerY" id="stQ-gW-y4c"/>
                     </constraints>
                     <viewLayoutGuide key="safeArea" id="zkX-4T-Nfr"/>
+                    <connections>
+                        <outletCollection property="gestureRecognizers" destination="fxf-y7-eKu" appends="YES" id="I31-pl-am0"/>
+                    </connections>
                 </view>
             </subviews>
             <constraints>
@@ -96,6 +104,16 @@
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="112.5" y="-224.5"/>
         </view>
+        <tapGestureRecognizer id="3D2-Ih-XyP">
+            <connections>
+                <action selector="addArticleToReadingList:" destination="-1" id="Dx4-pO-wKa"/>
+            </connections>
+        </tapGestureRecognizer>
+        <tapGestureRecognizer id="fxf-y7-eKu">
+            <connections>
+                <action selector="openReadingList" destination="-1" id="USn-ka-kqU"/>
+            </connections>
+        </tapGestureRecognizer>
     </objects>
     <resources>
         <image name="add-to-list" width="26" height="26"/>

--- a/Wikipedia/Code/ReadingListHintViewController.xib
+++ b/Wikipedia/Code/ReadingListHintViewController.xib
@@ -6,6 +6,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -31,18 +32,19 @@
                 <action selector="openReadingList" destination="-1" id="USn-ka-kqU"/>
             </connections>
         </tapGestureRecognizer>
-        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="A0g-px-xTY">
+        <view contentMode="scaleToFill" id="A0g-px-xTY">
             <rect key="frame" x="0.0" y="0.0" width="548" height="108"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="eG8-5x-OUi">
+                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="eG8-5x-OUi">
                     <rect key="frame" x="0.0" y="0.0" width="548" height="108"/>
                     <subviews>
-                        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f2T-xz-pPZ" userLabel="Hint View">
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f2T-xz-pPZ" userLabel="Hint View">
                             <rect key="frame" x="0.0" y="0.0" width="548" height="52"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hint default title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ni7-Ic-c9C">
                                     <rect key="frame" x="50" y="14" width="486" height="24"/>
+                                    <viewLayoutGuide key="safeArea" id="rVu-1p-TMz"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
@@ -53,6 +55,7 @@
                                         <constraint firstAttribute="height" priority="999" constant="40" id="XBd-aa-skT"/>
                                         <constraint firstAttribute="width" priority="999" constant="50" id="zx2-am-b8e"/>
                                     </constraints>
+                                    <viewLayoutGuide key="safeArea" id="SKG-dM-SlL"/>
                                 </imageView>
                             </subviews>
                             <gestureRecognizers/>
@@ -64,11 +67,12 @@
                                 <constraint firstAttribute="bottom" secondItem="ni7-Ic-c9C" secondAttribute="bottom" priority="999" constant="14" id="pvD-um-67m"/>
                                 <constraint firstItem="ZRK-Wk-NPA" firstAttribute="leading" secondItem="f2T-xz-pPZ" secondAttribute="leading" id="y5D-m8-DRj"/>
                             </constraints>
+                            <viewLayoutGuide key="safeArea" id="jiA-rv-sie"/>
                             <connections>
                                 <outletCollection property="gestureRecognizers" destination="3D2-Ih-XyP" appends="YES" id="5R9-gq-LMx"/>
                             </connections>
                         </view>
-                        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Mi-lB-pMN" userLabel="Confirmation View">
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Mi-lB-pMN" userLabel="Confirmation View">
                             <rect key="frame" x="0.0" y="52" width="548" height="56"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="BjB-ib-pB7">
@@ -80,6 +84,7 @@
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="1" id="bR6-tK-FOy"/>
                                             </constraints>
+                                            <viewLayoutGuide key="safeArea" id="rba-w9-5eo"/>
                                         </view>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Q55-Ot-WJE">
                                             <rect key="frame" x="13" y="0.0" width="40" height="40"/>
@@ -87,18 +92,21 @@
                                                 <constraint firstAttribute="height" priority="999" constant="40" id="8fF-21-JIz"/>
                                                 <constraint firstAttribute="width" priority="999" constant="40" id="sKL-mj-ebh"/>
                                             </constraints>
+                                            <viewLayoutGuide key="safeArea" id="c3R-HI-4dV"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Confimation default title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9CN-TE-qsp">
                                             <rect key="frame" x="65" y="0.0" width="431" height="40"/>
+                                            <viewLayoutGuide key="safeArea" id="8sy-qs-43Q"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <button opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wCS-DM-ckl" userLabel="Chevron Button">
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wCS-DM-ckl" userLabel="Chevron Button">
                                             <rect key="frame" x="508" y="0.0" width="40" height="40"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="40" id="C1K-zv-Bq4"/>
                                             </constraints>
+                                            <viewLayoutGuide key="safeArea" id="Aon-vd-IWO"/>
                                             <state key="normal" image="chevron-right"/>
                                             <connections>
                                                 <action selector="openReadingList" destination="-1" eventType="touchUpInside" id="k5I-NY-Sad"/>
@@ -115,22 +123,25 @@
                                 <constraint firstItem="BjB-ib-pB7" firstAttribute="leading" secondItem="9Mi-lB-pMN" secondAttribute="leading" id="kVb-xB-XEm"/>
                                 <constraint firstItem="BjB-ib-pB7" firstAttribute="top" secondItem="9Mi-lB-pMN" secondAttribute="top" priority="999" constant="8" id="z4b-bC-5KJ"/>
                             </constraints>
+                            <viewLayoutGuide key="safeArea" id="krx-JI-Ofa"/>
                             <connections>
                                 <outletCollection property="gestureRecognizers" destination="fxf-y7-eKu" appends="YES" id="I31-pl-am0"/>
                             </connections>
                         </view>
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <viewLayoutGuide key="safeArea" id="dc6-zn-PPy"/>
                 </stackView>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="eG8-5x-OUi" secondAttribute="trailing" id="1kY-GU-RtS"/>
-                <constraint firstItem="eG8-5x-OUi" firstAttribute="leading" secondItem="A0g-px-xTY" secondAttribute="leading" id="9fE-AE-VCT"/>
                 <constraint firstItem="eG8-5x-OUi" firstAttribute="top" secondItem="A0g-px-xTY" secondAttribute="top" id="XRR-mo-SlV"/>
+                <constraint firstItem="RCC-Bl-xSh" firstAttribute="leading" secondItem="eG8-5x-OUi" secondAttribute="leading" id="bne-AT-n4n"/>
                 <constraint firstAttribute="bottom" secondItem="eG8-5x-OUi" secondAttribute="bottom" id="fqs-Hs-g9Q"/>
+                <constraint firstItem="eG8-5x-OUi" firstAttribute="trailing" secondItem="RCC-Bl-xSh" secondAttribute="trailing" id="nPN-D7-ra8"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="RCC-Bl-xSh"/>
             <point key="canvasLocation" x="138" y="291"/>
         </view>
     </objects>

--- a/Wikipedia/Code/ReadingListHintViewController.xib
+++ b/Wikipedia/Code/ReadingListHintViewController.xib
@@ -13,11 +13,13 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReadingListHintViewController" customModule="Wikipedia" customModuleProvider="target">
             <connections>
                 <outlet property="confirmationChevron" destination="wCS-DM-ckl" id="hit-xc-Gyl"/>
+                <outlet property="confirmationContainerView" destination="9Mi-lB-pMN" id="QWO-OY-pDu"/>
                 <outlet property="confirmationImageView" destination="Q55-Ot-WJE" id="gaq-NA-3pq"/>
                 <outlet property="confirmationLabel" destination="9CN-TE-qsp" id="jgp-S9-0aO"/>
-                <outlet property="confirmationView" destination="9Mi-lB-pMN" id="Kbc-xo-QXg"/>
+                <outlet property="confirmationStackView" destination="BjB-ib-pB7" id="5TN-DB-seg"/>
                 <outlet property="hintLabel" destination="ni7-Ic-c9C" id="78y-zo-fKF"/>
                 <outlet property="hintView" destination="f2T-xz-pPZ" id="X0h-wu-gdZ"/>
+                <outlet property="outerStackView" destination="eG8-5x-OUi" id="nNo-SZ-k1q"/>
                 <outlet property="view" destination="A0g-px-xTY" id="cfU-LL-9YD"/>
             </connections>
         </placeholder>
@@ -75,7 +77,7 @@
                                 <outletCollection property="gestureRecognizers" destination="3D2-Ih-XyP" appends="YES" id="5R9-gq-LMx"/>
                             </connections>
                         </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Mi-lB-pMN" userLabel="Confirmation View">
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Mi-lB-pMN">
                             <rect key="frame" x="0.0" y="48" width="548" height="40"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="BjB-ib-pB7">

--- a/Wikipedia/Code/ReadingListHintViewController.xib
+++ b/Wikipedia/Code/ReadingListHintViewController.xib
@@ -6,104 +6,21 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReadingListHintViewController" customModule="Wikipedia" customModuleProvider="target">
             <connections>
-                <outlet property="confirmationButton" destination="rVc-9B-yHX" id="FFt-IR-CbT"/>
                 <outlet property="confirmationChevron" destination="wCS-DM-ckl" id="hit-xc-Gyl"/>
                 <outlet property="confirmationImageView" destination="Q55-Ot-WJE" id="gaq-NA-3pq"/>
+                <outlet property="confirmationLabel" destination="9CN-TE-qsp" id="jgp-S9-0aO"/>
                 <outlet property="confirmationView" destination="9Mi-lB-pMN" id="Kbc-xo-QXg"/>
-                <outlet property="hintButton" destination="cDy-Kw-ATH" id="qxv-Yr-lUx"/>
+                <outlet property="hintLabel" destination="ni7-Ic-c9C" id="78y-zo-fKF"/>
                 <outlet property="hintView" destination="f2T-xz-pPZ" id="X0h-wu-gdZ"/>
-                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="view" destination="A0g-px-xTY" id="cfU-LL-9YD"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="529" height="109"/>
-            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f2T-xz-pPZ" userLabel="Hint View">
-                    <rect key="frame" x="0.0" y="0.0" width="529" height="109"/>
-                    <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cDy-Kw-ATH" customClass="WMFAlignedImageButton">
-                            <rect key="frame" x="12" y="41.5" width="26" height="26"/>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                            <state key="normal" image="add-to-list"/>
-                            <connections>
-                                <action selector="addArticleToReadingList:" destination="-1" eventType="touchUpInside" id="ecI-Nw-uUP"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <gestureRecognizers/>
-                    <constraints>
-                        <constraint firstItem="cDy-Kw-ATH" firstAttribute="leading" secondItem="f2T-xz-pPZ" secondAttribute="leading" constant="12" id="63q-oq-wI0"/>
-                        <constraint firstItem="cDy-Kw-ATH" firstAttribute="centerY" secondItem="f2T-xz-pPZ" secondAttribute="centerY" id="Btc-d4-WOK"/>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cDy-Kw-ATH" secondAttribute="trailing" constant="12" id="yRl-B4-i4c"/>
-                    </constraints>
-                    <viewLayoutGuide key="safeArea" id="sA1-Du-pXz"/>
-                    <connections>
-                        <outletCollection property="gestureRecognizers" destination="3D2-Ih-XyP" appends="YES" id="5R9-gq-LMx"/>
-                    </connections>
-                </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Mi-lB-pMN" userLabel="Confirmation View">
-                    <rect key="frame" x="0.0" y="0.0" width="529" height="109"/>
-                    <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Q55-Ot-WJE">
-                            <rect key="frame" x="12" y="34" width="40" height="40"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="40" id="8fF-21-JIz"/>
-                                <constraint firstAttribute="width" constant="40" id="sKL-mj-ebh"/>
-                            </constraints>
-                        </imageView>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rVc-9B-yHX">
-                            <rect key="frame" x="64" y="37.5" width="30" height="33"/>
-                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
-                            <connections>
-                                <action selector="openReadingList" destination="-1" eventType="touchUpInside" id="X7R-ds-Yeo"/>
-                            </connections>
-                        </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wCS-DM-ckl" userLabel="Chevron Button">
-                            <rect key="frame" x="505" y="43" width="12" height="22"/>
-                            <state key="normal" image="chevron-right"/>
-                            <connections>
-                                <action selector="openReadingList" destination="-1" eventType="touchUpInside" id="k5I-NY-Sad"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <gestureRecognizers/>
-                    <constraints>
-                        <constraint firstItem="rVc-9B-yHX" firstAttribute="leading" secondItem="Q55-Ot-WJE" secondAttribute="trailing" constant="12" placeholder="YES" id="1RW-7g-g8G"/>
-                        <constraint firstItem="zkX-4T-Nfr" firstAttribute="trailing" secondItem="wCS-DM-ckl" secondAttribute="trailing" constant="12" id="7S1-d7-lM6"/>
-                        <constraint firstItem="wCS-DM-ckl" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="rVc-9B-yHX" secondAttribute="trailing" constant="12" id="7c2-4c-oQZ"/>
-                        <constraint firstItem="Q55-Ot-WJE" firstAttribute="leading" secondItem="9Mi-lB-pMN" secondAttribute="leading" constant="12" id="VYm-vs-rRQ"/>
-                        <constraint firstItem="rVc-9B-yHX" firstAttribute="centerY" secondItem="9Mi-lB-pMN" secondAttribute="centerY" id="iHs-rt-8pc"/>
-                        <constraint firstItem="wCS-DM-ckl" firstAttribute="centerY" secondItem="9Mi-lB-pMN" secondAttribute="centerY" id="nwh-ZC-ZfW"/>
-                        <constraint firstItem="Q55-Ot-WJE" firstAttribute="centerY" secondItem="9Mi-lB-pMN" secondAttribute="centerY" id="stQ-gW-y4c"/>
-                    </constraints>
-                    <viewLayoutGuide key="safeArea" id="zkX-4T-Nfr"/>
-                    <connections>
-                        <outletCollection property="gestureRecognizers" destination="fxf-y7-eKu" appends="YES" id="I31-pl-am0"/>
-                    </connections>
-                </view>
-            </subviews>
-            <constraints>
-                <constraint firstItem="f2T-xz-pPZ" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="1eh-WB-uCT"/>
-                <constraint firstAttribute="bottom" secondItem="f2T-xz-pPZ" secondAttribute="bottom" id="CnK-va-xVo"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="f2T-xz-pPZ" secondAttribute="trailing" id="E4W-is-ubF"/>
-                <constraint firstAttribute="bottom" secondItem="9Mi-lB-pMN" secondAttribute="bottom" id="QUN-cv-K6l"/>
-                <constraint firstItem="f2T-xz-pPZ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="RPH-lV-PrV"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="9Mi-lB-pMN" secondAttribute="trailing" id="dUe-s0-yAS"/>
-                <constraint firstItem="9Mi-lB-pMN" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="jnG-HS-pMS"/>
-                <constraint firstItem="9Mi-lB-pMN" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="zk2-38-fqs"/>
-            </constraints>
-            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <point key="canvasLocation" x="112.5" y="-224.5"/>
-        </view>
         <tapGestureRecognizer id="3D2-Ih-XyP">
             <connections>
                 <action selector="addArticleToReadingList:" destination="-1" id="Dx4-pO-wKa"/>
@@ -114,6 +31,108 @@
                 <action selector="openReadingList" destination="-1" id="USn-ka-kqU"/>
             </connections>
         </tapGestureRecognizer>
+        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="A0g-px-xTY">
+            <rect key="frame" x="0.0" y="0.0" width="548" height="108"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="eG8-5x-OUi">
+                    <rect key="frame" x="0.0" y="0.0" width="548" height="108"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f2T-xz-pPZ" userLabel="Hint View">
+                            <rect key="frame" x="0.0" y="0.0" width="548" height="52"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hint default title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ni7-Ic-c9C">
+                                    <rect key="frame" x="50" y="14" width="486" height="24"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="add-to-list" translatesAutoresizingMaskIntoConstraints="NO" id="ZRK-Wk-NPA">
+                                    <rect key="frame" x="0.0" y="6" width="50" height="40"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" priority="999" constant="40" id="XBd-aa-skT"/>
+                                        <constraint firstAttribute="width" priority="999" constant="50" id="zx2-am-b8e"/>
+                                    </constraints>
+                                </imageView>
+                            </subviews>
+                            <gestureRecognizers/>
+                            <constraints>
+                                <constraint firstItem="ni7-Ic-c9C" firstAttribute="leading" secondItem="ZRK-Wk-NPA" secondAttribute="trailing" id="D4i-2I-Zom"/>
+                                <constraint firstItem="ZRK-Wk-NPA" firstAttribute="centerY" secondItem="f2T-xz-pPZ" secondAttribute="centerY" id="IdG-Ak-9WV"/>
+                                <constraint firstAttribute="trailing" secondItem="ni7-Ic-c9C" secondAttribute="trailing" constant="12" id="fRH-hC-xRw"/>
+                                <constraint firstItem="ni7-Ic-c9C" firstAttribute="top" secondItem="f2T-xz-pPZ" secondAttribute="top" priority="999" constant="14" id="hZH-xJ-hb1"/>
+                                <constraint firstAttribute="bottom" secondItem="ni7-Ic-c9C" secondAttribute="bottom" priority="999" constant="14" id="pvD-um-67m"/>
+                                <constraint firstItem="ZRK-Wk-NPA" firstAttribute="leading" secondItem="f2T-xz-pPZ" secondAttribute="leading" id="y5D-m8-DRj"/>
+                            </constraints>
+                            <connections>
+                                <outletCollection property="gestureRecognizers" destination="3D2-Ih-XyP" appends="YES" id="5R9-gq-LMx"/>
+                            </connections>
+                        </view>
+                        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Mi-lB-pMN" userLabel="Confirmation View">
+                            <rect key="frame" x="0.0" y="52" width="548" height="56"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="BjB-ib-pB7">
+                                    <rect key="frame" x="0.0" y="8" width="548" height="40"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gqF-Ty-pGy" userLabel="Spacer">
+                                            <rect key="frame" x="0.0" y="0.0" width="1" height="40"/>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="1" id="bR6-tK-FOy"/>
+                                            </constraints>
+                                        </view>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Q55-Ot-WJE">
+                                            <rect key="frame" x="13" y="0.0" width="40" height="40"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" priority="999" constant="40" id="8fF-21-JIz"/>
+                                                <constraint firstAttribute="width" priority="999" constant="40" id="sKL-mj-ebh"/>
+                                            </constraints>
+                                        </imageView>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Confimation default title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9CN-TE-qsp">
+                                            <rect key="frame" x="65" y="0.0" width="431" height="40"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <button opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wCS-DM-ckl" userLabel="Chevron Button">
+                                            <rect key="frame" x="508" y="0.0" width="40" height="40"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="40" id="C1K-zv-Bq4"/>
+                                            </constraints>
+                                            <state key="normal" image="chevron-right"/>
+                                            <connections>
+                                                <action selector="openReadingList" destination="-1" eventType="touchUpInside" id="k5I-NY-Sad"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <gestureRecognizers/>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="BjB-ib-pB7" secondAttribute="trailing" id="2Q8-nj-9g4"/>
+                                <constraint firstAttribute="bottom" secondItem="BjB-ib-pB7" secondAttribute="bottom" priority="999" constant="8" id="jID-Kv-qLw"/>
+                                <constraint firstItem="BjB-ib-pB7" firstAttribute="leading" secondItem="9Mi-lB-pMN" secondAttribute="leading" id="kVb-xB-XEm"/>
+                                <constraint firstItem="BjB-ib-pB7" firstAttribute="top" secondItem="9Mi-lB-pMN" secondAttribute="top" priority="999" constant="8" id="z4b-bC-5KJ"/>
+                            </constraints>
+                            <connections>
+                                <outletCollection property="gestureRecognizers" destination="fxf-y7-eKu" appends="YES" id="I31-pl-am0"/>
+                            </connections>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="eG8-5x-OUi" secondAttribute="trailing" id="1kY-GU-RtS"/>
+                <constraint firstItem="eG8-5x-OUi" firstAttribute="leading" secondItem="A0g-px-xTY" secondAttribute="leading" id="9fE-AE-VCT"/>
+                <constraint firstItem="eG8-5x-OUi" firstAttribute="top" secondItem="A0g-px-xTY" secondAttribute="top" id="XRR-mo-SlV"/>
+                <constraint firstAttribute="bottom" secondItem="eG8-5x-OUi" secondAttribute="bottom" id="fqs-Hs-g9Q"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="138" y="291"/>
+        </view>
     </objects>
     <resources>
         <image name="add-to-list" width="26" height="26"/>

--- a/Wikipedia/Code/ReadingListHintViewController.xib
+++ b/Wikipedia/Code/ReadingListHintViewController.xib
@@ -33,39 +33,42 @@
             </connections>
         </tapGestureRecognizer>
         <view contentMode="scaleToFill" id="A0g-px-xTY">
-            <rect key="frame" x="0.0" y="0.0" width="548" height="108"/>
+            <rect key="frame" x="0.0" y="0.0" width="548" height="112"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="eG8-5x-OUi">
-                    <rect key="frame" x="0.0" y="0.0" width="548" height="108"/>
+                    <rect key="frame" x="0.0" y="12" width="548" height="88"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f2T-xz-pPZ" userLabel="Hint View">
-                            <rect key="frame" x="0.0" y="0.0" width="548" height="52"/>
+                            <rect key="frame" x="0.0" y="0.0" width="548" height="48"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hint default title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ni7-Ic-c9C">
-                                    <rect key="frame" x="50" y="14" width="486" height="24"/>
+                                <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="add-to-list" translatesAutoresizingMaskIntoConstraints="NO" id="ZRK-Wk-NPA">
+                                    <rect key="frame" x="12" y="11" width="26" height="26"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" priority="999" constant="26" id="XBd-aa-skT"/>
+                                        <constraint firstAttribute="width" priority="999" constant="26" id="zx2-am-b8e"/>
+                                    </constraints>
+                                    <viewLayoutGuide key="safeArea" id="SKG-dM-SlL"/>
+                                </imageView>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Hint default title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ni7-Ic-c9C">
+                                    <rect key="frame" x="50" y="14" width="486" height="20.5"/>
                                     <viewLayoutGuide key="safeArea" id="rVu-1p-TMz"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="add-to-list" translatesAutoresizingMaskIntoConstraints="NO" id="ZRK-Wk-NPA">
-                                    <rect key="frame" x="0.0" y="6" width="50" height="40"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" priority="999" constant="40" id="XBd-aa-skT"/>
-                                        <constraint firstAttribute="width" priority="999" constant="50" id="zx2-am-b8e"/>
-                                    </constraints>
-                                    <viewLayoutGuide key="safeArea" id="SKG-dM-SlL"/>
-                                </imageView>
                             </subviews>
                             <gestureRecognizers/>
                             <constraints>
-                                <constraint firstItem="ni7-Ic-c9C" firstAttribute="leading" secondItem="ZRK-Wk-NPA" secondAttribute="trailing" id="D4i-2I-Zom"/>
+                                <constraint firstItem="ZRK-Wk-NPA" firstAttribute="top" relation="greaterThanOrEqual" secondItem="f2T-xz-pPZ" secondAttribute="top" id="0TI-Q7-V1A"/>
+                                <constraint firstItem="ni7-Ic-c9C" firstAttribute="leading" secondItem="ZRK-Wk-NPA" secondAttribute="trailing" constant="12" id="D4i-2I-Zom"/>
+                                <constraint firstItem="ni7-Ic-c9C" firstAttribute="centerY" secondItem="f2T-xz-pPZ" secondAttribute="centerY" id="H3D-Jb-WTk"/>
                                 <constraint firstItem="ZRK-Wk-NPA" firstAttribute="centerY" secondItem="f2T-xz-pPZ" secondAttribute="centerY" id="IdG-Ak-9WV"/>
+                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ZRK-Wk-NPA" secondAttribute="bottom" id="IeE-QG-4Mz"/>
                                 <constraint firstAttribute="trailing" secondItem="ni7-Ic-c9C" secondAttribute="trailing" constant="12" id="fRH-hC-xRw"/>
-                                <constraint firstItem="ni7-Ic-c9C" firstAttribute="top" secondItem="f2T-xz-pPZ" secondAttribute="top" priority="999" constant="14" id="hZH-xJ-hb1"/>
-                                <constraint firstAttribute="bottom" secondItem="ni7-Ic-c9C" secondAttribute="bottom" priority="999" constant="14" id="pvD-um-67m"/>
-                                <constraint firstItem="ZRK-Wk-NPA" firstAttribute="leading" secondItem="f2T-xz-pPZ" secondAttribute="leading" id="y5D-m8-DRj"/>
+                                <constraint firstItem="ni7-Ic-c9C" firstAttribute="top" relation="greaterThanOrEqual" secondItem="f2T-xz-pPZ" secondAttribute="top" id="hZH-xJ-hb1"/>
+                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ni7-Ic-c9C" secondAttribute="bottom" id="pvD-um-67m"/>
+                                <constraint firstItem="ZRK-Wk-NPA" firstAttribute="leading" secondItem="f2T-xz-pPZ" secondAttribute="leading" constant="12" id="y5D-m8-DRj"/>
                             </constraints>
                             <viewLayoutGuide key="safeArea" id="jiA-rv-sie"/>
                             <connections>
@@ -73,10 +76,10 @@
                             </connections>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Mi-lB-pMN" userLabel="Confirmation View">
-                            <rect key="frame" x="0.0" y="52" width="548" height="56"/>
+                            <rect key="frame" x="0.0" y="48" width="548" height="40"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="BjB-ib-pB7">
-                                    <rect key="frame" x="0.0" y="8" width="548" height="40"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="548" height="40"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gqF-Ty-pGy" userLabel="Spacer">
                                             <rect key="frame" x="0.0" y="0.0" width="1" height="40"/>
@@ -94,7 +97,7 @@
                                             </constraints>
                                             <viewLayoutGuide key="safeArea" id="c3R-HI-4dV"/>
                                         </imageView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Confimation default title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9CN-TE-qsp">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Confimation default title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9CN-TE-qsp">
                                             <rect key="frame" x="65" y="0.0" width="431" height="40"/>
                                             <viewLayoutGuide key="safeArea" id="8sy-qs-43Q"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -119,9 +122,9 @@
                             <gestureRecognizers/>
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="BjB-ib-pB7" secondAttribute="trailing" id="2Q8-nj-9g4"/>
-                                <constraint firstAttribute="bottom" secondItem="BjB-ib-pB7" secondAttribute="bottom" priority="999" constant="8" id="jID-Kv-qLw"/>
+                                <constraint firstAttribute="bottom" secondItem="BjB-ib-pB7" secondAttribute="bottom" id="jID-Kv-qLw"/>
                                 <constraint firstItem="BjB-ib-pB7" firstAttribute="leading" secondItem="9Mi-lB-pMN" secondAttribute="leading" id="kVb-xB-XEm"/>
-                                <constraint firstItem="BjB-ib-pB7" firstAttribute="top" secondItem="9Mi-lB-pMN" secondAttribute="top" priority="999" constant="8" id="z4b-bC-5KJ"/>
+                                <constraint firstItem="BjB-ib-pB7" firstAttribute="top" secondItem="9Mi-lB-pMN" secondAttribute="top" id="z4b-bC-5KJ"/>
                             </constraints>
                             <viewLayoutGuide key="safeArea" id="krx-JI-Ofa"/>
                             <connections>
@@ -135,14 +138,14 @@
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstItem="eG8-5x-OUi" firstAttribute="top" secondItem="A0g-px-xTY" secondAttribute="top" id="XRR-mo-SlV"/>
+                <constraint firstItem="eG8-5x-OUi" firstAttribute="top" secondItem="A0g-px-xTY" secondAttribute="top" priority="999" constant="12" id="XRR-mo-SlV"/>
                 <constraint firstItem="RCC-Bl-xSh" firstAttribute="leading" secondItem="eG8-5x-OUi" secondAttribute="leading" id="bne-AT-n4n"/>
-                <constraint firstAttribute="bottom" secondItem="eG8-5x-OUi" secondAttribute="bottom" id="fqs-Hs-g9Q"/>
+                <constraint firstAttribute="bottom" secondItem="eG8-5x-OUi" secondAttribute="bottom" priority="999" constant="12" id="fqs-Hs-g9Q"/>
                 <constraint firstItem="eG8-5x-OUi" firstAttribute="trailing" secondItem="RCC-Bl-xSh" secondAttribute="trailing" id="nPN-D7-ra8"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="RCC-Bl-xSh"/>
-            <point key="canvasLocation" x="138" y="291"/>
+            <point key="canvasLocation" x="138" y="293"/>
         </view>
     </objects>
     <resources>

--- a/Wikipedia/Code/SaveButton.swift
+++ b/Wikipedia/Code/SaveButton.swift
@@ -46,11 +46,15 @@ import UIKit
             }
             let addToReadingListAction = UIAccessibilityCustomAction(name: CommonStrings.addToReadingListActionTitle, target: self, selector: #selector(addToReadingList(_:)))
             accessibilityCustomActions = [addToReadingListAction]
-            UIView.performWithoutAnimation {
-                setTitle(saveTitle, for: .normal)
-                setImage(saveImage, for: .normal)
-                layoutIfNeeded()
-            }
+            setTitle(saveTitle, for: .normal)
+            setImage(saveImage, for: .normal)
+            layoutIfNeeded()
+        }
+    }
+
+    override open func layoutSubviews() {
+        UIView.performWithoutAnimation {
+            super.layoutSubviews()
         }
     }
     

--- a/Wikipedia/Code/ScrollableEducationPanelViewController.swift
+++ b/Wikipedia/Code/ScrollableEducationPanelViewController.swift
@@ -127,7 +127,7 @@ class ScrollableEducationPanelViewController: UIViewController, Themeable {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        assert(stackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint() == nil, "\n\nAll stackview arrangedSubview height constraints need to have a priority of < 1000 so the stackview can collapse the 'cell' if the arrangedSubview's isHidden property is set to true. This arrangedSubview was determined to have a required height: \(String(describing: stackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint())). To fix reduce the priority of its height constraint to < 1000.\n\n")
+        assert(stackView.wmf_firstArrangedSubviewWithRequiredNonZeroHeightConstraint() == nil, stackView.wmf_anArrangedSubviewHasRequiredNonZeroHeightConstraintAssertString())
         
         reset()
         primaryButton.titleLabel?.wmf_configureToAutoAdjustFontSize()

--- a/Wikipedia/Code/WMFArticleNavigationController.m
+++ b/Wikipedia/Code/WMFArticleNavigationController.m
@@ -59,6 +59,11 @@ static const NSTimeInterval WMFArticleNavigationControllerSecondToolbarAnimation
     [self layoutSecondToolbarForViewBounds:self.view.bounds hidden:self.isSecondToolbarHidden animated:YES];
 }
 
+- (void)setReadingListHintHeight:(CGFloat)readingListHintHeight {
+    _readingListHintHeight = readingListHintHeight;
+    [self layoutSecondToolbarForViewBounds:self.view.bounds hidden:self.isSecondToolbarHidden animated:YES];
+}
+
 #pragma mark - Layout
 
 - (void)viewDidLayoutSubviews {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T191855

- expand vertically if string is long for both hint and confirmation views
- play nice with random button
- play nice with rotation

# Before #
<img width="431" alt="screen shot 2018-04-12 at 6 11 58 pm" src="https://user-images.githubusercontent.com/3143487/38711860-122d118c-3e7d-11e8-9f12-e290e9984a26.png">
<img width="723" alt="screen shot 2018-04-12 at 6 12 03 pm" src="https://user-images.githubusercontent.com/3143487/38711861-12444456-3e7d-11e8-8481-bf7d33c7cf48.png">


# After #
<img width="431" alt="screen shot 2018-04-12 at 6 08 01 pm" src="https://user-images.githubusercontent.com/3143487/38711843-ece4be7a-3e7c-11e8-9831-b90b4f210328.png">
<img width="723" alt="screen shot 2018-04-12 at 6 08 45 pm" src="https://user-images.githubusercontent.com/3143487/38711844-ecfb375e-3e7c-11e8-9b26-e99dfea5fd22.png">




