### PR TITLE
Second set of RTL audit fixes

### DIFF
--- a/Wikipedia/Code/MWKImageInfo.h
+++ b/Wikipedia/Code/MWKImageInfo.h
@@ -18,6 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Short description of the image contents (e.g. "John Smith posing for a picture").
 @property (nullable, nonatomic, readonly, copy) NSString *imageDescription;
 
+@property (nonatomic, assign, readonly) BOOL imageDescriptionIsRTL;
+
 @property (nullable, nonatomic, readonly, strong) MWKLicense *license;
 
 /// URL pointing to the corresponding file page for the receiver.
@@ -44,6 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCanonicalPageTitle:(nullable NSString *)canonicalPageTitle
                           canonicalFileURL:(nullable NSURL *)canonicalFileURL
                           imageDescription:(nullable NSString *)imageDescription
+                     imageDescriptionIsRTL:(BOOL)imageDescriptionIsRTL
                                    license:(nullable MWKLicense *)license
                                filePageURL:(nullable NSURL *)filePageURL
                              imageThumbURL:(nullable NSURL *)imageThumbURL

--- a/Wikipedia/Code/MWKImageInfo.m
+++ b/Wikipedia/Code/MWKImageInfo.m
@@ -15,6 +15,7 @@ NSUInteger const MWKImageInfoModelVersion_1 = 1;
 NSString *const MWKImageInfoCanonicalPageTitleKey = @"canonicalPageTitle";
 NSString *const MWKImageInfoCanonicalFileURLKey = @"canonicalFileURL";
 NSString *const MWKImageInfoImageDescriptionKey = @"imageDescription";
+NSString *const MWKImageInfoImageDescriptionIsRTLKey = @"imageDescriptionIsRTL";
 NSString *const MWKImageInfoFilePageURLKey = @"filePageURL";
 NSString *const MWKImageInfoImageThumbURLKey = @"imageThumbURL";
 NSString *const MWKImageInfoOwnerKey = @"owner";
@@ -27,6 +28,7 @@ NSString *const MWKImageInfoThumbSize = @"thumbSize";
 @property (nonatomic, readwrite, copy) NSString *canonicalPageTitle;
 @property (nonatomic, readwrite, copy) NSURL *canonicalFileURL;
 @property (nonatomic, readwrite, copy) NSString *imageDescription;
+@property (nonatomic, assign, readwrite) BOOL imageDescriptionIsRTL;
 @property (nonatomic, readwrite, strong) MWKLicense *license;
 @property (nonatomic, readwrite, copy) NSURL *filePageURL;
 @property (nonatomic, readwrite, copy) NSURL *imageThumbURL;
@@ -42,6 +44,7 @@ NSString *const MWKImageInfoThumbSize = @"thumbSize";
 - (instancetype)initWithCanonicalPageTitle:(NSString *)canonicalPageTitle
                           canonicalFileURL:(NSURL *)canonicalFileURL
                           imageDescription:(NSString *)imageDescription
+                     imageDescriptionIsRTL:(BOOL)imageDescriptionIsRTL
                                    license:(MWKLicense *)license
                                filePageURL:(NSURL *)filePageURL
                              imageThumbURL:(NSURL *)imageThumbURL
