### PR TITLE
Reading lists event logging follow-up

### DIFF
--- a/WMF Framework/EventLoggingStandardEventProviding+EventLoggingEventValuesProviding+EventLoggingCategory+EventLoggingLabel.swift
+++ b/WMF Framework/EventLoggingStandardEventProviding+EventLoggingEventValuesProviding+EventLoggingCategory+EventLoggingLabel.swift
@@ -87,6 +87,7 @@ public extension EventLoggingStandardEventProviding where Self: EventLoggingFunn
     case login
     case syncArticle
     case location
+    case mainPage
     case none
     
     public var value: String? {
@@ -125,6 +126,8 @@ public extension EventLoggingStandardEventProviding where Self: EventLoggingFunn
             return "sync_article" // Article storage and syncing settings screen
         case .location:
             return "location"
+        case .mainPage:
+            return "main_page"
         case .none:
             return nil
         }

--- a/WMF Framework/EventLoggingStandardEventProviding+EventLoggingEventValuesProviding+EventLoggingCategory+EventLoggingLabel.swift
+++ b/WMF Framework/EventLoggingStandardEventProviding+EventLoggingEventValuesProviding+EventLoggingCategory+EventLoggingLabel.swift
@@ -1,6 +1,6 @@
-public protocol EventLoggingEventValuesProviding {
+@objc public protocol EventLoggingEventValuesProviding {
     var eventLoggingCategory: EventLoggingCategory { get }
-    var eventLoggingLabel: EventLoggingLabel? { get }
+    var eventLoggingLabel: EventLoggingLabel { get }
 }
 
 public protocol EventLoggingStandardEventProviding {
@@ -24,38 +24,109 @@ public extension EventLoggingStandardEventProviding where Self: EventLoggingFunn
     }
 }
 
