### PR TITLE
Disable indent/outdent buttons dynamically

### DIFF
--- a/Wikipedia/Code/SectionEditorInputViewsController.swift
+++ b/Wikipedia/Code/SectionEditorInputViewsController.swift
@@ -31,9 +31,17 @@ class SectionEditorInputViewsController: SectionEditorInputViewsSource, Themeabl
         if inputViewType == nil {
             inputAccessoryViewType = isRangeSelected ? .highlight : .default
         }
+        defaultEditToolbarView?.enableAllButtons()
+        contextualHighlightEditToolbarView?.enableAllButtons()
         defaultEditToolbarView?.deselectAllButtons()
         contextualHighlightEditToolbarView?.deselectAllButtons()
         textFormattingInputViewController.textSelectionDidChange(isRangeSelected: isRangeSelected)
+    }
+
+    func disableButton(button: SectionEditorWebViewMessagingController.Button) {
+        defaultEditToolbarView?.disableButton(button)
+        contextualHighlightEditToolbarView?.disableButton(button)
+        textFormattingInputViewController.disableButton(button: button)
     }
 
     func buttonSelectionDidChange(button: SectionEditorWebViewMessagingController.Button) {

--- a/Wikipedia/Code/SectionEditorNavigationItemController.swift
+++ b/Wikipedia/Code/SectionEditorNavigationItemController.swift
@@ -105,23 +105,22 @@ class SectionEditorNavigationItemController: NSObject, Themeable {
             UIBarButtonItem.wmf_barButtonItem(ofFixedWidth: 20),
             undoButton
         ]
-
-        progressButton.isEnabled = false
     }
 
     func textSelectionDidChange(isRangeSelected: Bool) {
-        undoButton.isEnabled = false
-        redoButton.isEnabled = false
+        undoButton.isEnabled = true
+        redoButton.isEnabled = true
+        progressButton.isEnabled = true
     }
 
-    func buttonSelectionDidChange(button: SectionEditorWebViewMessagingController.Button) {
+    func disableButton(button: SectionEditorWebViewMessagingController.Button) {
         switch button.kind {
         case .undo:
-            undoButton.isEnabled = true
+            undoButton.isEnabled = false
         case .redo:
-            redoButton.isEnabled = true
-        case .progress(let changesMade):
-            progressButton.isEnabled = changesMade
+            redoButton.isEnabled = false
+        case .progress:
+            progressButton.isEnabled = false
         default:
             break
         }

--- a/Wikipedia/Code/SectionEditorViewController.swift
+++ b/Wikipedia/Code/SectionEditorViewController.swift
@@ -79,6 +79,7 @@ class SectionEditorViewController: UIViewController {
         
         contentController.add(messagingController, name: SectionEditorWebViewMessagingController.Message.Name.selectionChanged)
         contentController.add(messagingController, name: SectionEditorWebViewMessagingController.Message.Name.highlightTheseButtons)
+        contentController.add(messagingController, name: SectionEditorWebViewMessagingController.Message.Name.disableTheseButtons)
 
         configuration.userContentController = contentController
         webView = SectionEditorWebView(frame: .zero, configuration: configuration)
@@ -204,10 +205,13 @@ extension SectionEditorViewController: SectionEditorWebViewMessagingControllerTe
     }
 }
 
-extension SectionEditorViewController: SectionEditorWebViewMessagingControllerButtonSelectionDelegate {
+extension SectionEditorViewController: SectionEditorWebViewMessagingControllerButtonMessageDelegate {
     func sectionEditorWebViewMessagingControllerDidReceiveButtonSelectionChangeMessage(_ sectionEditorWebViewMessagingController: SectionEditorWebViewMessagingController, button: SectionEditorWebViewMessagingController.Button) {
-        navigationItemController.buttonSelectionDidChange(button: button)
         inputViewsController.buttonSelectionDidChange(button: button)
+    }
+    func sectionEditorWebViewMessagingControllerDidReceiveDisableButtonMessage(_ sectionEditorWebViewMessagingController: SectionEditorWebViewMessagingController, button: SectionEditorWebViewMessagingController.Button) {
+        navigationItemController.disableButton(button: button)
+        inputViewsController.disableButton(button: button)
     }
 }
 

--- a/Wikipedia/Code/SectionEditorWebViewMessagingController.swift
+++ b/Wikipedia/Code/SectionEditorWebViewMessagingController.swift
@@ -61,9 +61,7 @@ class SectionEditorWebViewMessagingController: NSObject, WKScriptMessageHandler 
 
         let ordered = info[Button.Info.ordered] as? Bool
 
-        let changesMade = info[Button.Info.changesMade] as? Bool
-
-        return Button.Info(textStyleType: textStyleType, textSizeType: textSizeType, ordered: ordered, changesMade: changesMade)
+        return Button.Info(textStyleType: textStyleType, textSizeType: textSizeType, ordered: ordered)
     }
 
     // MARK: - Sending messages
@@ -381,12 +379,10 @@ extension SectionEditorWebViewMessagingController {
             static let ordered = "ordered"
             static let depth = "depth"
             static let size = "size"
-            static let changesMade = "changesMade"
 
             let textStyleType: TextStyleType?
             let textSizeType: TextSizeType?
             let ordered: Bool?
-            let changesMade: Bool?
         }
         let kind: Kind
     }

