### PR TITLE
Search tweaks

### DIFF
--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -16,7 +16,9 @@ class SearchViewController: ColumnarCollectionViewController, UISearchBarDelegat
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        navigationBar.isBarHidingEnabled = true
         navigationBar.setNavigationBarPercentHidden(1, underBarViewPercentHidden: 0, extendedViewPercentHidden: 0, animated: animated && shouldAnimateSearchBar, additionalAnimations: { self.updateScrollViewInsets() })
+        navigationBar.isBarHidingEnabled = false
         searchBar.setShowsCancelButton(true, animated: animated && shouldAnimateSearchBar)
         if animated {
             searchBar.becomeFirstResponder()
@@ -37,7 +39,9 @@ class SearchViewController: ColumnarCollectionViewController, UISearchBarDelegat
         super.viewWillDisappear(animated)
         if shouldAnimateSearchBar {
             searchBar.text = nil
+            navigationBar.isBarHidingEnabled = true
             navigationBar.setNavigationBarPercentHidden(0, underBarViewPercentHidden: 0, extendedViewPercentHidden: 0, animated: animated, additionalAnimations: { self.updateScrollViewInsets() })
+            navigationBar.isBarHidingEnabled = false
             searchBar.setShowsCancelButton(false, animated: animated)
         }
         shouldAnimateSearchBar = false

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -3,7 +3,8 @@ import UIKit
 class SearchViewController: ColumnarCollectionViewController, UISearchBarDelegate {
     @objc var dataStore: MWKDataStore!
     var shouldAnimateSearchBar: Bool = false
-    
+    @objc var shouldBecomeFirstResponder: Bool = false
+
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationBar.isBackVisible = false
@@ -20,7 +21,7 @@ class SearchViewController: ColumnarCollectionViewController, UISearchBarDelegat
         navigationBar.setNavigationBarPercentHidden(1, underBarViewPercentHidden: 0, extendedViewPercentHidden: 0, animated: animated && shouldAnimateSearchBar, additionalAnimations: { self.updateScrollViewInsets() })
         navigationBar.isBarHidingEnabled = false
         searchBar.setShowsCancelButton(true, animated: animated && shouldAnimateSearchBar)
-        if animated {
+        if animated && shouldBecomeFirstResponder {
             searchBar.becomeFirstResponder()
         }
         shouldAnimateSearchBar = false
@@ -30,7 +31,7 @@ class SearchViewController: ColumnarCollectionViewController, UISearchBarDelegat
         super.viewDidAppear(animated)
         funnel.logSearchStart()
         NSUserActivity.wmf_makeActive(NSUserActivity.wmf_searchView())
-        if !animated {
+        if !animated && shouldBecomeFirstResponder {
             searchBar.becomeFirstResponder()
         }
     }
@@ -185,6 +186,10 @@ class SearchViewController: ColumnarCollectionViewController, UISearchBarDelegat
         resultsViewController.wmf_hideEmptyView()
         searchBar.text = nil
         fakeProgressController.stop()
+    }
+    
+    @objc func clear() {
+        didCancelSearch()
     }
     
     lazy var searchBarContainerView: UIView = {

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -184,6 +184,7 @@ class SearchViewController: ColumnarCollectionViewController, UISearchBarDelegat
         resultsViewController.results = []
         resultsViewController.wmf_hideEmptyView()
         searchBar.text = nil
+        fakeProgressController.stop()
     }
     
     lazy var searchBarContainerView: UIView = {

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1821,10 +1821,11 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
     }
 
     if (searchVC) {
+        [searchVC clear]; // clear search VC before bringing it forward
         [nc setViewControllers:mutableVCs animated:NO];
     } else {
         searchVC = [[SearchViewController alloc] init];
-        //searchVC.hidesBottomBarWhenPushed = YES;
+        searchVC.shouldBecomeFirstResponder = YES;
         [searchVC applyTheme:self.theme];
         searchVC.dataStore = self.dataStore;
     }


### PR DESCRIPTION
- Disable bar hiding in search
- Stop fake progress on empty search
- Clear search when it's moved forward in the navigation stack
- Don't become first responder when entering search from the tab