### PR TITLE
Fix shadow clipping during card hiding animation

### DIFF
--- a/WMF Framework/ColumnarCollectionViewLayoutInfo.swift
+++ b/WMF Framework/ColumnarCollectionViewLayoutInfo.swift
@@ -32,7 +32,7 @@ public class ColumnarCollectionViewLayoutInfo {
                 headerAttributes.layoutMargins = metrics.itemLayoutMargins
                 headerAttributes.precalculated = headerHeightEstimate.precalculated
                 headerAttributes.frame = CGRect(origin: section.originForNextSupplementaryView, size: CGSize(width: headerWidth, height: headerHeightEstimate.height))
-                headerAttributes.zIndex = 10
+                headerAttributes.zIndex = -10
                 section.addHeader(headerAttributes)
             }
             for itemIndex in 0..<countOfItems {

--- a/WMF Framework/ExploreCardCollectionViewCell.swift
+++ b/WMF Framework/ExploreCardCollectionViewCell.swift
@@ -280,12 +280,11 @@ public class ExploreCardCollectionViewCell: CollectionViewCell, Themeable {
     
     public func apply(theme: Theme) {
         contentView.tintColor = theme.colors.link
-        contentView.backgroundColor = theme.colors.paperBackground
         let backgroundColor = isCollapsed ? theme.colors.cardButtonBackground : theme.colors.paperBackground
         let selectedBackgroundColor = isCollapsed ? theme.colors.cardButtonBackground : theme.colors.midBackground
         let cardBackgroundViewBorderColor = isCollapsed ? backgroundColor.cgColor : theme.colors.cardBorder.cgColor
         cardBackgroundView.layer.borderColor = cardBackgroundViewBorderColor
-        setBackgroundColors(backgroundColor, selected: selectedBackgroundColor)
+        setBackgroundColors(.clear, selected: selectedBackgroundColor)
         titleLabel.textColor = theme.colors.primaryText
         subtitleLabel.textColor = theme.colors.secondaryText
         customizationButton.setTitleColor(theme.colors.link, for: .normal)


### PR DESCRIPTION
Repro steps:

Hide a particularly tall card, observe animation

Expected results:

Shadow on the "Card hidden" card remains visible

Actual:

Shadow on the "Card hidden" card is clipped by the card animating up from below
