### PR TITLE
Handle article URLs with query parameters

### DIFF
--- a/Wikipedia/Code/MWKSection.m
+++ b/Wikipedia/Code/MWKSection.m
@@ -42,9 +42,7 @@ NSString *const MWKSectionShareSnippetXPath = @"/html/body/p[not(.//span[@id='co
         self.index = [self optionalString:@"index" dict:dict];   // deceptively named, this must be a string
 
         if ([dict[@"fromtitle"] length] > 0) {
-            NSURLComponents *components = [NSURLComponents componentsWithURL:self.url resolvingAgainstBaseURL:NO];
-            components.wmf_titleWithUnderscores = dict[@"fromtitle"];
-            self.fromURL = components.URL;
+            self.fromURL = [self.url wmf_URLWithTitle:dict[@"fromtitle"]];
         }
         self.anchor = [self optionalString:@"anchor" dict:dict];
         self.sectionId = [[self requiredNumber:@"id" dict:dict] intValue];

--- a/Wikipedia/Code/MWKSection.m
+++ b/Wikipedia/Code/MWKSection.m
@@ -42,7 +42,7 @@ NSString *const MWKSectionShareSnippetXPath = @"/html/body/p[not(.//span[@id='co
         self.index = [self optionalString:@"index" dict:dict];   // deceptively named, this must be a string
 
         if ([dict[@"fromtitle"] length] > 0) {
-            self.fromURL = [NSURL wmf_URLWithSiteURL:self.url unescapedDenormalizedTitleAndFragment:dict[@"fromtitle"]];
+            self.fromURL = [NSURL wmf_URLWithSiteURL:self.url unescapedDenormalizedTitleQueryAndFragment:dict[@"fromtitle"]];
         }
         self.anchor = [self optionalString:@"anchor" dict:dict];
         self.sectionId = [[self requiredNumber:@"id" dict:dict] intValue];

--- a/Wikipedia/Code/MWKSection.m
+++ b/Wikipedia/Code/MWKSection.m
@@ -42,7 +42,9 @@ NSString *const MWKSectionShareSnippetXPath = @"/html/body/p[not(.//span[@id='co
         self.index = [self optionalString:@"index" dict:dict];   // deceptively named, this must be a string
 
         if ([dict[@"fromtitle"] length] > 0) {
-            self.fromURL = [self.url wmf_URLWithTitle:dict[@"fromtitle"]];
+            NSURLComponents *components = [NSURLComponents componentsWithURL:self.url resolvingAgainstBaseURL:NO];
+            components.wmf_titleWithUnderscores = dict[@"fromtitle"];
+            self.fromURL = components.URL;
         }
         self.anchor = [self optionalString:@"anchor" dict:dict];
         self.sectionId = [[self requiredNumber:@"id" dict:dict] intValue];

--- a/Wikipedia/Code/MWKSection.m
+++ b/Wikipedia/Code/MWKSection.m
@@ -42,7 +42,7 @@ NSString *const MWKSectionShareSnippetXPath = @"/html/body/p[not(.//span[@id='co
         self.index = [self optionalString:@"index" dict:dict];   // deceptively named, this must be a string
 
         if ([dict[@"fromtitle"] length] > 0) {
-            self.fromURL = [NSURL wmf_URLWithSiteURL:self.url unescapedDenormalizedTitleQueryAndFragment:dict[@"fromtitle"]];
+            self.fromURL = [self.url wmf_URLWithTitle:dict[@"fromtitle"]];
         }
         self.anchor = [self optionalString:@"anchor" dict:dict];
         self.sectionId = [[self requiredNumber:@"id" dict:dict] intValue];

--- a/Wikipedia/Code/MWKSite.h
+++ b/Wikipedia/Code/MWKSite.h
@@ -76,18 +76,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A title initialized with the receiver as its @c site.
  * @see -[MWKTitle initWithString:site:]
  */
