### PR TITLE
Fix theme not sticking

### DIFF
--- a/Wikipedia/Code/ArticleLocationCollectionViewController.swift
+++ b/Wikipedia/Code/ArticleLocationCollectionViewController.swift
@@ -15,6 +15,7 @@ class ArticleLocationCollectionViewController: ColumnarCollectionViewController,
         self.articleURLs = articleURLs
         self.dataStore = dataStore
         super.init()
+        self.theme = theme
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/Wikipedia/Code/NewsViewController.swift
+++ b/Wikipedia/Code/NewsViewController.swift
@@ -12,6 +12,7 @@ class NewsViewController: ColumnarCollectionViewController {
         self.stories = stories
         self.dataStore = dataStore
         super.init()
+        self.theme = theme
         title = CommonStrings.inTheNewsTitle
         navigationItem.backBarButtonItem = UIBarButtonItem(title: CommonStrings.backTitle, style: .plain, target:nil, action:nil)
     }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T199143

- from an explore `in the news` or `places near` detail view select any article
- switch the theme
- return to explore and go back to the detail view you selected previously
- the detail view didn't reflect the theme change

![sdfasdf mov](https://user-images.githubusercontent.com/3143487/42470842-94a3af4e-8370-11e8-8480-771437dd0f77.gif)
