### PR TITLE
Fix wikidata description editing & notifications for certain languages

### DIFF
--- a/WMF Framework/Remote Notifications/RemoteNotificationsAPIController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsAPIController.swift
@@ -200,7 +200,7 @@ struct RemoteNotificationsAPIController {
                     "notlimit": limit.value,
                     "notfilter": filter.rawValue]
 
-            let wikis = subdomains.compactMap { "\($0)wiki" }
+            let wikis = subdomains.compactMap { $0.replacingOccurrences(of: "-", with: "_").appending("wiki") }
             if let listOfWikis = WMFJoinedPropertyParameters(wikis) {
                 dictionary["notwikis"] = listOfWikis
             }

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -101,8 +101,7 @@ enum WikidataPublishingError: LocalizedError {
     private let normalizedLanguages: [String: String] = [
         "zh-yue": "yue",
         "zh-min-nan": "nan",
-        "zh-classical": "lzh",
-        "fiu-vro": "vro"
+        "zh-classical": "lzh"
     ]
 }
 

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -87,16 +87,31 @@ enum WikidataPublishingError: LocalizedError {
                 }
             }
         }
+        let normalizedLang = normalizedLanguage(from: language)
         let queryParameters = ["action": "wbsetdescription",
                                "format": "json",
                                "formatversion": "2"]
-        let bodyParameters = ["language": language,
-                              "uselang": language,
+        let bodyParameters = ["language": normalizedLang,
+                              "uselang": normalizedLang,
                               "id": wikidataID,
                               "value": newWikidataDescription]
         var components = WikidataAPI.components
         components.replacePercentEncodedQueryWithQueryParameters(queryParameters)
         let _ = session.requestWithCSRF(type: CSRFTokenJSONDecodableOperation.self, components: components, method: .post, bodyParameters: bodyParameters, bodyEncoding: .form, tokenContext: CSRFTokenOperation.TokenContext(tokenName: "token", tokenPlacement: .body), completion: requestWithCSRFCompletion)
+    }
+
+    private lazy var languageRegex: NSRegularExpression? = {
+        return try? NSRegularExpression(pattern: "(?<=-).*", options: .caseInsensitive)
+    }()
+
+    private func normalizedLanguage(from language: String) -> String {
+        guard
+            let match = languageRegex?.firstMatch(in: language, options: [], range: NSRange(location: 0, length: language.count)),
+            let range = Range(match.range, in: language)
+            else {
+                return language
+        }
+        return String(language[range])
     }
 }
 

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -107,9 +107,8 @@ enum WikidataPublishingError: LocalizedError {
     private func normalizedLanguage(from language: String) -> String {
         guard
             let match = languageRegex?.firstMatch(in: language, options: [], range: NSRange(location: 0, length: language.count)),
-            let range = Range(match.range, in: language)
-            else {
-                return language
+            let range = Range(match.range, in: language) else {
+            return language
         }
         return String(language[range])
     }

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -55,8 +55,6 @@ enum WikidataPublishingError: LocalizedError {
         self.session = session
     }
 
-
-
     /// Publish new wikidata description.
     ///
     /// - Parameters:
@@ -87,12 +85,12 @@ enum WikidataPublishingError: LocalizedError {
                 }
             }
         }
-        let normalizedLang = normalizedLanguage(from: language)
+        let normalizedLanguage = normalizedLanguages[language] ?? language
         let queryParameters = ["action": "wbsetdescription",
                                "format": "json",
                                "formatversion": "2"]
-        let bodyParameters = ["language": normalizedLang,
-                              "uselang": normalizedLang,
+        let bodyParameters = ["language": normalizedLanguage,
+                              "uselang": normalizedLanguage,
                               "id": wikidataID,
                               "value": newWikidataDescription]
         var components = WikidataAPI.components
@@ -100,18 +98,12 @@ enum WikidataPublishingError: LocalizedError {
         let _ = session.requestWithCSRF(type: CSRFTokenJSONDecodableOperation.self, components: components, method: .post, bodyParameters: bodyParameters, bodyEncoding: .form, tokenContext: CSRFTokenOperation.TokenContext(tokenName: "token", tokenPlacement: .body), completion: requestWithCSRFCompletion)
     }
 
-    private lazy var languageRegex: NSRegularExpression? = {
-        return try? NSRegularExpression(pattern: "(?<=-).*", options: .caseInsensitive)
-    }()
-
-    private func normalizedLanguage(from language: String) -> String {
-        guard
-            let match = languageRegex?.firstMatch(in: language, options: [], range: NSRange(location: 0, length: language.count)),
-            let range = Range(match.range, in: language) else {
-            return language
-        }
-        return String(language[range])
-    }
+    private var normalizedLanguages: [String: String] = [
+        "zh-yue": "yue",
+        "zh-min-nan": "nan",
+        "zh-classical": "lzh",
+        "fiu-vro": "vro"
+    ]
 }
 
 public extension MWKArticle {

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -98,7 +98,7 @@ enum WikidataPublishingError: LocalizedError {
         let _ = session.requestWithCSRF(type: CSRFTokenJSONDecodableOperation.self, components: components, method: .post, bodyParameters: bodyParameters, bodyEncoding: .form, tokenContext: CSRFTokenOperation.TokenContext(tokenName: "token", tokenPlacement: .body), completion: requestWithCSRFCompletion)
     }
 
-    private var normalizedLanguages: [String: String] = [
+    private let normalizedLanguages: [String: String] = [
         "zh-yue": "yue",
         "zh-min-nan": "nan",
         "zh-classical": "lzh",


### PR DESCRIPTION
There are some language codes that make the request "fail" silently, as in the request succeeds but the new description is not saved, even though it's saved in edit history. For example, Cantonese ("zh-yue" fails but "yue" works), Min Nan Chinese ("zh-min-nan" fails but "nan" works) or Classical Chinese ("zh-classical" fails but "lzh" works)

Alternative codes from https://www.wikidata.org/wiki/Help:Wikimedia_language_codes/lists/all

🤔