### PR TITLE
Log snapshot after app upgrade when session starts, log feed impression after delay

### DIFF
--- a/Wikipedia/Code/AppDelegate.m
+++ b/Wikipedia/Code/AppDelegate.m
@@ -67,6 +67,7 @@ static NSTimeInterval const WMFBackgroundFetchInterval = 10800; // 3 Hours
 #pragma mark - UIApplicationDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    [UserHistoryFunnel.shared logSnapshot];
 #if WMF_IS_NEW_EVENT_LOGGING_ENABLED
     [[WMFEventLoggingService sharedInstance] start];
 #endif

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -26,6 +26,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+        NSObject.cancelPreviousPerformRequests(withTarget: self)
     }
     
     
@@ -35,7 +36,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         showOfflineEmptyViewIfNeeded()
         imageScaleTransitionView = nil
         detailTransitionSourceRect = nil
-        logFeedImpression()
+        logFeedImpressionAfterDelay()
     }
     
     override func viewWillHaveFirstAppearance(_ animated: Bool) {
@@ -140,12 +141,17 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
     }
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        logFeedImpression()
+        logFeedImpressionAfterDelay()
     }
 
     // MARK: - Event logging
 
-    private func logFeedImpression() {
+    private func logFeedImpressionAfterDelay() {
+        NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(logFeedImpression), object: nil)
+        perform(#selector(logFeedImpression), with: self, afterDelay: 3)
+    }
+
+    @objc private func logFeedImpression() {
         guard let fetchedResultsController = fetchedResultsController else {
             return
         }

--- a/Wikipedia/Code/UserHistoryFunnel.swift
+++ b/Wikipedia/Code/UserHistoryFunnel.swift
@@ -90,15 +90,15 @@ private typealias ContentGroupKindAndLoggingCode = (kind: WMFContentGroupKind, l
     }
     
     @objc public func logSnapshot() {
-        guard let latestSnapshot = latestSnapshot else {
-            return
-        }
         guard isTarget else {
             return
         }
         guard let lastAppVersion = UserDefaults.wmf_userDefaults().wmf_lastAppVersion else {
             UserDefaults.wmf_userDefaults().wmf_lastAppVersion = WikipediaAppUtils.appVersion()
             log(event())
+            return
+        }
+        guard let latestSnapshot = latestSnapshot else {
             return
         }
 


### PR DESCRIPTION
- If user upgrades the app, snapshot is logged at the beginning of the session (not the end)
- Feed impressions are logged after 3s delay