### PR TITLE
Do not make sync fail if API returns readinglists-db-error-already-set-up

### DIFF
--- a/WMF Framework/CSRFTokenOperation.swift
+++ b/WMF Framework/CSRFTokenOperation.swift
@@ -51,7 +51,7 @@ class CSRFTokenOperation: AsyncOperation {
         }
         tokenFetcher.fetchToken(ofType: .csrf, siteURL: siteURL, success: { (token) in
             self.session.jsonDictionaryTask(host: self.host, method: self.method, path: self.path, queryParameters: ["csrf_token": token.token], bodyParameters: self.bodyParameters) { (result , response, error) in
-                if let apiErrorType = result?["title"] as? String, let apiError = APIReadingListError(rawValue: apiErrorType) {
+                if let apiErrorType = result?["title"] as? String, let apiError = APIReadingListError(rawValue: apiErrorType), apiError != .alreadySetUp {
                     DDLogDebug("RLAPI FAILED: \(self.method.stringValue) \(self.path) \(apiError)")
                     self.completion?(result, nil, apiError)
                 } else {


### PR DESCRIPTION
If the reading lists API returns a `APIReadingListError` that we handle (i.e., it's one of the cases of `enum APIReadingListError`), sync fails (line `56` in `CSRFTokenOperation`). We used to ignore some of the errors to let sync continue (all the errors added in #2243 used to be ignored).

If we don't ignore `readinglists-db-error-already-set-up` error, sync will fail every time user logs in to an account that has sync enabled (see line `218` in `ReadingListsSyncOperation`).

We can either ignore `readinglists-db-error-already-set-up` by removing it from `APIReadingListError` or  flag it (what this PR is doing right now).