### PR TITLE
Fix thread safety of asyncMap and asyncCompactMap

### DIFF
--- a/WMF Framework/Collection+AsyncMap.swift
+++ b/WMF Framework/Collection+AsyncMap.swift
@@ -28,11 +28,14 @@ public extension Sequence {
 public extension Collection {
     func asyncMap<R>(_ block: (Element, @escaping (R) -> Void) -> Void, completion:  @escaping ([R]) -> Void) {
         let group = DispatchGroup()
+        let semaphore = DispatchSemaphore(value: 1)
         var results = [R?](repeating: nil, count: count)
         for (index, object) in self.enumerated() {
             group.enter()
             block(object, { result in
+                semaphore.wait()
                 results[index] = result
+                semaphore.signal()
                 group.leave()
             })
         }
@@ -43,6 +46,7 @@ public extension Collection {
 
     func asyncCompactMap<R>(_ block: (Element, @escaping (R?) -> Void) -> Void, completion:  @escaping ([R]) -> Void) {
         let group = DispatchGroup()
+        let semaphore = DispatchSemaphore(value: 1)
         var results = [R?](repeating: nil, count: count)
         for (index, object) in self.enumerated() {
             group.enter()
@@ -51,7 +55,9 @@ public extension Collection {
                     group.leave()
                     return
                 }
+                semaphore.wait()
                 results[index] = result
+                semaphore.signal()
                 group.leave()
             })
         }

--- a/WikipediaUnitTests/Code/Collection+AsyncMapTests.swift
+++ b/WikipediaUnitTests/Code/Collection+AsyncMapTests.swift
@@ -132,4 +132,28 @@ class CollectionAsyncMapTests: XCTestCase {
         
         wait(for:[expectation], timeout: 5, enforceOrder: true)
     }
+    
+    func testLargeAsyncMap() {
+        let randomDelayBlock: (String, @escaping (String) -> Void) -> Void = { (string, completion) in
+            let randomMillisecondDelay = DispatchTimeInterval.milliseconds(Int.random(in: 1...10))
+            let time = DispatchTime.now() + randomMillisecondDelay
+            DispatchQueue.global(qos: .default).asyncAfter(deadline: time) {
+                completion(string.uppercased())
+            }
+            
+        }
+        let count = 1000
+        var identifiers: [String] = []
+        identifiers.reserveCapacity(count)
+        for _ in 1...count {
+            identifiers.append(UUID().uuidString)
+        }
+        let expectation = XCTestExpectation(description: "wait for completion")
+        identifiers.asyncMap(randomDelayBlock) { (processedIdentifiers) in
+            XCTAssert(processedIdentifiers.count == identifiers.count)
+            expectation.fulfill()
+        }
+        wait(for:[expectation], timeout: 5, enforceOrder: true)
+    }
+    
 }


### PR DESCRIPTION
`array[index] = obj` isn't thread safe, adds semaphore to control access to arrays. Also adds tests that fail prior to these changes, succeeds after these changes.