### PR TITLE
Handle non-wikipedia scheme URLs in openURL

### DIFF
--- a/Wikipedia/Code/AppDelegate.m
+++ b/Wikipedia/Code/AppDelegate.m
@@ -140,7 +140,7 @@ static NSTimeInterval const WMFBackgroundFetchInterval = 10800; // 3 Hours
 - (BOOL)application:(UIApplication *)app
             openURL:(NSURL *)url
             options:(NSDictionary<NSString *, id> *)options {
-    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url] ?: [NSUserActivity wmf_activityForURL:url];
     if (activity) {
         BOOL result = [self.appViewController processUserActivity:activity
                                                          animated:NO

--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.h
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.h
@@ -41,6 +41,8 @@ extern NSString *const WMFNavigateToActivityNotification;
 
 + (nullable instancetype)wmf_activityForWikipediaScheme:(NSURL *)url;
 
++ (nullable instancetype)wmf_activityForURL:(NSURL *)url;
+
 - (WMFUserActivityType)wmf_type;
 
 - (nullable NSString *)wmf_searchTerm;

--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.m
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.m
@@ -140,6 +140,16 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
     return nil;
 }
 
++ (nullable instancetype)wmf_activityForURL:(NSURL *)url {
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+    components.scheme = @"https";
+    NSURL *wikipediaURL = components.URL;
+    if (![wikipediaURL wmf_isWikiResource]) {
+        return nil;
+    }
+    return [self wmf_articleViewActivityWithURL:wikipediaURL];
+}
+
 + (instancetype)wmf_articleViewActivityWithArticle:(MWKArticle *)article {
     NSParameterAssert(article.url.wmf_title);
     NSParameterAssert(article.displaytitle);


### PR DESCRIPTION
Repro steps:

- Ask siri "Search Wikipedia for sturgeon"
- Tap "See more on Wikipedia"

Expected:
App opens to sturgeon article

Actual:
App opens to explore feed

This action was previously handed to us as a NSUserActivity, now it's being funneled through the old "openURL" method. Either way, it seems openURL should handle non-wikipedia scheme URLs.