### PR TITLE
Show wikidata editor for non-local descriptions

### DIFF
--- a/WMF Framework/MWKArticle+Description.swift
+++ b/WMF Framework/MWKArticle+Description.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @objc public enum ArticleDescriptionSource: Int {
-    case unknown
+    case none
     case central
     case local
 }
@@ -9,6 +9,6 @@ import Foundation
 extension MWKArticle {
     public var descriptionSource: ArticleDescriptionSource {
         let value = descriptionSourceNumber?.intValue ?? 0
-        return ArticleDescriptionSource(rawValue: value) ?? .unknown
+        return ArticleDescriptionSource(rawValue: value) ?? .none
     }
 }

--- a/WMF Framework/MWKArticle+Description.swift
+++ b/WMF Framework/MWKArticle+Description.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+@objc public enum ArticleDescriptionSource: Int {
+    case unknown
+    case central
+    case local
+}
+
+extension MWKArticle {
+    public var descriptionSource: ArticleDescriptionSource {
+        let value = descriptionSourceNumber?.intValue ?? 0
+        return ArticleDescriptionSource(rawValue: value) ?? .unknown
+    }
+}

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		7A3AD05B20ADB1DF00C92E04 /* WMFCurrentlyLoggedInUserFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0ED173A1E497AE7008B70AD /* WMFCurrentlyLoggedInUserFetcher.swift */; };
 		7A3AD05C20ADB1F500C92E04 /* WMFKeychainCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = B066F0D11E4F00B100A199F8 /* WMFKeychainCredentials.swift */; };
 		7A45AB8020AB2A4C006A92F5 /* Dictionary+Equality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A45AB7F20AB2A4C006A92F5 /* Dictionary+Equality.swift */; };
+		7A4941E0216FE96400038D0F /* MWKArticle+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4941DF216FE96400038D0F /* MWKArticle+Description.swift */; };
 		7A49A20121231510005C574C /* CollectionViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A49A20021231510005C574C /* CollectionViewFooter.swift */; };
 		7A49A20221231510005C574C /* CollectionViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A49A20021231510005C574C /* CollectionViewFooter.swift */; };
 		7A49A20321231510005C574C /* CollectionViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A49A20021231510005C574C /* CollectionViewFooter.swift */; };
@@ -3272,6 +3273,7 @@
 		7A35CB861FD82B6300AAF3B7 /* ReadingListDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListDetailViewController.swift; sourceTree = "<group>"; };
 		7A3AD05620ADAFEF00C92E04 /* WMFCaptcha.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WMFCaptcha.swift; path = "../../WMF Framework/WMFCaptcha.swift"; sourceTree = "<group>"; };
 		7A45AB7F20AB2A4C006A92F5 /* Dictionary+Equality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Equality.swift"; sourceTree = "<group>"; };
+		7A4941DF216FE96400038D0F /* MWKArticle+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MWKArticle+Description.swift"; sourceTree = "<group>"; };
 		7A49A20021231510005C574C /* CollectionViewFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewFooter.swift; sourceTree = "<group>"; };
 		7A4ABA8520AA8966007AA405 /* UserHistoryFunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserHistoryFunnel.swift; sourceTree = "<group>"; };
 		7A4B333B2136EDED00C6C820 /* UnderlineButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnderlineButton.swift; sourceTree = "<group>"; };
@@ -5363,6 +5365,7 @@
 			children = (
 				B0E807B91C0CF04A0065EBC0 /* MWKArticle.h */,
 				B0E807BA1C0CF04A0065EBC0 /* MWKArticle.m */,
+				7A4941DF216FE96400038D0F /* MWKArticle+Description.swift */,
 				B0E807CD1C0CF04A0065EBC0 /* MWKSectionList.h */,
 				B0E807CE1C0CF04A0065EBC0 /* MWKSectionList.m */,
 				B0E807CF1C0CF04A0065EBC0 /* MWKSectionMetaData.h */,
