### PR TITLE
[BUG] Missing reading lists hint when article added to list via long press

### DIFF
--- a/Wikipedia/Code/AddArticlesToReadingListViewController.swift
+++ b/Wikipedia/Code/AddArticlesToReadingListViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 
 protocol AddArticlesToReadingListDelegate: NSObjectProtocol {
     func addArticlesToReadingListWillBeDismissed(_ addArticlesToReadingList: AddArticlesToReadingListViewController)
+    func addArticlesToReadingListDidDisappear(_ addArticlesToReadingList: AddArticlesToReadingListViewController)
     func addArticlesToReadingList(_ addArticlesToReadingList: AddArticlesToReadingListViewController, didAddArticles articles: [WMFArticle], to readingList: ReadingList)
 }
 
@@ -12,6 +13,10 @@ extension AddArticlesToReadingListDelegate where Self: EditableCollection {
     
     func addArticlesToReadingList(_ addArticlesToReadingList: AddArticlesToReadingListViewController, didAddArticles articles: [WMFArticle], to readingList: ReadingList) {
         editController.close()
+    }
+
+    func addArticlesToReadingListDidDisappear(_ addArticlesToReadingList: AddArticlesToReadingListViewController) {
+
     }
 }
 
@@ -43,6 +48,11 @@ class AddArticlesToReadingListViewController: ViewController {
     @objc private func dismissAnimated() {
         dismiss(animated: true)
         delegate?.addArticlesToReadingListWillBeDismissed(self)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        delegate?.addArticlesToReadingListDidDisappear(self)
     }
     
     @objc private func createNewReadingListButtonPressed() {

--- a/Wikipedia/Code/AddArticlesToReadingListViewController.swift
+++ b/Wikipedia/Code/AddArticlesToReadingListViewController.swift
@@ -1,13 +1,13 @@
 import UIKit
 
 protocol AddArticlesToReadingListDelegate: NSObjectProtocol {
-    func addArticlesToReadingListWillBeDismissed(_ addArticlesToReadingList: AddArticlesToReadingListViewController)
+    func addArticlesToReadingListWillBeClosed(_ addArticlesToReadingList: AddArticlesToReadingListViewController)
     func addArticlesToReadingListDidDisappear(_ addArticlesToReadingList: AddArticlesToReadingListViewController)
     func addArticlesToReadingList(_ addArticlesToReadingList: AddArticlesToReadingListViewController, didAddArticles articles: [WMFArticle], to readingList: ReadingList)
 }
 
 extension AddArticlesToReadingListDelegate where Self: EditableCollection {
-    func addArticlesToReadingListWillBeDismissed(_ addArticlesToReadingList: AddArticlesToReadingListViewController) {
+    func addArticlesToReadingListWillBeClosed(_ addArticlesToReadingList: AddArticlesToReadingListViewController) {
         editController.close()
     }
     
@@ -45,9 +45,9 @@ class AddArticlesToReadingListViewController: ViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    @objc private func dismissAnimated() {
+    @objc private func closeButtonPressed() {
         dismiss(animated: true)
-        delegate?.addArticlesToReadingListWillBeDismissed(self)
+        delegate?.addArticlesToReadingListWillBeClosed(self)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -73,7 +73,7 @@ class AddArticlesToReadingListViewController: ViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "close"), style: .plain, target: self, action: #selector(dismissAnimated))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "close"), style: .plain, target: self, action: #selector(closeButtonPressed))
         let title = moveFromReadingList != nil ? WMFLocalizedString("move-articles-to-reading-list", value:"Move {{PLURAL:%1$d|%1$d article|%1$d articles}} to reading list", comment:"Title for the view in charge of moving articles to a reading list - %1$@ is replaced with the number of articles to move") : WMFLocalizedString("add-articles-to-reading-list", value:"Add {{PLURAL:%1$d|%1$d article|%1$d articles}} to reading list", comment:"Title for the view in charge of adding articles to a reading list - %1$@ is replaced with the number of articles to add")
         navigationItem.title = String.localizedStringWithFormat(title, articles.count)
         navigationBar.displayType = .modal
@@ -109,7 +109,7 @@ extension AddArticlesToReadingListViewController: ReadingListsViewControllerDele
         }
         delegate?.addArticlesToReadingList(self, didAddArticles: articles, to: readingList)
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) {
-            self.dismissAnimated()
+            self.dismiss(animated: true)
         }
         eventLogAction?()
     }

--- a/Wikipedia/Code/AddArticlesToReadingListViewController.swift
+++ b/Wikipedia/Code/AddArticlesToReadingListViewController.swift
@@ -40,8 +40,8 @@ class AddArticlesToReadingListViewController: ViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    @objc private func closeButtonPressed() {
-        dismiss(animated: true, completion: nil)
+    @objc private func dismissAnimated() {
+        dismiss(animated: true)
         delegate?.addArticlesToReadingListWillBeDismissed(self)
     }
     
@@ -63,7 +63,7 @@ class AddArticlesToReadingListViewController: ViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "close"), style: .plain, target: self, action: #selector(closeButtonPressed))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "close"), style: .plain, target: self, action: #selector(dismissAnimated))
         let title = moveFromReadingList != nil ? WMFLocalizedString("move-articles-to-reading-list", value:"Move {{PLURAL:%1$d|%1$d article|%1$d articles}} to reading list", comment:"Title for the view in charge of moving articles to a reading list - %1$@ is replaced with the number of articles to move") : WMFLocalizedString("add-articles-to-reading-list", value:"Add {{PLURAL:%1$d|%1$d article|%1$d articles}} to reading list", comment:"Title for the view in charge of adding articles to a reading list - %1$@ is replaced with the number of articles to add")
         navigationItem.title = String.localizedStringWithFormat(title, articles.count)
         navigationBar.displayType = .modal
@@ -99,7 +99,7 @@ extension AddArticlesToReadingListViewController: ReadingListsViewControllerDele
         }
         delegate?.addArticlesToReadingList(self, didAddArticles: articles, to: readingList)
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) {
-            self.dismiss(animated: true, completion: nil)
+            self.dismissAnimated()
         }
         eventLogAction?()
     }

