### PR TITLE
Use asyncMapToDictionary for fetchArticleSummaryResponsesForArticles

### DIFF
--- a/WMF Framework/Collection+AsyncMap.swift
+++ b/WMF Framework/Collection+AsyncMap.swift
@@ -1,17 +1,22 @@
 import Foundation
 
 public extension Sequence {
-    func asyncMapToDictionary<K,V>( block: (Element, @escaping (K, V) -> Void) -> Void, queue: DispatchQueue = DispatchQueue.global(qos: .default), completion:  @escaping ([K: V]) -> Void) {
+    func asyncMapToDictionary<K,V>( block: (Element, @escaping (K?, V?) -> Void) -> Void, queue: DispatchQueue = DispatchQueue.global(qos: .default), completion:  @escaping ([K: V]) -> Void) {
         let group = DispatchGroup()
         let semaphore = DispatchSemaphore(value: 1)
         var results = Dictionary<K,V>(minimumCapacity: underestimatedCount)
         for object in self {
             group.enter()
             block(object, { (key, value) in
+                defer {
+                    group.leave()
+                }
+                guard let key = key, let value = value else {
+                    return
+                }
                 semaphore.wait()
                 results[key] = value
                 semaphore.signal()
-                group.leave()
             })
         }
         group.notify(queue: queue) {

--- a/WMF Framework/ReadingListsSyncOperation.swift
+++ b/WMF Framework/ReadingListsSyncOperation.swift
@@ -733,6 +733,7 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
             return
         }
         let group = WMFTaskGroup()
+        let semaphore = DispatchSemaphore(value: 1)
         var remoteEntriesToCreateLocallyByArticleKey: [String: APIReadingListEntry] = [:]
         var requestedArticleKeys: Set<String> = []
         var articleSummariesByArticleKey: [String: [String: Any]] = [:]
@@ -761,7 +762,9 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
                             group.leave()
                             return
                         }
+                        semaphore.wait()
                         articleSummariesByArticleKey[articleKey] = result
+                        semaphore.signal()
                         group.leave()
                     })
                     entryCount += 1

--- a/WikipediaUnitTests/Code/Collection+AsyncMapTests.swift
+++ b/WikipediaUnitTests/Code/Collection+AsyncMapTests.swift
@@ -93,7 +93,7 @@ class CollectionAsyncMapTests: XCTestCase {
         let expectedOutput = ["A":"a", "B":"b", "C":"c", "D":"d", "E":"e", "F":"f", "G":"g", "H":"h"]
         
         input.asyncMapToDictionary(block: { (input, completion) in
-            DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + .seconds(Int.random(in: 0 ... 3))) {
+            DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + .milliseconds(Int.random(in: 0 ... 500))) {
                 completion(input, input.lowercased())
             }
         }, queue: DispatchQueue.main) { (output) in
@@ -102,7 +102,7 @@ class CollectionAsyncMapTests: XCTestCase {
             expectation.fulfill()
         }
         
-        wait(for:[expectation], timeout: 10, enforceOrder: true)
+        wait(for:[expectation], timeout: 5, enforceOrder: true)
     }
     
     
@@ -121,7 +121,7 @@ class CollectionAsyncMapTests: XCTestCase {
         }
         
         input.asyncMapToDictionary(block: { (input, completion) in
-            DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + .seconds(Int.random(in: 0 ... 3))) {
+            DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + .milliseconds(Int.random(in: 0 ... 500))) {
                 completion(input, transform(input))
             }
         }, queue: DispatchQueue.main) { (output) in
@@ -130,6 +130,6 @@ class CollectionAsyncMapTests: XCTestCase {
             expectation.fulfill()
         }
         
-        wait(for:[expectation], timeout: 10, enforceOrder: true)
+        wait(for:[expectation], timeout: 5, enforceOrder: true)
     }
 }

--- a/WikipediaUnitTests/Code/Collection+AsyncMapTests.swift
+++ b/WikipediaUnitTests/Code/Collection+AsyncMapTests.swift
@@ -71,10 +71,10 @@ class CollectionAsyncMapTests: XCTestCase {
         let asyncItemBlock = { (item: String, completion: @escaping () -> Void) in
             // fake out a process which takes 'item' and asynchronously performs a block with it
             DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + .milliseconds(Int.random(in: 0 ... 500))) { // use random delay to more closely simulate read async usage
-                completion()
                 semaphore.wait()
                 results.insert(item)
                 semaphore.signal()
+                completion()
             }
         }
         

--- a/WikipediaUnitTests/Code/Collection+AsyncMapTests.swift
+++ b/WikipediaUnitTests/Code/Collection+AsyncMapTests.swift
@@ -85,4 +85,51 @@ class CollectionAsyncMapTests: XCTestCase {
         inputItems.asyncForEach(asyncItemBlock, completion: completionHandler)
         wait(for:[expectation], timeout: 5, enforceOrder: true)
     }
+    
+    func testAsyncMapToDictionary() {
+        let expectation = XCTestExpectation(description: "wait for notification")
+        
+        let input = ["A", "B", "C", "D", "E", "F", "G", "H"]
+        let expectedOutput = ["A":"a", "B":"b", "C":"c", "D":"d", "E":"e", "F":"f", "G":"g", "H":"h"]
+        
+        input.asyncMapToDictionary(block: { (input, completion) in
+            DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + .seconds(Int.random(in: 0 ... 3))) {
+                completion(input, input.lowercased())
+            }
+        }, queue: DispatchQueue.main) { (output) in
+            XCTAssert(Thread.isMainThread)
+            XCTAssertEqual(output, expectedOutput, "Result of asyncMapToDictionary not the same as the expected")
+            expectation.fulfill()
+        }
+        
+        wait(for:[expectation], timeout: 10, enforceOrder: true)
+    }
+    
+    
+    func testAsyncMapToDictionaryWithLargeInput() {
+        let expectation = XCTestExpectation(description: "wait for notification")
+        
+        let count = 10000
+        var input = [Int]()
+        input.reserveCapacity(count)
+        var expectedOutput = [Int:Int]()
+        expectedOutput.reserveCapacity(count)
+        let transform = { (i: Int) in return i * i }
+        for i in 1...count {
+            input.append(i)
+            expectedOutput[i] = transform(i)
+        }
+        
+        input.asyncMapToDictionary(block: { (input, completion) in
+            DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + .seconds(Int.random(in: 0 ... 3))) {
+                completion(input, transform(input))
+            }
+        }, queue: DispatchQueue.main) { (output) in
+            XCTAssert(Thread.isMainThread)
+            XCTAssertEqual(output, expectedOutput, "Result of asyncMapToDictionary not the same as the expected")
+            expectation.fulfill()
+        }
+        
+        wait(for:[expectation], timeout: 10, enforceOrder: true)
+    }
 }


### PR DESCRIPTION
- Use `asyncMapToDictionary` for `fetchArticleSummaryResponsesForArticles`
- Add missing semaphore in`ReadingListsSyncOperation`