### PR TITLE
Fix first "Edit" tap for empty reading lists

### DIFF
--- a/Wikipedia/Code/ReadingListDetailViewController.swift
+++ b/Wikipedia/Code/ReadingListDetailViewController.swift
@@ -435,6 +435,8 @@ extension ReadingListDetailViewController: CollectionViewEditControllerNavigatio
         }
         
         switch newEditingState {
+        case .editing:
+            fallthrough
         case .open where isEmpty:
             readingListDetailUnderBarViewController.beginEditing()
         case .done:


### PR DESCRIPTION
Without it, tapping on "Edit" inside an empty reading list won't make the title text field become first responder

Repro steps

1. Create an empty reading list
2. Go to the detail view
3. Tap "Edit"

Expected
Title text field becomes first responder, editing begins

Actual
Title text field doesn't become first responder