### PR TITLE
Rename key measure to measure_time for LoginFunnel and SessionsFunnel

### DIFF
--- a/Wikipedia/Code/LoginFunnel.swift
+++ b/Wikipedia/Code/LoginFunnel.swift
@@ -4,7 +4,7 @@
     @objc public static let shared = LoginFunnel()
     
     private override init() {
-        super.init(schema: "MobileWikiAppiOSLoginAction", version: 18064101)
+        super.init(schema: "MobileWikiAppiOSLoginAction", version: 18121305)
     }
     
     private enum Action: String {
@@ -25,7 +25,7 @@
             event["label"] = label
         }
         if let measure = measure {
-            event["measure"] = Int(round(measure))
+            event["measure_time"] = Int(round(measure))
         }
         return event
     }

--- a/Wikipedia/Code/SessionsFunnel.swift
+++ b/Wikipedia/Code/SessionsFunnel.swift
@@ -4,7 +4,7 @@
     @objc public static let shared = SessionsFunnel()
     
     private override init() {
-        super.init(schema: "MobileWikiAppiOSSessions", version: 18064102)
+        super.init(schema: "MobileWikiAppiOSSessions", version: 18121261)
     }
     
     private enum Action: String {
@@ -22,7 +22,7 @@
             event["label"] = label
         }
         if let measure = measure {
-            event["measure"] = Int(round(measure))
+            event["measure_time"] = Int(round(measure))
         }
         
         return event


### PR DESCRIPTION
Rename key measure to measure_time for LoginFunnel and SessionsFunnel, and change the revision number correspondingly