### PR TITLE
Update zindicies to fix clipping during explore card deletion animation

### DIFF
--- a/WMF Framework/ColumnarCollectionViewLayout.swift
+++ b/WMF Framework/ColumnarCollectionViewLayout.swift
@@ -235,7 +235,7 @@ public class ColumnarCollectionViewLayout: UICollectionViewLayout {
             guard animateItems, appearingIndexPaths.contains(indexPath) else {
                 return
             }
-            attributes.zIndex = -1000
+            attributes.zIndex = -1
             attributes.transform = CGAffineTransform.init(scaleX: 0.75, y: 0.75)
             attributes.alpha = 0
             return
@@ -271,7 +271,7 @@ public class ColumnarCollectionViewLayout: UICollectionViewLayout {
         guard animateItems, disappearingIndexPaths.contains(itemIndexPath) else {
             return attributes
         }
-        attributes.zIndex = -1000
+        attributes.zIndex = -1
         attributes.transform = CGAffineTransform.init(scaleX: 0.75, y: 0.75)
         attributes.alpha = 0
         return attributes

--- a/WMF Framework/ColumnarCollectionViewLayoutInfo.swift
+++ b/WMF Framework/ColumnarCollectionViewLayoutInfo.swift
@@ -32,6 +32,7 @@ public class ColumnarCollectionViewLayoutInfo {
                 headerAttributes.layoutMargins = metrics.itemLayoutMargins
                 headerAttributes.precalculated = headerHeightEstimate.precalculated
                 headerAttributes.frame = CGRect(origin: section.originForNextSupplementaryView, size: CGSize(width: headerWidth, height: headerHeightEstimate.height))
+                headerAttributes.zIndex = 10
                 section.addHeader(headerAttributes)
             }
             for itemIndex in 0..<countOfItems {
@@ -41,6 +42,7 @@ public class ColumnarCollectionViewLayoutInfo {
                 let itemAttributes = ColumnarCollectionViewLayoutAttributes(forCellWith: indexPath)
                 itemAttributes.precalculated = itemSizeEstimate.precalculated
                 itemAttributes.layoutMargins = metrics.itemLayoutMargins
+                itemAttributes.zIndex = 0
                 itemAttributes.frame = CGRect(origin: section.originForNextItem, size: CGSize(width: itemWidth, height: itemSizeEstimate.height))
                 section.addItem(itemAttributes)
             }
@@ -51,6 +53,7 @@ public class ColumnarCollectionViewLayoutInfo {
                 footerAttributes.layoutMargins = metrics.itemLayoutMargins
                 footerAttributes.precalculated = footerHeightEstimate.precalculated
                 footerAttributes.frame = CGRect(origin: section.originForNextSupplementaryView, size: CGSize(width: width, height: footerHeightEstimate.height))
+                footerAttributes.zIndex = -10
                 section.addFooter(footerAttributes)
             }
             y += section.frame.size.height + metrics.interSectionSpacing


### PR DESCRIPTION
The header would be clipped by one of the animating cards, this ensures the headers are above the cards.