### PR TITLE
Fix crash on selecting "No recent searches yet" cell

### DIFF
--- a/Wikipedia/Code/MWKList.m
+++ b/Wikipedia/Code/MWKList.m
@@ -191,6 +191,9 @@
 }
 
 - (id)objectInEntriesAtIndex:(NSUInteger)idx {
+    if (![self countOfEntries] || [self countOfEntries] < idx) {
+        return NULL;
+    }
     return [_mutableEntries objectAtIndex:idx];
 }
 


### PR DESCRIPTION
Repro steps

1) Make sure you have no recent searches
2) Go to the Search tab
3) Tap on "No recent searches yet"