-- (MWKTitle *)titleWithString:(NSString *)string;
-
-/**
- * @return A title initialized with the receiver as its @c site.
- * @see -[MWKTitle initWithUnescapedString:site:]
- */
-- (MWKTitle *)titleWithUnescapedString:(NSString *)string;
-
-/**
- * @return A title initialized with the receiver as its @c site.
- * @see -[MWKTitle initWithString:site:]
- */
 - (MWKTitle *)titleWithInternalLink:(NSString *)path;
 
 /**

--- a/Wikipedia/Code/MWKSite.m
+++ b/Wikipedia/Code/MWKSite.m
@@ -76,14 +76,6 @@ typedef NS_ENUM(NSUInteger, MWKSiteNSCodingSchemaVersion) {
 
 #pragma mark - Title Helpers
 
-- (MWKTitle *)titleWithString:(NSString *)string {
-    return [MWKTitle titleWithUnescapedString:string site:self];
-}
-
-- (MWKTitle *)titleWithUnescapedString:(NSString *)string {
-    return [MWKTitle titleWithUnescapedString:string site:self];
-}
-
 - (MWKTitle *)titleWithInternalLink:(NSString *)path {
     return [[MWKTitle alloc] initWithInternalLink:path site:self];
 }

--- a/Wikipedia/Code/MWKTitle.h
+++ b/Wikipedia/Code/MWKTitle.h
@@ -69,8 +69,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// Convenience factory method wrapping `initWithString:site:`.
 + (MWKTitle *)titleWithString:(NSString *)str site:(MWKSite *)site;
 
-+ (MWKTitle *)titleWithUnescapedString:(NSString *)str site:(MWKSite *)site;
-
 #pragma mark - Comparison
 
 - (BOOL)isEqualToTitle:(MWKTitle *)title;

--- a/Wikipedia/Code/MWKTitle.m
+++ b/Wikipedia/Code/MWKTitle.m
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
             MWKSite *site = [self decodeValueForKey:@"site" withCoder:coder modelVersion:0];
             NSString *fragment = [self decodeValueForKey:@"fragment" withCoder:coder modelVersion:0];
             if (site && text) {
-                self.URL = [NSURL wmf_URLWithSiteURL:site.URL title:text fragment:fragment];
+                self.URL = [NSURL wmf_URLWithSiteURL:site.URL title:text fragment:fragment query:nil];
             } else {
                 return nil;
             }
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithSite:(MWKSite *)site
              normalizedTitle:(NSString *)text
                     fragment:(NSString *__nullable)fragment {
-    NSURL *titleURL = [site.URL wmf_URLWithTitle:text fragment:fragment];
+    NSURL *titleURL = [site.URL wmf_URLWithTitle:text fragment:fragment query:nil];
     return [self initWithURL:titleURL];
 }
 

--- a/Wikipedia/Code/MWKTitle.m
+++ b/Wikipedia/Code/MWKTitle.m
@@ -60,12 +60,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithString:(NSString *)string site:(MWKSite *)site {
-    NSURL *URL = [NSURL wmf_URLWithSiteURL:site.URL escapedDenormalizedTitleAndFragment:string];
+    NSURL *URL = [NSURL wmf_URLWithSiteURL:site.URL escapedDenormalizedTitleQueryAndFragment:string];
     return [self initWithURL:URL];
 }
 
 - (instancetype)initWithUnescapedString:(NSString *)string site:(MWKSite *)site {
-    NSURL *URL = [NSURL wmf_URLWithSiteURL:site.URL unescapedDenormalizedTitleAndFragment:string];
+    NSURL *URL = [NSURL wmf_URLWithSiteURL:site.URL unescapedDenormalizedTitleQueryAndFragment:string];
     return [self initWithURL:URL];
 }
 

--- a/Wikipedia/Code/MWKTitle.m
+++ b/Wikipedia/Code/MWKTitle.m
@@ -64,19 +64,9 @@ NS_ASSUME_NONNULL_BEGIN
     return [self initWithURL:URL];
 }
 
-- (instancetype)initWithUnescapedString:(NSString *)string site:(MWKSite *)site {
-    NSURL *URL = [NSURL wmf_URLWithSiteURL:site.URL unescapedDenormalizedTitleQueryAndFragment:string];
-    return [self initWithURL:URL];
-}
-
 + (MWKTitle *)titleWithString:(NSString *)str site:(MWKSite *)site {
     return [[MWKTitle alloc] initWithString:str site:site];
 }
-
-+ (MWKTitle *)titleWithUnescapedString:(NSString *)str site:(MWKSite *)site {
-    return [[MWKTitle alloc] initWithUnescapedString:str site:site];
-}
-
 #pragma mark - Computed Properties
 
 - (NSString *)text {

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.h
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.h
@@ -59,10 +59,11 @@ extern NSString *const WMFEditPencil;
  * @param siteURL       A Wikimedia site URL. For exmaple: `https://en.wikipedia.org`.
  * @param title         A Wikimedia title. For exmaple: `Main Page`.
  * @param fragment      An optional fragment, for example if you want the URL to contain `#section`, the fragment is `section`.
+ * @param query         An optional query string, for example `wprov=spi1&foo=bar`.
  *
  * @return A new URL constructed from the `siteURL`, replacing the `title` and `fragment` with the given values.
  **/
