### PR TITLE
Show section editor for articles without wikidata items

### DIFF
--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -80,6 +80,6 @@ enum WikidataPublishingError: LocalizedError {
 
 public extension MWKArticle {
     @objc var isWikidataDescriptionEditable: Bool {
-        return descriptionSource != .local
+        return descriptionSource == .central
     }
 }


### PR DESCRIPTION
It looks like articles without wikidata items have no wikidata id and no description source - can there ever be a case where an article has wikidata id but source is not specified? 

https://phabricator.wikimedia.org/T206871