@@ -55,6 +58,7 @@ NSString *const MWKImageInfoThumbSize = @"thumbSize";
     if (self) {
         self.canonicalPageTitle = canonicalPageTitle;
         self.imageDescription = imageDescription;
+        self.imageDescriptionIsRTL = imageDescriptionIsRTL;
         self.owner = owner;
         self.license = license;
         self.canonicalFileURL = canonicalFileURL;
@@ -75,6 +79,7 @@ NSString *const MWKImageInfoThumbSize = @"thumbSize";
         initWithCanonicalPageTitle:exportedData[MWKImageInfoCanonicalPageTitleKey]
                   canonicalFileURL:[NSURL URLWithString:exportedData[MWKImageInfoCanonicalFileURLKey]]
                   imageDescription:exportedData[MWKImageInfoImageDescriptionKey]
+             imageDescriptionIsRTL:exportedData[MWKImageInfoImageDescriptionIsRTLKey]
                            license:[MWKLicense licenseWithExportedData:exportedData[MWKImageInfoLicenseKey]]
                        filePageURL:[NSURL URLWithString:exportedData[MWKImageInfoFilePageURLKey]]
                      imageThumbURL:[NSURL URLWithString:exportedData[MWKImageInfoImageThumbURLKey]]

--- a/Wikipedia/Code/MWKImageInfoFetcher+PicOfTheDayInfo.m
+++ b/Wikipedia/Code/MWKImageInfoFetcher+PicOfTheDayInfo.m
@@ -40,6 +40,7 @@ static MWKImageInfoResolve addPictureOfTheDayToDescriptionForDate(NSDate *date) 
         return [[MWKImageInfo alloc] initWithCanonicalPageTitle:info.canonicalPageTitle
                                                canonicalFileURL:info.canonicalFileURL
                                                imageDescription:potdDescription
+                                          imageDescriptionIsRTL:info.imageDescriptionIsRTL
                                                         license:info.license
                                                     filePageURL:info.filePageURL
                                                   imageThumbURL:info.imageThumbURL

--- a/Wikipedia/Code/MWKImageInfoFetcher.m
+++ b/Wikipedia/Code/MWKImageInfoFetcher.m
@@ -120,6 +120,7 @@
             @"prop": @"imageinfo",
             @"iiprop": WMFJoinedPropertyParameters(@[@"url", @"extmetadata", @"dimensions"]),
             @"iiextmetadatafilter": WMFJoinedPropertyParameters(extMetadataKeys),
+            @"iiextmetadatamultilang": @1,
             @"iiurlwidth": thumbnailWidth } mutableCopy];
 
     if (useGenerator) {

--- a/Wikipedia/Code/MWKImageInfoResponseSerializer.m
+++ b/Wikipedia/Code/MWKImageInfoResponseSerializer.m
@@ -40,6 +40,11 @@ static CGSize MWKImageInfoSizeFromJSON(NSDictionary *json, NSString *widthKey, N
     }
     NSDictionary *indexedImages = json[@"query"][@"pages"];
     NSMutableArray *itemListBuilder = [NSMutableArray arrayWithCapacity:[[indexedImages allKeys] count]];
+    
+    NSArray<NSString*>* preferredLangCodes = [[[MWKLanguageLinkController sharedInstance] preferredLanguages] wmf_map:^NSString*(MWKLanguageLink* language){
+        return [language languageCode];
+    }];
+    
     [indexedImages enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSDictionary *image, BOOL *stop) {
         NSDictionary *imageInfo = [image[@"imageinfo"] firstObject];
         NSDictionary *extMetadata = imageInfo[@"extmetadata"];
@@ -52,20 +57,66 @@ static CGSize MWKImageInfoSizeFromJSON(NSDictionary *json, NSString *widthKey, N
                             shortDescription:extMetadata[ExtMetadataLicenseShortNameKey][@"value"]
                                          URL:[NSURL wmf_optionalURLWithString:extMetadata[ExtMetadataLicenseUrlKey][@"value"]]];
 
+        NSString *description = nil;
+        BOOL descriptionIsRTL = NO;
+        NSString *descriptionLangCode = nil;
+        
+        id imageDescriptionValue = extMetadata[ExtMetadataImageDescriptionKey][@"value"];
+        if ([imageDescriptionValue isKindOfClass:[NSDictionary class]]) {
+            NSDictionary *availableDescriptionsByLangCode = imageDescriptionValue;
+            descriptionLangCode = [self descriptionLangCodeToUseFromAvailableDescriptionsByLangCode:availableDescriptionsByLangCode forPreferredLangCodes:preferredLangCodes];
+            if (descriptionLangCode) {
+                description = availableDescriptionsByLangCode[descriptionLangCode];
+                descriptionIsRTL = [[MWLanguageInfo rtlLanguages] containsObject:descriptionLangCode];
+            }
+        } else if ([imageDescriptionValue isKindOfClass:[NSString class]]) {
+            description = imageDescriptionValue;
+        }
+        
+        NSString *artist = nil;
+        id artistValue = extMetadata[ExtMetadataArtistKey][@"value"];
+        if ([artistValue isKindOfClass:[NSDictionary class]]) {
+            artist = artistValue[descriptionLangCode];
+        } else if ([artistValue isKindOfClass:[NSString class]]) {
+            artist = artistValue;
+        }
+        
         MWKImageInfo *item =
             [[MWKImageInfo alloc]
                 initWithCanonicalPageTitle:image[@"title"]
                           canonicalFileURL:[NSURL wmf_optionalURLWithString:imageInfo[@"url"]]
-                          imageDescription:[[extMetadata[ExtMetadataImageDescriptionKey][@"value"] wmf_joinedHtmlTextNodes] wmf_getCollapsedWhitespaceStringAdjustedForTerminalPunctuation]
+                          imageDescription:[[description wmf_joinedHtmlTextNodes] wmf_getCollapsedWhitespaceStringAdjustedForTerminalPunctuation]
+                     imageDescriptionIsRTL:descriptionIsRTL
                                    license:license
                                filePageURL:[NSURL wmf_optionalURLWithString:imageInfo[@"descriptionurl"]]
                              imageThumbURL:[NSURL wmf_optionalURLWithString:imageInfo[@"thumburl"]]
-                                     owner:[[extMetadata[ExtMetadataArtistKey][@"value"] wmf_joinedHtmlTextNodes] wmf_getCollapsedWhitespaceStringAdjustedForTerminalPunctuation]
+                                     owner:[[artist wmf_joinedHtmlTextNodes] wmf_getCollapsedWhitespaceStringAdjustedForTerminalPunctuation]
                                  imageSize:MWKImageInfoSizeFromJSON(imageInfo, @"width", @"height")
                                  thumbSize:MWKImageInfoSizeFromJSON(imageInfo, @"thumbwidth", @"thumbheight")];
         [itemListBuilder addObject:item];
     }];
     return itemListBuilder;
