### PR TITLE
Pixel push on this day enable location card

### DIFF
--- a/Wikipedia/Code/ArticleLocationAuthorizationCollectionViewCell.swift
+++ b/Wikipedia/Code/ArticleLocationAuthorizationCollectionViewCell.swift
@@ -12,7 +12,7 @@ class ArticleLocationAuthorizationCollectionViewCell: ArticleLocationExploreColl
     
     override func setup() {
         super.setup()
-        authorizeTitleLabel.textAlignment = .center
+        authorizeTitleLabel.textAlignment = .natural
         authorizeTitleLabel.numberOfLines = 0
         addSubview(authorizeTitleLabel)
         
@@ -23,7 +23,7 @@ class ArticleLocationAuthorizationCollectionViewCell: ArticleLocationExploreColl
         authorizeButton.addTarget(self, action: #selector(authorizeButtonPressed(_:)), for: .touchUpInside)
         addSubview(authorizeButton)
         
-        authorizeDescriptionLabel.textAlignment = .center
+        authorizeDescriptionLabel.textAlignment = .natural
         authorizeDescriptionLabel.numberOfLines = 0
         addSubview(authorizeDescriptionLabel)
     }

--- a/Wikipedia/Code/ArticleLocationAuthorizationCollectionViewCell.swift
+++ b/Wikipedia/Code/ArticleLocationAuthorizationCollectionViewCell.swift
@@ -40,9 +40,9 @@ class ArticleLocationAuthorizationCollectionViewCell: ArticleLocationExploreColl
         var origin = CGPoint(x: layoutMargins.left, y: size.height + spacing - layoutMargins.bottom)
         let widthForLabels = size.width - layoutMargins.left - layoutMargins.right
         let authorizeSpacing = 3 * spacing
-        origin.y += authorizeTitleLabel.wmf_preferredHeight(at: origin, maximumWidth: widthForLabels, horizontalAlignment: .center, spacing: authorizeSpacing, apply: apply)
-        origin.y += authorizeButton.wmf_preferredHeight(at: origin, maximumWidth: widthForLabels, minimumWidth: min(300, widthForLabels), horizontalAlignment: .center, spacing: authorizeSpacing, apply: apply)
-        origin.y += authorizeDescriptionLabel.wmf_preferredHeight(at: origin, maximumWidth: widthForLabels, horizontalAlignment: .center, spacing: authorizeSpacing, apply: apply)
+        origin.y += authorizeTitleLabel.wmf_preferredHeight(at: origin, maximumWidth: widthForLabels, horizontalAlignment: .left, spacing: authorizeSpacing, apply: apply)
+        origin.y += authorizeButton.wmf_preferredHeight(at: origin, maximumWidth: widthForLabels, minimumWidth: widthForLabels, horizontalAlignment: .center, spacing: authorizeSpacing, apply: apply)
+        origin.y += authorizeDescriptionLabel.wmf_preferredHeight(at: origin, maximumWidth: widthForLabels, horizontalAlignment: .left, spacing: authorizeSpacing, apply: apply)
         return CGSize(width: size.width, height: origin.y + layoutMargins.bottom)
     }
     

--- a/Wikipedia/Code/ArticleLocationAuthorizationCollectionViewCell.swift
+++ b/Wikipedia/Code/ArticleLocationAuthorizationCollectionViewCell.swift
@@ -40,9 +40,10 @@ class ArticleLocationAuthorizationCollectionViewCell: ArticleLocationExploreColl
         var origin = CGPoint(x: layoutMargins.left, y: size.height + spacing - layoutMargins.bottom)
         let widthForLabels = size.width - layoutMargins.left - layoutMargins.right
         let authorizeSpacing = 3 * spacing
-        origin.y += authorizeTitleLabel.wmf_preferredHeight(at: origin, maximumWidth: widthForLabels, horizontalAlignment: .left, spacing: authorizeSpacing, apply: apply)
+        let horizontalAlignment: HorizontalAlignment = isDeviceRTL ? .right : .left
+        origin.y += authorizeTitleLabel.wmf_preferredHeight(at: origin, maximumWidth: widthForLabels, horizontalAlignment: horizontalAlignment, spacing: authorizeSpacing, apply: apply)
         origin.y += authorizeButton.wmf_preferredHeight(at: origin, maximumWidth: widthForLabels, minimumWidth: widthForLabels, horizontalAlignment: .center, spacing: authorizeSpacing, apply: apply)
-        origin.y += authorizeDescriptionLabel.wmf_preferredHeight(at: origin, maximumWidth: widthForLabels, horizontalAlignment: .left, spacing: authorizeSpacing, apply: apply)
+        origin.y += authorizeDescriptionLabel.wmf_preferredHeight(at: origin, maximumWidth: widthForLabels, horizontalAlignment: horizontalAlignment, spacing: authorizeSpacing, apply: apply)
         return CGSize(width: size.width, height: origin.y + layoutMargins.bottom)
     }
     


### PR DESCRIPTION
https://phabricator.wikimedia.org/T198438

Based on design review comment [here](https://phabricator.wikimedia.org/T198438#4417596).

- [x] left align label text
- [x] make button and labels above and below it use same left margin

| Before | After |
| ------------- | ------------- |
| <img width="431" alt="screen shot 2018-07-12 at 6 06 35 pm" src="https://user-images.githubusercontent.com/3143487/42667171-73d04652-85fe-11e8-9980-7de4a6ef8a17.png"> | <img width="431" alt="screen shot 2018-07-12 at 6 05 21 pm" src="https://user-images.githubusercontent.com/3143487/42667173-7842faa4-85fe-11e8-8eb7-da94551cb2e3.png">|

