### PR TITLE
When the app is upgraded, we want to send a new snapshot to MobileWikiAppiOSUserHistory

### DIFF
--- a/Wikipedia/Code/AppDelegate.m
+++ b/Wikipedia/Code/AppDelegate.m
@@ -67,6 +67,10 @@ static NSTimeInterval const WMFBackgroundFetchInterval = 10800; // 3 Hours
 #pragma mark - UIApplicationDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    NSString *lastAppVersion = NSUserDefaults.wmf_userDefaults.wmf_lastAppVersion;
+    if (!lastAppVersion) {
+        NSUserDefaults.wmf_userDefaults.wmf_lastAppVersion = WikipediaAppUtils.appVersion;
+    }
 
 #if WMF_IS_NEW_EVENT_LOGGING_ENABLED
     [[WMFEventLoggingService sharedInstance] start];

--- a/Wikipedia/Code/AppDelegate.m
+++ b/Wikipedia/Code/AppDelegate.m
@@ -67,11 +67,6 @@ static NSTimeInterval const WMFBackgroundFetchInterval = 10800; // 3 Hours
 #pragma mark - UIApplicationDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    NSString *lastAppVersion = NSUserDefaults.wmf_userDefaults.wmf_lastAppVersion;
-    if (!lastAppVersion) {
-        NSUserDefaults.wmf_userDefaults.wmf_lastAppVersion = WikipediaAppUtils.appVersion;
-    }
-
 #if WMF_IS_NEW_EVENT_LOGGING_ENABLED
     [[WMFEventLoggingService sharedInstance] start];
 #endif

--- a/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
+++ b/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
@@ -102,6 +102,16 @@ let WMFSearchLanguageKey = "WMFSearchLanguageKey"
         }
         self.synchronize()
     }
+
+    @objc public var wmf_lastAppVersion: String? {
+        get {
+            return string(forKey: "WMFLastAppVersion")
+        }
+        set {
+            set(newValue, forKey: "WMFLastAppVersion")
+            synchronize()
+        }
+    }
     
     @objc public func wmf_setFeedRefreshDate(_ date: Date) {
         self.set(date, forKey: WMFFeedRefreshDateKey)

--- a/Wikipedia/Code/UserHistoryFunnel.swift
+++ b/Wikipedia/Code/UserHistoryFunnel.swift
@@ -95,10 +95,14 @@ private typealias ContentGroupKindAndLoggingCode = (kind: WMFContentGroupKind, l
         guard isTarget else {
             return
         }
-        
+        guard let lastAppVersion = UserDefaults.wmf_userDefaults().wmf_lastAppVersion else {
+            assertionFailure("Last app version should be set by now")
+            return
+        }
+
         let newSnapshot = event()
         
-        guard !newSnapshot.wmf_isEqualTo(latestSnapshot, excluding: standardEvent.keys) else {
+        guard !newSnapshot.wmf_isEqualTo(latestSnapshot, excluding: standardEvent.keys) || lastAppVersion != WikipediaAppUtils.appVersion() else {
             // DDLogDebug("User History snapshots are identical; logging new User History snapshot aborted")
             return
         }

--- a/Wikipedia/Code/UserHistoryFunnel.swift
+++ b/Wikipedia/Code/UserHistoryFunnel.swift
@@ -82,6 +82,7 @@ private typealias ContentGroupKindAndLoggingCode = (kind: WMFContentGroupKind, l
             return
         }
         EventLoggingService.shared.lastLoggedSnapshot = eventData as NSCoding
+        UserDefaults.wmf_userDefaults().wmf_lastAppVersion = WikipediaAppUtils.appVersion()
     }
     
     private var latestSnapshot: Dictionary<String, Any>? {

--- a/Wikipedia/Code/UserHistoryFunnel.swift
+++ b/Wikipedia/Code/UserHistoryFunnel.swift
@@ -97,7 +97,8 @@ private typealias ContentGroupKindAndLoggingCode = (kind: WMFContentGroupKind, l
             return
         }
         guard let lastAppVersion = UserDefaults.wmf_userDefaults().wmf_lastAppVersion else {
-            assertionFailure("Last app version should be set by now")
+            UserDefaults.wmf_userDefaults().wmf_lastAppVersion = WikipediaAppUtils.appVersion()
+            log(event())
             return
         }
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T200388

This would work on the 2nd upgrade - I don't think there's a way to dig out previous app version for current users? 🧐