### PR TITLE
Fix collection was mutated while being enumerated crash

### DIFF
--- a/WMF Framework/NSManagedObjectContext+WMFKeyValue.m
+++ b/WMF Framework/NSManagedObjectContext+WMFKeyValue.m
@@ -45,7 +45,8 @@
     if (results.count > 1) {
         // failsafe to delete extra key value objects
         NSArray<WMFKeyValue *> *subarray = [results subarrayWithRange:NSMakeRange(1, results.count - 1)];
-        for (WMFKeyValue *value in subarray) {
+        NSArray<WMFKeyValue *> *subarrayCopy = [subarray copy];
+        for (WMFKeyValue *value in subarrayCopy) {
             [self deleteObject:value];
         }
     }


### PR DESCRIPTION
https://rink.hockeyapp.net/manage/apps/152731/app_versions/558/crash_reasons/216678437

https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/Collections/Articles/Enumerators.html
> The enumerator raises an exception if you modify the collection while enumerating.