### PR TITLE
Keep event logging rate at 1 for WMFSearchFunnel

### DIFF
--- a/Wikipedia/Code/WMFSearchFunnel.m
+++ b/Wikipedia/Code/WMFSearchFunnel.m
@@ -19,9 +19,6 @@ static NSString *const kSearchResultsCount = @"numberOfResults";
 
 - (instancetype)init {
     self = [super initWithSchema:kSchemaName version:kSchemaVersion];
-    if (self) {
-        self.rate = 100;
-    }
     return self;
 }
 


### PR DESCRIPTION
Keeping the rate for `WMFSearchFunnel` at 1 (child subclasses will get the rate from parent - https://github.com/wikimedia/wikipedia-ios/blob/2c59a14e4ffd07fab54ca6a4ac4794bf292bc84c/Wikipedia/Code/EventLoggingFunnel.m#L14) as requested by Chelsy. 