@@ -10706,6 +10709,7 @@
 				D82C3A99213451100073EEAC /* DeviceInfo.swift in Sources */,
 				D80ACD291EA0DD0000DC3F20 /* FLAnimatedImage+SafeForSwift.m in Sources */,
 				D8FA18F21E1BDA35009675C3 /* UIImageView+WMFImageFetchingInternal.m in Sources */,
+				7A4941E0216FE96400038D0F /* MWKArticle+Description.swift in Sources */,
 				0E728D251DAEE2B50074EB4B /* WMFFeedContentFetcher.m in Sources */,
 				0E728D401DAEEC380074EB4B /* WMFRelatedSearchFetcher.m in Sources */,
 				D84C35F11F323CCA00895FA1 /* CollectionViewCell.swift in Sources */,

--- a/Wikipedia/Code/DescriptionEditViewController.swift
+++ b/Wikipedia/Code/DescriptionEditViewController.swift
@@ -189,7 +189,7 @@ class DescriptionEditViewController: WMFScrollViewController, Themeable, UITextV
             return
         }
         
-        dataStore.wikidataDescriptionEditingController.publish(newWikidataDescription: descriptionToSave, for: articleURL) {error in
+        dataStore.wikidataDescriptionEditingController.publish(newWikidataDescription: descriptionToSave, from: article.descriptionSource, for: articleURL) {error in
             let presentingVC = self.presentingViewController
             DispatchQueue.main.async {
                 guard let error = error else {

--- a/Wikipedia/Code/MWKArticle.h
+++ b/Wikipedia/Code/MWKArticle.h
@@ -21,6 +21,7 @@ static const NSInteger kMWKArticleSectionNone = -1;
 @property (readonly, strong, nonatomic, nullable) MWKUser *lastmodifiedby; // required
 @property (readonly, assign, nonatomic) int articleId;                     // required; -> 'id'
 @property (readonly, strong, nonatomic, nullable) NSNumber *revisionId;
+@property (readonly, strong, nonatomic, nullable) NSNumber *descriptionSourceNumber;
 
 @property (copy, nonatomic, nullable) NSString *acceptLanguageRequestHeader;
 

--- a/Wikipedia/Code/MWKArticle.m
+++ b/Wikipedia/Code/MWKArticle.m
@@ -30,6 +30,7 @@ static MWKArticleSchemaVersion const MWKArticleCurrentSchemaVersion = MWKArticle
 @property (readwrite, assign, nonatomic) BOOL editable;                   // required
 @property (readwrite, assign, nonatomic, getter=isMain) BOOL main;
 @property (readwrite, strong, nonatomic) NSNumber *revisionId;
+@property (readwrite, strong, nonatomic) NSNumber *descriptionSourceNumber; // optional
 
 @property (readwrite, nonatomic) NSInteger ns; //optional, defaults to 0
 
@@ -97,7 +98,7 @@ static MWKArticleSchemaVersion const MWKArticleCurrentSchemaVersion = MWKArticle
 }
 
 - (BOOL)isEqualToArticle:(MWKArticle *)other {
-    return WMF_EQUAL(self.url, isEqual:, other.url) && WMF_EQUAL(self.lastmodified, isEqualToDate:, other.lastmodified) && WMF_IS_EQUAL(self.lastmodifiedby, other.lastmodifiedby) && WMF_EQUAL(self.displaytitle, isEqualToString:, other.displaytitle) && WMF_EQUAL(self.protection, isEqual:, other.protection) && WMF_EQUAL(self.thumbnailURL, isEqualToString:, other.thumbnailURL) && WMF_EQUAL(self.imageURL, isEqualToString:, other.imageURL) && WMF_EQUAL(self.revisionId, isEqualToNumber:, other.revisionId) && self.articleId == other.articleId && self.languagecount == other.languagecount && self.isMain == other.isMain && self.sections.count == other.sections.count;
+    return WMF_EQUAL(self.url, isEqual:, other.url) && WMF_EQUAL(self.lastmodified, isEqualToDate:, other.lastmodified) && WMF_IS_EQUAL(self.lastmodifiedby, other.lastmodifiedby) && WMF_EQUAL(self.displaytitle, isEqualToString:, other.displaytitle) && WMF_EQUAL(self.protection, isEqual:, other.protection) && WMF_EQUAL(self.thumbnailURL, isEqualToString:, other.thumbnailURL) && WMF_EQUAL(self.imageURL, isEqualToString:, other.imageURL) && WMF_EQUAL(self.revisionId, isEqualToNumber:, other.revisionId) && self.articleId == other.articleId && self.languagecount == other.languagecount && self.isMain == other.isMain && self.sections.count == other.sections.count && self.descriptionSourceNumber == self.descriptionSourceNumber;
 }
 
 - (BOOL)isDeeplyEqualToArticle:(MWKArticle *)article {
@@ -162,6 +163,7 @@ static MWKArticleSchemaVersion const MWKArticleCurrentSchemaVersion = MWKArticle
     self.lastmodifiedby = [self requiredUser:@"lastmodifiedby" dict:dict];
     self.articleId = [[self requiredNumber:@"id" dict:dict] intValue];
     self.languagecount = [[self requiredNumber:@"languagecount" dict:dict] intValue];
+    self.descriptionSourceNumber = [self descriptionSourceNumberFromStringValue:[self optionalString:@"descriptionsource" dict:dict]];
 
     self.ns = [[self optionalNumber:@"ns" dict:dict] integerValue];
 
@@ -234,6 +236,18 @@ static MWKArticleSchemaVersion const MWKArticleCurrentSchemaVersion = MWKArticle
 
     self.media = dict[@"media"];
     [self importMediaJSON:self.media];
+}
+
+- (NSNumber *)descriptionSourceNumberFromStringValue:(NSString *)stringValue {
+    ArticleDescriptionSource source;
+    if ([stringValue isEqualToString:@"central"]) {
+        source = ArticleDescriptionSourceCentral;
+    } else if ([stringValue isEqualToString:@"local"]) {
+        source = ArticleDescriptionSourceLocal;
+    } else {
+        source = ArticleDescriptionSourceUnknown;
+    }
+    return [NSNumber numberWithInteger:source];
 }
 
 + (NSInteger)articleImageWidth {

--- a/Wikipedia/Code/MWKArticle.m
+++ b/Wikipedia/Code/MWKArticle.m
@@ -98,7 +98,7 @@ static MWKArticleSchemaVersion const MWKArticleCurrentSchemaVersion = MWKArticle
 }
 
 - (BOOL)isEqualToArticle:(MWKArticle *)other {
-    return WMF_EQUAL(self.url, isEqual:, other.url) && WMF_EQUAL(self.lastmodified, isEqualToDate:, other.lastmodified) && WMF_IS_EQUAL(self.lastmodifiedby, other.lastmodifiedby) && WMF_EQUAL(self.displaytitle, isEqualToString:, other.displaytitle) && WMF_EQUAL(self.protection, isEqual:, other.protection) && WMF_EQUAL(self.thumbnailURL, isEqualToString:, other.thumbnailURL) && WMF_EQUAL(self.imageURL, isEqualToString:, other.imageURL) && WMF_EQUAL(self.revisionId, isEqualToNumber:, other.revisionId) && self.articleId == other.articleId && self.languagecount == other.languagecount && self.isMain == other.isMain && self.sections.count == other.sections.count && self.descriptionSourceNumber == self.descriptionSourceNumber;
+    return WMF_EQUAL(self.url, isEqual:, other.url) && WMF_EQUAL(self.lastmodified, isEqualToDate:, other.lastmodified) && WMF_IS_EQUAL(self.lastmodifiedby, other.lastmodifiedby) && WMF_EQUAL(self.displaytitle, isEqualToString:, other.displaytitle) && WMF_EQUAL(self.protection, isEqual:, other.protection) && WMF_EQUAL(self.thumbnailURL, isEqualToString:, other.thumbnailURL) && WMF_EQUAL(self.imageURL, isEqualToString:, other.imageURL) && WMF_EQUAL(self.revisionId, isEqualToNumber:, other.revisionId) && self.articleId == other.articleId && self.languagecount == other.languagecount && self.isMain == other.isMain && self.sections.count == other.sections.count && WMF_EQUAL(self.descriptionSourceNumber, isEqualToNumber:, other.descriptionSourceNumber);
 }
 
 - (BOOL)isDeeplyEqualToArticle:(MWKArticle *)article {

--- a/Wikipedia/Code/MWKArticle.m
+++ b/Wikipedia/Code/MWKArticle.m
@@ -245,7 +245,7 @@ static MWKArticleSchemaVersion const MWKArticleCurrentSchemaVersion = MWKArticle
     } else if ([stringValue isEqualToString:@"local"]) {
         source = ArticleDescriptionSourceLocal;
     } else {
-        source = ArticleDescriptionSourceUnknown;
+        source = ArticleDescriptionSourceNone;
     }
     return [NSNumber numberWithInteger:source];
 }

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -168,7 +168,7 @@ static uint64_t bundleHash() {
         self.feedContentController.siteURLs = [[MWKLanguageLinkController sharedInstance] preferredSiteURLs];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveMemoryWarningWithNotification:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
         self.articleLocationController = [ArticleLocationController new];
-        self.wikidataDescriptionEditingController = [[WikidataDescriptionEditingController alloc] initWith:self.viewContext];
+        self.wikidataDescriptionEditingController = [[WikidataDescriptionEditingController alloc] init];
     }
     return self;
 }
@@ -220,8 +220,8 @@ static uint64_t bundleHash() {
 
     NSURL *coreDataDBURL = [containerURL URLByAppendingPathComponent:coreDataDBName isDirectory:NO];
     NSPersistentStoreCoordinator *persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:model];
-    NSDictionary *options = @{ NSMigratePersistentStoresAutomaticallyOption: @YES,
-                               NSInferMappingModelAutomaticallyOption: @YES };
+    NSDictionary *options = @{NSMigratePersistentStoresAutomaticallyOption: @YES,
+                              NSInferMappingModelAutomaticallyOption: @YES};
     NSError *persistentStoreError = nil;
     if (nil == [persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:coreDataDBURL options:options error:&persistentStoreError]) {
         // TODO: Metrics
@@ -520,26 +520,26 @@ static uint64_t bundleHash() {
         defaultReadingList.canonicalName = [ReadingList defaultListCanonicalName];
         defaultReadingList.isDefault = YES;
     }
-    
+
     for (ReadingListEntry *entry in defaultReadingList.entries) {
         entry.isUpdatedLocally = YES;
     }
-    
+
     if ([moc hasChanges] && ![moc save:migrationError]) {
         return NO;
     }
-    
+
     NSFetchRequest<WMFArticle *> *request = [WMFArticle fetchRequest];
     request.fetchLimit = 500;
     request.predicate = [NSPredicate predicateWithFormat:@"savedDate != NULL && readingLists.@count == 0", defaultReadingList];
-    
+
     NSArray<WMFArticle *> *results = [moc executeFetchRequest:request error:migrationError];
     if (!results) {
         return NO;
     }
-    
+
     NSError *addError = nil;
-    
+
     while (results.count > 0) {
         for (WMFArticle *article in results) {
             [self.readingListsController addArticleToDefaultReadingList:article error:&addError];
@@ -598,7 +598,7 @@ static uint64_t bundleHash() {
             return;
         }
     }
-    
+
     if (currentLibraryVersion < 6) {
         if (![self migrateMainPageContentGroupInManagedObjectContext:moc error:&migrationError]) {
             DDLogError(@"Error during migration: %@", migrationError);
@@ -1111,7 +1111,7 @@ static uint64_t bundleHash() {
     }
 
     if (article.url.wmf_isNonStandardURL) {
-        return YES;  // OK to fail without error
+        return YES; // OK to fail without error
     }
     [self addArticleToMemoryCache:article];
     NSString *path = [self pathForArticle:article];
@@ -1568,9 +1568,10 @@ static uint64_t bundleHash() {
 - (void)clearCachesForUnsavedArticles {
     [[WMFImageController sharedInstance] deleteTemporaryCache];
     [[WMFImageController sharedInstance] removeLegacyCache];
-    [self removeUnreferencedArticlesFromDiskCacheWithFailure:^(NSError *_Nonnull error) {
-        DDLogError(@"Error removing unreferenced articles: %@", error);
-    }
+    [self
+        removeUnreferencedArticlesFromDiskCacheWithFailure:^(NSError *_Nonnull error) {
+            DDLogError(@"Error removing unreferenced articles: %@", error);
+        }
         success:^{
             DDLogDebug(@"Successfully removed unreferenced articles");
         }];
@@ -1588,7 +1589,6 @@ static uint64_t bundleHash() {
     __block NSError *updateError = nil;
     NSError *invalidRequestParametersError = [NSError wmf_errorWithType:WMFErrorTypeInvalidRequestParameters userInfo:nil];
     WMFTaskGroup *taskGroup = [[WMFTaskGroup alloc] init];
-
 
     // Site info
     NSURL *siteInfoURL = [NSURL URLWithString:@"https://meta.wikimedia.org/w/api.php?action=query&format=json&meta=siteinfo"];
@@ -1648,8 +1648,6 @@ static uint64_t bundleHash() {
     NSNumber *disableReadingListSyncNumber = remoteConfigurationDictionary[@"disableReadingListSync"];
     BOOL shouldDisableReadingListSync = [disableReadingListSyncNumber boolValue];
     self.readingListsController.isSyncRemotelyEnabled = !shouldDisableReadingListSync;
-
-    [self.wikidataDescriptionEditingController setBlacklistedLanguages:remoteConfigurationDictionary[@"descriptionEditLangBlacklist"]];
 }
 
 - (void)updateReadingListsLimits:(NSDictionary *)readingListsConfig {

--- a/Wikipedia/Code/OnThisDayViewController.swift
+++ b/Wikipedia/Code/OnThisDayViewController.swift
@@ -60,10 +60,11 @@ class OnThisDayViewController: ColumnarCollectionViewController, ReadingListHint
     }
     
     func scrollToInitialEvent() {
-        guard let event = initialEvent, let index = events.index(of: event), events.indices.contains(index) else {
+        guard let event = initialEvent, let eventIndex = events.index(of: event), events.indices.contains(eventIndex) else {
             return
         }
-        collectionView.scrollToItem(at: IndexPath(item: 0, section: index), at: index < 1 ? .top : .centeredVertically, animated: false)
+        let sectionIndex = eventIndex + 1 // index + 1 because section 0 is the header
+        collectionView.scrollToItem(at: IndexPath(item: 0, section: sectionIndex), at: sectionIndex < 1 ? .top : .centeredVertically, animated: false)
     }
     
     override func scrollViewInsetsDidChange() {

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -72,8 +72,7 @@ enum WikidataPublishingError: LocalizedError {
         return blacklistedLanguages.contains(languageCode)
     }
 
-    @objc(publishNewWikidataDescription:forArticleURL:completion:)
-    public func publish(newWikidataDescription: String, for articleURL: URL, completion: @escaping (Error?) -> Void) {
+    public func publish(newWikidataDescription: String, from source: ArticleDescriptionSource, for articleURL: URL, completion: @escaping (Error?) -> Void) {
         guard let title = articleURL.wmf_title,
         let language = articleURL.wmf_language,
         let wiki = articleURL.wmf_wiki else {


### PR DESCRIPTION
Description can come from 3 different sources:

- `local`
- `central`
- none (`descriptionsource` is not in the response, article has no description)

---

Here's what I'm understanding:

If a description comes from a local source, we want to show wikitext.
If a description comes from a central source, we want to show wikidata editor.
If there is no description source, we want to show wikidata editor?

So in summary, **unless** a description comes from a local source, we want to show a wikidata editor?

If the above is correct, what's the point of having a list of blacklisted languages? 🤔

---

Or maybe if there is no description source and the language is blacklisted, we want to show wikitext?

---

Sample articles:

*Greek language* on English has a **central** description
*Oceanography* on English has a **local** description
*Hlersu language* on English has **no** description (no source)