--- a/Wikipedia/Code/SectionEditorWebViewMessagingController.swift
+++ b/Wikipedia/Code/SectionEditorWebViewMessagingController.swift
@@ -24,24 +24,14 @@ class SectionEditorWebViewMessagingController: NSObject, WKScriptMessageHandler 
                 guard let kind = buttonKind(from: element) else {
                     continue
                 }
-                let button = Button(kind: kind)
-                // Ignore debug buttons for now
-                guard button.kind != .debug else {
-                    continue
-                }
-                buttonSelectionDelegate?.sectionEditorWebViewMessagingControllerDidReceiveButtonSelectionChangeMessage(self, button: button)
+                buttonSelectionDelegate?.sectionEditorWebViewMessagingControllerDidReceiveButtonSelectionChangeMessage(self, button: Button(kind: kind))
             }
         case (Message.Name.disableTheseButtons, let message as [[String: Any]]):
             for element in message {
                 guard let kind = buttonKind(from: element) else {
                     continue
                 }
-                let button = Button(kind: kind)
-                // Ignore debug buttons for now
-                guard button.kind != .debug else {
-                    continue
-                }
-                buttonSelectionDelegate?.sectionEditorWebViewMessagingControllerDidReceiveDisableButtonMessage(self, button: button)
+                buttonSelectionDelegate?.sectionEditorWebViewMessagingControllerDidReceiveDisableButtonMessage(self, button: Button(kind: kind))
             }
         default:
             assertionFailure("Unsupported message: \(message.name), \(message.body)")
