### PR TITLE
fix explore refresh spinner clipping

### DIFF
--- a/Wikipedia/Code/ColumnarCollectionViewController.swift
+++ b/Wikipedia/Code/ColumnarCollectionViewController.swift
@@ -93,7 +93,6 @@ class ColumnarCollectionViewController: ViewController, ColumnarCollectionViewLa
         didSet {
             if isRefreshControlEnabled {
                 let refreshControl = UIRefreshControl()
-                refreshControl.layer.zPosition = -100
                 refreshControl.addTarget(self, action: #selector(refreshControlActivated), for: .valueChanged)
                 collectionView.refreshControl = refreshControl
             } else {


### PR DESCRIPTION
on explore if you pull to refresh by pulling very far down, pausing for a second, then releasing, when the top card moves back up it clips the spinner before the spinner disappears

(this is super minor - feel free to close if there are issues)