### PR TITLE
Fix iOS 12 article search result vertical centering

### DIFF
--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -532,6 +532,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
                                                  } else if (newOffsetY > (self.delegate.navigationBar.frame.size.height - self.delegate.navigationBar.safeAreaInsets.top)) {
                                                      [self.delegate.navigationBar setNavigationBarPercentHidden:1 underBarViewPercentHidden:1 extendedViewPercentHidden:1 topSpacingPercentHidden:1 shadowAlpha:1 animated:YES additionalAnimations:NULL];
                                                  }
+                                                 newOffsetY += [self iOS12yOffsetHack];
                                                  CGPoint centeredOffset = CGPointMake(self.webView.scrollView.contentOffset.x, newOffsetY);
                                                  [self.webView.scrollView wmf_safeSetContentOffset:centeredOffset
                                                                                           animated:YES

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -943,6 +943,9 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
     CGRect windowCoordsRefGroupRect = [self windowCoordsReferenceGroupRect];
     UIView *firstPanel = [controller firstPanelView];
     if (!CGRectIsEmpty(windowCoordsRefGroupRect) && firstPanel && controller.backgroundView) {
+
+        windowCoordsRefGroupRect = CGRectOffset(windowCoordsRefGroupRect, 0, [self iOS12yOffsetHack]);
+
         CGRect panelRectInWindowCoords = [firstPanel convertRect:firstPanel.bounds toView:nil];
         CGRect refGroupRectInWindowCoords = [controller.backgroundView convertRect:windowCoordsRefGroupRect toView:nil];
         if (CGRectIntersectsRect(windowCoordsRefGroupRect, panelRectInWindowCoords)) {
@@ -974,21 +977,22 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
             rect = CGRectUnion(rect, reference.rect);
         }
         rect = [self.webView convertRect:rect toView:nil];
-
-        CGFloat yOffset = 1;
-        if (@available(iOS 12, *)) {
-            CGFloat topContentInset = self.webView.scrollView.contentInset.top;
-            CGFloat yContentOffset = self.webView.scrollView.contentOffset.y;
-            if (topContentInset + yContentOffset != 0) {
-                yOffset = yOffset - topContentInset;
-            }
-        }
-
-        rect = CGRectOffset(rect, 0, yOffset);
+        rect = CGRectOffset(rect, 0, 1);
         rect = CGRectInset(rect, -1, -3);
         return rect;
     }
     return CGRectNull;
+}
+
+- (CGFloat)iOS12yOffsetHack {
+    if (@available(iOS 12, *)) {
+        CGFloat topContentInset = self.webView.scrollView.contentInset.top;
+        CGFloat yContentOffset = self.webView.scrollView.contentOffset.y;
+        if (topContentInset + yContentOffset != 0) {
+            return 0 - topContentInset;
+        }
+    }
+    return 0;
 }
 
 - (void)showReferencePopoverMessageViewControllerWithGroup:(NSArray<WMFReference *> *)referenceGroup selectedIndex:(NSInteger)selectedIndex {

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -990,7 +990,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
         CGFloat topContentInset = self.webView.scrollView.contentInset.top;
         CGFloat yContentOffset = self.webView.scrollView.contentOffset.y;
         if (topContentInset + yContentOffset != 0) {
-            return 0 - topContentInset;
+            return 0 - topContentInset - MIN(0, yContentOffset);
         }
     }
     return 0;


### PR DESCRIPTION
https://phabricator.wikimedia.org/T207408

## Fixes search result vertical centering
| Before  | After |
| ------------- | ------------- |
|![before 22 mov](https://user-images.githubusercontent.com/3143487/47191785-2c350b00-d2fe-11e8-9550-32f56c4d0ede.gif)|![after 22 mov](https://user-images.githubusercontent.com/3143487/47191786-2c350b00-d2fe-11e8-903b-40ffa992d511.gif)|


## Fixes another iOS 12 reference highlight regression
- load an article with references visible w/o scrolling (ie refs near very top)
- scroll ever so slightly just enough so when you release the nav bar hides
- tap a reference (remember these should already be onscreen and tappable without scrolling)
- notice the ref highlight is not in the correct position after the ref is tapped

| Before  | After |
| ------------- | ------------- |
|![before 2 mov](https://user-images.githubusercontent.com/3143487/47191815-4bcc3380-d2fe-11e8-9653-414fe5d602bf.gif)|![after 2 mov](https://user-images.githubusercontent.com/3143487/47191817-4bcc3380-d2fe-11e8-987d-f9b784f30ea2.gif)|
