### PR TITLE
Fix cause of `Build failed in Jenkins: Test Beta Cluster` emails

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,7 +19,7 @@ beta_cluster_configurations_to_test = [
 ]
 
 def get_devices_by_scheme_from_options(options)
-  configs = options[:configurations] || [{device: 'iPhone 6s', os: '11.3'}]
+  configs = options[:configurations] || [{device: 'iPhone 6s', os: '11.4'}]
   devices_by_scheme = {}
   configs.each do |options|
     scheme = options[:scheme] || 'Wikipedia'


### PR DESCRIPTION
attempt to fix the cause of the `[ci-apps] Build failed in Jenkins: Test Beta Cluster` emails.

looks like we missed this one when other values in `fastlane/Fastfile` were bumped to `11.4`
