### PR TITLE
Show announcements if countries array is missing or empty

### DIFF
--- a/WMF Framework/WMFAnnouncementsFetcher.m
+++ b/WMF Framework/WMFAnnouncementsFetcher.m
@@ -75,7 +75,11 @@
             return NO;
         }
         __block BOOL valid = NO;
-        [[obj countries] enumerateObjectsUsingBlock:^(NSString *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
+        NSArray *countries = [obj countries];
+        if (countries.count == 0) {
+            return YES;
+        }
+        [countries enumerateObjectsUsingBlock:^(NSString *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
             if ([header containsString:[NSString stringWithFormat:@"GeoIP=%@", obj]]) {
                 valid = YES;
                 *stop = YES;

--- a/WMF Framework/WMFAnnouncementsFetcher.m
+++ b/WMF Framework/WMFAnnouncementsFetcher.m
@@ -74,11 +74,11 @@
         if (![obj isKindOfClass:[WMFAnnouncement class]]) {
             return NO;
         }
-        __block BOOL valid = NO;
         NSArray *countries = [obj countries];
         if (countries.count == 0) {
             return YES;
         }
+        __block BOOL valid = NO;
         [countries enumerateObjectsUsingBlock:^(NSString *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
             if ([header containsString:[NSString stringWithFormat:@"GeoIP=%@", obj]]) {
                 valid = YES;


### PR DESCRIPTION
A minor bug found while investigating adding the `iOSAppV2` announcement schema that should be patched sooner rather than later