### PR TITLE
Move lead image back out of the navigation bar

### DIFF
--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -306,6 +306,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 
         _headerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, self.headerViewHeight)];
         _headerView.backgroundColor = self.theme.colors.midBackground;
+        _headerView.hidden = YES;
 
         self.headerImageView.translatesAutoresizingMaskIntoConstraints = NO;
         [_headerView addSubview:self.headerImageView];

--- a/Wikipedia/Code/WMFViewController.h
+++ b/Wikipedia/Code/WMFViewController.h
@@ -24,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nullable) UIScrollView *scrollView; // Override to provide the scroll view for inset adjustment
 
+@property (nonatomic) UIEdgeInsets additionalScrollIndicatorInsets;
+
 - (void)scrollViewInsetsDidChange;
 
 - (void)scrollToTop;

--- a/Wikipedia/Code/WMFViewController.m
+++ b/Wikipedia/Code/WMFViewController.m
@@ -148,7 +148,7 @@
         safeInsets = UIEdgeInsetsMake(self.topLayoutGuide.length, 0, MIN(44, self.bottomLayoutGuide.length), 0); // MIN 44 is a workaround for an iOS 10 only issue where the bottom layout guide is too tall when pushing from explore
     }
     CGFloat bottom = safeInsets.bottom;
-    UIEdgeInsets scrollIndicatorInsets = UIEdgeInsetsMake(top, safeInsets.left, bottom, safeInsets.right);
+    UIEdgeInsets scrollIndicatorInsets = UIEdgeInsetsMake(top + self.additionalScrollIndicatorInsets.top, safeInsets.left + self.additionalScrollIndicatorInsets.left, bottom + self.additionalScrollIndicatorInsets.bottom, safeInsets.right + self.additionalScrollIndicatorInsets.right);
     if (scrollView.refreshControl.isRefreshing) {
         top += scrollView.refreshControl.frame.size.height;
     }


### PR DESCRIPTION
This wasn't really working as full width. This reverts to being the width of the WebView, but keeps it out of the web view scroll view to avoid position jumps.