### PR TITLE
Fix wmf_push methods view controller traversal

### DIFF
--- a/Wikipedia/Code/UIViewController+WMFArticlePresentation.m
+++ b/Wikipedia/Code/UIViewController+WMFArticlePresentation.m
@@ -32,6 +32,28 @@ NS_ASSUME_NONNULL_BEGIN
     [self wmf_pushArticleWithURL:url dataStore:dataStore theme:theme restoreScrollPosition:NO animated:animated];
 }
 
+- (nullable UINavigationController *)wmf_tabBarControllerSelectedNavigationController {
+    UITabBarController *tab = nil;
+    if ([self isKindOfClass:[UITabBarController class]]) {
+        tab = (UITabBarController *)self;
+    } else if (self.tabBarController) {
+        tab = self.tabBarController;
+    } else {
+        NSAssert(false, @"Unexpected view controller hierarchy - missing UITabBarController");
+    }
+
+    UIViewController *selectedVC = [tab selectedViewController];
+
+    UINavigationController *nav = nil;
+    if ([selectedVC isKindOfClass:[UINavigationController class]]) {
+        nav = (UINavigationController *)selectedVC;
+    } else {
+        NSAssert(false, @"Unexpected view controller hierarchy - missing UINavigationController");
+    }
+
+    return nav;
+}
+
 - (void)wmf_pushArticleViewController:(WMFArticleViewController *)viewController animated:(BOOL)animated {
     if (self.parentViewController != nil && self.parentViewController.navigationController) {
         [self.parentViewController wmf_pushArticleViewController:viewController animated:animated];
@@ -43,21 +65,17 @@ NS_ASSUME_NONNULL_BEGIN
                                                      }];
     } else if (self.navigationController != nil) {
         [self.navigationController pushViewController:viewController animated:animated];
-    } else if ([[self.childViewControllers firstObject] isKindOfClass:[UITabBarController class]]) {
-        UITabBarController *tab = (UITabBarController *)[self.childViewControllers firstObject];
-        UINavigationController *nav = [tab selectedViewController];
-        [nav pushViewController:viewController animated:animated];
     } else {
-        NSAssert(false, @"Unexpected view controller hierarchy");
+        UINavigationController *nav = [self wmf_tabBarControllerSelectedNavigationController];
+        [nav pushViewController:viewController animated:animated];
     }
 }
 
 - (void)wmf_pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
     if (self.navigationController != nil) {
         [self.navigationController pushViewController:viewController animated:animated];
-    } else if ([[self.childViewControllers firstObject] isKindOfClass:[UITabBarController class]]) {
-        UITabBarController *tab = (UITabBarController *)[self.childViewControllers firstObject];
-        UINavigationController *nav = [tab selectedViewController];
+    } else if ([self isKindOfClass:[UITabBarController class]] || self.tabBarController) {
+        UINavigationController *nav = [self wmf_tabBarControllerSelectedNavigationController];
         [nav pushViewController:viewController animated:animated];
     } else if (self.presentingViewController != nil) {
         UIViewController *presentingViewController = self.presentingViewController;
@@ -68,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
     } else if (self.parentViewController != nil) {
         [self.parentViewController wmf_pushViewController:viewController animated:animated];
     } else {
-        NSAssert(0, @"Unexpected view controller hierarchy");
+        NSAssert(false, @"Unexpected view controller hierarchy");
     }
 }
 

--- a/Wikipedia/Code/UIViewController+WMFArticlePresentation.m
+++ b/Wikipedia/Code/UIViewController+WMFArticlePresentation.m
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)wmf_pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
     if (self.navigationController != nil) {
         [self.navigationController pushViewController:viewController animated:animated];
-    } else if ([self isKindOfClass:[UITabBarController class]] || self.tabBarController) {
+    } else if ([self isKindOfClass:[UITabBarController class]]) { // WMFAppViewController
         UINavigationController *nav = [self wmf_tabBarControllerSelectedNavigationController];
         [nav pushViewController:viewController animated:animated];
     } else if (self.presentingViewController != nil) {
@@ -86,7 +86,11 @@ NS_ASSUME_NONNULL_BEGIN
     } else if (self.parentViewController != nil) {
         [self.parentViewController wmf_pushViewController:viewController animated:animated];
     } else {
-        NSAssert(false, @"Unexpected view controller hierarchy");
+        UINavigationController *nav = [self wmf_tabBarControllerSelectedNavigationController];
+        if (!nav) {
+            NSAssert(false, @"Unexpected view controller hierarchy");
+        }
+        [nav pushViewController:viewController animated:animated];
     }
 }
 


### PR DESCRIPTION
- `WMFAppViewController` is now a `UITabBarController` subclass, so the `wmf_push` methods were no longer correctly finding a navigation controller to push to