### PR TITLE
Apply explore feed preferences when fetch is completed in the background

### DIFF
--- a/WMF Framework/WMFExploreFeedContentController.m
+++ b/WMF Framework/WMFExploreFeedContentController.m
@@ -295,6 +295,7 @@ NSString *const WMFNewExploreFeedPreferencesWereRejectedNotification = @"WMFNewE
                                     [moc performBlock:^{
                                         BOOL didUpdate = NO;
                                         if ([moc hasChanges]) {
+                                            [self applyExploreFeedPreferencesToAllObjectsInManagedObjectContext:moc];
                                             NSFetchRequest *afterFetchRequest = [WMFContentGroup fetchRequest];
                                             NSInteger afterCount = [moc countForFetchRequest:afterFetchRequest error:nil];
                                             didUpdate = afterCount != beforeCount;


### PR DESCRIPTION
Repro steps:

- Ensure background fetching is on
- Allow a new feed day to load via background fetch (or simulated background fetch)
- Observe feed order

Expected:
Order is correct (Featured Article, Top Read, Picture of the day...)

Actual:
Order is incorrect (Random, Picture of the day, Featured Article...)