### PR TITLE
Fixes for search transition for issues introduced by top spacing

### DIFF
--- a/WMF Framework/NavigationBar.swift
+++ b/WMF Framework/NavigationBar.swift
@@ -16,6 +16,8 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
     public var underBarViewPercentHiddenForShowingTitle: CGFloat?
     public var title: String?
     
+    public var isAdjustingHidingFromContentInsetChangesEnabled: Bool = true
+    
     public var isShadowHidingEnabled: Bool = false // turn on/off shadow alpha adjusment
     public var isTitleShrinkingEnabled: Bool = false
     public var isInteractiveHidingEnabled: Bool = true // turn on/off any interactive adjustment of bar or view visibility
@@ -281,7 +283,7 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
             return _topSpacingPercentHidden
         }
         set {
-            setNavigationBarPercentHidden(_navigationBarPercentHidden, underBarViewPercentHidden: _underBarViewPercentHidden, extendedViewPercentHidden: _extendedViewPercentHidden, topSpacingPercentHidden: topSpacingPercentHidden, animated: false)
+            setNavigationBarPercentHidden(_navigationBarPercentHidden, underBarViewPercentHidden: _underBarViewPercentHidden, extendedViewPercentHidden: _extendedViewPercentHidden, topSpacingPercentHidden: newValue, animated: false)
         }
     }
     
