### PR TITLE
Time profiler fixes

### DIFF
--- a/WMF Framework/Localization/WMFLocalization.m
+++ b/WMF Framework/Localization/WMFLocalization.m
@@ -57,7 +57,7 @@
         }
         bundle = [NSBundle bundleWithPath:path];
         if (bundle) {
-            bundles[path] = bundle;
+            bundles[language] = bundle;
         }
     }
     return bundle;

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -1274,7 +1274,7 @@ static uint64_t bundleHash() {
 
 - (NSInteger)sitesDirectorySize {
     NSURL *sitesURL = [NSURL fileURLWithPath:[self pathForSites]];
-    return [[NSFileManager defaultManager] sizeOfDirectoryAt:sitesURL];
+    return (NSInteger)[[NSFileManager defaultManager] sizeOfDirectoryAt:sitesURL];
 }
 
 - (void)removeUnreferencedArticlesFromDiskCacheWithFailure:(WMFErrorHandler)failure success:(WMFSuccessHandler)success {

--- a/Wikipedia/Code/SaveButton.swift
+++ b/Wikipedia/Code/SaveButton.swift
@@ -54,12 +54,6 @@ import UIKit
             layoutIfNeeded()
         }
     }
-
-    override open func layoutSubviews() {
-        UIView.performWithoutAnimation {
-            super.layoutSubviews()
-        }
-    }
     
     @objc func addToReadingList(_ sender: UIControl) -> Bool {
         return saveButtonDelegate?.saveButtonDidReceiveAddToReadingListAction(self) ?? false

--- a/Wikipedia/Code/WMFContentGroup+WMFFeedContentDisplaying.m
+++ b/Wikipedia/Code/WMFContentGroup+WMFFeedContentDisplaying.m
@@ -10,34 +10,52 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - In The News
 
-- (nullable UIImage *)headerIcon {
+- (nullable NSString *)headerIconName {
     switch (self.contentGroupKind) {
         case WMFContentGroupKindContinueReading:
-            return [UIImage imageNamed:@"home-continue-reading-mini"];
+            return @"home-continue-reading-mini";
         case WMFContentGroupKindMainPage:
-            return [UIImage imageNamed:@"today-mini"];
+            return @"today-mini";
         case WMFContentGroupKindRelatedPages:
-            return [UIImage imageNamed:@"recent-mini"];
+            return @"recent-mini";
         case WMFContentGroupKindLocation:
-            return [UIImage imageNamed:@"nearby-mini"];
+            return @"nearby-mini";
         case WMFContentGroupKindLocationPlaceholder:
-            return [UIImage imageNamed:@"nearby-mini"];
+            return @"nearby-mini";
         case WMFContentGroupKindPictureOfTheDay:
-            return [UIImage imageNamed:@"potd-mini"];
+            return @"potd-mini";
         case WMFContentGroupKindRandom:
-            return [UIImage imageNamed:@"random-mini"];
+            return @"random-mini";
         case WMFContentGroupKindFeaturedArticle:
-            return [UIImage imageNamed:@"featured-mini"];
+            return @"featured-mini";
         case WMFContentGroupKindTopRead:
-            return [UIImage imageNamed:@"trending-mini"];
+            return @"trending-mini";
         case WMFContentGroupKindNews:
-            return [UIImage imageNamed:@"in-the-news-mini"];
+            return @"in-the-news-mini";
         case WMFContentGroupKindOnThisDay:
-            return [UIImage imageNamed:@"on-this-day-mini"];
+            return @"on-this-day-mini";
         default:
             break;
     }
     return nil;
+}
+
+- (nullable UIImage *)headerIcon {
+    static dispatch_once_t onceToken;
+    static NSMutableDictionary<NSString *, UIImage *> *headerIcons;
+    dispatch_once(&onceToken, ^{
+        headerIcons = [NSMutableDictionary dictionaryWithCapacity:12];
+    });
+    NSString *name = [self headerIconName];
+    if (!name) {
+        return nil;
+    }
+    UIImage *image = headerIcons[name];
+    if (!image) {
+        image = [UIImage imageNamed:name];
+        headerIcons[name] = image;
+    }
+    return image;
 }
 
 - (nullable UIColor *)headerIconTintColor {


### PR DESCRIPTION
- Fix language bundle caching bug (lookup was by language, cache was by path)
- Remove `performWithoutAnimation` inside of `SaveButton`'s `layoutSubviews` - @montehurd do you remember what this was fixing?
- Cache header icons
- Fix compiler warning for precision loss without cast