### PR TITLE
Add a field to MobileWikiAppDailyStats to identify whether a user is logged in, and a client side timestamp

### DIFF
--- a/Wikipedia/Code/WMFDailyStatsLoggingFunnel.m
+++ b/Wikipedia/Code/WMFDailyStatsLoggingFunnel.m
@@ -4,6 +4,8 @@
 
 static NSString *const kAppInstallIdKey = @"appInstallID";
 static NSString *const kAppInstallAgeKey = @"appInstallAgeDays";
+static NSString *const kTimestampKey = @"ts";
+static NSString *const kIsAnonKey = @"is_anon";
 
 @implementation WMFDailyStatsLoggingFunnel
 
@@ -18,7 +20,7 @@ static NSString *const kAppInstallAgeKey = @"appInstallAgeDays";
 
 - (instancetype)init {
     // https://meta.wikimedia.org/wiki/Schema:MobileWikiAppDailyStats
-    self = [super initWithSchema:@"MobileWikiAppDailyStats" version:12637385];
+    self = [super initWithSchema:@"MobileWikiAppDailyStats" version:17984412];
     return self;
 }
 

--- a/Wikipedia/Code/WMFDailyStatsLoggingFunnel.m
+++ b/Wikipedia/Code/WMFDailyStatsLoggingFunnel.m
@@ -51,6 +51,9 @@ static NSString *const kIsAnonKey = @"is_anon";
 - (NSDictionary *)preprocessData:(NSDictionary *)eventData {
     NSMutableDictionary *dict = [eventData mutableCopy];
     dict[kAppInstallIdKey] = [self wmf_appInstallID];
+    BOOL isAnonymous = ![WMFAuthenticationManager sharedInstance].isLoggedIn;
+    dict[kIsAnonKey] = [NSNumber numberWithBool:isAnonymous];
+    dict[kTimestampKey] = [[NSDateFormatter wmf_iso8601Formatter] stringFromDate:[NSDate date]];
     return [NSDictionary dictionaryWithDictionary:dict];
 }
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T193370

Branched off #2303, should be merged after #2303.

Relevant commits: https://github.com/wikimedia/wikipedia-ios/commit/a3d559439c55d04de4a46a472083d0fdc004f357 and https://github.com/wikimedia/wikipedia-ios/commit/b75b85e2bb070a58f0fb4a921a208c410c5da59e