@@ -328,6 +330,7 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
     
     @objc public func setNavigationBarPercentHidden(_ navigationBarPercentHidden: CGFloat, underBarViewPercentHidden: CGFloat, extendedViewPercentHidden: CGFloat, topSpacingPercentHidden: CGFloat, shadowAlpha: CGFloat = -1, animated: Bool, additionalAnimations: (() -> Void)? = nil) {
         layoutIfNeeded()
+        print("nbx: \(topSpacingPercentHidden) \(navigationBarPercentHidden) \(underBarViewPercentHidden) \(extendedViewPercentHidden)")
         if isTopSpacingHidingEnabled {
             _topSpacingPercentHidden = topSpacingPercentHidden
         }

--- a/WMF Framework/NavigationBar.swift
+++ b/WMF Framework/NavigationBar.swift
@@ -330,7 +330,7 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
     
     @objc public func setNavigationBarPercentHidden(_ navigationBarPercentHidden: CGFloat, underBarViewPercentHidden: CGFloat, extendedViewPercentHidden: CGFloat, topSpacingPercentHidden: CGFloat, shadowAlpha: CGFloat = -1, animated: Bool, additionalAnimations: (() -> Void)? = nil) {
         layoutIfNeeded()
-        print("nbx: \(topSpacingPercentHidden) \(navigationBarPercentHidden) \(underBarViewPercentHidden) \(extendedViewPercentHidden)")
+
         if isTopSpacingHidingEnabled {
             _topSpacingPercentHidden = topSpacingPercentHidden
         }

--- a/WMF Framework/UIScrollView+Limits.swift
+++ b/WMF Framework/UIScrollView+Limits.swift
@@ -25,7 +25,7 @@ extension UIScrollView {
         return contentOffset.y >= wmf_bottomOffsetY
     }
 
-    @objc public func wmf_setContentInsetPreservingTopAndBottomOffset(_ updatedContentInset: UIEdgeInsets, scrollIndicatorInsets updatedScrollIndicatorInsets: UIEdgeInsets, withNavigationBar navigationBar: NavigationBar?) -> Bool {
+    @objc public func wmf_setContentInset(_ updatedContentInset: UIEdgeInsets, scrollIndicatorInsets updatedScrollIndicatorInsets: UIEdgeInsets, preserveContentOffset: Bool = true) -> Bool {
         guard updatedContentInset != contentInset || updatedScrollIndicatorInsets != scrollIndicatorInsets else {
             return false
         }
@@ -38,16 +38,16 @@ extension UIScrollView {
         contentInset = updatedContentInset
         UIView.setAnimationsEnabled(wereAnimationsEnabled)
         
+        guard preserveContentOffset else {
+            return true
+        }
+        
         if wasAtTop {
             contentOffset = wmf_topOffset
         } else if contentSize.height > UIEdgeInsetsInsetRect(bounds, contentInset).height && wasAtBottom {
             contentOffset = wmf_bottomOffset
         }
-
-        if wmf_isAtTop, let nb = navigationBar, nb.isInteractiveHidingEnabled {
-            nb.setNavigationBarPercentHidden(0, underBarViewPercentHidden: 0, extendedViewPercentHidden: 0, topSpacingPercentHidden: 0, animated: false)
-        }
-
+        
         return true
     }
 }

--- a/Wikipedia/Code/NavigationBarHider.swift
+++ b/Wikipedia/Code/NavigationBarHider.swift
@@ -50,11 +50,13 @@ public class NavigationBarHider: NSObject {
         }
         
         guard scrollView.contentSize.height > 0 else {
-            navigationBar.setNavigationBarPercentHidden(0, underBarViewPercentHidden: 0, extendedViewPercentHidden: 0, topSpacingPercentHidden: 0, animated: false)
-            if navigationBar.isShadowHidingEnabled {
-                navigationBar.shadowAlpha = 0
-            } else {
-                navigationBar.shadowAlpha = 1
+            if navigationBar.isAdjustingHidingFromContentInsetChangesEnabled  {
+                navigationBar.setNavigationBarPercentHidden(0, underBarViewPercentHidden: 0, extendedViewPercentHidden: 0, topSpacingPercentHidden: 0, animated: false)
+                if navigationBar.isShadowHidingEnabled {
+                    navigationBar.shadowAlpha = 0
+                } else {
+                    navigationBar.shadowAlpha = 1
+                }
             }
             return
         }

--- a/Wikipedia/Code/SearchTransition.swift
+++ b/Wikipedia/Code/SearchTransition.swift
@@ -28,6 +28,7 @@ class SearchTransition: NSObject, UIViewControllerAnimatedTransitioning {
         toViewController.view.frame = toFinalFrame
         
         if isEnteringSearch {
+            searchViewController.navigationBarTopSpacingPercentHidden = exploreViewController.navigationBar.topSpacingPercentHidden
             searchViewController.nonSearchAlpha = 0
             exploreViewController.searchBar.alpha = 0
             containerView.insertSubview(toViewController.view, aboveSubview: fromViewController.view)

--- a/Wikipedia/Code/ViewController.swift
+++ b/Wikipedia/Code/ViewController.swift
@@ -270,7 +270,7 @@ class ViewController: PreviewingViewController, Themeable, NavigationBarHiderDel
             top += rc.frame.height
         }
         let contentInset = UIEdgeInsets(top: top, left: 0, bottom: bottom, right: 0)
-        if scrollView.wmf_setContentInsetPreservingTopAndBottomOffset(contentInset, scrollIndicatorInsets: scrollIndicatorInsets, withNavigationBar: navigationBar) {
+        if scrollView.wmf_setContentInset(contentInset, scrollIndicatorInsets: scrollIndicatorInsets, preserveContentOffset: navigationBar.isAdjustingHidingFromContentInsetChangesEnabled) {
             scrollViewInsetsDidChange()
         }
     }

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -412,7 +412,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
         scrollViewContentInset.top = self.navigationBar.visibleHeight;
         UIEdgeInsets scrollViewScrollIndicatorInsets = self.scrollView.scrollIndicatorInsets;
         scrollViewScrollIndicatorInsets.top = self.navigationBar.visibleHeight;
-        BOOL didSet = [scrollView wmf_setContentInsetPreservingTopAndBottomOffset:scrollViewContentInset scrollIndicatorInsets:scrollViewScrollIndicatorInsets withNavigationBar:nil];
+        BOOL didSet = [scrollView wmf_setContentInset:scrollViewContentInset scrollIndicatorInsets:scrollViewScrollIndicatorInsets preserveContentOffset:YES];
         if (didSet) {
             NSIndexPath *indexPath = [[self.tableOfContentsViewController.tableView indexPathsForSelectedRows] firstObject];
             if (indexPath && ![[self.tableOfContentsViewController.tableView indexPathsForVisibleRows] containsObject:indexPath]) {

--- a/Wikipedia/Code/WMFViewController.m
+++ b/Wikipedia/Code/WMFViewController.m
@@ -157,7 +157,7 @@
         return;
     }
     
-    if ([self.scrollView wmf_setContentInsetPreservingTopAndBottomOffset:contentInset scrollIndicatorInsets:scrollIndicatorInsets withNavigationBar:self.navigationBar]) {
+    if ([self.scrollView wmf_setContentInset:contentInset scrollIndicatorInsets:scrollIndicatorInsets preserveContentOffset:YES]) {
         [self scrollViewInsetsDidChange];
     }
 }


### PR DESCRIPTION
- Transfer top spacing hidden percentage from explore to search
- Disable adjustment of content offset while search is transitioning