### PR TITLE
Fix search layout on rotate

### DIFF
--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -1,10 +1,8 @@
 import UIKit
 
 class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate {
-    var shouldAnimateSearchBar: Bool = true
-    @objc var areRecentSearchesEnabled: Bool = true
-    @objc var shouldBecomeFirstResponder: Bool = false
-
+    // MARK - UIViewController
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationBar.displayType = .largeTitle
@@ -18,9 +16,7 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
         resultsViewController.view.isHidden = true
         navigationBar.isShadowHidingEnabled = true
     }
-    
-    var isAnimatingSearchBarState: Bool = false
- 
+
     override func viewWillAppear(_ animated: Bool) {
         updateLanguageBarVisibility()
         super.viewWillAppear(animated)
@@ -39,6 +35,21 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
         }
         shouldAnimateSearchBar = true
     }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        coordinator.animate(alongsideTransition: { (context) in
+            self.view.setNeedsLayout()
+            self.view.layoutIfNeeded()
+        })
+    }
+    
+    // MARK - State
+    
+    var shouldAnimateSearchBar: Bool = true
+    var isAnimatingSearchBarState: Bool = false
+    @objc var areRecentSearchesEnabled: Bool = true
+    @objc var shouldBecomeFirstResponder: Bool = false
     
     var nonSearchAlpha: CGFloat = 1 {
         didSet {


### PR DESCRIPTION
Doing this in SearchViewController instead of ViewController because it seems to work fine without it everywhere else.

Only addition is

```

    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
        super.viewWillTransition(to: size, with: coordinator)
        coordinator.animate(alongsideTransition: { (context) in
            self.view.setNeedsLayout()
            self.view.layoutIfNeeded()
        })
    }

```

The rest is cleaning up the class structure a bit

https://phabricator.wikimedia.org/T200217