-public enum EventLoggingCategory: String {
+@objc public enum EventLoggingCategory: Int {
     case feed
     case history
     case places
     case article
     case search
-    case addToList = "add_to_list"
+    case addToList
     case saved
     case login
     case setting
-    case loginToSyncPopover = "login_to_sync_popover"
-    case enableSyncPopover = "enable_sync_popover"
+    case loginToSyncPopover
+    case enableSyncPopover
     case unknown
+    
+    public var value: String {
+        switch self {
+        case .feed:
+            return "feed"
+        case .history:
+            return "history"
+        case .places:
+            return "places"
+        case .article:
+            return "article"
+        case .search:
+            return "search"
+        case .addToList:
+            return "add_to_list"
+        case .saved:
+            return "saved"
+        case .login:
+            return "login"
+        case .setting:
+            return "setting"
+        case .loginToSyncPopover:
+            return "login_to_sync_popover"
+        case .enableSyncPopover:
+            return "enable_sync_popover"
+        case .unknown:
+            return "unknown"
+        }
+    }
 }
 
 
-public enum EventLoggingLabel: String {
-    case featuredArticle = "featured_article"
-    case topRead = "top_read"
-    case onThisDay = "on_this_day"
-    case readMore = "read_more"
+@objc public enum EventLoggingLabel: Int {
+    case featuredArticle
+    case topRead
+    case onThisDay
+    case readMore
     case random
     case news
-    case relatedPages = "related_pages" // because you read
-    case articleList = "article_list"
-    case outLink = "out_link"
-    case similarPage = "similar_page"
+    case relatedPages
+    case articleList
+    case outLink
+    case similarPage
     case items
     case lists
-    case current = "default" // refers to the current article the user is reading, default is a reserved word
-    case syncEducation = "sync_education"
+    case current
+    case syncEducation
     case login
-    case syncArticle = "sync_article" // Article storage and syncing settings screen
+    case syncArticle
     case location
+    case none
+    
+    public var value: String? {
+        switch self {
+        case .featuredArticle:
+            return "featured_article"
+        case .topRead:
+            return "top_read"
+        case .onThisDay:
+            return "on_this_day"
+        case .readMore:
+            return "read_more"
+        case .random:
+            return "random"
+        case .news:
+            return "news"
+        case .relatedPages:
+            return "related_pages" // because you read
+        case .articleList:
+            return "article_list"
+        case .outLink:
+            return "out_link"
+        case .similarPage:
+            return "similar_page"
+        case .items:
+            return "items"
+        case .lists:
+            return "lists"
+        case .current:
+            return "default" // refers to the current article the user is reading, default is a reserved word
+        case .syncEducation:
+            return "sync_education"
+        case .login:
+            return "login"
+        case .syncArticle:
+            return "sync_article" // Article storage and syncing settings screen
+        case .location:
+            return "location"
+        case .none:
+            return nil
+        }
+    }
 }

--- a/WMF Framework/WMFContentGroup+EventLogging.swift
+++ b/WMF Framework/WMFContentGroup+EventLogging.swift
@@ -1,5 +1,5 @@
-public extension WMFContentGroup {
-    public var eventLoggingLabel: EventLoggingLabel? {
+@objc public extension WMFContentGroup {
+    public var eventLoggingLabel: EventLoggingLabel {
         switch contentGroupKind {
         case .featuredArticle:
             return .featuredArticle
@@ -18,12 +18,8 @@ public extension WMFContentGroup {
         case .location:
             return .location
         default:
-            return nil
+            return .none
         }
-    }
-    
-    @objc public var eventLoggingLabelRawValue: String? {
-        return eventLoggingLabel?.rawValue
     }
 }
 

--- a/WMF Framework/WMFContentGroup+EventLogging.swift
+++ b/WMF Framework/WMFContentGroup+EventLogging.swift
@@ -17,6 +17,8 @@
             fallthrough
         case .location:
             return .location
+        case .mainPage:
+            return .mainPage
         default:
             return .none
         }

--- a/Wikipedia/Code/AddArticlesToReadingListViewController.swift
+++ b/Wikipedia/Code/AddArticlesToReadingListViewController.swift
@@ -29,6 +29,8 @@ class AddArticlesToReadingListViewController: UIViewController {
     private var readingListsViewController: ReadingListsViewController?
     @IBOutlet weak var containerView: UIView!
     public weak var delegate: AddArticlesToReadingListDelegate?
+    
+    @objc var eventLogAction: (() -> Void)?
 
     private var theme: Theme
     
@@ -86,6 +88,7 @@ extension AddArticlesToReadingListViewController: ReadingListsViewControllerDele
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) {
             self.dismiss(animated: true, completion: nil)
         }
+        eventLogAction?()
     }
 }
 

--- a/Wikipedia/Code/AppDelegate.m
+++ b/Wikipedia/Code/AppDelegate.m
@@ -90,6 +90,7 @@ static NSTimeInterval const WMFBackgroundFetchInterval = 10800; // 3 Hours
     NSDate *appInstallDate = [[NSUserDefaults wmf_userDefaults] wmf_appInstallDate];
     if (!appInstallDate) {
         [[KeychainCredentialsManager shared] resetAppInstallID];
+        [[KeychainCredentialsManager shared] resetLastLoggedUserHistorySnapshot];
     }
     [[NSUserDefaults wmf_userDefaults] wmf_setAppInstallDateIfNil:[NSDate date]];
 

--- a/Wikipedia/Code/ArticleCollectionViewController.swift
+++ b/Wikipedia/Code/ArticleCollectionViewController.swift
@@ -85,8 +85,8 @@ class ArticleCollectionViewController: ColumnarCollectionViewController, Reading
         return .unknown
     }
     
-    var eventLoggingLabel: EventLoggingLabel? {
-        return nil
+    var eventLoggingLabel: EventLoggingLabel {
+        return .none
     }
 }
 

--- a/Wikipedia/Code/ArticleLocationCollectionViewController.swift
+++ b/Wikipedia/Code/ArticleLocationCollectionViewController.swift
@@ -160,7 +160,7 @@ extension ArticleLocationCollectionViewController: EventLoggingEventValuesProvid
         return .places
     }
     
-    var eventLoggingLabel: EventLoggingLabel? {
-        return nil
+    var eventLoggingLabel: EventLoggingLabel {
+        return .none
     }
 }