-+ (nullable NSURL *)wmf_URLWithSiteURL:(NSURL *)siteURL title:(nullable NSString *)title fragment:(nullable NSString *)fragment;
++ (nullable NSURL *)wmf_URLWithSiteURL:(NSURL *)siteURL title:(nullable NSString *)title fragment:(nullable NSString *)fragment query:(nullable NSString *)query;
 
 /**
  * Return a new URL constructed from the `siteURL`, replacing the `path` with the `internalLink`.
@@ -160,10 +161,11 @@ extern NSString *const WMFEditPencil;
  *
  * @param title         A Wikimedia title. For exmaple: `Main Page`.
  * @param fragment      An optional fragment, for example if you want the URL to contain `#section`, the fragment is `section`.
+ * @param query         An optional query string.
  *
  * @return A new URL based on the URL you call this method on with the given title and fragment.
  **/
-- (nullable NSURL *)wmf_URLWithTitle:(NSString *)title fragment:(nullable NSString *)fragment;
+- (nullable NSURL *)wmf_URLWithTitle:(NSString *)title fragment:(nullable NSString *)fragment query:(nullable NSString *)query;
 
 /**
  * Return a new URL similar to the URL you call this method on but replace the fragemnt.

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.h
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.h
@@ -80,22 +80,22 @@ extern NSString *const WMFEditPencil;
  * Return a new URL constructed from the `siteURL`, replacing the `path` with the internal link prefix and the `path`.
  *
  * @param siteURL                                       A Wikimedia site URL. For exmaple: `https://en.wikipedia.org`.
- * @param escapedDenormalizedTitleAndFragment           A Wikimedia path and fragment. For exmaple: `/Main_Page#section`.
+ * @param escapedDenormalizedTitleQueryAndFragment           A Wikimedia path and fragment. For exmaple: `/Main_Page?wprov=sfii1#section`.
  *
  * @return A new URL constructed from the `siteURL`, replacing the `path` with the internal link prefix and the `path`.
  **/
 //WMF_TECH_DEBT_TODO(this method should be folded into the above method and should handle the presence of a #)
-+ (nullable NSURL *)wmf_URLWithSiteURL:(NSURL *)siteURL escapedDenormalizedTitleAndFragment:(NSString *)escapedDenormalizedTitleAndFragment;
++ (nullable NSURL *)wmf_URLWithSiteURL:(NSURL *)siteURL escapedDenormalizedTitleQueryAndFragment:(NSString *)escapedDenormalizedTitleQueryAndFragment;
 
 /**
  * Return a new URL constructed from the `siteURL`, replacing the `path` with the internal link prefix and the `path`.
  *
  * @param siteURL                                       A Wikimedia site URL. For exmaple: `https://en.wikipedia.org`.
- * @param unescapedDenormalizedTitleAndFragment           A Wikimedia path and fragment. For exmaple: `/99%_Invisible#section`. Note the % is not escaped.
+ * @param unescapedDenormalizedTitleQueryAndFragment    A Wikimedia path and fragment. For exmaple: `/99%_Invisible?wprov=sfii1#section`. Note the % is not escaped.
  *
  * @return A new URL constructed from the `siteURL`, replacing the `path` with the internal link prefix and the `path`.
  **/
