### PR TITLE
Fix account messaging & logout status when in airplane mode

### DIFF
--- a/WMF Framework/ReadingListsSyncOperation.swift
+++ b/WMF Framework/ReadingListsSyncOperation.swift
@@ -78,7 +78,7 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
             taskGroup.enter()
             authenticationDelegate.attemptLogin({
                 taskGroup.leave()
-            }, failure: {})
+            }, failure: { _ in })
             taskGroup.wait()
         }
         

--- a/Wikipedia/Code/AuthenticationDelegate.swift
+++ b/Wikipedia/Code/AuthenticationDelegate.swift
@@ -1,5 +1,5 @@
 public protocol AuthenticationDelegate: class {
     func isUserLoggedInLocally() -> Bool
     func isUserLoggedInRemotely() -> Bool
-    func attemptLogin(_ completion: @escaping () -> Void, failure: @escaping () -> Void)
+    func attemptLogin(_ completion: @escaping () -> Void, failure: @escaping (_ error: Error) -> Void)
 }

--- a/Wikipedia/Code/WMFAccountLogin.swift
+++ b/Wikipedia/Code/WMFAccountLogin.swift
@@ -29,6 +29,9 @@ public enum WMFAccountLoginError: LocalizedError {
 public typealias WMFAccountLoginResultBlock = (WMFAccountLoginResult) -> Void
 
 public class WMFAccountLoginResult: NSObject {
+    public struct Status {
+        static let offline = "offline"
+    }
     @objc var status: String
     @objc var username: String
     @objc var message: String?

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -425,7 +425,10 @@ static NSString *const WMFLastRemoteAppConfigCheckAbsoluteTimeKey = @"WMFLastRem
                 });
             }];
         }
-            failure:^{
+            failure:^(NSError *error){
+                if ([error.domain isEqualToString:NSURLErrorDomain]) {
+                    return;
+                }
                 [self wmf_showReloginFailedPanelIfNecessaryWithTheme:self.theme];
             }];
     });
@@ -705,7 +708,10 @@ static NSString *const WMFLastRemoteAppConfigCheckAbsoluteTimeKey = @"WMFLastRem
         [self.savedArticlesFetcher start];
         self.resumeComplete = YES;
     }
-        failure:^{
+        failure:^(NSError *error){
+            if ([error.domain isEqualToString:NSURLErrorDomain]) {
+                return;
+            }
             [self wmf_showReloginFailedPanelIfNecessaryWithTheme:self.theme];
         }];
 

--- a/Wikipedia/Code/WMFAuthenticationManager.swift
+++ b/Wikipedia/Code/WMFAuthenticationManager.swift
@@ -142,12 +142,19 @@ public class WMFAuthenticationManager: NSObject {
             self.loggedInUsername = result.name
             userAlreadyLoggedInHandler(result)
         }, failure:{ error in
-            self.loggedInUsername = nil
-            
+            guard !(error is URLError) else {
+                self.loggedInUsername = userName
+                success(WMFAccountLoginResult(status: WMFAccountLoginResult.Status.offline, username: userName, message: nil))
+                return
+            }
             self.login(username: userName, password: password, retypePassword: nil, oathToken: nil, captchaID: nil, captchaWord: nil, success: success, failure: { error in
-                if !(error is URLError) {
-                    self.logout()
+                guard !(error is URLError) else {
+                    self.loggedInUsername = userName
+                    success(WMFAccountLoginResult(status: WMFAccountLoginResult.Status.offline, username: userName, message: nil))
+                    return
                 }
+                self.loggedInUsername = nil
+                self.logout()
                 failure(error)
             })
         })

--- a/Wikipedia/Code/WMFAuthenticationManager.swift
+++ b/Wikipedia/Code/WMFAuthenticationManager.swift
@@ -145,10 +145,8 @@ public class WMFAuthenticationManager: NSObject {
             self.loggedInUsername = nil
             
             self.login(username: userName, password: password, retypePassword: nil, oathToken: nil, captchaID: nil, captchaWord: nil, success: success, failure: { error in
-                if let error = error as? URLError {
-                    if error.code != .notConnectedToInternet {
-                        self.logout()
-                    }
+                if !(error is URLError) {
+                    self.logout()
                 }
                 failure(error)
             })

--- a/Wikipedia/Code/WMFAuthenticationManager.swift
+++ b/Wikipedia/Code/WMFAuthenticationManager.swift
@@ -73,7 +73,7 @@ public class WMFAuthenticationManager: NSObject {
         return baseURL!
     }
     
-    @objc public func attemptLogin(_ completion: @escaping () -> Void = {}, failure: @escaping () -> Void = {}) {
+    @objc public func attemptLogin(_ completion: @escaping () -> Void = {}, failure: @escaping (_ error: Error) -> Void = {_ in }) {
         let performCompletionOnTheMainThread = {
             DispatchQueue.main.async {
                 completion()
@@ -88,7 +88,9 @@ public class WMFAuthenticationManager: NSObject {
         }, failure: { (error) in
             DDLogDebug("\n\nloginWithSavedCredentials failed with error \(error).\n\n")
             performCompletionOnTheMainThread()
-            failure()
+            DispatchQueue.main.async {
+                failure(error)
+            }
         })
     }
     


### PR DESCRIPTION
https://phabricator.wikimedia.org/T196184

- Only fail re-auth on server-side failures, not `NSURLErrorDomain` failures
- Keep `loggedInUsername` if re-auth fails due to network connection so the user doesn't appear logged out