### PR TITLE
Pop to root view controller when switching to search to ensure search is visible

### DIFF
--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1472,6 +1472,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
     if (self.selectedIndex != WMFAppTabTypeSearch) {
         [self setSelectedIndex:WMFAppTabTypeSearch];
     }
+    [self.navigationController popToRootViewControllerAnimated:animated];
 }
 
 #pragma mark - App Shortcuts


### PR DESCRIPTION
Repro steps:

- Tap through to an explore feed detail view (on this day, top read, etc - anything but an article)
- Exit app
- 3d touch -> Search Wikipedia

https://phabricator.wikimedia.org/T208969