### PR TITLE
Fix inset on iOS 12 after pull to refresh

### DIFF
--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -205,7 +205,6 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
     [self wmf_dismissReferencePopoverAnimated:NO
                                    completion:^{
                                        [self hideFindInPageWithCompletion:^{
-
                                            NSString *href = messageDict[@"href"];
 
                                            if (href.length == 0) {
@@ -304,6 +303,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
 
 - (void)handleArticleStateScriptMessage:(NSString *)messageString {
     if ([messageString isEqualToString:@"indexHTMLDocumentLoaded"]) {
+        self.afterFirstUserScrollInteraction = NO;
 
         NSString *decodedFragment = [[self.articleURL fragment] stringByRemovingPercentEncoding];
         BOOL collapseTables = ![[NSUserDefaults wmf_userDefaults] wmf_isAutomaticTableOpeningEnabled];
@@ -312,11 +312,11 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
         [self updateWebContentMarginForSize:self.view.bounds.size force:YES];
         NSAssert(self.article, @"Article not set");
         [self.delegate webViewController:self didLoadArticle:self.article];
-        
+
         if (!self.isHeaderFadingEnabled) {
             return;
         }
-        
+
         [UIView animateWithDuration:0.3
                               delay:0.0f
                             options:UIViewAnimationOptionBeginFromCurrentState
@@ -324,7 +324,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
                              self.headerView.alpha = 1;
                          }
                          completion:^(BOOL done){
-                             
+
                          }];
     }
 }
@@ -857,7 +857,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
     if (!self.article) {
         return;
     }
-    
+
     self.headerView.alpha = self.isHeaderFadingEnabled ? 0 : 1;
     CGFloat headerHeight = [self headerHeightForCurrentArticle];
     self.headerHeightConstraint.constant = headerHeight;
@@ -879,7 +879,6 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
 - (void)refererenceLinkTappedWithNotification:(NSNotification *)notification {
     [self wmf_dismissReferencePopoverAnimated:NO
                                    completion:^{
-
                                        NSAssert([notification.object isMemberOfClass:[NSURL class]], @"WMFReferenceLinkTappedNotification did not contain NSURL");
                                        NSURL *URL = notification.object;
                                        NSAssert(URL != nil, @"WMFReferenceLinkTappedNotification NSURL was unexpectedly nil");


### PR DESCRIPTION
Repro steps:

1. On iOS 12, pull to refresh an article

Expected:
Article ends up scrolled to top

Actual:
Article is scrolled down slightly

Notes:

Continuation of the iOS 12 hackaround for content offset. Also verified this is not yet fixed in iOS 12.1
