### PR TITLE
Fixes issue with newlines in Wikidata descriptions that led to T195551

### DIFF
--- a/WMF Framework/NSRegularExpression+HTML.h
+++ b/WMF Framework/NSRegularExpression+HTML.h
@@ -10,6 +10,9 @@ NS_ASSUME_NONNULL_BEGIN
 // Matches HTML entities &amp; &nbsp; etc
 + (NSRegularExpression *)wmf_HTMLEntityRegularExpression;
 
+// Matches ' " ; '
++ (NSRegularExpression *)wmf_charactersToEscapeForJSRegex;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WMF Framework/NSRegularExpression+HTML.m
+++ b/WMF Framework/NSRegularExpression+HTML.m
@@ -26,4 +26,16 @@
     return tagRegex;
 }
 
++ (NSRegularExpression *)wmf_charactersToEscapeForJSRegex {
+    static NSRegularExpression *wmf_charactersToEscapeForJSRegex;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSString *pattern = @"[\"'\\n]";
+        wmf_charactersToEscapeForJSRegex = [NSRegularExpression regularExpressionWithPattern:pattern
+                                                             options:NSRegularExpressionCaseInsensitive
+                                                               error:nil];
+    });
+    return wmf_charactersToEscapeForJSRegex;
+}
+
 @end

--- a/Wikipedia/Code/NSString+WMFExtras.h
+++ b/Wikipedia/Code/NSString+WMFExtras.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)wmf_stringByReplacingSpacesWithUnderscores;
 
-- (NSString *)wmf_stringByReplacingApostrophesWithBackslashApostrophes;
+- (NSString *)wmf_stringBySanitizingForJavascript;
 
 - (NSString *)wmf_stringByCapitalizingFirstCharacterUsingWikipediaLanguage:(nullable NSString *)wikipediaLanguage; //Language is the string `en` in `en.wikipedia.org` or `de` in `de.wikipedia.org`. nil will use the current locale
 

--- a/Wikipedia/Code/NSString+WMFExtras.h
+++ b/Wikipedia/Code/NSString+WMFExtras.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)wmf_stringByReplacingSpacesWithUnderscores;
 
-- (NSString *)wmf_stringBySanitizingForJavascript;
+- (NSString *)wmf_stringBySanitizingForJavaScript;
 
 - (NSString *)wmf_stringByCapitalizingFirstCharacterUsingWikipediaLanguage:(nullable NSString *)wikipediaLanguage; //Language is the string `en` in `en.wikipedia.org` or `de` in `de.wikipedia.org`. nil will use the current locale
 

--- a/Wikipedia/Code/NSString+WMFExtras.m
+++ b/Wikipedia/Code/NSString+WMFExtras.m
@@ -72,8 +72,21 @@
     return [self stringByReplacingOccurrencesOfString:@" " withString:@"_"];
 }
 
