### PR TITLE
Fix description editing cursor jump

### DIFF
--- a/Wikipedia/Code/DescriptionEditViewController.swift
+++ b/Wikipedia/Code/DescriptionEditViewController.swift
@@ -182,7 +182,6 @@ class DescriptionEditViewController: WMFScrollViewController, Themeable, UITextV
         wmf_hideKeyboard()
         
         guard
-            let descriptionToSave = descriptionTextView.normalizedWhitespaceText(),
             let article = article,
             let dataStore = article.dataStore,
             let articleURL = article.url
@@ -190,6 +189,16 @@ class DescriptionEditViewController: WMFScrollViewController, Themeable, UITextV
             enableProgressiveButton(true)
             assertionFailure("Expected article, datastore or article url not found")
             return
+        }
+
+        guard
+            let descriptionToSave = descriptionTextView.normalizedWhitespaceText(),
+            descriptionToSave.count > 0
+            else {
+                descriptionTextView.text = nil
+                // manually call `textViewDidChange` since it's not called when UITextView text is changed programmatically
+                textViewDidChange(descriptionTextView)
+                return
         }
         
         dataStore.wikidataDescriptionEditingController.publish(newWikidataDescription: descriptionToSave, from: article.descriptionSource, for: articleURL) {error in
@@ -217,12 +226,10 @@ class DescriptionEditViewController: WMFScrollViewController, Themeable, UITextV
     }
     
     public func textViewDidChange(_ textView: UITextView) {
-        guard let description = descriptionTextView.text else{
-            enableProgressiveButton(false)
-            return
-        }
-        enableProgressiveButton(description.count > 0)
+        let hasText = descriptionTextView.text.count > 0
+        enableProgressiveButton(hasText)
         updateWarningLabelsForDescriptionCount()
+        isPlaceholderLabelHidden = hasText
     }
     
     func apply(theme: Theme) {

--- a/Wikipedia/Code/DescriptionEditViewController.swift
+++ b/Wikipedia/Code/DescriptionEditViewController.swift
@@ -181,10 +181,12 @@ class DescriptionEditViewController: WMFScrollViewController, Themeable, UITextV
         enableProgressiveButton(false)
         wmf_hideKeyboard()
         
-        // Final trim to remove leading and trailing space
-        let descriptionToSave = descriptionTextView.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        guard let article = article, let dataStore = article.dataStore, let articleURL = article.url else {
+        guard
+            let descriptionToSave = descriptionTextView.normalizedWhitespaceText(),
+            let article = article,
+            let dataStore = article.dataStore,
+            let articleURL = article.url
+        else {
             enableProgressiveButton(true)
             assertionFailure("Expected article, datastore or article url not found")
             return
@@ -219,7 +221,6 @@ class DescriptionEditViewController: WMFScrollViewController, Themeable, UITextV
             enableProgressiveButton(false)
             return
         }
-        descriptionTextView.normalizeWhitespace()
         enableProgressiveButton(description.count > 0)
         updateWarningLabelsForDescriptionCount()
     }
@@ -258,9 +259,11 @@ private extension UITextView {
         return text.count
     }
 
-    func normalizeWhitespace() {
+    // Text with no leading and trailing space and with repeating internal spaces reduced to single spaces
+    func normalizedWhitespaceText() -> String? {
         if let text = text, let whiteSpaceNormalizationRegex = whiteSpaceNormalizationRegex {
-            self.text = whiteSpaceNormalizationRegex.stringByReplacingMatches(in: text, options: [], range: NSMakeRange(0, text.count), withTemplate: " ")
+            return whiteSpaceNormalizationRegex.stringByReplacingMatches(in: text, options: [], range: NSMakeRange(0, text.count), withTemplate: " ").trimmingCharacters(in: .whitespacesAndNewlines)
         }
+        return text
     }
 }


### PR DESCRIPTION
was caused by whitespace normalization on the text view being called in its `textViewDidChange`

instead just normalized whitespace on save (otherwise we'd have to dynamically adjust cursor point based on how much leading whitespace was trimmed, which seemed silly)

https://phabricator.wikimedia.org/T207646