### PR TITLE
Fix reset of side scrolling cell content offset while the cell is still visible

### DIFF
--- a/Wikipedia/Code/NewsCollectionViewCell+WMFFeedContentDisplaying.swift
+++ b/Wikipedia/Code/NewsCollectionViewCell+WMFFeedContentDisplaying.swift
@@ -26,6 +26,7 @@ extension NewsCollectionViewCell {
             isImageViewHidden = true
         }
         apply(theme: theme)
+        resetContentOffset()
         setNeedsLayout()
     }    
 }

--- a/Wikipedia/Code/OnThisDayCollectionViewCell+WMFFeedContentDisplaying.swift
+++ b/Wikipedia/Code/OnThisDayCollectionViewCell+WMFFeedContentDisplaying.swift
@@ -32,7 +32,7 @@ extension OnThisDayCollectionViewCell {
         
         isImageViewHidden = true
         timelineView.shouldAnimateDots = shouldAnimateDots
-
+        resetContentOffset()
         setNeedsLayout()
     }
 }

--- a/Wikipedia/Code/SideScrollingCollectionViewCell.swift
+++ b/Wikipedia/Code/SideScrollingCollectionViewCell.swift
@@ -143,7 +143,6 @@ public class SideScrollingCollectionViewCell: CollectionViewCell, SubCellProtoco
             }
             collectionView.reloadData()
             collectionView.layoutIfNeeded()
-            resetContentOffset()
             deselectSelectedSubItems(animated: false)
         }
 


### PR DESCRIPTION
Repro steps:

1. Go to the explore feed on this day detail view
2. Scroll one of the horizontal lists of articles to the side
3. Scroll vertically down the list

Expected:
Horizontal scroll position is maintained until the cell goes off screen

Actual:
Horizontal scroll position resets while the cell is still on screen

https://phabricator.wikimedia.org/T207299