### PR TITLE
Kellyroach/fix warnings

### DIFF
--- a/WMF Framework/WMFExploreFeedContentController.m
+++ b/WMF Framework/WMFExploreFeedContentController.m
@@ -706,7 +706,7 @@ NSString *const WMFNewExploreFeedPreferencesWereRejectedNotification = @"WMFNewE
             dispatch_async(dispatch_get_main_queue(), ^{
                 WMFContentGroup *newsContentGroup = [self.dataStore.viewContext newestGroupOfKind:WMFContentGroupKindNews];
                 if (newsContentGroup) {
-                    NSArray<WMFFeedNewsStory *> *stories = (NSArray<WMFFeedNewsStory *> *)newsContentGroup.content;
+                    NSArray<WMFFeedNewsStory *> *stories = (NSArray<WMFFeedNewsStory *> *)newsContentGroup.contentPreview;
                     if (stories.count > 0) {
                         NSInteger randomIndex = (NSInteger)arc4random_uniform((uint32_t)stories.count);
                         WMFFeedNewsStory *randomStory = stories[randomIndex];

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -12580,7 +12580,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_SWIFT_FLAGS = "-DDEBUG -Xfrontend -warn-long-function-bodies=500 -DUI_TEST";
+				OTHER_SWIFT_FLAGS = "-DDEBUG -Xfrontend -warn-long-function-bodies=1000 -DUI_TEST";
 				SDKROOT = iphoneos;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -13677,7 +13677,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_SWIFT_FLAGS = "-DDEBUG -Xfrontend -warn-long-function-bodies=500";
+				OTHER_SWIFT_FLAGS = "-DDEBUG -Xfrontend -warn-long-function-bodies=1000";
 				SDKROOT = iphoneos;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -17339,7 +17339,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_SWIFT_FLAGS = "-DDEBUG -Xfrontend -warn-long-function-bodies=500";
+				OTHER_SWIFT_FLAGS = "-DDEBUG -Xfrontend -warn-long-function-bodies=1000";
 				SDKROOT = iphoneos;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -2777,6 +2777,7 @@
 		D8FA19161E1BE069009675C3 /* WMFArticlePreviewViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D8D2703A1D75ED5000D093A8 /* WMFArticlePreviewViewController.xib */; };
 		D8FAC7DD1D6F88AB00C2A6BC /* WMF.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D844D96C1D6CB2600042D692 /* WMF.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D8FEECCD1DE3729400B883F0 /* WMFChange.m in Sources */ = {isa = PBXBuildFile; fileRef = D8FEECCC1DE3729400B883F0 /* WMFChange.m */; };
+		E1CFD6E6210C103900D8E37C /* ExploreCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CA612920D1675800EF0C4A /* ExploreCardViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -11454,6 +11455,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E1CFD6E6210C103900D8E37C /* ExploreCardViewController.swift in Sources */,
 				D8EC3DD81E9BDA35006712EB /* UserLocationAnnotationView.swift in Sources */,
 				7ABAD6B620338CFB006A364C /* ReadingListDetailUnderBarViewController.swift in Sources */,
 				D8EC3DD91E9BDA35006712EB /* WMFSearchFunnel.m in Sources */,

--- a/Wikipedia/Code/AboutViewController.plist
+++ b/Wikipedia/Code/AboutViewController.plist
@@ -182,6 +182,7 @@ THE SOFTWARE.</string>
 		<string>Joshua Minor</string>
 		<string>Julien Bodet</string>
 		<string>Kaity Hammerstein</string>
+		<string>Kelly Roach</string>
 		<string>Kenan Wang</string>
 		<string>Kotaro Fujita</string>
 		<string>Kunal Mehta</string>

--- a/Wikipedia/Code/MWKImageInfo.h
+++ b/Wikipedia/Code/MWKImageInfo.h
@@ -37,10 +37,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Value which can be used to associate the receiver with a @c MWKImage.
 @property (nullable, nonatomic, readonly, strong) id imageAssociationValue;
+NS_ASSUME_NONNULL_END
 
 /// Factory method for creating an instance from the output of @c exportData.
-+ (instancetype)imageInfoWithExportedData:(nullable NSDictionary *)exportedData;
++ (nullable instancetype)imageInfoWithExportedData:(nullable NSDictionary *)exportedData;
 
+NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCanonicalPageTitle:(nullable NSString *)canonicalPageTitle
                           canonicalFileURL:(nullable NSURL *)canonicalFileURL
                           imageDescription:(nullable NSString *)imageDescription

--- a/Wikipedia/Code/MWKSectionList.h
+++ b/Wikipedia/Code/MWKSectionList.h
@@ -31,12 +31,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSUInteger)count;
 - (MWKSection *)objectAtIndexedSubscript:(NSUInteger)idx;
+NS_ASSUME_NONNULL_END
 
 /// @return The first section whose `text` is not empty, or `nil` if all sections (or the receiver) are empty.
-- (MWKSection *)firstNonEmptySection;
+- (nullable MWKSection *)firstNonEmptySection;
 
-- (MWKSection *)sectionWithFragment:(NSString *)fragment;
+- (nullable MWKSection *)sectionWithFragment:(nonnull NSString *)fragment;
 
+NS_ASSUME_NONNULL_BEGIN
 - (BOOL)save:(NSError **)outError;
 
 - (BOOL)isEqualToSectionList:(MWKSectionList *)sectionList;

--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.m
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.m
@@ -6,6 +6,12 @@
 
 NSString *const WMFNavigateToActivityNotification = @"WMFNavigateToActivityNotification";
 
+// Use to suppress "User-facing text should use localized string macro" Analyzer warning
+// where appropriate.
+__attribute__((annotate("returns_localized_nsstring"))) static inline NSString *wmf_localizationNotNeeded(NSString *s) {
+    return s;
+}
+
 @implementation NSUserActivity (WMFExtensions)
 
 + (void)wmf_makeActivityActive:(NSUserActivity *)activity {
@@ -33,7 +39,7 @@ NSString *const WMFNavigateToActivityNotification = @"WMFNavigateToActivityNotif
 
 + (instancetype)wmf_pageActivityWithName:(NSString *)pageName {
     NSUserActivity *activity = [self wmf_activityWithType:[pageName lowercaseString]];
-    activity.title = pageName;
+    activity.title = wmf_localizationNotNeeded(pageName);
     activity.userInfo = @{@"WMFPage": pageName};
 
     if ([[NSProcessInfo processInfo] wmf_isOperatingSystemMajorVersionAtLeast:9]) {

--- a/Wikipedia/Code/WMFAuthenticationManager.swift
+++ b/Wikipedia/Code/WMFAuthenticationManager.swift
@@ -101,7 +101,7 @@ public class WMFAuthenticationManager: NSObject {
      *  @param password The password for the user
      *  @param retypePassword The password used for confirming password changes. Optional.
      *  @param oathToken Two factor password required if user's account has 2FA enabled. Optional.
-     *  @param success  The handler for success - at this point the user is logged in
+     *  @param loginSuccess  The handler for success - at this point the user is logged in
      *  @param failure     The handler for any errors
      */
     @objc public func login(username: String, password:String, retypePassword:String?, oathToken:String?, captchaID: String?, captchaWord: String?, success loginSuccess:@escaping WMFAccountLoginResultBlock, failure:@escaping WMFErrorHandler){
@@ -124,7 +124,7 @@ public class WMFAuthenticationManager: NSObject {
      *  Logs in a user using saved credentials in the keychain
      *
      *  @param success  The handler for success - at this point the user is logged in
-     *  @param userWasAlreadyLoggedIn     The handler called if a user was found to already be logged in
+     *  @param userAlreadyLoggedInHandler     The handler called if a user was found to already be logged in
      *  @param failure     The handler for any errors
      */
     @objc public func loginWithSavedCredentials(success:@escaping WMFAccountLoginResultBlock, userAlreadyLoggedInHandler:@escaping WMFCurrentlyLoggedInUserBlock, failure:@escaping WMFErrorHandler){

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -229,6 +229,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
                                                        // Expand protocol-relative link to https -- secure by default!
                                                        href = [@"https:" stringByAppendingString:href];
                                                    }
+                                                   url = [NSURL URLWithString:href];
                                                    NSCAssert(url, @"Failed to from URL from link %@", href);
                                                    if (url) {
                                                        [self wmf_openExternalUrl:url];

--- a/Wikipedia/Third Party Code/RMessage/RMessageView.m
+++ b/Wikipedia/Third Party Code/RMessage/RMessageView.m
@@ -150,19 +150,17 @@ static NSMutableDictionary *globalDesignDictionary;
  */
 + (BOOL)viewControllerEdgesExtendUnderTopBars:(UIViewController *)viewController
 {
-  BOOL vcAskedToExtendUnderTopBars = NO;
-
   if (viewController.edgesForExtendedLayout == UIRectEdgeTop ||
       viewController.edgesForExtendedLayout == UIRectEdgeAll) {
-    vcAskedToExtendUnderTopBars = YES;
+    /* viewController is asking to extend under top bars */
   } else {
-    vcAskedToExtendUnderTopBars = NO;
+    /* viewController isn't asking to extend under top bars */
     return NO;
   }
 
   /* When a table view controller asks to extend under top bars, if the navigation bar is
    translucent iOS will not extend the edges of the table view controller under the top bars. */
-  if ([viewController isKindOfClass:[UITableViewController class]] && vcAskedToExtendUnderTopBars &&
+  if ([viewController isKindOfClass:[UITableViewController class]] &&
       !viewController.navigationController.navigationBar.translucent) {
     return NO;
   }

--- a/Wikipedia/Third Party Code/RMessage/RMessageView.m
+++ b/Wikipedia/Third Party Code/RMessage/RMessageView.m
@@ -325,25 +325,20 @@ static NSMutableDictionary *globalDesignDictionary;
 
 - (void)updateCurrentIconIfNeeded
 {
-  UIImage *image = nil;
   switch (self.messageType) {
   case RMessageTypeNormal: {
-    image = _messageIcon;
     self.iconImageView.image = _messageIcon;
     break;
   }
   case RMessageTypeError: {
-    image = _errorIcon;
     self.iconImageView.image = _errorIcon;
     break;
   }
   case RMessageTypeSuccess: {
-    image = _successIcon;
     self.iconImageView.image = _successIcon;
     break;
   }
   case RMessageTypeWarning: {
-    image = _warningIcon;
     self.iconImageView.image = _warningIcon;
     break;
   }

--- a/WikipediaUITests/SnapshotHelper.swift
+++ b/WikipediaUITests/SnapshotHelper.swift
@@ -128,7 +128,7 @@ open class Snapshot: NSObject {
         }
         
         let path = cacheDirectory.appendingPathComponent("snapshot-launch_arguments.txt")
-        app.launchArguments += "YES", "-ui_testing"]
+        app.launchArguments += ["YES", "-ui_testing"]
 
         do {
             let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)


### PR DESCRIPTION
This pull request addresses Xcode Analyze warnings (mostly static lint) in wikipedia-ios .
The aim is to get Xcode Analyze to "No issues" on all the wikipedia-ios project schemes.
* Suppress 'User-facing text should use localized string macro' Analyze warning
* Fix 'Value stored to href is never read' Analyze issue
* Fix 4 'Value store to image is never read' Analyze issues in RMessageView.m
* Fix 'Value stored to vcAskedToExtendUnderTopBars is never read' Analyze issue
* Fix 3 'nil returned from a method that is expected to return a non-null value' Analyze issues in MWKSectionList.m
* Fix 'nil returned from a method that is expected to return a non-null value' Analyze issue in MWKImageInfo.m
* Increase to -warn-long-function-bodies=1000 in Wikipedia / Build Settings / Other Swift Flags to avoid a yellow warning
* Fix missing [ in SnapshotHelper.swift returning WikipediaUITests / Build For Testing to No issues compilation state
* content --> contentPreview to avoid yellow deprecation warning in WMFExploreFeedContentController.m
* Add ExploreCardViewController.swift to Wikipedia Beta compile sources fixes 8 build errors to No issues compilation
* Fix 2 documentation compiler yellow warnings in WMFAuthenticationManager.swift
* Add 'Kelly Roach' to AboutViewController.plist
