### PR TITLE
Add flag so we can tell if peeked item is a `Read more` item.

### DIFF
--- a/Wikipedia/Code/WKScriptMessage+WMFScriptMessage.swift
+++ b/Wikipedia/Code/WKScriptMessage+WMFScriptMessage.swift
@@ -15,6 +15,7 @@ import WebKit
     case footerLegalLicenseLinkClicked
     case footerBrowserLinkClicked
     case footerContainerAdded
+    case readMoreItemTouch
 }
 
 extension WKScriptMessage {
@@ -47,6 +48,8 @@ extension WKScriptMessage {
             return .footerBrowserLinkClicked
         case "footerContainerAdded":
             return .footerContainerAdded
+        case "readMoreItemTouch":
+            return .readMoreItemTouch
         default:
             return .unknown
         }
@@ -66,7 +69,8 @@ extension WKScriptMessage {
         case .articleState,
              .footerLegalLicenseLinkClicked,
              .footerBrowserLinkClicked,
-             .footerContainerAdded:
+             .footerContainerAdded,
+             .readMoreItemTouch:
             if body is String {
                 return body
             }

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1690,7 +1690,23 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 
 #pragma mark - Article link and image peeking via WKUIDelegate
 
+- (BOOL)wasReadMoreItemTouchedRecently {
+    NSDate *lastReadMoreItemTouchStartDate = self.webViewController.lastReadMoreItemTouchStartDate;
+    if (lastReadMoreItemTouchStartDate != nil) {
+        NSTimeInterval timeSinceLastReadMoreItemTouchStart = [[NSDate date] timeIntervalSinceDate: self.webViewController.lastReadMoreItemTouchStartDate];
+        if (timeSinceLastReadMoreItemTouchStart < 1) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
 - (BOOL)webView:(WKWebView *)webView shouldPreviewElement:(WKPreviewElementInfo *)elementInfo {
+    BOOL isReadMoreItemBeingPeeked = [self wasReadMoreItemTouchedRecently];
+    
+// TODO: add event logging here (can now know if peeked item is a `Read more` item by checking `isReadMoreItemBeingPeeked`.
+NSLog(@"\nisReadMoreItemBeingPeeked = %d\n", isReadMoreItemBeingPeeked);
+    
     return elementInfo.linkURL && [elementInfo.linkURL wmf_isPeekable];
 }
 

--- a/Wikipedia/Code/WebViewController.h
+++ b/Wikipedia/Code/WebViewController.h
@@ -26,6 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) WMFTheme *theme;
 
+@property (nonatomic, strong, nullable) NSDate *lastReadMoreItemTouchStartDate;
+
 #if DEBUG || TEST
 @property (nonatomic, copy, nullable) void (^wkUserContentControllerTestingConfigurationBlock)(WKUserContentController *);
 - (void)applyTheme:(WMFTheme *)theme;

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -122,6 +122,9 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
         case WMFWKScriptMessageFooterContainerAdded:
             [self handleFooterContainerAddedScriptMessage:safeMessageBody];
             break;
+        case WMFWKScriptMessageReadMoreItemTouch:
+            [self handleReadMoreItemTouchScriptMessage:safeMessageBody];
+            break;
         case WMFWKScriptMessageUnknown:
             NSAssert(NO, @"Unhandled script message type!");
             break;
@@ -423,6 +426,12 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
     return MAX(MAX(layoutMargins.left, layoutMargins.right), floor(0.5 * size.width * (1 - self.contentWidthPercentage)));
 }
 
+- (void)handleReadMoreItemTouchScriptMessage:(NSString*)message {
+    if([message isEqualToString:@"start"]){
+        self.lastReadMoreItemTouchStartDate = [NSDate date];
+    }
+}
+
 - (void)handleFooterContainerAddedScriptMessage:(id)message {
     //TODO: only need to do the "window.wmf.footerContainer.updateLeftAndRightMargin" part here... may be ok though as it's not changing the other values so shouldn't cause extra reflow...
     [self updateWebContentMarginForSize:self.view.bounds.size force:YES];
@@ -588,7 +597,8 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
         @"footerContainerAdded",
         @"footerMenuItemClicked",
         @"footerLegalLicenseLinkClicked",
-        @"footerBrowserLinkClicked"
+        @"footerBrowserLinkClicked",
+        @"readMoreItemTouch"
     ];
     for (NSString *handlerName in handlerNames) {
         [userContentController addScriptMessageHandler:[[WeakScriptMessageDelegate alloc] initWithDelegate:self] name:handlerName];

--- a/Wikipedia/assets/index.js
+++ b/Wikipedia/assets/index.js
@@ -173,6 +173,19 @@ document.addEventListener('click', event => {
   event.preventDefault()
   handleClickEvent(event)
 }, false)
+
+/**
+ * Used to know if a `Read more` item is being peeked. Needed because
+ * `webView:shouldPreviewElement:` doesn't provide context on peeked items beyond their url.
+ * We use this handler to record the time at which a `Read more` item was last touched and then in
+ * `webView:shouldPreviewElement` we can see if this happened recently (i.e. within the last second)
+ * to know that the peek is on a `Read more` item.
+ */
+document.addEventListener('touchstart', event => {
+  if(event.srcElement.closest('a.pagelib_footer_readmore_page')){
+    window.webkit.messageHandlers.readMoreItemTouch.postMessage('start')
+  }
+}, false)
 },{"./refs":6,"./utilities":8,"wikimedia-page-library":10}],3:[function(require,module,exports){
 //  Used by methods in "UIWebView+ElementLocation.h" category.
 

--- a/www/js/clickHandling.js
+++ b/www/js/clickHandling.js
@@ -155,3 +155,16 @@ document.addEventListener('click', event => {
   event.preventDefault()
   handleClickEvent(event)
 }, false)
+
+/**
+ * Used to know if a `Read more` item is being peeked. Needed because
+ * `webView:shouldPreviewElement:` doesn't provide context on peeked items beyond their url.
+ * We use this handler to record the time at which a `Read more` item was last touched and then in
+ * `webView:shouldPreviewElement` we can see if this happened recently (i.e. within the last second)
+ * to know that the peek is on a `Read more` item.
+ */
+document.addEventListener('touchstart', event => {
+  if(event.srcElement.closest('a.pagelib_footer_readmore_page')){
+    window.webkit.messageHandlers.readMoreItemTouch.postMessage('start')
+  }
+}, false)


### PR DESCRIPTION
Adds a flag to the webVC which is used to record last time a `Read more` item was touched.

Then we simply can check in `webView:shouldPreviewElement:` if this happened recently - right now its checking if it happened within the last second.

This way was less invasive and didn't involve and pagelib or url hackery.