### PR TITLE
Fix explore feed full width image cell save button alignment

### DIFF
--- a/Wikipedia/Code/ArticleFullWidthImageCollectionViewCell.swift
+++ b/Wikipedia/Code/ArticleFullWidthImageCollectionViewCell.swift
@@ -92,7 +92,7 @@ open class ArticleFullWidthImageCollectionViewCell: ArticleCollectionViewCell {
 
         if !isSaveButtonHidden {
             origin.y += spacing
-            let saveButtonFrame = saveButton.wmf_preferredFrame(at: origin, maximumWidth: widthMinusMargins, alignedBy: articleSemanticContentAttribute, apply: apply)
+            let saveButtonFrame = saveButton.wmf_preferredFrame(at: origin, maximumWidth: widthMinusMargins, horizontalAlignment: isDeviceRTL ? .right : .left, apply: apply)
             origin.y += saveButtonFrame.height - 2 * saveButton.verticalPadding + spacing
         }
         


### PR DESCRIPTION
Should follow user interface direction since it's in the user interface language

After fix:

![simulator screen shot - iphone x - 2018-07-13 at 07 35 05](https://user-images.githubusercontent.com/741327/42689701-7cd049d4-866f-11e8-8621-31ee4c5d1b12.png)
