### PR TITLE
Fix on this day explore card occasionally showing only a single event

### DIFF
--- a/WMF Framework/WMFContentGroup+Extensions.m
+++ b/WMF Framework/WMFContentGroup+Extensions.m
@@ -278,6 +278,12 @@
                 NSInteger startIndex = featuredEventIndex;
                 NSInteger length = startIndex + 1 < contentArray.count ? 2 : 1;
                 NSRange range = NSMakeRange(startIndex, length);
+                // If we have only the last item but there's more than one, move back one so we get 2 total.
+                // Only do so in this specific case so we usually have the `featuredContent` first (it's chosen based on a score weighing its various properties).
+                BOOL shouldBackUpByOne = range.length == 1 && startIndex > 0 && contentArray.count > 1;
+                if (shouldBackUpByOne) {
+                    range = NSMakeRange(startIndex - 1, 2);
+                }
                 self.contentPreview = [contentArray subarrayWithRange:range];
             }
         } break;


### PR DESCRIPTION
https://phabricator.wikimedia.org/T200360

If the highest scored on this day explore card event is the last event for that day, expand the range back to encompass the previous event (if present) as well.

| Before  | After |
| ------------- | ------------- |
|   <img width="431" alt="screen shot 2018-07-31 at 12 27 53 am" src="https://user-images.githubusercontent.com/3143487/43447817-2c6b455c-9461-11e8-80e0-8e6708be6994.png"> | <img width="431" alt="screen shot 2018-07-31 at 1 24 35 am" src="https://user-images.githubusercontent.com/3143487/43447818-2c81d7c2-9461-11e8-9376-17033f285644.png"> |

 