-+ (nullable NSURL *)wmf_URLWithSiteURL:(NSURL *)siteURL unescapedDenormalizedTitleAndFragment:(NSString *)unescapedDenormalizedTitleAndFragment;
++ (nullable NSURL *)wmf_URLWithSiteURL:(NSURL *)siteURL unescapedDenormalizedTitleQueryAndFragment:(NSString *)unescapedDenormalizedTitleQueryAndFragment;
 
 /**
  *  Return a URL for the mobile API Endpoint for the current URL

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.h
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.h
@@ -88,16 +88,6 @@ extern NSString *const WMFEditPencil;
 + (nullable NSURL *)wmf_URLWithSiteURL:(NSURL *)siteURL escapedDenormalizedTitleQueryAndFragment:(NSString *)escapedDenormalizedTitleQueryAndFragment;
 
 /**
- * Return a new URL constructed from the `siteURL`, replacing the `path` with the internal link prefix and the `path`.
- *
- * @param siteURL                                       A Wikimedia site URL. For exmaple: `https://en.wikipedia.org`.
- * @param unescapedDenormalizedTitleQueryAndFragment    A Wikimedia path and fragment. For exmaple: `/99%_Invisible?wprov=sfii1#section`. Note the % is not escaped.
- *
- * @return A new URL constructed from the `siteURL`, replacing the `path` with the internal link prefix and the `path`.
- **/
-+ (nullable NSURL *)wmf_URLWithSiteURL:(NSURL *)siteURL unescapedDenormalizedTitleQueryAndFragment:(NSString *)unescapedDenormalizedTitleQueryAndFragment;
-
-/**
  *  Return a URL for the mobile API Endpoint for the current URL
  *
  *  @return return value description

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.m
@@ -308,6 +308,7 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
     NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:NO];
     components.host = [NSURLComponents wmf_hostWithDomain:self.wmf_domain language:self.wmf_language isMobile:NO];
     components.fragment = nil;
+    components.query = nil;
     components.scheme = @"https";
     return components.URL;
 }

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.m
@@ -97,6 +97,9 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
     if ([path wmf_isWikiResource]) {
         return [NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedInternalLink:path];
     } else {
+        // Resist the urge to use NSURLComponents, it doesn't handle special page paths like "Talk:India"
+        NSArray *splitQuery = [path componentsSeparatedByString:@"?"];
+        path = [splitQuery firstObject];
         NSArray *bits = [path componentsSeparatedByString:@"#"];
         NSString *fragment = nil;
         if (bits.count > 1) {

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.m
@@ -84,7 +84,7 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
     NSString *fragment = nil;
     if (bits.count > 1) {
         if (removePercentEncoding) {
-            fragment = [bits[1] stringByRemovingPercentEncoding]
+            fragment = [bits[1] stringByRemovingPercentEncoding];
         } else {
             fragment = bits[1];
         }
@@ -96,7 +96,7 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
     } else {
         title = [[bits firstObject] wmf_normalizedPageTitle];
     }
-    return [NSURL wmf_URLWithSiteURL:siteURL title: fragment:fragment query:query];
+    return [NSURL wmf_URLWithSiteURL:siteURL title:title fragment:fragment query:query];
 }
 
 + (NSURL *)wmf_URLWithSiteURL:(NSURL *)siteURL unescapedDenormalizedTitleAndFragment:(NSString *)path {

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.m
@@ -59,8 +59,8 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
     return [[NSURLComponents wmf_componentsWithDomain:domain language:language title:title fragment:fragment] URL];
 }
 
-+ (NSURL *)wmf_URLWithSiteURL:(NSURL *)siteURL title:(nullable NSString *)title fragment:(nullable NSString *)fragment {
-    return [siteURL wmf_URLWithTitle:title fragment:fragment];
++ (NSURL *)wmf_URLWithSiteURL:(NSURL *)siteURL title:(nullable NSString *)title fragment:(nullable NSString *)fragment query:(nullable NSString *)query {
+    return [siteURL wmf_URLWithTitle:title fragment:fragment query:query];
 }
 
 + (NSRegularExpression *)invalidPercentEscapesRegex {
@@ -79,13 +79,19 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
     if ([path wmf_isWikiResource]) {
         return [NSURL wmf_URLWithSiteURL:siteURL unescapedDenormalizedInternalLink:path];
     } else {
+        NSArray *splitQuery = [path componentsSeparatedByString:@"?"];
+        path = [splitQuery firstObject];
+        NSString *query = nil;
+        if (splitQuery.count > 1) {
+            query = [splitQuery lastObject];
+        }
         NSArray *bits = [path componentsSeparatedByString:@"#"];
         NSString *fragment = nil;
         if (bits.count > 1) {
             fragment = bits[1];
         }
         fragment = [fragment precomposedStringWithCanonicalMapping];
-        return [NSURL wmf_URLWithSiteURL:siteURL title:[[bits firstObject] wmf_normalizedPageTitle] fragment:fragment];
+        return [NSURL wmf_URLWithSiteURL:siteURL title:[[bits firstObject] wmf_normalizedPageTitle] fragment:fragment query:query];
     }
 }
 
@@ -100,12 +106,16 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
         // Resist the urge to use NSURLComponents, it doesn't handle special page paths like "Talk:India"
         NSArray *splitQuery = [path componentsSeparatedByString:@"?"];
         path = [splitQuery firstObject];
+        NSString *query = nil;
+        if (splitQuery.count > 1) {
+            query = [splitQuery lastObject];
+        }
         NSArray *bits = [path componentsSeparatedByString:@"#"];
         NSString *fragment = nil;
         if (bits.count > 1) {
             fragment = [bits[1] stringByRemovingPercentEncoding];
         }
-        return [NSURL wmf_URLWithSiteURL:siteURL title:[[bits firstObject] wmf_unescapedNormalizedPageTitle] fragment:fragment];
+        return [NSURL wmf_URLWithSiteURL:siteURL title:[[bits firstObject] wmf_unescapedNormalizedPageTitle] fragment:fragment query:query];
     }
 }
 
@@ -140,10 +150,11 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
     return components.URL;
 }
 
-- (NSURL *)wmf_URLWithTitle:(NSString *)title fragment:(NSString *)fragment {
+- (NSURL *)wmf_URLWithTitle:(NSString *)title fragment:(nullable NSString *)fragment query:(nullable NSString *)query {
     NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:NO];
     components.wmf_title = title;
     components.wmf_fragment = fragment;
+    components.query = query;
     return components.URL;
 }
 

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -169,7 +169,9 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
         self.theme = theme;
         self.addingArticleToHistoryListEnabled = YES;
         self.savingOpenArticleTitleEnabled = YES;
-        self.articleURL = url;
+        NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+        components.query = nil;
+        self.articleURL = components.URL;
         self.dataStore = dataStore;
         self.readingListHintController = [[WMFReadingListHintController alloc] initWithDataStore:dataStore presenter:self];
 

--- a/WikipediaUnitTests/Code/MWKSite+Random.m
+++ b/WikipediaUnitTests/Code/MWKSite+Random.m
@@ -13,7 +13,7 @@
 }
 
 + (instancetype)wmf_randomArticleURLWithFragment:(NSString *)fragment {
-    return [[self wmf_randomSiteURL] wmf_URLWithTitle:[[NSUUID UUID] UUIDString] fragment:fragment ?: [@"#" stringByAppendingString:[[NSUUID UUID] UUIDString]]];
+    return [[self wmf_randomSiteURL] wmf_URLWithTitle:[[NSUUID UUID] UUIDString] fragment:fragment ?: [@"#" stringByAppendingString:[[NSUUID UUID] UUIDString]] query:nil];
 }
 
 @end

--- a/WikipediaUnitTests/Code/MWKSiteTests.m
+++ b/WikipediaUnitTests/Code/MWKSiteTests.m
@@ -48,7 +48,7 @@
 - (void)testStringsWithQuery {
     XCTAssertEqualObjects([siteURL wmf_URLWithTitle:@"India"].wmf_title, @"India");
     XCTAssertEqualObjects([siteURL wmf_URLWithTitle:@"Talk:India"].wmf_title, @"Talk:India");
-    XCTAssertEqualObjects([NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedTitleQueryAndFragment:@"Talk:India?wprov=stii1&a=b&c=d#History"].wmf_title, @"Talk:India");
+    XCTAssertEqualObjects([NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedTitleQueryAndFragment:@"Talk:India?wprov=stii1&a=%3Fb&c=%3F%3F#History"].wmf_title, @"Talk:India");
 }
 
 - (void)testLinks {

--- a/WikipediaUnitTests/Code/MWKSiteTests.m
+++ b/WikipediaUnitTests/Code/MWKSiteTests.m
@@ -42,7 +42,13 @@
 - (void)testStrings {
     XCTAssertEqualObjects([siteURL wmf_URLWithTitle:@"India"].wmf_title, @"India");
     XCTAssertEqualObjects([siteURL wmf_URLWithTitle:@"Talk:India"].wmf_title, @"Talk:India");
-    XCTAssertEqualObjects([NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedTitleAndFragment:@"Talk:India#History"].wmf_title, @"Talk:India");
+    XCTAssertEqualObjects([NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedTitleQueryAndFragment:@"Talk:India#History"].wmf_title, @"Talk:India");
+}
+
+- (void)testStringsWithQuery {
+    XCTAssertEqualObjects([siteURL wmf_URLWithTitle:@"India"].wmf_title, @"India");
+    XCTAssertEqualObjects([siteURL wmf_URLWithTitle:@"Talk:India"].wmf_title, @"Talk:India");
+    XCTAssertEqualObjects([NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedTitleQueryAndFragment:@"Talk:India?wprov=stii1&a=b&c=d#History"].wmf_title, @"Talk:India");
 }
 
 - (void)testLinks {

--- a/WikipediaUnitTests/Code/MWKTitleTests.m
+++ b/WikipediaUnitTests/Code/MWKTitleTests.m
@@ -57,14 +57,14 @@
 }
 
 - (void)testFragment {
-    NSURL *title = [NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedTitleAndFragment:@"foo#bar"];
+    NSURL *title = [NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedTitleQueryAndFragment:@"foo#bar"];
     assertThat(title.wmf_siteURL, is(siteURL));
     assertThat(title.wmf_title, is(@"foo"));
     assertThat(title.fragment, is(@"bar"));
 }
 
 - (void)testPercentEscaped {
-    NSURL *title = [NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedTitleAndFragment:@"foo%20baz#bar"];
+    NSURL *title = [NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedTitleQueryAndFragment:@"foo%20baz#bar"];
     assertThat(title.wmf_siteURL, is(siteURL));
     assertThat(title.wmf_title, is(@"foo baz"));
     assertThat(title.fragment, is(@"bar"));

--- a/WikipediaUnitTests/Code/NSURL+WMFLinkParsingTests.m
+++ b/WikipediaUnitTests/Code/NSURL+WMFLinkParsingTests.m
@@ -53,4 +53,5 @@
     XCTAssert([[[NSURL URLWithString:testPathWithQueryAndFragment] wmf_pathWithoutWikiPrefix] isEqualToString:testPath]);
 }
 
+
 @end

--- a/WikipediaUnitTests/Code/WMFLinkParsingTests.m
+++ b/WikipediaUnitTests/Code/WMFLinkParsingTests.m
@@ -43,11 +43,11 @@
 
 - (void)testWMFLinksFromLinks {
     NSURL *siteURL = [NSURL wmf_URLWithDomain:@"wikipedia.org" language:@"fr"];
-    NSURL *titledURL = [siteURL wmf_URLWithTitle:@"Main Page" fragment:nil];
+    NSURL *titledURL = [siteURL wmf_URLWithTitle:@"Main Page" fragment:nil query:nil];
     XCTAssertEqualObjects(@"https://fr.wikipedia.org/wiki/Main_Page", titledURL.absoluteString);
     titledURL = [siteURL wmf_URLWithTitle:@"Main Page"];
     XCTAssertEqualObjects(@"https://fr.wikipedia.org/wiki/Main_Page", titledURL.absoluteString);
-    NSURL *titledAndFragmentedURL = [siteURL wmf_URLWithTitle:@"Main Page" fragment:@"section"];
+    NSURL *titledAndFragmentedURL = [siteURL wmf_URLWithTitle:@"Main Page" fragment:@"section" query:nil];
     XCTAssertEqualObjects(@"https://fr.wikipedia.org/wiki/Main_Page#section", titledAndFragmentedURL.absoluteString);
     NSURL *mobileURL = [siteURL wmf_URLWithPath:@"/w/api.php" isMobile:YES];
     XCTAssertEqualObjects(@"https://fr.m.wikipedia.org/w/api.php", mobileURL.absoluteString);
@@ -58,7 +58,7 @@
     XCTAssertEqualObjects(@"en.wikipedia.org", siteURL.host);
     NSURL *pageURL = [NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedInternalLink:@"/wiki/Main_Page"];
     XCTAssertEqualObjects(@"https://en.wikipedia.org/wiki/Main_Page", pageURL.absoluteString);
-    NSURL *nonInternalPageURL = [NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedTitleAndFragment:@"Main_Page"];
+    NSURL *nonInternalPageURL = [NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedTitleQueryAndFragment:@"Main_Page"];
     XCTAssertEqualObjects(@"https://en.wikipedia.org/wiki/Main_Page", nonInternalPageURL.absoluteString);
 }
 
@@ -147,9 +147,9 @@
     XCTAssertEqualObjects(ole, secondOle);
     XCTAssertEqualObjects(ole, thirdOle);
 
-    ole = [URL wmf_URLWithTitle:@"Olé" fragment:@"Olé"];
-    secondOle = [URL wmf_URLWithTitle:@"Ol\u00E9" fragment:@"Ol\u00E9"];
-    thirdOle = [URL wmf_URLWithTitle:@"Ole\u0301" fragment:@"Ole\u0301"];
+    ole = [URL wmf_URLWithTitle:@"Olé" fragment:@"Olé" query:nil];
+    secondOle = [URL wmf_URLWithTitle:@"Ol\u00E9" fragment:@"Ol\u00E9" query:nil];
+    thirdOle = [URL wmf_URLWithTitle:@"Ole\u0301" fragment:@"Ole\u0301" query:nil];
     XCTAssertEqualObjects(ole, secondOle);
     XCTAssertEqualObjects(ole, thirdOle);
 

--- a/WikipediaUnitTests/Code/WMFLinkParsingTests.m
+++ b/WikipediaUnitTests/Code/WMFLinkParsingTests.m
@@ -62,6 +62,12 @@
     XCTAssertEqualObjects(@"https://en.wikipedia.org/wiki/Main_Page", nonInternalPageURL.absoluteString);
 }
 
+- (void)testQueryPreservation {
+    NSURL *siteURL = [NSURL wmf_URLWithDomain:@"wikipedia.org" language:@"en"];
+    NSURL *nonInternalPageURL = [NSURL wmf_URLWithSiteURL:siteURL escapedDenormalizedTitleQueryAndFragment:@"Main_Page?wprov=stii1&a=%3F#blah"];
+    XCTAssertEqualObjects(@"https://en.wikipedia.org/wiki/Main_Page?wprov=stii1&a=%3F#blah", nonInternalPageURL.absoluteString);
+}
+
 - (void)testWMFLanguagelessLinks {
     NSURL *siteURL = [NSURL wmf_URLWithDomain:@"mediawiki.org" language:nil];
     NSURL *desktopURL = [NSURL wmf_desktopURLForURL:siteURL];


### PR DESCRIPTION
- Remove methods that attempted to parse fragment from an unescaped string. This is prone to error and assumes that no part of the path has a `#` that should be escaped (for example `/wiki/this_title_has_a_#_in_it#section0`)
- Preserve query strings when handling relative links
- Remove query strings from database keys