### PR TITLE
Add a new error case so that we can identify readinglists-db-error-cannot-update-default-list errors

### DIFF
--- a/WMF Framework/ReadingListsAPIController.swift
+++ b/WMF Framework/ReadingListsAPIController.swift
@@ -11,6 +11,7 @@ public enum APIReadingListError: String, Error, Equatable {
     case duplicateEntry = "readinglists-db-error-duplicate-page"
     case needsFullSync = "readinglists-client-error-needs-full-sync"
     case listDeleted = "readinglists-db-error-list-deleted"
+    case defaultListCannotBeUpdated = "readinglists-db-error-cannot-update-default-list"
     
     public var localizedDescription: String {
         switch self {


### PR DESCRIPTION
Related to https://phabricator.wikimedia.org/T192284