### PR TITLE
Fixed settings navigation controller after turning on explore feed

### DIFF
--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1941,7 +1941,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
         _settingsNavigationController = navController;
     }
 
-    if (_settingsNavigationController.viewControllers.count == 0) {
+    if (_settingsNavigationController.viewControllers.firstObject != self.settingsViewController) {
         _settingsNavigationController.viewControllers = @[self.settingsViewController];
     }
 


### PR DESCRIPTION
This PR fixes the issue where turning on explore feed and then tapping settings immediately would display Explore Feed Settings view instead of main settings view and there was no way to go back to the other parts of the app without switching off the explore feed again. 

**Steps to Reproduce**
1.) Go to settings and turn of explore feed 
2.) Turn on Explore Feed again
3.) Tap the settings icon. Explore feed settings view appears and both the back button on navigation bar and the cross button are missing. so the only way to go out of this view is to toggle the explore feed off again

**Description**

The issue was occurring due to the fact that turning off the explore feed would install the `WMFSettingsViewController` as a child view controller of the main tab bar view controller which would in turn remove the `WMFSettingsViewController` from the settings navigation controller heirarchy. The simplest solution is just to check that if the first view controller of `settingsNavigationController` is not the `settingsViewController` then install the `settingsViewController` as the rootViewController of `settingsNavigationController1