-- (NSString *)wmf_stringByReplacingApostrophesWithBackslashApostrophes {
-    return [self stringByReplacingOccurrencesOfString:@"'" withString:@"\\'"];
+- (NSString *)wmf_stringBySanitizingForJavascript {
+    NSRegularExpression *regex = [NSRegularExpression wmf_charactersToEscapeForJSRegex];
+    NSMutableString *mutableSelf = [self mutableCopy];
+    __block NSInteger offset = 0;
+    [regex enumerateMatchesInString:self options:0 range:NSMakeRange(0, self.length) usingBlock:^(NSTextCheckingResult * _Nullable result, NSMatchingFlags flags, BOOL * _Nonnull stop) {
+        NSString *match = [regex replacementStringForResult:result inString:mutableSelf offset:offset template:@"$0"];
+        if (!match) {
+            return;
+        }
+        NSRange range = NSMakeRange(result.range.location + offset, result.range.length);
+        NSString *replacement = [@[@"\\", match] componentsJoinedByString:@""];
+        [mutableSelf replaceCharactersInRange:range withString:replacement];
+        offset += replacement.length - range.length;
+    }];
+    return mutableSelf;
 }
 
 - (NSString *)wmf_stringByCapitalizingFirstCharacterUsingWikipediaLanguage:(nullable NSString *)wikipediaLanguage {

--- a/Wikipedia/Code/NSString+WMFExtras.m
+++ b/Wikipedia/Code/NSString+WMFExtras.m
@@ -77,14 +77,12 @@
     NSMutableString *mutableSelf = [self mutableCopy];
     __block NSInteger offset = 0;
     [regex enumerateMatchesInString:self options:0 range:NSMakeRange(0, self.length) usingBlock:^(NSTextCheckingResult * _Nullable result, NSMatchingFlags flags, BOOL * _Nonnull stop) {
-        NSString *match = [regex replacementStringForResult:result inString:mutableSelf offset:offset template:@"$0"];
-        if (!match) {
+        NSInteger indexForBackslash = result.range.location + offset;
+        if (indexForBackslash >= mutableSelf.length) {
             return;
         }
-        NSRange range = NSMakeRange(result.range.location + offset, result.range.length);
-        NSString *replacement = [@[@"\\", match] componentsJoinedByString:@""];
-        [mutableSelf replaceCharactersInRange:range withString:replacement];
-        offset += replacement.length - range.length;
+        [mutableSelf insertString:@"\\" atIndex:indexForBackslash];
+        offset += 1;
     }];
     return mutableSelf;
 }

--- a/Wikipedia/Code/NSString+WMFExtras.m
+++ b/Wikipedia/Code/NSString+WMFExtras.m
@@ -72,7 +72,7 @@
     return [self stringByReplacingOccurrencesOfString:@" " withString:@"_"];
 }
 
-- (NSString *)wmf_stringBySanitizingForJavascript {
+- (NSString *)wmf_stringBySanitizingForJavaScript {
     NSRegularExpression *regex = [NSRegularExpression wmf_charactersToEscapeForJSRegex];
     NSMutableString *mutableSelf = [self mutableCopy];
     __block NSInteger offset = 0;

--- a/Wikipedia/Code/WKWebView+ElementLocation.m
+++ b/Wikipedia/Code/WKWebView+ElementLocation.m
@@ -4,7 +4,7 @@
 @implementation WKWebView (ElementLocation)
 
 - (void)getScreenRectForHtmlElementWithId:(NSString *)elementId completion:(void (^)(CGRect rect))completion {
-    [self getScreenRectForHtmlElementFromJavascriptString:[NSString stringWithFormat:@"window.wmf.elementLocation.getElementRect(document.getElementById('%@'));", [elementId wmf_stringByReplacingApostrophesWithBackslashApostrophes]]
+    [self getScreenRectForHtmlElementFromJavascriptString:[NSString stringWithFormat:@"window.wmf.elementLocation.getElementRect(document.getElementById('%@'));", [elementId wmf_stringBySanitizingForJavascript]]
                                                completion:completion];
 }
 
@@ -16,7 +16,7 @@
 }
 
 - (void)getScreenRectForHtmlImageWithSrc:(NSString *)src completion:(void (^)(CGRect rect))completion {
-    [self getScreenRectForHtmlElementFromJavascriptString:[NSString stringWithFormat:@"window.wmf.elementLocation.getElementRect(window.wmf.elementLocation.getImageWithSrc('%@'));", [src wmf_stringByReplacingApostrophesWithBackslashApostrophes]]
+    [self getScreenRectForHtmlElementFromJavascriptString:[NSString stringWithFormat:@"window.wmf.elementLocation.getElementRect(window.wmf.elementLocation.getImageWithSrc('%@'));", [src wmf_stringBySanitizingForJavascript]]
                                                completion:completion];
 }
 
@@ -55,7 +55,7 @@
 }
 
 - (void)getIndexOfTopOnScreenElementWithPrefix:(NSString *)prefix count:(NSUInteger)count completion:(void (^)(id index, NSError *error))completion {
-    [self evaluateJavaScript:[NSString stringWithFormat:@"window.wmf.elementLocation.getIndexOfFirstOnScreenElement('%@', %lu)", [prefix wmf_stringByReplacingApostrophesWithBackslashApostrophes], (unsigned long)count]
+    [self evaluateJavaScript:[NSString stringWithFormat:@"window.wmf.elementLocation.getIndexOfFirstOnScreenElement('%@', %lu)", [prefix wmf_stringBySanitizingForJavascript], (unsigned long)count]
            completionHandler:^(id _Nullable index, NSError *_Nullable error) {
                completion(index, error);
            }];

--- a/Wikipedia/Code/WKWebView+ElementLocation.m
+++ b/Wikipedia/Code/WKWebView+ElementLocation.m
@@ -4,7 +4,7 @@
 @implementation WKWebView (ElementLocation)
 
 - (void)getScreenRectForHtmlElementWithId:(NSString *)elementId completion:(void (^)(CGRect rect))completion {
-    [self getScreenRectForHtmlElementFromJavascriptString:[NSString stringWithFormat:@"window.wmf.elementLocation.getElementRect(document.getElementById('%@'));", [elementId wmf_stringBySanitizingForJavascript]]
+    [self getScreenRectForHtmlElementFromJavascriptString:[NSString stringWithFormat:@"window.wmf.elementLocation.getElementRect(document.getElementById('%@'));", [elementId wmf_stringBySanitizingForJavaScript]]
                                                completion:completion];
 }
 
@@ -16,7 +16,7 @@
 }
 
 - (void)getScreenRectForHtmlImageWithSrc:(NSString *)src completion:(void (^)(CGRect rect))completion {
-    [self getScreenRectForHtmlElementFromJavascriptString:[NSString stringWithFormat:@"window.wmf.elementLocation.getElementRect(window.wmf.elementLocation.getImageWithSrc('%@'));", [src wmf_stringBySanitizingForJavascript]]
+    [self getScreenRectForHtmlElementFromJavascriptString:[NSString stringWithFormat:@"window.wmf.elementLocation.getElementRect(window.wmf.elementLocation.getImageWithSrc('%@'));", [src wmf_stringBySanitizingForJavaScript]]
                                                completion:completion];
 }
 
@@ -55,7 +55,7 @@
 }
 
 - (void)getIndexOfTopOnScreenElementWithPrefix:(NSString *)prefix count:(NSUInteger)count completion:(void (^)(id index, NSError *error))completion {
-    [self evaluateJavaScript:[NSString stringWithFormat:@"window.wmf.elementLocation.getIndexOfFirstOnScreenElement('%@', %lu)", [prefix wmf_stringBySanitizingForJavascript], (unsigned long)count]
+    [self evaluateJavaScript:[NSString stringWithFormat:@"window.wmf.elementLocation.getIndexOfFirstOnScreenElement('%@', %lu)", [prefix wmf_stringBySanitizingForJavaScript], (unsigned long)count]
            completionHandler:^(id _Nullable index, NSError *_Nullable error) {
                completion(index, error);
            }];

--- a/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
+++ b/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
@@ -149,8 +149,8 @@ extension WKWebView {
         
         return """
         new window.wmf.sections.Language(
-            '\(langCode.wmf_stringByReplacingApostrophesWithBackslashApostrophes())',
-            '\(langDir.wmf_stringByReplacingApostrophesWithBackslashApostrophes())',
+            '\(langCode.wmf_stringBySanitizingForJavascript())',
+            '\(langDir.wmf_stringBySanitizingForJavascript())',
             \((langDir == "rtl").toString())
         )
         """
@@ -163,9 +163,9 @@ extension WKWebView {
         return """
         new window.wmf.sections.Article(
             \(article.isMain.toString()),
-            '\(title.wmf_stringByReplacingApostrophesWithBackslashApostrophes())',
-            '\(articleDisplayTitle.wmf_stringByReplacingApostrophesWithBackslashApostrophes())',
-            '\(articleEntityDescription.wmf_stringByReplacingApostrophesWithBackslashApostrophes())',
+            '\(title.wmf_stringBySanitizingForJavascript())',
+            '\(articleDisplayTitle.wmf_stringBySanitizingForJavascript())',
+            '\(articleEntityDescription.wmf_stringBySanitizingForJavascript())',
             \(article.editable.toString()),
             \(languageJS(for: article))
         )
@@ -206,12 +206,12 @@ extension WKWebView {
         let addFooterCallbackJS = """
         () => {
             const footer = new window.wmf.footers.Footer(
-                '\(title.wmf_stringByReplacingApostrophesWithBackslashApostrophes())',
+                '\(title.wmf_stringBySanitizingForJavascript())',
                 \(menuItemsJS(for: article)),
                 \(article.hasReadMore.toString()),
                 3,
                 \(FooterLocalizedStrings.init(for: article).toJSON()),
-                '\(proxyURLString.wmf_stringByReplacingApostrophesWithBackslashApostrophes())'
+                '\(proxyURLString.wmf_stringBySanitizingForJavascript())'
             )
             footer.add()
         }
@@ -220,13 +220,13 @@ extension WKWebView {
         let sectionErrorMessageLocalizedString = WMFLocalizedString("article-unable-to-load-section", language: (article.url as NSURL).wmf_language, value: "Unable to load this section. Try refreshing the article to see if it fixes the problem.", comment: "Displayed within the article content when a section fails to render for some reason.")
         
         evaluateJavaScript("""
-            window.wmf.sections.sectionErrorMessageLocalizedString = '\(sectionErrorMessageLocalizedString.wmf_stringByReplacingApostrophesWithBackslashApostrophes())'
+            window.wmf.sections.sectionErrorMessageLocalizedString = '\(sectionErrorMessageLocalizedString.wmf_stringBySanitizingForJavascript())'
             window.wmf.sections.collapseTablesLocalizedStrings = \(CollapseTablesLocalizedStrings.init(for: (article.url as NSURL).wmf_language).toJSON())
             window.wmf.sections.collapseTablesInitially = \(collapseTables ? "true" : "false")
             window.wmf.sections.fetchTransformAndAppendSectionsToDocument(
                 \(articleJS(for: article, title: title)),
-                '\(apiURLString.wmf_stringByReplacingApostrophesWithBackslashApostrophes())',
-                '\((fragment ?? "").wmf_stringByReplacingApostrophesWithBackslashApostrophes())',
+                '\(apiURLString.wmf_stringBySanitizingForJavascript())',
+                '\((fragment ?? "").wmf_stringBySanitizingForJavascript())',
                 \(addFooterCallbackJS)
             )
             """) { (result, error) in

--- a/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
+++ b/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.swift
@@ -149,8 +149,8 @@ extension WKWebView {
         
         return """
         new window.wmf.sections.Language(
-            '\(langCode.wmf_stringBySanitizingForJavascript())',
-            '\(langDir.wmf_stringBySanitizingForJavascript())',
+            '\(langCode.wmf_stringBySanitizingForJavaScript())',
+            '\(langDir.wmf_stringBySanitizingForJavaScript())',
             \((langDir == "rtl").toString())
         )
         """
@@ -163,9 +163,9 @@ extension WKWebView {
         return """
         new window.wmf.sections.Article(
             \(article.isMain.toString()),
-            '\(title.wmf_stringBySanitizingForJavascript())',
-            '\(articleDisplayTitle.wmf_stringBySanitizingForJavascript())',
-            '\(articleEntityDescription.wmf_stringBySanitizingForJavascript())',
+            '\(title.wmf_stringBySanitizingForJavaScript())',
+            '\(articleDisplayTitle.wmf_stringBySanitizingForJavaScript())',
+            '\(articleEntityDescription.wmf_stringBySanitizingForJavaScript())',
             \(article.editable.toString()),
             \(languageJS(for: article))
         )
@@ -206,12 +206,12 @@ extension WKWebView {
         let addFooterCallbackJS = """
         () => {
             const footer = new window.wmf.footers.Footer(
-                '\(title.wmf_stringBySanitizingForJavascript())',
+                '\(title.wmf_stringBySanitizingForJavaScript())',
                 \(menuItemsJS(for: article)),
                 \(article.hasReadMore.toString()),
                 3,
                 \(FooterLocalizedStrings.init(for: article).toJSON()),
-                '\(proxyURLString.wmf_stringBySanitizingForJavascript())'
+                '\(proxyURLString.wmf_stringBySanitizingForJavaScript())'
             )
             footer.add()
         }
@@ -220,13 +220,13 @@ extension WKWebView {
         let sectionErrorMessageLocalizedString = WMFLocalizedString("article-unable-to-load-section", language: (article.url as NSURL).wmf_language, value: "Unable to load this section. Try refreshing the article to see if it fixes the problem.", comment: "Displayed within the article content when a section fails to render for some reason.")
         
         evaluateJavaScript("""
-            window.wmf.sections.sectionErrorMessageLocalizedString = '\(sectionErrorMessageLocalizedString.wmf_stringBySanitizingForJavascript())'
+            window.wmf.sections.sectionErrorMessageLocalizedString = '\(sectionErrorMessageLocalizedString.wmf_stringBySanitizingForJavaScript())'
             window.wmf.sections.collapseTablesLocalizedStrings = \(CollapseTablesLocalizedStrings.init(for: (article.url as NSURL).wmf_language).toJSON())
             window.wmf.sections.collapseTablesInitially = \(collapseTables ? "true" : "false")
             window.wmf.sections.fetchTransformAndAppendSectionsToDocument(
                 \(articleJS(for: article, title: title)),
-                '\(apiURLString.wmf_stringBySanitizingForJavascript())',
-                '\((fragment ?? "").wmf_stringBySanitizingForJavascript())',
+                '\(apiURLString.wmf_stringBySanitizingForJavaScript())',
+                '\((fragment ?? "").wmf_stringBySanitizingForJavaScript())',
                 \(addFooterCallbackJS)
             )
             """) { (result, error) in

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -178,11 +178,11 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
 
 - (void)updateReadMoreSaveButtonIsSavedStateForURL:(NSURL *)url {
     BOOL isSaved = [self.article.dataStore.savedPageList isSaved:url];
-    NSString *title = [[url.absoluteString.lastPathComponent stringByRemovingPercentEncoding] wmf_stringByReplacingApostrophesWithBackslashApostrophes];
+    NSString *title = [[url.absoluteString.lastPathComponent stringByRemovingPercentEncoding] wmf_stringBySanitizingForJavascript];
     if (title) {
         NSString *saveTitle = [WMFCommonStrings saveTitleWithLanguage:url.wmf_language];
         NSString *savedTitle = [WMFCommonStrings savedTitleWithLanguage:url.wmf_language];
-        NSString *saveButtonText = [(isSaved ? savedTitle : saveTitle)wmf_stringByReplacingApostrophesWithBackslashApostrophes];
+        NSString *saveButtonText = [(isSaved ? savedTitle : saveTitle)wmf_stringBySanitizingForJavascript];
         [self.webView evaluateJavaScript:[NSString stringWithFormat:@"window.wmf.footerReadMore.updateSaveButtonForTitle('%@', '%@', %@, document)", title, saveButtonText, (isSaved ? @"true" : @"false")] completionHandler:nil];
     }
 }
@@ -543,7 +543,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
 #pragma FindInPageKeyboardBarDelegate
 
 - (void)keyboardBar:(WMFFindInPageKeyboardBar *)keyboardBar searchTermChanged:(NSString *)term {
-    term = [term wmf_stringByReplacingApostrophesWithBackslashApostrophes];
+    term = [term wmf_stringBySanitizingForJavascript];
     [self.webView evaluateJavaScript:[NSString stringWithFormat:@"window.wmf.findInPage.findAndHighlightAllMatchesForSearchTerm('%@')", term]
                    completionHandler:^(id _Nullable obj, NSError *_Nullable error) {
                        [self scrollToAndFocusOnFirstMatch];

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -178,11 +178,11 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
 
 - (void)updateReadMoreSaveButtonIsSavedStateForURL:(NSURL *)url {
     BOOL isSaved = [self.article.dataStore.savedPageList isSaved:url];
-    NSString *title = [[url.absoluteString.lastPathComponent stringByRemovingPercentEncoding] wmf_stringBySanitizingForJavascript];
+    NSString *title = [[url.absoluteString.lastPathComponent stringByRemovingPercentEncoding] wmf_stringBySanitizingForJavaScript];
     if (title) {
         NSString *saveTitle = [WMFCommonStrings saveTitleWithLanguage:url.wmf_language];
         NSString *savedTitle = [WMFCommonStrings savedTitleWithLanguage:url.wmf_language];
-        NSString *saveButtonText = [(isSaved ? savedTitle : saveTitle)wmf_stringBySanitizingForJavascript];
+        NSString *saveButtonText = [(isSaved ? savedTitle : saveTitle)wmf_stringBySanitizingForJavaScript];
         [self.webView evaluateJavaScript:[NSString stringWithFormat:@"window.wmf.footerReadMore.updateSaveButtonForTitle('%@', '%@', %@, document)", title, saveButtonText, (isSaved ? @"true" : @"false")] completionHandler:nil];
     }
 }
@@ -543,7 +543,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
 #pragma FindInPageKeyboardBarDelegate
 
 - (void)keyboardBar:(WMFFindInPageKeyboardBar *)keyboardBar searchTermChanged:(NSString *)term {
-    term = [term wmf_stringBySanitizingForJavascript];
+    term = [term wmf_stringBySanitizingForJavaScript];
     [self.webView evaluateJavaScript:[NSString stringWithFormat:@"window.wmf.findInPage.findAndHighlightAllMatchesForSearchTerm('%@')", term]
                    completionHandler:^(id _Nullable obj, NSError *_Nullable error) {
                        [self scrollToAndFocusOnFirstMatch];


### PR DESCRIPTION
In addition to apostrophes, escape newlines (caused the issue) and quotes (extra protection for future use) as well

https://phabricator.wikimedia.org/T195551