### PR TITLE
fix on this day detail view header title font regression

### DIFF
--- a/WMF Framework/UIFont+WMFDynamicType.swift
+++ b/WMF Framework/UIFont+WMFDynamicType.swift
@@ -12,6 +12,7 @@ import UIKit
     
     public static let headline = DynamicTextStyle(.system, .headline)
     public static let semiboldHeadline = DynamicTextStyle(.system, .headline, .semibold)
+    public static let heavyHeadline = DynamicTextStyle(.system, .headline, .heavy)
 
     public static let footnote = DynamicTextStyle(.system, .footnote)
     public static let mediumFootnote = DynamicTextStyle(.system, .footnote, .medium)

--- a/Wikipedia/Code/OnThisDayViewControllerHeader.swift
+++ b/Wikipedia/Code/OnThisDayViewControllerHeader.swift
@@ -13,7 +13,7 @@ class OnThisDayViewControllerHeader: UICollectionReusableView {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        onLabel.font = UIFont.wmf_font(.semiboldHeadline, compatibleWithTraitCollection: traitCollection)
+        onLabel.font = UIFont.wmf_font(.heavyHeadline, compatibleWithTraitCollection: traitCollection)
     }
     
     func configureFor(eventCount: Int, firstEvent: WMFFeedOnThisDayEvent?, lastEvent: WMFFeedOnThisDayEvent?, midnightUTCDate: Date) {


### PR DESCRIPTION
Per chat with @carolynlimadeo, this just brings back the font we were previously using:

| Before  | After |
| ------------- | ------------- |
| <img width="431" alt="screen shot 2018-07-13 at 12 52 00 pm" src="https://user-images.githubusercontent.com/3143487/42711101-971d9e64-869b-11e8-9037-256b58afa87a.png">|<img width="431" alt="screen shot 2018-07-13 at 12 50 10 pm" src="https://user-images.githubusercontent.com/3143487/42711076-7cc927cc-869b-11e8-93c9-f112c37a0632.png">|
