### PR TITLE
Wikidata description API tweaks

### DIFF
--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -168,7 +168,7 @@ static uint64_t bundleHash() {
         self.feedContentController.siteURLs = [[MWKLanguageLinkController sharedInstance] preferredSiteURLs];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveMemoryWarningWithNotification:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
         self.articleLocationController = [ArticleLocationController new];
-        self.wikidataDescriptionEditingController = [[WikidataDescriptionEditingController alloc] init];
+        self.wikidataDescriptionEditingController = [[WikidataDescriptionEditingController alloc] initWith:self.viewContext];
     }
     return self;
 }

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -40,6 +40,7 @@ enum WikidataPublishingError: LocalizedError {
 
 @objc public final class WikidataDescriptionEditingController: NSObject {
     weak var viewContext: NSManagedObjectContext?
+    private let semaphore = DispatchSemaphore(value: 1)
 
     @objc public init(with viewContext: NSManagedObjectContext) {
         self.viewContext = viewContext
@@ -48,6 +49,10 @@ enum WikidataPublishingError: LocalizedError {
     private let BlacklistedLanguagesKey = "WMFWikidataDescriptionEditingBlacklistedLanguagesKey"
     private var blacklistedLanguages: NSSet {
         assert(Thread.isMainThread)
+        semaphore.wait()
+        defer {
+            semaphore.signal()
+        }
         let fallback = NSSet(set: ["en"])
         guard
             let viewContext = viewContext,
@@ -62,6 +67,10 @@ enum WikidataPublishingError: LocalizedError {
     @objc public func setBlacklistedLanguages(_ blacklistedLanguagesFromRemoteConfig: Array<String>) {
         assert(Thread.isMainThread)
         assert(viewContext != nil)
+        semaphore.wait()
+        defer {
+            semaphore.signal()
+        }
         let blacklistedLanguages = NSSet(array: blacklistedLanguagesFromRemoteConfig)
         viewContext?.wmf_setValue(blacklistedLanguages, forKey: BlacklistedLanguagesKey)
     }

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -40,7 +40,6 @@ enum WikidataPublishingError: LocalizedError {
 
 @objc public final class WikidataDescriptionEditingController: NSObject {
     weak var viewContext: NSManagedObjectContext?
-    private let semaphore = DispatchSemaphore(value: 1)
 
     @objc public init(with viewContext: NSManagedObjectContext) {
         self.viewContext = viewContext
@@ -49,10 +48,6 @@ enum WikidataPublishingError: LocalizedError {
     private let BlacklistedLanguagesKey = "WMFWikidataDescriptionEditingBlacklistedLanguagesKey"
     private var blacklistedLanguages: NSSet {
         assert(Thread.isMainThread)
-        semaphore.wait()
-        defer {
-            semaphore.signal()
-        }
         let fallback = NSSet(set: ["en"])
         guard
             let viewContext = viewContext,
@@ -67,10 +62,6 @@ enum WikidataPublishingError: LocalizedError {
     @objc public func setBlacklistedLanguages(_ blacklistedLanguagesFromRemoteConfig: Array<String>) {
         assert(Thread.isMainThread)
         assert(viewContext != nil)
-        semaphore.wait()
-        defer {
-            semaphore.signal()
-        }
         let blacklistedLanguages = NSSet(array: blacklistedLanguagesFromRemoteConfig)
         viewContext?.wmf_setValue(blacklistedLanguages, forKey: BlacklistedLanguagesKey)
     }

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -39,14 +39,35 @@ enum WikidataPublishingError: LocalizedError {
 }
 
 @objc public final class WikidataDescriptionEditingController: NSObject {
-    private var blacklistedLanguages = Set<String>()
+    weak var viewContext: NSManagedObjectContext?
+
+    @objc public init(with viewContext: NSManagedObjectContext) {
+        self.viewContext = viewContext
+    }
+
+    private let BlacklistedLanguagesKey = "WMFWikidataDescriptionEditingBlacklistedLanguagesKey"
+    private var blacklistedLanguages: NSSet {
+        assert(Thread.isMainThread)
+        let fallback = NSSet(set: ["en"])
+        guard
+            let viewContext = viewContext,
+            let keyValue = viewContext.wmf_keyValue(forKey: BlacklistedLanguagesKey),
+            let value = keyValue.value as? NSSet else {
+                assertionFailure("Failed to retrieve WMFKeyValue for key \(BlacklistedLanguagesKey), returning fallback object \(fallback)")
+                return fallback
+        }
+        return value
+    }
 
     @objc public func setBlacklistedLanguages(_ blacklistedLanguagesFromRemoteConfig: Array<String>) {
-        blacklistedLanguages = Set(blacklistedLanguagesFromRemoteConfig)
+        assert(Thread.isMainThread)
+        assert(viewContext != nil)
+        let blacklistedLanguages = NSSet(array: blacklistedLanguagesFromRemoteConfig)
+        viewContext?.wmf_setValue(blacklistedLanguages, forKey: BlacklistedLanguagesKey)
     }
 
     public func isBlacklisted(_ languageCode: String) -> Bool {
-        guard !blacklistedLanguages.isEmpty else {
+        guard blacklistedLanguages.count > 0 else {
             return false
         }
         return blacklistedLanguages.contains(languageCode)

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -97,6 +97,6 @@ public extension MWKArticle {
         guard let dataStore = dataStore, let language = self.url.wmf_language else {
             return false
         }
-        return dataStore.wikidataDescriptionEditingController.isBlacklisted(language)
+        return !dataStore.wikidataDescriptionEditingController.isBlacklisted(language)
     }
 }


### PR DESCRIPTION
* persists blacklisted languages as `WMFKeyValue`
* fixes `isWikidataDescriptionEditable` by adding `!`