### PR TITLE
update fastlane snapshot helper file

### DIFF
--- a/WikipediaUITests/SnapshotHelper.swift
+++ b/WikipediaUITests/SnapshotHelper.swift
@@ -114,10 +114,14 @@ open class Snapshot: NSObject {
         } catch {
             print("Couldn't detect/set locale...")
         }
+        
         if locale.isEmpty {
             locale = Locale(identifier: deviceLanguage).identifier
         }
-        app.launchArguments += ["-AppleLocale", "\"\(locale)\""]
+        
+        if !locale.isEmpty {
+            app.launchArguments += ["-AppleLocale", "\"\(locale)\""]
+        }
     }
 
     class func setLaunchArguments(_ app: XCUIApplication) {
@@ -273,4 +277,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.12]
+// SnapshotHelperVersion [1.13]


### PR DESCRIPTION
The screenshot helper file is out of date. Needed so the `kickoff-screenshots` script I wrote (on `appsci`) can run - fastlane refuses to run screenshot process if this file version falls behind.

The `kickoff-screenshots` script (on Desktop of `appsci`) does the following:
- starts screenshot process
- then starts simple python server on port 9090 on the screenshots folder
- when VPN'ed in screenshots can then be accessed at `http://appsci:9090/screenshots.html`

Once this is merged I'll have Automator (or some such) run the script - probably once a day or week depending on how long the full process takes.