--- a/Wikipedia/Code/ArticleURLListViewController.swift
+++ b/Wikipedia/Code/ArticleURLListViewController.swift
@@ -21,7 +21,7 @@ class ArticleURLListViewController: ArticleCollectionViewController {
     }
     
     override func article(at indexPath: IndexPath) -> WMFArticle? {
-        return dataStore.fetchArticle(with: articleURL(at: indexPath))
+        return dataStore.fetchOrCreateArticle(with: articleURL(at: indexPath))
     }
     
     override func viewDidLoad() {

--- a/Wikipedia/Code/ArticleURLListViewController.swift
+++ b/Wikipedia/Code/ArticleURLListViewController.swift
@@ -42,8 +42,8 @@ class ArticleURLListViewController: ArticleCollectionViewController {
         return .feed
     }
     
-    override var eventLoggingLabel: EventLoggingLabel? {
-        return contentGroup?.eventLoggingLabel
+    override var eventLoggingLabel: EventLoggingLabel {
+        return contentGroup?.eventLoggingLabel ?? .none
     }
 }
 

--- a/Wikipedia/Code/DisambiguationPagesViewController.swift
+++ b/Wikipedia/Code/DisambiguationPagesViewController.swift
@@ -71,4 +71,12 @@ class DisambiguationPagesViewController: ArticleURLListViewController {
     override var analyticsName: String {
         return "Disambiguation"
     }
+    
+    override var eventLoggingLabel: EventLoggingLabel {
+        return .similarPage
+    }
+    
+    override var eventLoggingCategory: EventLoggingCategory {
+        return .article
+    }
 }

--- a/Wikipedia/Code/KeychainCredentialsManager.swift
+++ b/Wikipedia/Code/KeychainCredentialsManager.swift
@@ -50,4 +50,8 @@ public class KeychainCredentialsManager: NSObject {
             keychainCredentials.lastLoggedUserHistorySnapshot = newValue
         }
     }
+    
+    @objc func resetLastLoggedUserHistorySnapshot() {
+        lastLoggedUserHistorySnapshot = nil
+    }
 }

--- a/Wikipedia/Code/LoginFunnel.swift
+++ b/Wikipedia/Code/LoginFunnel.swift
@@ -4,7 +4,7 @@
     @objc public static let shared = LoginFunnel()
     
     private override init() {
-        super.init(schema: "MobileWikiAppiOSLoginAction", version: 17990227)
+        super.init(schema: "MobileWikiAppiOSLoginAction", version: 18064101)
     }
     
     private enum Action: String {
@@ -27,7 +27,7 @@
             event["label"] = labelValue
         }
         if let measure = measure {
-            event["measure"] = measure
+            event["measure"] = Int(measure)
         }
         return event
     }

