### PR TITLE
Add empty string protection for app install id

### DIFF
--- a/Wikipedia/Code/WMFKeychainCredentials.swift
+++ b/Wikipedia/Code/WMFKeychainCredentials.swift
@@ -45,8 +45,8 @@ struct WMFKeychainCredentials {
     
     public var appInstallID: String? {
         get {
-            guard let appInstallID = tryGetString(forKey: appInstallIDKey) else {
-                if let previousID = UserDefaults.wmf_userDefaults().string(forKey: "WMFAppInstallID") {
+            guard let appInstallID = tryGetString(forKey: appInstallIDKey), appInstallID != "" else {
+                if let previousID = UserDefaults.wmf_userDefaults().string(forKey: "WMFAppInstallID"), previousID != "" {
                     trySet(previousID, forKey: appInstallIDKey)
                     return previousID
                 }


### PR DESCRIPTION
Best guess fix for https://phabricator.wikimedia.org/T196131 . Other possibilities are underlying issues with keychain access.