### PR TITLE
Fix layout of explore feed footer button

### DIFF
--- a/Wikipedia/Code/AlignedImageButton.swift
+++ b/Wikipedia/Code/AlignedImageButton.swift
@@ -39,7 +39,8 @@ public class AlignedImageButton: UIButton {
     
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        guard effectiveUserInterfaceLayoutDirection != layoutDirection else {
+        let newLayoutDirection: UIUserInterfaceLayoutDirection = traitCollection.layoutDirection == .rightToLeft ? .rightToLeft : .leftToRight
+        guard newLayoutDirection != layoutDirection else {
             return
         }
         updateSemanticContentAttribute()
@@ -48,7 +49,7 @@ public class AlignedImageButton: UIButton {
     
     var layoutDirection: UIUserInterfaceLayoutDirection = .leftToRight
     fileprivate func updateSemanticContentAttribute() {
-        layoutDirection = effectiveUserInterfaceLayoutDirection
+        layoutDirection = traitCollection.layoutDirection == .rightToLeft ? .rightToLeft : .leftToRight
         if imageIsRightAligned {
             if layoutDirection == .leftToRight {
                 semanticContentAttribute = .forceRightToLeft


### PR DESCRIPTION
Effective user interface direction changes when you change the semantic content attribute, so the value from the trait collection should be used. Left to right is assumed when `.unspecified`, thus the check for `.rightToLeft` and conversion to `UIUserInterfaceLayoutDirection` from `UITraitEnvironmentLayoutDirection`