### PR TITLE
Fix widget layout

### DIFF
--- a/ContinueReadingWidget/WMFTodayContinueReadingWidgetViewController.swift
+++ b/ContinueReadingWidget/WMFTodayContinueReadingWidgetViewController.swift
@@ -137,16 +137,12 @@ class WMFTodayContinueReadingWidgetViewController: UIViewController, NCWidgetPro
         
         self.titleLabel.attributedText = article.displayTitleHTML.byAttributingHTML(with: .headline, matching: traitCollection)
         
-        if #available(iOSApplicationExtension 10.0, *) {
-            if let imageURL = article.imageURL(forWidth: self.traitCollection.wmf_nearbyThumbnailWidth) {
-                self.collapseImageAndWidenLabels = false
-                self.imageView.wmf_setImage(with: imageURL, detectFaces: true, onGPU: true, failure: { (error) in
-                    self.collapseImageAndWidenLabels = true
-                }) {
-                    self.collapseImageAndWidenLabels = false
-                }
-            } else {
+        if let imageURL = article.imageURL(forWidth: self.traitCollection.wmf_nearbyThumbnailWidth) {
+            self.collapseImageAndWidenLabels = false
+            self.imageView.wmf_setImage(with: imageURL, detectFaces: true, onGPU: true, failure: { (error) in
                 self.collapseImageAndWidenLabels = true
+            }) {
+                self.collapseImageAndWidenLabels = false
             }
         } else {
             self.collapseImageAndWidenLabels = true

--- a/FeaturedArticleWidget/FeaturedArticleWidget.swift
+++ b/FeaturedArticleWidget/FeaturedArticleWidget.swift
@@ -93,13 +93,8 @@ class FeaturedArticleWidget: UIViewController, NCWidgetProviding {
         }
         var maximumSize = CGSize(width: view.bounds.size.width, height: UIViewNoIntrinsicMetric)
         if let context = extensionContext {
-            if #available(iOSApplicationExtension 10.0, *) {
-                isExpanded = context.widgetActiveDisplayMode == .expanded
-                maximumSize = context.widgetMaximumSize(for: context.widgetActiveDisplayMode)
-            } else {
-                isExpanded = true
-                maximumSize = UIScreen.main.bounds.size
-            }
+            isExpanded = context.widgetActiveDisplayMode == .expanded
+            maximumSize = context.widgetMaximumSize(for: context.widgetActiveDisplayMode)
         }
         updateViewAlpha(isExpanded: isExpanded)
         updateViewWithMaximumSize(maximumSize, isExpanded: isExpanded)
@@ -118,7 +113,6 @@ class FeaturedArticleWidget: UIViewController, NCWidgetProviding {
         preferredContentSize = CGSize(width: maximumSize.width, height: sizeThatFits.height)
     }
     
-    @available(iOSApplicationExtension 10.0, *)
     func widgetActiveDisplayModeDidChange(_ activeDisplayMode: NCWidgetDisplayMode, withMaximumSize maxSize: CGSize) {
         debounceViewUpdate()
     }

--- a/FeaturedArticleWidget/FeaturedArticleWidget.swift
+++ b/FeaturedArticleWidget/FeaturedArticleWidget.swift
@@ -25,6 +25,8 @@ class FeaturedArticleWidget: UIViewController, NCWidgetProviding {
         expandedArticleView.saveButton.addTarget(self, action: #selector(saveButtonPressed), for: .touchUpInside)
         expandedArticleView.frame = view.bounds
         view.addSubview(expandedArticleView)
+        
+        extensionContext?.widgetLargestAvailableDisplayMode = .expanded
     }
     
     var isEmptyViewHidden = true {
@@ -92,7 +94,6 @@ class FeaturedArticleWidget: UIViewController, NCWidgetProviding {
         var maximumSize = CGSize(width: view.bounds.size.width, height: UIViewNoIntrinsicMetric)
         if let context = extensionContext {
             if #available(iOSApplicationExtension 10.0, *) {
-                context.widgetLargestAvailableDisplayMode = .expanded
                 isExpanded = context.widgetActiveDisplayMode == .expanded
                 maximumSize = context.widgetMaximumSize(for: context.widgetActiveDisplayMode)
             } else {

--- a/TopReadWidget/WMFTodayTopReadWidgetViewController.swift
+++ b/TopReadWidget/WMFTodayTopReadWidgetViewController.swift
@@ -71,14 +71,15 @@ class WMFTodayTopReadWidgetViewController: UIViewController, NCWidgetProviding {
         guard let appLanguage = MWKLanguageLinkController.sharedInstance().appLanguage else {
             return
         }
-
+    
         siteURL = appLanguage.siteURL()
         userStore = SessionSingleton.sharedInstance().dataStore
         contentSource = WMFFeedContentSource(siteURL: siteURL, userDataStore: userStore, notificationsController: nil)
 
         let tapGR = UITapGestureRecognizer(target: self, action: #selector(self.handleTapGestureRecognizer(_:)))
         view.addGestureRecognizer(tapGR)
-
+        
+        extensionContext?.widgetLargestAvailableDisplayMode = .expanded
     }
     
     func layoutForSize(_ size: CGSize) {
@@ -135,7 +136,6 @@ class WMFTodayTopReadWidgetViewController: UIViewController, NCWidgetProviding {
         }
         if let context = self.extensionContext {
             var updatedIsExpanded: Bool?
-            context.widgetLargestAvailableDisplayMode = .expanded
             updatedIsExpanded = context.widgetActiveDisplayMode == .expanded
             maximumSize = context.widgetMaximumSize(for: context.widgetActiveDisplayMode)
             if isExpanded != updatedIsExpanded {

--- a/TopReadWidget/WMFTodayTopReadWidgetViewController.swift
+++ b/TopReadWidget/WMFTodayTopReadWidgetViewController.swift
@@ -75,12 +75,6 @@ class WMFTodayTopReadWidgetViewController: UIViewController, NCWidgetProviding {
         siteURL = appLanguage.siteURL()
         userStore = SessionSingleton.sharedInstance().dataStore
         contentSource = WMFFeedContentSource(siteURL: siteURL, userDataStore: userStore, notificationsController: nil)
-        
-        if #available(iOSApplicationExtension 10.0, *) {
-        } else {
-            headerLabelLeadingConstraint.constant = 0
-            footerLabelLeadingConstraint.constant = 0
-        }
 
         let tapGR = UITapGestureRecognizer(target: self, action: #selector(self.handleTapGestureRecognizer(_:)))
         view.addGestureRecognizer(tapGR)
@@ -110,18 +104,12 @@ class WMFTodayTopReadWidgetViewController: UIViewController, NCWidgetProviding {
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        
-        if #available(iOSApplicationExtension 10.0, *) {
-            coordinator.animate(alongsideTransition: { (context) in
-
+        coordinator.animate(alongsideTransition: { (context) in
+            self.layoutForSize(size)
+        }) { (context) in
+            if (!context.isAnimated) {
                 self.layoutForSize(size)
-            }) { (context) in
-                if (!context.isAnimated) {
-                    self.layoutForSize(size)
-                }
             }
-        } else {
-            layoutForSize(size)
         }
     }
     
@@ -132,9 +120,6 @@ class WMFTodayTopReadWidgetViewController: UIViewController, NCWidgetProviding {
         rowCount = isExpanded ? maximumRowCount : 1
     }
 
-
-    
-    @available(iOSApplicationExtension 10.0, *)
     func widgetActiveDisplayModeDidChange(_ activeDisplayMode: NCWidgetDisplayMode, withMaximumSize maxSize: CGSize) {
         debounceViewUpdate()
     }
@@ -150,16 +135,9 @@ class WMFTodayTopReadWidgetViewController: UIViewController, NCWidgetProviding {
         }
         if let context = self.extensionContext {
             var updatedIsExpanded: Bool?
-            if #available(iOSApplicationExtension 10.0, *) {
-                context.widgetLargestAvailableDisplayMode = .expanded
-                updatedIsExpanded = context.widgetActiveDisplayMode == .expanded
-                maximumSize = context.widgetMaximumSize(for: context.widgetActiveDisplayMode)
-            } else {
-                updatedIsExpanded = true
-                maximumSize = UIScreen.main.bounds.size
-                headerViewHeightConstraint.constant = 40
-                footerViewHeightConstraint.constant = 40
-            }
+            context.widgetLargestAvailableDisplayMode = .expanded
+            updatedIsExpanded = context.widgetActiveDisplayMode == .expanded
+            maximumSize = context.widgetMaximumSize(for: context.widgetActiveDisplayMode)
             if isExpanded != updatedIsExpanded {
                 isExpanded = updatedIsExpanded
                 updateViewPropertiesForIsExpanded(isExpanded ?? false)
@@ -277,15 +255,11 @@ class WMFTodayTopReadWidgetViewController: UIViewController, NCWidgetProviding {
                 vc.viewCountAndSparklineContainerView.isHidden = true
             }
             
-            if #available(iOSApplicationExtension 10.0, *) {
-                if let imageURL = result.thumbnailURL {
-                    vc.imageView.wmf_setImage(with: imageURL, detectFaces: true, onGPU: true, failure: { (error) in
-                        vc.collapseImageAndWidenLabels = true
-                    }) {
-                        vc.collapseImageAndWidenLabels = false
-                    }
-                } else {
+            if let imageURL = result.thumbnailURL {
+                vc.imageView.wmf_setImage(with: imageURL, detectFaces: true, onGPU: true, failure: { (error) in
                     vc.collapseImageAndWidenLabels = true
+                }) {
+                    vc.collapseImageAndWidenLabels = false
                 }
             } else {
                 vc.collapseImageAndWidenLabels = true
@@ -297,11 +271,6 @@ class WMFTodayTopReadWidgetViewController: UIViewController, NCWidgetProviding {
                 vc.separatorView.isHidden = false
             }
             vc.separatorView.backgroundColor = theme.colors.border
-
-            if #available(iOSApplicationExtension 10.0, *) {
-            } else {
-                vc.marginWidthConstraint.constant = 0
-            }
             
             i += 1
         }

--- a/WMF Framework/UIFont+WMFDynamicType.swift
+++ b/WMF Framework/UIFont+WMFDynamicType.swift
@@ -107,11 +107,7 @@ let fontSizeTable: [FontFamily:[UIFontTextStyle:[UIContentSizeCategory:CGFloat]]
 
 public extension UITraitCollection {
     var wmf_preferredContentSizeCategory: UIContentSizeCategory {
-        if #available(iOSApplicationExtension 10.0, *) {
-            return preferredContentSizeCategory
-        } else {
-            return UIContentSizeCategory.medium
-        }
+         return preferredContentSizeCategory
     }
 }
 


### PR DESCRIPTION
- Remove code for older iOS versions that are no longer supported
- Only set `widgetLargestAvailableDisplayMode` on `viewDidLoad` since it isn't being changed. It seems setting this even without changing the value was triggering unnecessary view updates

https://phabricator.wikimedia.org/T196300