### PR TITLE
Bump feed refresh timeout interval to 60s

### DIFF
--- a/WMF Framework/WMFExploreFeedContentController.m
+++ b/WMF Framework/WMFExploreFeedContentController.m
@@ -11,7 +11,7 @@
 
 NSString *const WMFExploreFeedContentControllerBusyStateDidChange = @"WMFExploreFeedContentControllerBusyStateDidChange";
 const NSInteger WMFExploreFeedMaximumNumberOfDays = 30;
-static const NSTimeInterval WMFFeedRefreshTimeoutInterval = 12;
+static const NSTimeInterval WMFFeedRefreshTimeoutInterval = 60;
 static NSTimeInterval WMFFeedRefreshBackgroundTimeout = 30;
 static const NSString *kvo_WMFExploreFeedContentController_operationQueue_operationCount = @"kvo_WMFExploreFeedContentController_operationQueue_operationCount";
 


### PR DESCRIPTION
With multiple languages being requested and less frequent failures, this should be bumped to 60 seconds