--- a/Wikipedia/Code/AddArticlesToReadingListViewController.swift
+++ b/Wikipedia/Code/AddArticlesToReadingListViewController.swift
@@ -1,12 +1,12 @@
 import UIKit
 
 protocol AddArticlesToReadingListDelegate: NSObjectProtocol {
-    func addArticlesToReadingList(_ addArticlesToReadingList: AddArticlesToReadingListViewController, willBeDismissed: Bool)
+    func addArticlesToReadingListWillBeDismissed(_ addArticlesToReadingList: AddArticlesToReadingListViewController)
     func addArticlesToReadingList(_ addArticlesToReadingList: AddArticlesToReadingListViewController, didAddArticles articles: [WMFArticle], to readingList: ReadingList)
 }
 
 extension AddArticlesToReadingListDelegate where Self: EditableCollection {
-    func addArticlesToReadingList(_ addArticlesToReadingList: AddArticlesToReadingListViewController, willBeDismissed: Bool) {
+    func addArticlesToReadingListWillBeDismissed(_ addArticlesToReadingList: AddArticlesToReadingListViewController) {
         editController.close()
     }
     
@@ -42,7 +42,7 @@ class AddArticlesToReadingListViewController: ViewController {
     
     @objc private func closeButtonPressed() {
         dismiss(animated: true, completion: nil)
-        delegate?.addArticlesToReadingList(self, willBeDismissed: true)
+        delegate?.addArticlesToReadingListWillBeDismissed(self)
     }
     
     @objc private func createNewReadingListButtonPressed() {

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -771,7 +771,7 @@ extension ExploreViewController: SaveButtonsControllerDelegate {
 }
 
 extension ExploreViewController: AddArticlesToReadingListDelegate {
-    func addArticlesToReadingListWillBeDismissed(_ addArticlesToReadingList: AddArticlesToReadingListViewController) {
+    func addArticlesToReadingListWillBeClosed(_ addArticlesToReadingList: AddArticlesToReadingListViewController) {
     }
 
     func addArticlesToReadingListDidDisappear(_ addArticlesToReadingList: AddArticlesToReadingListViewController) {

--- a/Wikipedia/Code/ReadingListHintController.swift
+++ b/Wikipedia/Code/ReadingListHintController.swift
@@ -145,7 +145,7 @@ public class ReadingListHintController: NSObject, ReadingListHintViewControllerD
         })
     }
     
-    @objc func didSave(_ didSave: Bool, article: WMFArticle, theme: Theme) {
+    func didSave(_ didSave: Bool, article: WMFArticle, theme: Theme) {
         guard presenter?.presentedViewController == nil else {
             return
         }

--- a/Wikipedia/Code/ReadingListHintViewController.swift
+++ b/Wikipedia/Code/ReadingListHintViewController.swift
@@ -159,7 +159,7 @@ extension ReadingListHintViewController: AddArticlesToReadingListDelegate {
         delegate?.readingListHint(self, shouldBeHidden: false)
     }
     
-    func addArticlesToReadingListWillBeDismissed(_ addArticlesToReadingList: AddArticlesToReadingListViewController) {
+    func addArticlesToReadingListWillBeClosed(_ addArticlesToReadingList: AddArticlesToReadingListViewController) {
         delegate?.readingListHint(self, shouldBeHidden: true)
     }
 

--- a/Wikipedia/Code/ReadingListHintViewController.swift
+++ b/Wikipedia/Code/ReadingListHintViewController.swift
@@ -162,6 +162,8 @@ extension ReadingListHintViewController: AddArticlesToReadingListDelegate {
     func addArticlesToReadingListWillBeDismissed(_ addArticlesToReadingList: AddArticlesToReadingListViewController) {
         delegate?.readingListHint(self, shouldBeHidden: true)
     }
+
+    func addArticlesToReadingListDidDisappear(_ addArticlesToReadingList: AddArticlesToReadingListViewController) {
     }
 }
 

--- a/Wikipedia/Code/ReadingListHintViewController.swift
+++ b/Wikipedia/Code/ReadingListHintViewController.swift
@@ -159,8 +159,9 @@ extension ReadingListHintViewController: AddArticlesToReadingListDelegate {
         delegate?.readingListHint(self, shouldBeHidden: false)
     }
     
-    func addArticlesToReadingList(_ addArticlesToReadingList: AddArticlesToReadingListViewController, willBeDismissed: Bool) {
-        delegate?.readingListHint(self, shouldBeHidden: willBeDismissed)
+    func addArticlesToReadingListWillBeDismissed(_ addArticlesToReadingList: AddArticlesToReadingListViewController) {
+        delegate?.readingListHint(self, shouldBeHidden: true)
+    }
     }
 }
 

--- a/Wikipedia/Code/SaveButtonsController.swift
+++ b/Wikipedia/Code/SaveButtonsController.swift
@@ -68,6 +68,10 @@ class SaveButtonsController: NSObject, SaveButtonDelegate {
         guard let key = visibleArticleKeys[saveButton.tag], let article = dataStore.fetchArticle(withKey: key) else {
             return false
         }
+
+        activeKey = key
+        activeSender = saveButton
+
         delegate?.showAddArticlesToReadingListViewController(for: article)
         return true
     }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T207409

When `SaveButtonsController` notifies the delegate that article saved state changed, `ExploreViewController` is still presenting `AddArticlesToReadingListViewController` so `ReadingListHintController` fails to show the hint