+}
+
+- (NSString *)descriptionLangCodeToUseFromAvailableDescriptionsByLangCode:(NSDictionary *)availableDescriptionsByLangCode forPreferredLangCodes:(NSArray<NSString*>*) preferredLangCodes {
+    // use first of user's preferred lang codes for which we have a translation
+    for (NSString* langCode in preferredLangCodes) {
+        if ([availableDescriptionsByLangCode objectForKey:langCode]) {
+            return langCode;
+        }
+    }
+    // else use "en" description if available
+    if ([availableDescriptionsByLangCode objectForKey:@"en"]) {
+        return @"en";
+    }
+    // else use first description lang code
+    for (NSString* langCode in availableDescriptionsByLangCode.allKeys) {
+        if (![langCode hasPrefix:@"_"]) { // there's a weird "_type" key in the results for some reason
+            return langCode;
+        }
+    }
+    // else no luck
+    return nil;
 }
 
 @end

--- a/Wikipedia/Code/WMFImageGalleryDetailOverlayView.h
+++ b/Wikipedia/Code/WMFImageGalleryDetailOverlayView.h
@@ -4,6 +4,7 @@
 
 @interface WMFImageGalleryDetailOverlayView : UIView
 @property (nonatomic, copy) NSString *imageDescription;
+@property (nonatomic, assign) BOOL imageDescriptionIsRTL;
 @property (nonatomic, copy) dispatch_block_t ownerTapCallback;
 @property (nonatomic, copy) dispatch_block_t infoTapCallback;
 

--- a/Wikipedia/Code/WMFImageGalleryDetailOverlayView.m
+++ b/Wikipedia/Code/WMFImageGalleryDetailOverlayView.m
@@ -81,6 +81,10 @@
     self.imageDescriptionLabel.text = imageDescription;
 }
 
+- (void)setImageDescriptionIsRTL:(BOOL)isRTL {
+    self.imageDescriptionLabel.textAlignment = isRTL ? NSTextAlignmentRight : NSTextAlignmentLeft;
+}
+
 - (void)setLicense:(MWKLicense *)license owner:(NSString *)owner {
     NSString *code = [license.code lowercaseString];
     if (code) {

--- a/Wikipedia/Code/WMFImageGalleryViewController.m
+++ b/Wikipedia/Code/WMFImageGalleryViewController.m
@@ -385,6 +385,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     WMFImageGalleryDetailOverlayView *caption = [WMFImageGalleryDetailOverlayView wmf_viewFromClassNib];
 
+    caption.imageDescriptionIsRTL = imageInfo.imageDescriptionIsRTL;
+    
     caption.imageDescription =
         [imageInfo.imageDescription stringByTrimmingCharactersInSet:
                                         [NSCharacterSet whitespaceAndNewlineCharacterSet]];

--- a/WikipediaUnitTests/Code/MWKImage+AssociationTestUtils.m
+++ b/WikipediaUnitTests/Code/MWKImage+AssociationTestUtils.m
@@ -21,6 +21,7 @@
     return [[self alloc] initWithCanonicalPageTitle:imageURL
                                    canonicalFileURL:[NSURL URLWithString:imageURL]
                                    imageDescription:nil
+                              imageDescriptionIsRTL:false
                                             license:nil
                                         filePageURL:nil
                                       imageThumbURL:nil


### PR DESCRIPTION
https://phabricator.wikimedia.org/T199569

<table>
  <tr>
    <td align=center>Before</td>
    <td align=center>After</td>
  </tr>
  <tr>
    <td colspan="2" align=center>Incorrect LTR text alignment</td>
  </tr>
  <tr>
    <td>
<img width="431" alt="screen shot 2018-07-27 at 7 56 49 pm" src="https://user-images.githubusercontent.com/3143487/43352398-b4d17da8-91d7-11e8-852f-f19d4a289634.png">
    </td>
    <td>
<img width="431" alt="screen shot 2018-07-27 at 7 59 34 pm" src="https://user-images.githubusercontent.com/3143487/43352399-b798a2be-91d7-11e8-975e-864bf2984398.png">
    </td>
  </tr>
  <tr>
    <td colspan="2" align=center>Not getting description in user's language when available</td>
  </tr>
  <tr>
    <td>
<img width="431" alt="screen shot 2018-07-27 at 7 55 47 pm" src="https://user-images.githubusercontent.com/3143487/43352408-d8c80f56-91d7-11e8-899d-0e70de168d33.png">
    </td>
    <td>
<img width="431" alt="screen shot 2018-07-27 at 7 50 57 pm" src="https://user-images.githubusercontent.com/3143487/43352412-dbd150fe-91d7-11e8-8506-0812ac2acf7a.png">
    </td>
  </tr>
</table>