### PR TITLE
Popover panel close button alignment when device lang is RTL

### DIFF
--- a/Wikipedia/Code/ScrollableEducationPanelView.xib
+++ b/Wikipedia/Code/ScrollableEducationPanelView.xib
@@ -50,7 +50,7 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="zdf-Q2-cLc">
                                             <rect key="frame" x="15" y="16" width="250" height="420.5"/>
                                             <subviews>
-                                                <button opaque="NO" tag="1" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BAe-h0-y6b">
+                                                <button opaque="NO" tag="1" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BAe-h0-y6b">
                                                     <rect key="frame" x="0.0" y="0.0" width="250" height="15"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" priority="999" constant="15" id="Zfm-Kv-h00"/>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T192420

# Before 
<img width="431" alt="screen shot 2018-04-17 at 5 08 00 pm" src="https://user-images.githubusercontent.com/3143487/38904904-f65055e4-4261-11e8-9253-6b51605bca6a.png">

# After
<img width="431" alt="screen shot 2018-04-17 at 5 05 43 pm" src="https://user-images.githubusercontent.com/3143487/38904854-a6441c0c-4261-11e8-83e5-7164a5b305b6.png">