### PR TITLE
Fix reappearing global cards

### DIFF
--- a/WMF Framework/WMFExploreFeedContentController.m
+++ b/WMF Framework/WMFExploreFeedContentController.m
@@ -596,7 +596,6 @@ NSString *const WMFNewExploreFeedPreferencesWereRejectedNotification = @"WMFNewE
                     if (contentGroup.undoType == WMFContentGroupUndoTypeContentGroup) {
                         [contentGroup markDismissed];
                     }
-                    [contentGroup markDismissed];
                     contentGroup.isVisible = NO;
                     contentGroup.undoType = WMFContentGroupUndoTypeNone;
                 }
@@ -648,7 +647,6 @@ NSString *const WMFNewExploreFeedPreferencesWereRejectedNotification = @"WMFNewE
             continue;
         }
         WMFContentGroup *contentGroup = (WMFContentGroup *)object;
-        // Skip collapsed cards, let them be visible
         if (contentGroup.undoType != WMFContentGroupUndoTypeNone) {
             continue;
         }
@@ -656,7 +654,7 @@ NSString *const WMFNewExploreFeedPreferencesWereRejectedNotification = @"WMFNewE
         if ([self isGlobal:contentGroup.contentGroupKind]) {
             NSDictionary *globalCardPreferences = [exploreFeedPreferences objectForKey:WMFExploreFeedPreferencesGlobalCardsKey];
             BOOL isGlobalCardVisible = [[globalCardPreferences objectForKey:@(contentGroup.contentGroupKind)] boolValue];
-            contentGroup.isVisible = isGlobalCardVisible;
+            contentGroup.isVisible = isGlobalCardVisible && !contentGroup.wasDismissed;
         } else {
             NSSet<NSNumber *> *visibleContentGroupKinds = [exploreFeedPreferences objectForKey:contentGroup.siteURL.wmf_articleDatabaseKey];
             NSNumber *contentGroupNumber = @(contentGroup.contentGroupKindInteger);

--- a/WMF Framework/WMFExploreFeedContentController.m
+++ b/WMF Framework/WMFExploreFeedContentController.m
@@ -647,6 +647,7 @@ NSString *const WMFNewExploreFeedPreferencesWereRejectedNotification = @"WMFNewE
             continue;
         }
         WMFContentGroup *contentGroup = (WMFContentGroup *)object;
+        // Skip collapsed cards, let them be visible
         if (contentGroup.undoType != WMFContentGroupUndoTypeNone) {
             continue;
         }

--- a/WMF Framework/WMFExploreFeedContentController.m
+++ b/WMF Framework/WMFExploreFeedContentController.m
@@ -596,6 +596,7 @@ NSString *const WMFNewExploreFeedPreferencesWereRejectedNotification = @"WMFNewE
                     if (contentGroup.undoType == WMFContentGroupUndoTypeContentGroup) {
                         [contentGroup markDismissed];
                     }
+                    [contentGroup markDismissed];
                     contentGroup.isVisible = NO;
                     contentGroup.undoType = WMFContentGroupUndoTypeNone;
                 }


### PR DESCRIPTION
Repro steps

1. Clean install
2. Save an article from the feed
3. Pull to refresh to see "Because you read"
4. Tap on the overflow menu, choose "Hide this card"
5. Open another article
6. Go back to the feed
7. Scroll down to load content for older days
8. Scroll back to the top

Expected results: Previously dismissed global card is not in the feed