### PR TITLE
Adjust appInstallID for old revisions

### DIFF
--- a/Wikipedia/Code/CreateAccountFunnel.m
+++ b/Wikipedia/Code/CreateAccountFunnel.m
@@ -8,6 +8,7 @@
                         version:8240702];
     if (self) {
         self.createAccountSessionToken = [self singleUseUUID];
+        self.requiresAppInstallID = NO;
     }
     return self;
 }

--- a/Wikipedia/Code/EditFunnel.m
+++ b/Wikipedia/Code/EditFunnel.m
@@ -8,6 +8,7 @@
     self = [super initWithSchema:@"MobileWikiAppEdit" version:9003125];
     if (self) {
         self.editSessionToken = [self singleUseUUID];
+        self.requiresAppInstallID = NO;
     }
     self.userId = userId;
     return self;

--- a/Wikipedia/Code/EventLoggingFunnel.h
+++ b/Wikipedia/Code/EventLoggingFunnel.h
@@ -21,6 +21,7 @@ typedef NS_ENUM(NSUInteger, WMFEventLoggingMaxStringLength) {
 
 @property (nonatomic, strong) NSString *schema;
 @property (nonatomic, assign) int revision;
+@property (nonatomic, assign) BOOL requiresAppInstallID;
 
 /**
  *  Sampling rate used to calculate sampling ratio.

--- a/Wikipedia/Code/EventLoggingFunnel.m
+++ b/Wikipedia/Code/EventLoggingFunnel.m
@@ -12,6 +12,7 @@ static NSString *const kAppInstallIdKey = @"appInstallID";
         self.schema = schema;
         self.revision = revision;
         self.rate = 1;
+        self.requiresAppInstallID = YES;
     }
     return self;
 }
@@ -36,7 +37,9 @@ static NSString *const kAppInstallIdKey = @"appInstallID";
         }
         if (chosen) {
             NSMutableDictionary *preprocessedEventData = [[self preprocessData:eventData] mutableCopy];
-            preprocessedEventData[kAppInstallIdKey] = [self wmf_appInstallID];
+            if (self.requiresAppInstallID) {
+                preprocessedEventData[kAppInstallIdKey] = [self wmf_appInstallID];
+            }
             (void)[[EventLogger alloc] initAndLogEvent:preprocessedEventData
                                              forSchema:self.schema
                                               revision:self.revision

--- a/Wikipedia/Code/LoginFunnel.m
+++ b/Wikipedia/Code/LoginFunnel.m
@@ -8,6 +8,7 @@
                         version:8234533];
     if (self) {
         self.loginSessionToken = [self singleUseUUID];
+        self.requiresAppInstallID = NO;
     }
     return self;
 }

--- a/Wikipedia/Code/ProtectedEditAttemptFunnel.m
+++ b/Wikipedia/Code/ProtectedEditAttemptFunnel.m
@@ -6,6 +6,9 @@
     // https://meta.wikimedia.org/wiki/Schema:MobileWikiAppProtectedEditAttempt
     self = [super initWithSchema:@"MobileWikiAppProtectedEditAttempt"
                          version:8682497];
+    if (self) {
+        self.requiresAppInstallID = NO;
+    }
     return self;
 }
 


### PR DESCRIPTION
The revisions we're using for all event logging schemas are old and not all of them require `appInstallID`. We should get a confirmation from @chelsyx before pulling this in.

Revisions that don't require `appInstallID`:

1.  https://meta.wikimedia.org/w/index.php?title=Schema:MobileWikiAppCreateAccount&oldid=8240702
2. https://meta.wikimedia.org/w/index.php?title=Schema:MobileWikiAppEdit&oldid=9003125
3. https://meta.wikimedia.org/w/index.php?title=Schema:MobileWikiAppLogin&oldid=8234533
4. https://meta.wikimedia.org/w/index.php?title=Schema:MobileWikiAppProtectedEditAttempt&oldid=8682497

Revisions that require `appInstallID`:

1. https://meta.wikimedia.org/w/index.php?title=Schema:MobileWikiAppDailyStats&oldid=12637385
2. https://meta.wikimedia.org/w/index.php?title=Schema:MobileWikiAppToCInteraction&oldid=10375484
3. https://meta.wikimedia.org/w/index.php?title=Schema:MobileWikiAppNavMenu&oldid=12732211
4. https://meta.wikimedia.org/w/index.php?title=Schema:MobileWikiAppArticleSuggestions&oldid=10590869
5. https://meta.wikimedia.org/w/index.php?title=Schema:MobileWikiAppSearch&oldid=10641988
6. https://meta.wikimedia.org/w/index.php?title=Schema:MobileWikiAppShareAFact&oldid=11331974
7. https://meta.wikimedia.org/w/index.php?title=Schema:MobileWikiAppSavedPages&oldid=10375480

All new revisions require `appInstallID` but given that we're nearing a release, this seems like the most minimal change. Adopting new revisions would require adding more properties.