### PR TITLE
Improvement/array type constraints

### DIFF
--- a/Wikipedia/Code/AboutViewController.plist
+++ b/Wikipedia/Code/AboutViewController.plist
@@ -201,6 +201,7 @@ THE SOFTWARE.</string>
 		<string>Rummana Yasmeen</string>
 		<string>Salman Jamil</string>
 		<string>Sam Symons</string>
+		<string>Scott Petit</string>
 		<string>Sean Villalta</string>
 		<string>Seshadri Mahalingam</string>
 		<string>Sherah Smith</string>

--- a/Wikipedia/Code/MapUtilities.swift
+++ b/Wikipedia/Code/MapUtilities.swift
@@ -1,12 +1,9 @@
 import MapKit
 
-extension Array { // seems you can no longer do extension [CLLocationCoordinate2D] ?
+extension Array where Element == CLLocationCoordinate2D {
     func wmf_boundingRegion(with boundingMetersPerPoint: Double) -> MKCoordinateRegion {
         var rect: MKMapRect?
-        for element in self {
-            guard let coordinate = element as? CLLocationCoordinate2D else {
-                continue
-            }
+        for coordinate in self {
             let point = MKMapPoint(coordinate)
             let mapPointsPerMeter = MKMapPointsPerMeterAtLatitude(coordinate.latitude)
             let dimension = mapPointsPerMeter * boundingMetersPerPoint
@@ -33,4 +30,3 @@ extension Array { // seems you can no longer do extension [CLLocationCoordinate2
         return region
     }
 }
-


### PR DESCRIPTION
Constrains an Array extension meant to only operate on `CLLocationCoordinate2D` to that type.