### PR TITLE
Fix scroll/refresh issue on empty explore feed

### DIFF
--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -296,7 +296,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
             refreshControl.beginRefreshing()
             #endif
             if numberOfSectionsInExploreFeed == 0 {
-                collectionView.contentOffset = CGPoint(x: 0, y: 0 - collectionView.contentInset.top - refreshControl.frame.size.height)
+                scrollToTop()
             }
         }
         self.dataStore.feedContentController.updateFeedSources(with: date, userInitiated: userInitiated) {

--- a/Wikipedia/Code/NavigationBarHider.swift
+++ b/Wikipedia/Code/NavigationBarHider.swift
@@ -48,6 +48,16 @@ public class NavigationBarHider: NSObject {
         guard let navigationBar = navigationBar else {
             return
         }
+        
+        guard scrollView.contentSize.height > 0 else {
+            navigationBar.setNavigationBarPercentHidden(0, underBarViewPercentHidden: 0, extendedViewPercentHidden: 0, animated: false)
+            if navigationBar.isShadowHidingEnabled {
+                navigationBar.shadowAlpha = 0
+            } else {
+                navigationBar.shadowAlpha = 1
+            }
+            return
+        }
 
         let scrollY = scrollView.contentOffset.y + scrollView.contentInset.top
         let barHeight = navigationBar.bar.frame.size.height


### PR DESCRIPTION
Repro steps:

Hide all explore sections except "Because you read"
Individually hide all remaining "Because you read" cards

Expected:
Empty feed

Actual:
Refresh control flashes, navigation bar constantly hiding/unhiding

Notes:
We might want to add an empty state here, but this is a necessary fix before adding that anyway

https://phabricator.wikimedia.org/T200298