### PR TITLE
Fix breaking constraints in detail reading list view

### DIFF
--- a/Wikipedia/Code/ReadingListDetailUnderBarViewController.swift
+++ b/Wikipedia/Code/ReadingListDetailUnderBarViewController.swift
@@ -127,6 +127,7 @@ class ReadingListDetailUnderBarViewController: UIViewController {
     
     private var isAlertViewHidden: Bool = true {
         didSet {
+            alertStackView?.spacing = isAlertViewHidden ? 0 : 7
             alertStackView?.isHidden = isAlertViewHidden
         }
     }


### PR DESCRIPTION
On devices running iOS 10, in reading list detail view, we're unable to satisfy some constraints (see `Unable to simultaneously satisfy constraints` message in the debugger)