--- a/Wikipedia/Code/LoginFunnel.swift
+++ b/Wikipedia/Code/LoginFunnel.swift
@@ -17,14 +17,14 @@
     }
     
     private func event(category: EventLoggingCategory, label: EventLoggingLabel?, action: Action, measure: Double? = nil) -> Dictionary<String, Any> {
-        let category = category.rawValue
+        let category = category.value
         let action = action.rawValue
         let isAnon = !WMFAuthenticationManager.sharedInstance.isLoggedIn
         let primaryLanguage = MWKLanguageLinkController.sharedInstance().appLanguage?.languageCode ?? "en"
         
         var event: [String: Any] = ["category": category, "action": action, "primary_language": primaryLanguage, "is_anon": isAnon]
-        if let label = label {
-            event["label"] = label.rawValue
+        if let labelValue = label?.value {
+            event["label"] = labelValue
         }
         if let measure = measure {
             event["measure"] = measure

--- a/Wikipedia/Code/NewsViewController.swift
+++ b/Wikipedia/Code/NewsViewController.swift
@@ -158,7 +158,7 @@ extension NewsViewController: EventLoggingEventValuesProviding {
         return .feed
     }
     
-    var eventLoggingLabel: EventLoggingLabel? {
+    var eventLoggingLabel: EventLoggingLabel {
         return .news
     }
 }

--- a/Wikipedia/Code/OnThisDayViewController.swift
+++ b/Wikipedia/Code/OnThisDayViewController.swift
@@ -209,7 +209,7 @@ extension OnThisDayViewController: EventLoggingEventValuesProviding {
         return .feed
     }
     
-    var eventLoggingLabel: EventLoggingLabel? {
+    var eventLoggingLabel: EventLoggingLabel {
         return .onThisDay
     }
 }

--- a/Wikipedia/Code/ReadingListDetailViewController.swift
+++ b/Wikipedia/Code/ReadingListDetailViewController.swift
@@ -363,8 +363,11 @@ extension ReadingListDetailViewController: ActionDelegate {
         do {
             try dataStore.readingListsController.remove(entries: entries)
             let entriesCount = entries.count
-            ReadingListsFunnel.shared.logUnsaveInReadingList(articlesCount: entriesCount)
             UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, CommonStrings.articleDeletedNotification(articleCount: entriesCount))
+            guard readingList.isDefault else {
+                return
+            }
+            ReadingListsFunnel.shared.logUnsaveInReadingList(articlesCount: entriesCount)
         } catch let err {
             DDLogError("Error removing entries from a reading list: \(err)")
         }

--- a/Wikipedia/Code/ReadingListsController.swift
+++ b/Wikipedia/Code/ReadingListsController.swift
@@ -759,7 +759,7 @@ public extension NSManagedObjectContext {
     func allSavedArticlesCount() throws -> Int {
         assert(Thread.isMainThread)
         let request: NSFetchRequest<ReadingListEntry> = ReadingListEntry.fetchRequest()
-        request.predicate = NSPredicate(format: "isDeletedLocally == NO")
+        request.predicate = NSPredicate(format: "isDeletedLocally == NO && list.isDefault == YES")
         return try self.count(for: request)
     }
 }

--- a/Wikipedia/Code/ReadingListsFunnel.swift
+++ b/Wikipedia/Code/ReadingListsFunnel.swift
@@ -43,6 +43,14 @@
         logUnsave(category: .article, label: .current)
     }
     
+    @objc public func logOutLinkSaveInCurrentArticle() {
+        logSave(category: .article, label: .outLink)
+    }
+    
+    @objc public func logOutLinkUnsaveInCurrentArticle() {
+        logUnsave(category: .article, label: .outLink)
+    }
+    
     // - MARK: Read more
     
     @objc public func logArticleSaveInReadMore() {

--- a/Wikipedia/Code/ReadingListsFunnel.swift
+++ b/Wikipedia/Code/ReadingListsFunnel.swift
@@ -16,15 +16,15 @@
     }
     
     private func event(category: EventLoggingCategory, label: EventLoggingLabel?, action: Action, measure: Int = 1) -> Dictionary<String, Any> {
-        let category = category.rawValue
+        let category = category.value
         let action = action.rawValue
         let measure = Double(measure)
         let isAnon = !WMFAuthenticationManager.sharedInstance.isLoggedIn
         let primaryLanguage = MWKLanguageLinkController.sharedInstance().appLanguage?.languageCode ?? "en"
         
         var event: [String: Any] = ["category": category, "action": action, "measure": measure, "primary_language": primaryLanguage, "is_anon": isAnon]
-        if let label = label {
-            event["label"] = label.rawValue
+        if let labelValue = label?.value {
+            event["label"] = labelValue
         }
         return event
     }
@@ -84,6 +84,10 @@
     // - MARK: Generic article save & unsave actions
     
     public func logSave(category: EventLoggingCategory, label: EventLoggingLabel? = nil, measure: Int = 1) {
+        log(event(category: category, label: label, action: .save, measure: measure))
+    }
+    
+    @objc public func logSave(category: EventLoggingCategory, label: EventLoggingLabel, measure: Int = 1) {
         log(event(category: category, label: label, action: .save, measure: measure))
     }
     

--- a/Wikipedia/Code/ReadingListsFunnel.swift
+++ b/Wikipedia/Code/ReadingListsFunnel.swift
@@ -12,13 +12,12 @@
     }
     
     private override init() {
-        super.init(schema: "MobileWikiAppiOSReadingLists", version: 18047424)
+        super.init(schema: "MobileWikiAppiOSReadingLists", version: 18064062)
     }
     
     private func event(category: EventLoggingCategory, label: EventLoggingLabel?, action: Action, measure: Int = 1) -> Dictionary<String, Any> {
         let category = category.value
         let action = action.rawValue
-        let measure = Double(measure)
         let isAnon = !WMFAuthenticationManager.sharedInstance.isLoggedIn
         let primaryLanguage = MWKLanguageLinkController.sharedInstance().appLanguage?.languageCode ?? "en"
         

--- a/Wikipedia/Code/SaveButton.swift
+++ b/Wikipedia/Code/SaveButton.swift
@@ -20,7 +20,7 @@ import UIKit
     public var analyticsContext = "unknown"
     public var analyticsContentType = "unknown"
     
-    public var eventLoggingLabel: EventLoggingLabel? = nil
+    public var eventLoggingLabel: EventLoggingLabel = .none
     public var eventLoggingCategory: EventLoggingCategory = .feed
     
     public var saveButtonState: SaveButton.State = .shortSave {
@@ -83,9 +83,5 @@ import UIKit
             return
         }
         saveButtonDelegate?.saveButtonDidReceiveLongPress(self)
-    }
-    
-    @objc public func setEventLoggingLabel(rawValue: String) {
-        eventLoggingLabel = EventLoggingLabel(rawValue: rawValue)
     }
 }

--- a/Wikipedia/Code/SessionsFunnel.swift
+++ b/Wikipedia/Code/SessionsFunnel.swift
@@ -13,15 +13,15 @@
     }
     
     private func event(category: EventLoggingCategory, label: EventLoggingLabel?, action: Action, measure: Double? = nil) -> Dictionary<String, Any> {
-        let category = category.rawValue
+        let category = category.value
         let action = action.rawValue
         let isAnon = !WMFAuthenticationManager.sharedInstance.isLoggedIn
         let primaryLanguage = MWKLanguageLinkController.sharedInstance().appLanguage?.languageCode ?? "en"
         
         var event: [String: Any] = ["category": category, "action": action, "primary_language": primaryLanguage, "is_anon": isAnon]
         
-        if let label = label {
-            event["label"] = label.rawValue
+        if let labelValue = label?.value {
+            event["label"] = labelValue
         }
         if let measure = measure {
             event["measure"] = measure

--- a/Wikipedia/Code/SessionsFunnel.swift
+++ b/Wikipedia/Code/SessionsFunnel.swift
@@ -4,7 +4,7 @@
     @objc public static let shared = SessionsFunnel()
     
     private override init() {
-        super.init(schema: "MobileWikiAppiOSSessions", version: 18050320)
+        super.init(schema: "MobileWikiAppiOSSessions", version: 18064102)
     }
     
     private enum Action: String {
@@ -24,7 +24,7 @@
             event["label"] = labelValue
         }
         if let measure = measure {
-            event["measure"] = measure
+            event["measure"] = Int(measure)
         }
         
         return event

--- a/Wikipedia/Code/SettingsFunnel.swift
+++ b/Wikipedia/Code/SettingsFunnel.swift
@@ -14,14 +14,14 @@ class SettingsFunnel: EventLoggingFunnel, EventLoggingStandardEventProviding {
     }
     
     private func event(category: EventLoggingCategory, label: EventLoggingLabel?, action: Action) -> Dictionary<String, Any> {
-        let category = category.rawValue
+        let category = category.value
         let action = action.rawValue
         let isAnon = !WMFAuthenticationManager.sharedInstance.isLoggedIn
         let primaryLanguage = MWKLanguageLinkController.sharedInstance().appLanguage?.languageCode ?? "en"
         
         var event: [String: Any] = ["category": category, "action": action, "primary_language": primaryLanguage, "is_anon": isAnon]
-        if let label = label {
-            event["label"] = label.rawValue
+        if let labelValue = label?.value {
+            event["label"] = labelValue
         }
         return event
     }

--- a/Wikipedia/Code/SettingsFunnel.swift
+++ b/Wikipedia/Code/SettingsFunnel.swift
@@ -10,7 +10,7 @@ class SettingsFunnel: EventLoggingFunnel, EventLoggingStandardEventProviding {
     }
     
     private override init() {
-        super.init(schema: "MobileWikiAppiOSSettingAction", version: 17990226)
+        super.init(schema: "MobileWikiAppiOSSettingAction", version: 18064085)
     }
     
     private func event(category: EventLoggingCategory, label: EventLoggingLabel?, action: Action) -> Dictionary<String, Any> {

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1934,9 +1934,9 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 - (void)saveArticlePreviewActionSelectedWithArticleController:(nonnull WMFArticleViewController *)articleController didSave:(BOOL)didSave articleURL:(nonnull NSURL *)articleURL {
     [self.readingListHintController didSave:didSave articleURL:articleURL theme:self.theme];
     if (didSave) {
-        [[ReadingListsFunnel shared] logArticleSaveInCurrentArticle];
+        [[ReadingListsFunnel shared] logOutLinkSaveInCurrentArticle];
     } else {
-        [[ReadingListsFunnel shared] logArticleUnsaveInCurrentArticle];
+        [[ReadingListsFunnel shared] logOutLinkUnsaveInCurrentArticle];
     }
 }
 

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1250,7 +1250,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
             }
             return;
         } else {
-            UIActivityViewController *vc = [self.article sharingActivityViewControllerWithTextSnippet:nil fromButton:self->_shareToolbarItem shareFunnel:self.shareFunnel customActivity:[self addToReadingListActivity]];
+            UIActivityViewController *vc = [self.article sharingActivityViewControllerWithTextSnippet:nil fromButton:self->_shareToolbarItem shareFunnel:self.shareFunnel customActivity:[self addToReadingListActivityWithPresenter:self]];
             vc.excludedActivityTypes = @[UIActivityTypeAddToReadingList];
             if (vc) {
                 [self presentViewController:vc animated:YES completion:NULL];
@@ -1259,7 +1259,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
     }];
 }
 
-- (nullable UIActivity *)addToReadingListActivity {
+- (nullable UIActivity *)addToReadingListActivityWithPresenter:(UIViewController *)presenter {
     WMFArticle *article = [self.dataStore fetchArticleWithURL:self.articleURL];
     if (!article) {
         return nil;
@@ -1267,7 +1267,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 
     WMFAddToReadingListActivity *addToReadingListActivity = [[WMFAddToReadingListActivity alloc] initWithAction:^{
         WMFAddArticlesToReadingListViewController *addArticlesToReadingListViewController = [[WMFAddArticlesToReadingListViewController alloc] initWith:self.dataStore articles:@[article] moveFromReadingList:nil theme:self.theme];
-        [self presentViewController:addArticlesToReadingListViewController animated:YES completion:NULL];
+        [presenter presentViewController:addArticlesToReadingListViewController animated:YES completion:NULL];
         ;
     }];
 
@@ -1867,7 +1867,8 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
                                    style:UIPreviewActionStyleDefault
                                  handler:^(UIPreviewAction *_Nonnull action,
                                            UIViewController *_Nonnull previewViewController) {
-                                     UIActivityViewController *shareActivityController = [self.article sharingActivityViewControllerWithTextSnippet:nil fromButton:self.shareToolbarItem shareFunnel:self.shareFunnel customActivity:[self addToReadingListActivity]];
+                                     UIViewController *presenter = (UIViewController *)self.articlePreviewingActionsDelegate;
+                                     UIActivityViewController *shareActivityController = [self.article sharingActivityViewControllerWithTextSnippet:nil fromButton:self.shareToolbarItem shareFunnel:self.shareFunnel customActivity:[self addToReadingListActivityWithPresenter:presenter]];
                                      shareActivityController.excludedActivityTypes = @[UIActivityTypeAddToReadingList];
                                      if (shareActivityController) {
                                          NSAssert([previewViewController isKindOfClass:[WMFArticleViewController class]], @"Unexpected view controller type");
@@ -1883,7 +1884,8 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
             [UIPreviewAction actionWithTitle:WMFLocalizedStringWithDefaultValue(@"page-location", nil, nil, @"View on a map", @"Label for button used to show an article on the map")
                                        style:UIPreviewActionStyleDefault
                                      handler:^(UIPreviewAction *_Nonnull action, UIViewController *_Nonnull previewViewController) {
-                                         UIActivityViewController *shareActivityController = [self.article sharingActivityViewControllerWithTextSnippet:nil fromButton:self.shareToolbarItem shareFunnel:self.shareFunnel customActivity:[self addToReadingListActivity]];
+                                         UIViewController *presenter = (UIViewController *)self.articlePreviewingActionsDelegate;
+                                         UIActivityViewController *shareActivityController = [self.article sharingActivityViewControllerWithTextSnippet:nil fromButton:self.shareToolbarItem shareFunnel:self.shareFunnel customActivity:[self addToReadingListActivityWithPresenter:presenter]];
                                          shareActivityController.excludedActivityTypes = @[UIActivityTypeAddToReadingList];
                                          if (shareActivityController) {
                                              NSAssert([previewViewController isKindOfClass:[WMFArticleViewController class]], @"Unexpected view controller type");

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -1209,7 +1209,7 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
     [cell configureWithArticle:article displayType:displayType index:indexPath.item count:[self numberOfItemsInContentGroup:section] shouldAdjustMargins:YES theme:self.theme layoutOnly:layoutOnly];
     cell.saveButton.analyticsContext = [self analyticsContext];
     cell.saveButton.analyticsContentType = [section analyticsContentType];
-    [cell.saveButton setEventLoggingLabelWithRawValue:[section eventLoggingLabelRawValue]];
+    cell.saveButton.eventLoggingLabel = section.eventLoggingLabel;
 }
 
 - (void)configureNearbyCell:(WMFNearbyArticleCollectionViewCell *)cell withArticle:(WMFArticle *)article atIndexPath:(NSIndexPath *)indexPath {

--- a/Wikipedia/Code/WMFExploreViewController.m
+++ b/Wikipedia/Code/WMFExploreViewController.m
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 static NSString *const WMFFeedEmptyHeaderFooterReuseIdentifier = @"WMFFeedEmptyHeaderFooterReuseIdentifier";
 const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
 
-@interface WMFExploreViewController () <WMFLocationManagerDelegate, NSFetchedResultsControllerDelegate, WMFColumnarCollectionViewLayoutDelegate, WMFArticlePreviewingActionsDelegate, UIViewControllerPreviewingDelegate, WMFAnnouncementCollectionViewCellDelegate, UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDataSourcePrefetching, WMFSideScrollingCollectionViewCellDelegate, UIPopoverPresentationControllerDelegate, UISearchBarDelegate, WMFSaveButtonsControllerDelegate, WMFReadingListsAlertControllerDelegate, WMFReadingListHintPresenter>
+@interface WMFExploreViewController () <WMFLocationManagerDelegate, NSFetchedResultsControllerDelegate, WMFColumnarCollectionViewLayoutDelegate, WMFArticlePreviewingActionsDelegate, UIViewControllerPreviewingDelegate, WMFAnnouncementCollectionViewCellDelegate, UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDataSourcePrefetching, WMFSideScrollingCollectionViewCellDelegate, UIPopoverPresentationControllerDelegate, UISearchBarDelegate, WMFSaveButtonsControllerDelegate, WMFReadingListsAlertControllerDelegate, WMFReadingListHintPresenter, EventLoggingEventValuesProviding>
 
 @property (nonatomic, strong) UICollectionView *collectionView;
 
@@ -73,6 +73,9 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
 @end
 
 @implementation WMFExploreViewController
+
+@synthesize eventLoggingCategory;
+@synthesize eventLoggingLabel;
 
 - (void)setUserStore:(MWKDataStore *)userStore {
     if (_userStore == userStore) {
@@ -2092,6 +2095,14 @@ const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
     } else {
         [[ReadingListsFunnel shared] logUnsaveInFeedWithSaveButton:saveButton];
     }
+}
+
+- (EventLoggingCategory)eventLoggingCategory {
+    return EventLoggingCategoryFeed;
+}
+
+- (EventLoggingLabel)eventLoggingLabel {
+    return self.groupForPreviewedCell.eventLoggingLabel;
 }
 
 #if DEBUG && DEBUG_CHAOS

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -304,7 +304,6 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
     NSString *userName = [WMFAuthenticationManager sharedInstance].loggedInUsername;
     if (userName) {
         [self showLogoutActionSheet];
-        [[LoginFunnel shared] logLogoutInSettings];
     } else {
         WMFLoginViewController *loginVC = [WMFLoginViewController wmf_initialViewControllerFromClassStoryboard];
         [loginVC applyTheme:self.theme];
@@ -351,6 +350,7 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
                                                                      theme:self.theme
                                                                 completion:^{
                                                                     [[WMFAuthenticationManager sharedInstance] logoutWithCompletion:^{
+                                                                        [[LoginFunnel shared] logLogoutInSettings];
                                                                     }];
                                                                 }];
 }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T190748#

- [x] Update schema revisions
- [x] For updated schemas, send `measure` of type `Int` instead of `Double`
- [x] Log save via share sheet
- [x] For articles saved via 3d press in article view, update label to `out_link`
- [ ] For articles in "Read more" saved via 3d press in article view, update label to `read_more`
- [x] Log saving/unsaving main page with `main_page` label if it ever occurs
- [x] In article view, log saving a similar page with `similar_page` label and `article` category
- [ ] update `wiki` to be based on the wiki of the article affected ❓https://phabricator.wikimedia.org/T190748#
- [x] don't log unsave when removing articles from a non-default list
- [x] log `logout` only when user confirms logout
- [x] If the user doesn't opt in to send reports during onboarding and opts in in Settings later, send the snapshot when they opt in in Settings
- [x] set `measure_readinglist_itemcount` in MobileWikiAppiOSUserHistory to the count of unique saved articles