@@ -281,7 +271,7 @@ extension SectionEditorWebViewMessagingController {
             case template
             case undo
             case redo
-            case debug
+            case progress
             case comment
             case textSize(type: TextSizeType)
             case superscript
@@ -290,7 +280,6 @@ extension SectionEditorWebViewMessagingController {
             case strikethrough
             case decreaseIndentDepth
             case increaseIndentDepth
-            case progress
 
             var identifier: Int? {
                 switch self {
@@ -318,7 +307,7 @@ extension SectionEditorWebViewMessagingController {
                     return 11
                 case .redo:
                     return 12
-                case .debug:
+                case .progress:
                     return 13
                 case .comment:
                     return 14
@@ -334,8 +323,6 @@ extension SectionEditorWebViewMessagingController {
                     return 21
                 case .increaseIndentDepth:
                     return 22
-                case .progress:
-                    return 23
                 default:
                     return nil
                 }
@@ -368,8 +355,8 @@ extension SectionEditorWebViewMessagingController {
                         self = .undo
                     case "redo":
                         self = .redo
-                    case "debug":
-                        self = .debug
+                    case "progress":
+                        self = .progress
                     case "comment":
                         self = .comment
                     case "superscript":
@@ -384,8 +371,6 @@ extension SectionEditorWebViewMessagingController {
                         self = .decreaseIndentDepth
                     case "increaseIndentDepth":
                         self = .increaseIndentDepth
-                    case "progress":
-                        self = .progress
                     default:
                         return nil
                     }

--- a/Wikipedia/Code/TextFormattingButton.swift
+++ b/Wikipedia/Code/TextFormattingButton.swift
@@ -22,7 +22,7 @@ class TextFormattingButton: UIButton, Themeable {
     }
     
     private func updateColors() {
-        self.tintColor = self.isSelected ? theme.colors.secondaryText : theme.colors.primaryText
+        self.tintColor = theme.colors.primaryText
         self.backgroundColor = self.isSelected ? theme.colors.baseBackground : .clear
     }
     

--- a/Wikipedia/Code/TextFormattingInputViewController.swift
+++ b/Wikipedia/Code/TextFormattingInputViewController.swift
@@ -94,6 +94,11 @@ class TextFormattingInputViewController: UIInputViewController {
         textStyleFormattingTableViewController.buttonSelectionDidChange(button: button)
     }
     
+    func disableButton(button: SectionEditorWebViewMessagingController.Button) {
+        textFormattingTableViewController.disableButton(button: button)
+        textStyleFormattingTableViewController.disableButton(button: button)
+    }
+
 }
 
 extension TextFormattingInputViewController: Themeable {

--- a/Wikipedia/Code/TextFormattingProviding.swift
+++ b/Wikipedia/Code/TextFormattingProviding.swift
@@ -11,6 +11,14 @@ extension TextFormattingButtonsProviding {
         buttons.lazy.first(where: { $0.tag == button.kind.identifier })?.isSelected = true
     }
 
+    func disableButton(_ button: SectionEditorWebViewMessagingController.Button) {
+        buttons.lazy.first(where: { $0.tag == button.kind.identifier })?.isEnabled = false
+    }
+
+    func enableAllButtons() {
+        buttons.lazy.forEach { $0.isEnabled = true }
+    }
+
     func deselectAllButtons() {
         buttons.lazy.forEach { $0.isSelected = false }
     }

--- a/Wikipedia/Code/TextFormattingProvidingTableViewController.swift
+++ b/Wikipedia/Code/TextFormattingProvidingTableViewController.swift
@@ -138,6 +138,10 @@ class TextFormattingProvidingTableViewController: UITableViewController, TextFor
             break
         }
     }
+
+    open func disableButton(button: SectionEditorWebViewMessagingController.Button) {
+
+    }
 }
 
 extension TextFormattingProvidingTableViewController: Themeable {

--- a/Wikipedia/Code/TextFormattingTableViewController.swift
+++ b/Wikipedia/Code/TextFormattingTableViewController.swift
@@ -151,6 +151,8 @@ class TextFormattingTableViewController: TextFormattingProvidingTableViewControl
 
     override func textSelectionDidChange(isRangeSelected: Bool) {
         super.textSelectionDidChange(isRangeSelected: isRangeSelected)
+        textFormattingPlainToolbarView?.enableAllButtons()
+        textFormattingGroupedToolbarView?.enableAllButtons()
         textStyleFormattingTableViewController.textSelectionDidChange(isRangeSelected: isRangeSelected)
         textSizeFormattingTableViewController.textSelectionDidChange(isRangeSelected: isRangeSelected)
         textFormattingPlainToolbarView?.deselectAllButtons()
@@ -163,6 +165,14 @@ class TextFormattingTableViewController: TextFormattingProvidingTableViewControl
         textSizeFormattingTableViewController.buttonSelectionDidChange(button: button)
         textFormattingPlainToolbarView?.selectButton(button)
         textFormattingGroupedToolbarView?.selectButton(button)
+    }
+
+    override func disableButton(button: SectionEditorWebViewMessagingController.Button) {
+        super.disableButton(button: button)
+        textStyleFormattingTableViewController.disableButton(button: button)
+        textSizeFormattingTableViewController.disableButton(button: button)
+        textFormattingPlainToolbarView?.disableButton(button)
+        textFormattingGroupedToolbarView?.disableButton(button)
     }
 
 }

--- a/Wikipedia/assets/codemirror/codemirror-index.html
+++ b/Wikipedia/assets/codemirror/codemirror-index.html
@@ -324,39 +324,60 @@
      
       const listItemLineCallback = (char, depth, line) => {
         result.push(buttonPayload('li', {depth: depth, ordered: (char === '#')}))
-        if (depth > 1) {
-          result.push(buttonPayload('decreaseIndentDepth'))
-        }        
-        result.push(buttonPayload('increaseIndentDepth'))
         return false // No need to continue (only need to send one 'li' message)
       }
       performCallBackForSelectedListItemLines(doc, '#', listItemLineCallback)
       performCallBackForSelectedListItemLines(doc, '*', listItemLineCallback)
 
-      const historySize = doc.historySize()
-      
-      const changesMade = historySize.undo > 1
-      if (changesMade) {
-        result.push(buttonPayload('undo'))
-      }
-
-      result.push(buttonPayload('changesMade', {changesMade: changesMade}))
-
-      if (historySize.redo > 0) {
-        result.push(buttonPayload('redo'))
-      }
-        
       return result
+    }
+
+    const disabledButtons = (doc, selectedButtons) => {
+      let shouldDisableDecreaseIndent = true
+      let shouldDisableIncreaseIndent = true
+      const listPayload = selectionPayloadForButton('li', selectedButtons)
+      if (listPayload) {
+        const depth = listPayload.info.depth
+        if (depth > 1) { 
+          shouldDisableDecreaseIndent = false
+        }
+        shouldDisableIncreaseIndent = false
+      }
+
+      let buttonsToDisable = []
+
+      if (shouldDisableDecreaseIndent) {
+        buttonsToDisable.push(buttonPayload('decreaseIndentDepth'))
+      }
+      if (shouldDisableIncreaseIndent) {
+        buttonsToDisable.push(buttonPayload('increaseIndentDepth'))
+      }
+
+      const historySize = doc.historySize()
+      if (historySize.undo < 2) {
+        buttonsToDisable.push(buttonPayload('undo'))  
+        buttonsToDisable.push(buttonPayload('progress'))
+      }
+      if (historySize.redo < 1) {
+        buttonsToDisable.push(buttonPayload('redo'))
+      }
+
+      return buttonsToDisable
     }
 
     const sendNativeMessages = (doc) => {
       // sends message to native land that selection has changed,
-      // upon receipt native land should de-select all buttons
+      // upon receipt native land should de-select and re-enable all buttons
       window.webkit.messageHandlers.selectionChanged.postMessage(getSelectionRange(doc).isSelectionMoreThanOneChar)
 
       // sends message to native land about which buttons should be selected,
       // native land should assume only these buttons should appear selected
-      window.webkit.messageHandlers.highlightTheseButtons.postMessage(selectedButtons(doc))
+      const buttonsToSelect = selectedButtons(doc)
+      window.webkit.messageHandlers.highlightTheseButtons.postMessage(buttonsToSelect)
+      
+      // sends message to native land about which buttons should be disabled,
+      // native land should assume only these buttons should be disabled
+      window.webkit.messageHandlers.disableTheseButtons.postMessage(disabledButtons(doc, buttonsToSelect))
     }
         
     const applyTheme = (themeName) => {
@@ -504,8 +525,11 @@
     // determined to be a button. This is the same payload we send to native land to tell it which
     // buttons are selected and any associated relevant properties - in the case of a heading the
     // payload's info.depth tells us how many '=' the currently selected heading has.
-    const selectionPayloadForButton = (buttonType) => {
-      const payloadsForButton = selectedButtons(editor).filter((item) => {return item.button === buttonType})
+    const selectionPayloadForButton = (buttonType, selectedButtonsArray) => {
+      if (selectedButtonsArray === undefined) {
+        selectedButtonsArray = selectedButtons(editor)
+      }
+      const payloadsForButton = selectedButtonsArray.filter((item) => {return item.button === buttonType})
       if (payloadsForButton.length === 0) {
         return null
       }

--- a/Wikipedia/assets/codemirror/codemirror-index.html
+++ b/Wikipedia/assets/codemirror/codemirror-index.html
@@ -313,14 +313,6 @@
         const depth = numberFromPrefixedKey(typesArray, 'mw-signature-depth-')
         result.push(buttonPayload('signature', {depth: depth}))
       }
-
-      result.push(buttonPayload('debug', {
-         tokensIntersectingSelectionStrings: intersectingTokens.map(token => token.string).join(''),
-         tokensIntersectingSelectionTypesArray: typesArray,
-         selectionRange: getSelectionRange(doc),
-         getSelectionText: selection
-       }
-      ))
      
       const listItemLineCallback = (char, depth, line) => {
         result.push(buttonPayload('li', {depth: depth, ordered: (char === '#')}))

--- a/www/codemirror/codemirror-index.html
+++ b/www/codemirror/codemirror-index.html
@@ -324,39 +324,60 @@
      
       const listItemLineCallback = (char, depth, line) => {
         result.push(buttonPayload('li', {depth: depth, ordered: (char === '#')}))
-        if (depth > 1) {
-          result.push(buttonPayload('decreaseIndentDepth'))
-        }        
-        result.push(buttonPayload('increaseIndentDepth'))
         return false // No need to continue (only need to send one 'li' message)
       }
       performCallBackForSelectedListItemLines(doc, '#', listItemLineCallback)
       performCallBackForSelectedListItemLines(doc, '*', listItemLineCallback)
 
-      const historySize = doc.historySize()
-      
-      const changesMade = historySize.undo > 1
-      if (changesMade) {
-        result.push(buttonPayload('undo'))
-      }
-
-      result.push(buttonPayload('changesMade', {changesMade: changesMade}))
-
-      if (historySize.redo > 0) {
-        result.push(buttonPayload('redo'))
-      }
-        
       return result
+    }
+
+    const disabledButtons = (doc, selectedButtons) => {
+      let shouldDisableDecreaseIndent = true
+      let shouldDisableIncreaseIndent = true
+      const listPayload = selectionPayloadForButton('li', selectedButtons)
+      if (listPayload) {
+        const depth = listPayload.info.depth
+        if (depth > 1) { 
+          shouldDisableDecreaseIndent = false
+        }
+        shouldDisableIncreaseIndent = false
+      }
+
+      let buttonsToDisable = []
+
+      if (shouldDisableDecreaseIndent) {
+        buttonsToDisable.push(buttonPayload('decreaseIndentDepth'))
+      }
+      if (shouldDisableIncreaseIndent) {
+        buttonsToDisable.push(buttonPayload('increaseIndentDepth'))
+      }
+
+      const historySize = doc.historySize()
+      if (historySize.undo < 2) {
+        buttonsToDisable.push(buttonPayload('undo'))  
+        buttonsToDisable.push(buttonPayload('progress'))
+      }
+      if (historySize.redo < 1) {
+        buttonsToDisable.push(buttonPayload('redo'))
+      }
+
+      return buttonsToDisable
     }
 
     const sendNativeMessages = (doc) => {
       // sends message to native land that selection has changed,
-      // upon receipt native land should de-select all buttons
+      // upon receipt native land should de-select and re-enable all buttons
       window.webkit.messageHandlers.selectionChanged.postMessage(getSelectionRange(doc).isSelectionMoreThanOneChar)
 
       // sends message to native land about which buttons should be selected,
       // native land should assume only these buttons should appear selected
-      window.webkit.messageHandlers.highlightTheseButtons.postMessage(selectedButtons(doc))
+      const buttonsToSelect = selectedButtons(doc)
+      window.webkit.messageHandlers.highlightTheseButtons.postMessage(buttonsToSelect)
+      
+      // sends message to native land about which buttons should be disabled,
+      // native land should assume only these buttons should be disabled
+      window.webkit.messageHandlers.disableTheseButtons.postMessage(disabledButtons(doc, buttonsToSelect))
     }
         
     const applyTheme = (themeName) => {
@@ -504,8 +525,11 @@
     // determined to be a button. This is the same payload we send to native land to tell it which
     // buttons are selected and any associated relevant properties - in the case of a heading the
     // payload's info.depth tells us how many '=' the currently selected heading has.
-    const selectionPayloadForButton = (buttonType) => {
-      const payloadsForButton = selectedButtons(editor).filter((item) => {return item.button === buttonType})
+    const selectionPayloadForButton = (buttonType, selectedButtonsArray) => {
+      if (selectedButtonsArray === undefined) {
+        selectedButtonsArray = selectedButtons(editor)
+      }
+      const payloadsForButton = selectedButtonsArray.filter((item) => {return item.button === buttonType})
       if (payloadsForButton.length === 0) {
         return null
       }

--- a/www/codemirror/codemirror-index.html
+++ b/www/codemirror/codemirror-index.html
@@ -313,14 +313,6 @@
         const depth = numberFromPrefixedKey(typesArray, 'mw-signature-depth-')
         result.push(buttonPayload('signature', {depth: depth}))
       }
-
-      result.push(buttonPayload('debug', {
-         tokensIntersectingSelectionStrings: intersectingTokens.map(token => token.string).join(''),
-         tokensIntersectingSelectionTypesArray: typesArray,
-         selectionRange: getSelectionRange(doc),
-         getSelectionText: selection
-       }
-      ))
      
       const listItemLineCallback = (char, depth, line) => {
         result.push(buttonPayload('li', {depth: depth, ordered: (char === '#')}))


### PR DESCRIPTION
- disables indent/outdent buttons dynamically (disabled for non-list item selections)
- adds explicit 'disableTheseButtons' message (instead of overloading the 'selectTheseButtons' message)
- switches button tint color back to primaryText (for better contrast with disabled buttons)
- removes some debugging cruft

![sdfsfeeefewfe mov](https://user-images.githubusercontent.com/3143487/51015500-5a9f3c80-1521-11e9-9949-b854684e3ee4.gif)