### PR TITLE
Fix swipe for RTL saved and history cells.

### DIFF
--- a/Wikipedia/Code/ArticleCollectionViewCell.swift
+++ b/Wikipedia/Code/ArticleCollectionViewCell.swift
@@ -310,8 +310,14 @@ open class ArticleCollectionViewCell: CollectionViewCell, SwipeableCell, BatchEd
     public var swipeTranslation: CGFloat = 0 {
         didSet {
             assert(!swipeTranslation.isNaN && swipeTranslation.isFinite)
-            layoutMarginsAdditions.right = 0 - swipeTranslation
-            layoutMarginsAdditions.left = swipeTranslation
+            let isArticleRTL = articleSemanticContentAttribute == .forceRightToLeft
+            if isArticleRTL {
+                layoutMarginsAdditions.left = 0 - swipeTranslation
+                layoutMarginsAdditions.right = swipeTranslation
+            } else {
+                layoutMarginsAdditions.right = 0 - swipeTranslation
+                layoutMarginsAdditions.left = swipeTranslation
+            }
             setNeedsLayout()
         }
     }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T192406

I checked my fix on iOS 10.3.1 and 11.2 and both EN and HE as device langs with EN and HE article cells.