### PR TITLE
 master > develop for license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Wikipedia iOS
 The official Wikipedia iOS client.
 
-[![MIT license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/wikimedia/wikipedia-ios/master/LICENSE.txt)
+[![MIT license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/wikimedia/wikipedia-ios/develop/LICENSE.txt)
 
 * License: MIT License
 * Source repo: https://github.com/wikimedia/wikipedia-ios

--- a/Wikipedia/Code/AboutViewController.plist
+++ b/Wikipedia/Code/AboutViewController.plist
@@ -7,7 +7,7 @@
 		<key>sharealike</key>
 		<string>https://creativecommons.org/licenses/by-sa/3.0/</string>
 		<key>mit</key>
-		<string>https://raw.githubusercontent.com/wikimedia/wikipedia-ios/master/LICENSE.txt</string>
+		<string>https://raw.githubusercontent.com/wikimedia/wikipedia-ios/develop/LICENSE.txt</string>
 		<key>tsg</key>
 		<string>http://specialistsguild.org</string>
 		<key>feedback</key>


### PR DESCRIPTION
The license link in the app should reflect changes made on GitHub's develop branch rather than the MASTER, especially since the app is using content from the develop branch.