### PR TITLE
Add empty string protection for app install id and session id

### DIFF
--- a/WMF Framework/EventLoggingStandardEventProviding.swift
+++ b/WMF Framework/EventLoggingStandardEventProviding.swift
@@ -9,7 +9,10 @@ public protocol EventLoggingStandardEventProviding {
 
 public extension EventLoggingStandardEventProviding where Self: EventLoggingFunnel {
     var standardEvent: Dictionary<String, Any> {
-        return ["app_install_id": appInstallID, "session_id": sessionID, "event_dt": timestamp];
+        guard let aii = appInstallID, let si = sessionID else {
+            return ["event_dt": timestamp]
+        }
+        return ["app_install_id": aii, "session_id": si, "event_dt": timestamp]
     }
     
     func wholeEvent(with event: Dictionary<AnyHashable, Any>) -> Dictionary<String, Any> {

--- a/Wikipedia/Code/EventLoggingFunnel.h
+++ b/Wikipedia/Code/EventLoggingFunnel.h
@@ -62,11 +62,11 @@ extern EventLoggingLabel const EventLoggingLabelMainPage;
  * Helper function that returns a persistent appInstallID.
  * appInstallID is generated once per install.
  */
-@property (nonatomic, readonly) NSString *appInstallID;
+@property (nonatomic, readonly, nullable) NSString *appInstallID;
 /**
  * SessionID is reset when app is launched for the first time or resumed.
  */
-@property (nonatomic, readonly) NSString *sessionID;
+@property (nonatomic, readonly, nullable) NSString *sessionID;
 @property (nonatomic, readonly) NSString *timestamp;
 @property (nonatomic, readonly) NSNumber *isAnon;
 

--- a/Wikipedia/Code/WMFKeychainCredentials.swift
+++ b/Wikipedia/Code/WMFKeychainCredentials.swift
@@ -62,7 +62,7 @@ struct WMFKeychainCredentials {
     
     public var sessionID: String? {
         get {
-            guard let sessionID = tryGetString(forKey: sessionIDKey) else {
+            guard let sessionID = tryGetString(forKey: sessionIDKey), sessionID != "" else {
                 setNewUUID(forKey: sessionIDKey)
                 return tryGetString(forKey: sessionIDKey)
             }

--- a/Wikipedia/Code/WMFKeychainCredentials.swift
+++ b/Wikipedia/Code/WMFKeychainCredentials.swift
@@ -45,8 +45,8 @@ struct WMFKeychainCredentials {
     
     public var appInstallID: String? {
         get {
-            guard let appInstallID = tryGetString(forKey: appInstallIDKey) else {
-                if let previousID = UserDefaults.wmf_userDefaults().string(forKey: "WMFAppInstallID") {
+            guard let appInstallID = tryGetString(forKey: appInstallIDKey), appInstallID != "" else {
+                if let previousID = UserDefaults.wmf_userDefaults().string(forKey: "WMFAppInstallID"), previousID != "" {
                     trySet(previousID, forKey: appInstallIDKey)
                     return previousID
                 }

--- a/Wikipedia/Code/WMFKeychainCredentials.swift
+++ b/Wikipedia/Code/WMFKeychainCredentials.swift
@@ -167,6 +167,7 @@ struct WMFKeychainCredentials {
         do {
             return try set(value: newValue, forKey: key)
         } catch  {
+            DDLogError("Error setting keychain value for \(key): \(error)") // don't log the value
             assertionFailure("\(error)")
         }
     }


### PR DESCRIPTION
Best guess fix for https://phabricator.wikimedia.org/T196131 . Other possibilities are underlying issues with keychain access.