### PR TITLE
Enable data protection

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -8783,6 +8783,9 @@
 							com.apple.BackgroundModes = {
 								enabled = 1;
 							};
+							com.apple.DataProtection = {
+								enabled = 1;
+							};
 							com.apple.SafariKeychain = {
 								enabled = 1;
 							};

--- a/Wikipedia/Wikipedia.entitlements
+++ b/Wikipedia/Wikipedia.entitlements
@@ -11,6 +11,8 @@
 		<string>activitycontinuation:wikipedia.org</string>
 		<string>webcredentials:wikipedia.org</string>
 	</array>
+	<key>com.apple.developer.default-data-protection</key>
+	<string>NSFileProtectionCompleteUntilFirstUserAuthentication</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.wikimedia.wikipedia</string>


### PR DESCRIPTION
- Default value of `NSFileProtectionCompleteUntilFirstUserAuthentication`
- Explicitly set `NSFileProtectionCompleteUntilFirstUserAuthentication` on the app group container with a migration 