### PR TITLE
Updates to the On this day card

### DIFF
--- a/WMF Framework/WMFContentGroup+Display.swift
+++ b/WMF Framework/WMFContentGroup+Display.swift
@@ -79,7 +79,7 @@ extension WMFContentGroup {
         case .news:
             return 1
         case .onThisDay:
-            return 1
+            return min(countOfFeedContent, 2)
         case .relatedPages:
             return min(countOfFeedContent, Int(maxNumberOfCells)) + 1
         default:

--- a/Wikipedia/Code/ExploreCardViewController.swift
+++ b/Wikipedia/Code/ExploreCardViewController.swift
@@ -222,12 +222,12 @@ class ExploreCardViewController: PreviewingViewController, UICollectionViewDataS
         cell.selectionDelegate = self
     }
     
-    private func configureOnThisDayCell(_ cell: UICollectionViewCell, layoutOnly: Bool) {
-        guard let cell = cell as? OnThisDayExploreCollectionViewCell, let events = contentGroup?.contentPreview as? [WMFFeedOnThisDayEvent], events.count > 0 else {
+    private func configureOnThisDayCell(_ cell: UICollectionViewCell, forItemAt indexPath: IndexPath, layoutOnly: Bool) {
+        guard let cell = cell as? OnThisDayExploreCollectionViewCell, let events = contentGroup?.contentPreview as? [WMFFeedOnThisDayEvent], events.count > 0, events.indices.contains(indexPath.row) else {
             return
         }
-        let previousEvent: WMFFeedOnThisDayEvent? = events.count > 1 ? events[1] : events[0]
-        cell.configure(with: events[0], previousEvent: previousEvent, dataStore: dataStore, theme: theme, layoutOnly: layoutOnly)
+        let event = events[indexPath.row]
+        cell.configure(with: event, isFirst: events.first == event, isLast: events.last == event, dataStore: dataStore, theme: theme, layoutOnly: layoutOnly)
         cell.selectionDelegate = self
     }
     
@@ -302,7 +302,7 @@ class ExploreCardViewController: PreviewingViewController, UICollectionViewDataS
         case .story:
             configureNewsCell(cell, layoutOnly: layoutOnly)
         case .event:
-             configureOnThisDayCell(cell, layoutOnly: layoutOnly)
+            configureOnThisDayCell(cell, forItemAt: indexPath, layoutOnly: layoutOnly)
         case .theme, .notification, .announcement, .readingList:
             configureAnnouncementCell(cell, displayType: displayType, layoutOnly: layoutOnly)
         }

--- a/Wikipedia/Code/ExploreCardViewController.swift
+++ b/Wikipedia/Code/ExploreCardViewController.swift
@@ -223,11 +223,12 @@ class ExploreCardViewController: PreviewingViewController, UICollectionViewDataS
     }
     
     private func configureOnThisDayCell(_ cell: UICollectionViewCell, forItemAt indexPath: IndexPath, layoutOnly: Bool) {
-        guard let cell = cell as? OnThisDayExploreCollectionViewCell, let events = contentGroup?.contentPreview as? [WMFFeedOnThisDayEvent], events.count > 0, events.indices.contains(indexPath.row) else {
+        let index = indexPath.row
+        guard let cell = cell as? OnThisDayExploreCollectionViewCell, let events = contentGroup?.contentPreview as? [WMFFeedOnThisDayEvent], events.count > 0, events.indices.contains(index) else {
             return
         }
-        let event = events[indexPath.row]
-        cell.configure(with: event, isFirst: events.first == event, isLast: events.last == event, dataStore: dataStore, theme: theme, layoutOnly: layoutOnly)
+        let event = events[index]
+        cell.configure(with: event, isFirst: events.indices.first == index, isLast: events.indices.last == index, dataStore: dataStore, theme: theme, layoutOnly: layoutOnly)
         cell.selectionDelegate = self
     }
     

--- a/Wikipedia/Code/ExploreCardViewController.swift
+++ b/Wikipedia/Code/ExploreCardViewController.swift
@@ -381,8 +381,8 @@ class ExploreCardViewController: PreviewingViewController, UICollectionViewDataS
         let displayType = displayTypeAt(indexPath)
         let reuseIdentifier = resuseIdentifierFor(displayType)
         let key: String?
-        if displayType == .story || displayType == .event {
-            key = contentGroup?.key
+        if displayType == .story || displayType == .event, let contentGroupKey = contentGroup?.key {
+            key = "\(contentGroupKey)-\(indexPath.row)"
         } else {
             key = article(at: indexPath)?.key
         }

--- a/Wikipedia/Code/OnThisDayCollectionViewCell.swift
+++ b/Wikipedia/Code/OnThisDayCollectionViewCell.swift
@@ -52,7 +52,6 @@ public class OnThisDayCollectionViewCell: SideScrollingCollectionViewCell {
     override public func layoutSublayers(of layer: CALayer) {
         super.layoutSublayers(of: layer)
         timelineView.topDotsY = titleLabel.convert(titleLabel.bounds, to: timelineView).midY
-        timelineView.bottomDotY = bottomTitleLabel.convert(bottomTitleLabel.bounds, to: timelineView).midY
     }
     
     override public func apply(theme: Theme) {

--- a/Wikipedia/Code/OnThisDayCollectionViewCell.swift
+++ b/Wikipedia/Code/OnThisDayCollectionViewCell.swift
@@ -51,7 +51,7 @@ public class OnThisDayCollectionViewCell: SideScrollingCollectionViewCell {
     
     override public func layoutSublayers(of layer: CALayer) {
         super.layoutSublayers(of: layer)
-        timelineView.topDotsY = titleLabel.convert(titleLabel.bounds, to: timelineView).midY
+        timelineView.dotsY = titleLabel.convert(titleLabel.bounds, to: timelineView).midY
     }
     
     override public func apply(theme: Theme) {

--- a/Wikipedia/Code/OnThisDayCollectionViewCell.swift
+++ b/Wikipedia/Code/OnThisDayCollectionViewCell.swift
@@ -8,7 +8,6 @@ public class OnThisDayCollectionViewCell: SideScrollingCollectionViewCell {
         super.updateFonts(with: traitCollection)
         let titleFont = UIFont.wmf_font(.title3, compatibleWithTraitCollection: traitCollection)
         titleLabel.font = titleFont
-        bottomTitleLabel.font = titleFont
         
         let subTitleFont = UIFont.wmf_font(.subheadline, compatibleWithTraitCollection: traitCollection)
         subTitleLabel.font = subTitleFont
@@ -61,7 +60,6 @@ public class OnThisDayCollectionViewCell: SideScrollingCollectionViewCell {
         timelineView.backgroundColor = theme.colors.paperBackground
         timelineView.tintColor = theme.colors.link
         titleLabel.textColor = theme.colors.link
-        bottomTitleLabel.textColor = theme.colors.link
         subTitleLabel.textColor = theme.colors.secondaryText
         collectionView.backgroundColor = .clear
     }

--- a/Wikipedia/Code/OnThisDayExploreCollectionViewCell+WMFFeedContentDisplaying.swift
+++ b/Wikipedia/Code/OnThisDayExploreCollectionViewCell+WMFFeedContentDisplaying.swift
@@ -1,8 +1,10 @@
 import UIKit
 
 extension OnThisDayExploreCollectionViewCell {
-    public func configure(with onThisDayEvent: WMFFeedOnThisDayEvent,  previousEvent: WMFFeedOnThisDayEvent?, dataStore: MWKDataStore, theme: Theme, layoutOnly: Bool) {
-        bottomTitleLabel.text = previousEvent?.yearString
+    public func configure(with onThisDayEvent: WMFFeedOnThisDayEvent, isFirst: Bool, isLast: Bool, dataStore: MWKDataStore, theme: Theme, layoutOnly: Bool) {
+        self.isFirst = isFirst
+        self.isLast = isLast
+        timelineView.minimizeUnanimatedDots = !isFirst
         super.configure(with: onThisDayEvent, dataStore: dataStore, showArticles: false, theme: theme, layoutOnly: layoutOnly, shouldAnimateDots: false)
     }
 }

--- a/Wikipedia/Code/OnThisDayExploreCollectionViewCell.swift
+++ b/Wikipedia/Code/OnThisDayExploreCollectionViewCell.swift
@@ -22,7 +22,6 @@ public class OnThisDayExploreCollectionViewCell: OnThisDayCollectionViewCell {
 
     override open func setup() {
         super.setup()
-        clipsToBounds = true
         timelineView.addSubview(topGradientView)
         timelineView.addSubview(bottomGradientView)
         topGradientView.startPoint = CGPoint(x: 0.5, y: 0)

--- a/Wikipedia/Code/OnThisDayExploreCollectionViewCell.swift
+++ b/Wikipedia/Code/OnThisDayExploreCollectionViewCell.swift
@@ -1,25 +1,30 @@
 import UIKit
 
 public class OnThisDayExploreCollectionViewCell: OnThisDayCollectionViewCell {
-    fileprivate var topGradientView: WMFGradientView = WMFGradientView()
-    fileprivate var bottomGradientView: WMFGradientView = WMFGradientView()
-    
+    private var topGradientView: WMFGradientView = WMFGradientView()
+    private var bottomGradientView: WMFGradientView = WMFGradientView()
+    var isFirst: Bool = false
+    var isLast: Bool = false
+
     override public func sizeThatFits(_ size: CGSize, apply: Bool) -> CGSize {
         if (apply) {
             let topGradientHeight: CGFloat = 17
-            let bottomGradientHeight: CGFloat = 53
-            let topGradientSize = CGSize(width: size.width, height: topGradientHeight)
-            let bottomGradientSize = CGSize(width: size.width, height: bottomGradientHeight)
+            let bottomGradientHeight: CGFloat = 43
+            let topGradientSize = CGSize(width: timelineView.frame.size.width, height: topGradientHeight)
+            let bottomGradientSize = CGSize(width: timelineView.frame.size.width, height: bottomGradientHeight)
             topGradientView.frame = CGRect(origin: .zero, size: topGradientSize)
             bottomGradientView.frame = CGRect(origin: CGPoint(x: 0, y: size.height - bottomGradientHeight), size: bottomGradientSize)
+            topGradientView.isHidden = !isFirst
+            bottomGradientView.isHidden = !isLast
         }
         return super.sizeThatFits(size, apply: apply)
     }
 
     override open func setup() {
         super.setup()
-        addSubview(topGradientView)
-        addSubview(bottomGradientView)
+        clipsToBounds = true
+        timelineView.addSubview(topGradientView)
+        timelineView.addSubview(bottomGradientView)
         topGradientView.startPoint = CGPoint(x: 0.5, y: 0)
         topGradientView.endPoint = CGPoint(x: 0.5, y: 1)
         bottomGradientView.startPoint = CGPoint(x: 0.5, y: 0)

--- a/Wikipedia/Code/OnThisDayTimelineView.swift
+++ b/Wikipedia/Code/OnThisDayTimelineView.swift
@@ -26,31 +26,30 @@ public class OnThisDayTimelineView: UIView {
     private let dotRadius:CGFloat = 9.0
     private let dotMinRadiusNormal:CGFloat = 0.4
     
-    // TODO: the bottom dot was removed, so we can probably rename items in this file to not include the word 'top'.
-    public var topDotsY: CGFloat = 0 {
+    public var dotsY: CGFloat = 0 {
         didSet {
             guard shouldAnimateDots == false else {
                 return
             }
-            updateTopDotsRadii(to: minimizeUnanimatedDots ? 0.0 : 1.0, at: CGPoint(x: bounds.midX, y: topDotsY))
+            updateDotsRadii(to: minimizeUnanimatedDots ? 0.0 : 1.0, at: CGPoint(x: bounds.midX, y: dotsY))
         }
     }
     
     override public func tintColorDidChange() {
         super.tintColorDidChange()
-        topOuterDotShapeLayer.strokeColor = tintColor.cgColor
-        topInnerDotShapeLayer.fillColor = tintColor.cgColor
-        topInnerDotShapeLayer.strokeColor = tintColor.cgColor
+        outerDotShapeLayer.strokeColor = tintColor.cgColor
+        innerDotShapeLayer.fillColor = tintColor.cgColor
+        innerDotShapeLayer.strokeColor = tintColor.cgColor
         setNeedsDisplay()
     }
     
     override public var backgroundColor: UIColor? {
         didSet {
-            topOuterDotShapeLayer.fillColor = backgroundColor?.cgColor
+            outerDotShapeLayer.fillColor = backgroundColor?.cgColor
         }
     }
 
-    private lazy var topOuterDotShapeLayer: CAShapeLayer = {
+    private lazy var outerDotShapeLayer: CAShapeLayer = {
         let shape = CAShapeLayer()
         shape.fillColor = UIColor.white.cgColor
         shape.strokeColor = UIColor.blue.cgColor
@@ -59,7 +58,7 @@ public class OnThisDayTimelineView: UIView {
         return shape
     }()
 
-    private lazy var topInnerDotShapeLayer: CAShapeLayer = {
+    private lazy var innerDotShapeLayer: CAShapeLayer = {
         let shape = CAShapeLayer()
         shape.fillColor = UIColor.blue.cgColor
         shape.strokeColor = UIColor.blue.cgColor
@@ -72,7 +71,7 @@ public class OnThisDayTimelineView: UIView {
         guard self.shouldAnimateDots == true else {
             return nil
         }
-        let link = CADisplayLink(target: self, selector: #selector(maybeUpdateTopDotsRadii))
+        let link = CADisplayLink(target: self, selector: #selector(maybeUpdateDotsRadii))
         link.add(to: RunLoop.main, forMode: RunLoopMode.commonModes)
         return link
     }()
@@ -91,9 +90,9 @@ public class OnThisDayTimelineView: UIView {
         drawVerticalLine(in: context, rect: rect)
     }
     
-    public var extendTimelineAboveTopDot: Bool = true {
+    public var extendTimelineAboveDot: Bool = true {
         didSet {
-            if oldValue != extendTimelineAboveTopDot {
+            if oldValue != extendTimelineAboveDot {
                 setNeedsDisplay()
             }
         }
@@ -102,7 +101,7 @@ public class OnThisDayTimelineView: UIView {
     private func drawVerticalLine(in context: CGContext, rect: CGRect){
         context.setLineWidth(1.0)
         context.setStrokeColor(tintColor.cgColor)
-        let lineTopY = extendTimelineAboveTopDot ? rect.minY : topDotsY
+        let lineTopY = extendTimelineAboveDot ? rect.minY : dotsY
         context.move(to: CGPoint(x: rect.midX, y: lineTopY))
         context.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
         context.strokePath()
@@ -120,7 +119,7 @@ public class OnThisDayTimelineView: UIView {
 
     private var lastDotRadiusNormal: CGFloat = -1.0 // -1.0 so dots with dotAnimationNormal of "0.0" are visible initially
     
-    @objc private func maybeUpdateTopDotsRadii() {
+    @objc private func maybeUpdateDotsRadii() {
         guard let containerView = window else {
             return
         }
@@ -128,7 +127,7 @@ public class OnThisDayTimelineView: UIView {
         // Shift the "full-width dot" point up a bit - otherwise it's in the vertical center of screen.
         let yOffset = containerView.bounds.size.height * 0.15
 
-        var radiusNormal = dotRadiusNormal(with: topDotsY + yOffset, in: containerView)
+        var radiusNormal = dotRadiusNormal(with: dotsY + yOffset, in: containerView)
 
         // Reminder: can reduce precision to 1 (significant digit) to reduce how often dot radii are updated.
         let precision: CGFloat = 2
@@ -139,17 +138,17 @@ public class OnThisDayTimelineView: UIView {
             return
         }
         
-        updateTopDotsRadii(to: radiusNormal, at: CGPoint(x: bounds.midX, y: topDotsY))
+        updateDotsRadii(to: radiusNormal, at: CGPoint(x: bounds.midX, y: dotsY))
         
         // Progressively fade the inner dot when it gets tiny.
-        topInnerDotShapeLayer.opacity = easeInOutQuart(number: Float(radiusNormal))
+        innerDotShapeLayer.opacity = easeInOutQuart(number: Float(radiusNormal))
         
         lastDotRadiusNormal = radiusNormal
     }
     
-    private func updateTopDotsRadii(to radiusNormal: CGFloat, at center: CGPoint){
-        topOuterDotShapeLayer.updateDotRadius(dotRadius * max(radiusNormal, dotMinRadiusNormal), center: center)
-        topInnerDotShapeLayer.updateDotRadius(dotRadius * max((radiusNormal - dotMinRadiusNormal), 0.0), center: center)
+    private func updateDotsRadii(to radiusNormal: CGFloat, at center: CGPoint){
+        outerDotShapeLayer.updateDotRadius(dotRadius * max(radiusNormal, dotMinRadiusNormal), center: center)
+        innerDotShapeLayer.updateDotRadius(dotRadius * max((radiusNormal - dotMinRadiusNormal), 0.0), center: center)
     }
     
     private func easeInOutQuart(number:Float) -> Float {

--- a/Wikipedia/Code/OnThisDayTimelineView.swift
+++ b/Wikipedia/Code/OnThisDayTimelineView.swift
@@ -15,6 +15,7 @@ public class OnThisDayTimelineView: UIView {
     }
 
     public var shouldAnimateDots: Bool = false
+    public var minimizeUnanimatedDots: Bool = false
     
     public var pauseDotsAnimation: Bool = true {
         didSet {
@@ -25,27 +26,18 @@ public class OnThisDayTimelineView: UIView {
     private let dotRadius:CGFloat = 9.0
     private let dotMinRadiusNormal:CGFloat = 0.4
     
+    // TODO: the bottom dot was removed, so we can probably rename items in this file to not include the word 'top'.
     public var topDotsY: CGFloat = 0 {
         didSet {
             guard shouldAnimateDots == false else {
                 return
             }
-            updateTopDotsRadii(to: 1.0, at: CGPoint(x: bounds.midX, y: topDotsY))
-        }
-    }
-
-    public var bottomDotY: CGFloat = 0 {
-        didSet {
-            guard shouldAnimateDots == false else {
-                return
-            }
-            bottomDotShapeLayer.updateDotRadius(dotRadius * dotMinRadiusNormal, center: CGPoint(x: bounds.midX, y: bottomDotY))
+            updateTopDotsRadii(to: minimizeUnanimatedDots ? 0.0 : 1.0, at: CGPoint(x: bounds.midX, y: topDotsY))
         }
     }
     
     override public func tintColorDidChange() {
         super.tintColorDidChange()
-        bottomDotShapeLayer.strokeColor = tintColor.cgColor
         topOuterDotShapeLayer.strokeColor = tintColor.cgColor
         topInnerDotShapeLayer.fillColor = tintColor.cgColor
         topInnerDotShapeLayer.strokeColor = tintColor.cgColor
@@ -54,19 +46,9 @@ public class OnThisDayTimelineView: UIView {
     
     override public var backgroundColor: UIColor? {
         didSet {
-            bottomDotShapeLayer.fillColor = backgroundColor?.cgColor
             topOuterDotShapeLayer.fillColor = backgroundColor?.cgColor
         }
     }
-
-    private lazy var bottomDotShapeLayer: CAShapeLayer = {
-        let shape = CAShapeLayer()
-        shape.fillColor = UIColor.white.cgColor
-        shape.strokeColor = UIColor.blue.cgColor
-        shape.lineWidth = 1.0
-        self.layer.addSublayer(shape)
-        return shape
-    }()
 
     private lazy var topOuterDotShapeLayer: CAShapeLayer = {
         let shape = CAShapeLayer()

--- a/Wikipedia/Code/OnThisDayViewController.swift
+++ b/Wikipedia/Code/OnThisDayViewController.swift
@@ -99,7 +99,7 @@ extension OnThisDayViewController {
         let event = events[indexPath.section]
         onThisDayCell.layoutMargins = layout.itemLayoutMargins
         onThisDayCell.configure(with: event, dataStore: dataStore, theme: self.theme, layoutOnly: false, shouldAnimateDots: true)
-        onThisDayCell.timelineView.extendTimelineAboveTopDot = indexPath.section == 0 ? false : true
+        onThisDayCell.timelineView.extendTimelineAboveDot = indexPath.section == 0 ? false : true
 
         return onThisDayCell
     }

--- a/Wikipedia/Code/SideScrollingCollectionViewCell.swift
+++ b/Wikipedia/Code/SideScrollingCollectionViewCell.swift
@@ -26,7 +26,6 @@ public class SideScrollingCollectionViewCell: CollectionViewCell, SubCellProtoco
     public let titleLabel = UILabel()
     public let subTitleLabel = UILabel()
     public let descriptionLabel = UILabel()
-    public let bottomTitleLabel = UILabel()
 
     internal var flowLayout: UICollectionViewFlowLayout? {
         return collectionView.collectionViewLayout as? UICollectionViewFlowLayout
@@ -39,7 +38,6 @@ public class SideScrollingCollectionViewCell: CollectionViewCell, SubCellProtoco
             subTitleLabel.semanticContentAttribute = semanticContentAttributeOverride
             descriptionLabel.semanticContentAttribute = semanticContentAttributeOverride
             collectionView.semanticContentAttribute = semanticContentAttributeOverride
-            bottomTitleLabel.semanticContentAttribute = semanticContentAttributeOverride
         }
     }
     
@@ -49,13 +47,11 @@ public class SideScrollingCollectionViewCell: CollectionViewCell, SubCellProtoco
         titleLabel.isOpaque = true
         subTitleLabel.isOpaque = true
         descriptionLabel.isOpaque = true
-        bottomTitleLabel.isOpaque = true
         imageView.isOpaque = true
         
         addSubview(titleLabel)
         addSubview(subTitleLabel)
         addSubview(descriptionLabel)
-        addSubview(bottomTitleLabel)
     
         addSubview(imageView)
         addSubview(collectionView)
@@ -71,7 +67,6 @@ public class SideScrollingCollectionViewCell: CollectionViewCell, SubCellProtoco
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         titleLabel.numberOfLines = 1
-        bottomTitleLabel.numberOfLines = 1
         subTitleLabel.numberOfLines = 1
         descriptionLabel.numberOfLines = 0
         flowLayout?.scrollDirection = .horizontal
@@ -147,13 +142,7 @@ public class SideScrollingCollectionViewCell: CollectionViewCell, SubCellProtoco
         }
 
         origin.y += height
-
-        if bottomTitleLabel.wmf_hasAnyText {
-            origin.y += spacing
-            origin.y += bottomTitleLabel.wmf_preferredHeight(at: origin, maximumWidth: widthToFit, alignedBy: semanticContentAttributeOverride, spacing: spacing, apply: apply)
-        }else{
-            origin.y += layoutMargins.bottom
-        }
+        origin.y += layoutMargins.bottom
         
         return CGSize(width: size.width, height: origin.y)
     }
@@ -177,7 +166,6 @@ public class SideScrollingCollectionViewCell: CollectionViewCell, SubCellProtoco
         titleLabel.backgroundColor = labelBackgroundColor
         subTitleLabel.backgroundColor = labelBackgroundColor
         descriptionLabel.backgroundColor = labelBackgroundColor
-        bottomTitleLabel.backgroundColor = labelBackgroundColor
     }
 }
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T198429

- [x] 2 events
- [x] gradient adjustments
- [x] timeline adjustments

<img width="431" alt="screen shot 2018-06-29 at 5 13 04 pm" src="https://user-images.githubusercontent.com/3143487/42119367-be705b6e-7bbf-11e8-977a-0a5f3a9c7076.png">

Question: ^ the spacing between the bottom of the `On this day` card and the top of the `Random article` card is too tight. It looks like this is a pre-existing issue, but am unsure if I've made it worse somehow...