### PR TITLE
Limit the maximum number of concurrent face detection operations

### DIFF
--- a/Wikipedia/Code/CIDetector+WMFFaceDetection.h
+++ b/Wikipedia/Code/CIDetector+WMFFaceDetection.h
@@ -21,10 +21,7 @@ typedef NS_ENUM(NSInteger, WMFFaceDectionError) {
 /**
  * Asynchronously detect faces in `image`, without doing extra processing for smiles or eyes.
  */
-- (void)wmf_detectFeaturelessFacesInImage:(UIImage *)image withFailure:(WMFErrorHandler)failure success:(WMFSuccessIdHandler)success;
-
-/// Perform `featuresInImage:options:` on a background queue
-- (void)wmf_detectFeaturesInImage:(UIImage *)image options:(NSDictionary *)options onQueue:(dispatch_queue_t)queue failure:(WMFErrorHandler)failure success:(WMFSuccessIdHandler)success;
+- (NSOperation *)wmf_detectFeaturelessFacesInImage:(UIImage *)image withFailure:(WMFErrorHandler)failure success:(WMFSuccessIdHandler)success;
 
 @end
 

--- a/Wikipedia/Code/CIDetector+WMFFaceDetection.m
+++ b/Wikipedia/Code/CIDetector+WMFFaceDetection.m
@@ -39,19 +39,19 @@ NSString *const WMFFaceDetectionErrorDomain = @"org.wikimedia.face-detection-err
     return featurelessFaceOptions;
 }
 
-- (void)wmf_detectFeaturelessFacesInImage:(UIImage *)image withFailure:(WMFErrorHandler)failure success:(WMFSuccessIdHandler)success {
-    [self wmf_detectFeaturesInImage:image
+- (NSOperation *)wmf_detectFeaturelessFacesInImage:(UIImage *)image withFailure:(WMFErrorHandler)failure success:(WMFSuccessIdHandler)success {
+    return [self wmf_detectFeaturesInImage:image
                             options:[CIDetector wmf_featurelessFaceOptions]
-                            onQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
                             failure:failure
                             success:success];
 }
 
-- (void)wmf_detectFeaturesInImage:(UIImage *)image options:(NSDictionary *)options onQueue:(dispatch_queue_t)queue failure:(WMFErrorHandler)failure success:(WMFSuccessIdHandler)success {
-    dispatch_async(queue, ^{
+- (NSOperation *)wmf_detectFeaturesInImage:(UIImage *)image options:(NSDictionary *)options failure:(WMFErrorHandler)failure success:(WMFSuccessIdHandler)success {
+    NSOperation *blockOperation = [NSBlockOperation blockOperationWithBlock:^{
         id features = [self featuresInImage:[image wmf_getOrCreateCIImage] options:options];
         success(features);
-    });
+    }];
+    return blockOperation;
 }
 
 @end

--- a/Wikipedia/Code/UIImageView+WMFImageFetchingInternal.h
+++ b/Wikipedia/Code/UIImageView+WMFImageFetchingInternal.h
@@ -28,6 +28,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable, setter=wmf_setImageURLToCancel:) NSURL *wmf_imageURLToCancel;
 
 /**
+ *  The image URL associated with the current face detection
+ *
+ */
+@property (nonatomic, strong, nullable, setter=wmf_setFaceDetectionImageURLToCancel:) NSURL *wmf_faceDetectionImageURLToCancel;
+
+/**
  *  The cancellation token associated with the currently loading image
  *
  */

--- a/Wikipedia/Code/WMFFaceDetectionCache.h
+++ b/Wikipedia/Code/WMFFaceDetectionCache.h
@@ -9,6 +9,8 @@
 - (void)detectFaceBoundsInImage:(UIImage *)image onGPU:(BOOL)onGPU URL:(NSURL *)url failure:(WMFErrorHandler)failure success:(WMFSuccessNSValueHandler)success;
 - (NSValue *)faceBoundsForURL:(NSURL *)url;
 
+- (void)cancelFaceDetectionForURL:(NSURL *)url;
+
 - (void)clearCache;
 
 @end


### PR DESCRIPTION
Based on profiling, frame drops seemed to correspond with a lot of concurrent face detection operations