### PR TITLE
Fix toggling between list types

### DIFF
--- a/Wikipedia/assets/codemirror/codemirror-index.html
+++ b/Wikipedia/assets/codemirror/codemirror-index.html
@@ -318,8 +318,7 @@
         result.push(buttonPayload('li', {depth: depth, ordered: (char === '#')}))
         return false // No need to continue (only need to send one 'li' message)
       }
-      performCallBackForSelectedListItemLines(doc, '#', listItemLineCallback)
-      performCallBackForSelectedListItemLines(doc, '*', listItemLineCallback)
+      performCallBackForSelectedListItemLines(doc, listItemLineCallback)
 
       return result
     }
@@ -537,42 +536,53 @@
     }
 
     const toggleListForSelectedLines = (char) => {
-       const listPayload = selectionPayloadForButton('li')
-       const isExistingListSelected = listPayload !== null
-       if (isExistingListSelected) {
-         delistifySelectedLines(char)
-         return
-       }
-       convertSelectedLinesToList(char)
+      const listPayload = selectionPayloadForButton('li')
+      const isExistingListSelected = listPayload !== null
+      if (isExistingListSelected) {
+        delistifySelectedLines()
+        if (char === '#' && listPayload.info.ordered) {
+          return
+        }
+        if (char === '*' && !listPayload.info.ordered) {
+          return
+        }
+      }
+      convertSelectedLinesToList(char)
     }
 
-    const leadingListItemRepeatingCharactersAndWhitespace = (line, char) => {
-      const leadingCharAndWhitespace = line.match(new RegExp(`^\\${char}+\\s*`))
-      return leadingCharAndWhitespace ? leadingCharAndWhitespace[0] : ''
+    class LineListItem {
+      constructor(leadingCharsAndWhitespace, char, depth) {
+        this.leadingCharsAndWhitespace = leadingCharsAndWhitespace
+        this.char = char
+        this.depth = depth
+      }
+    }
+
+    const leadingListItemRepeatingCharactersAndWhitespace = (line) => {
+      const leadingCharsAndWhitespace = line.match(new RegExp(`^(?:(\\*+|#+))\\s*`))
+      if (!leadingCharsAndWhitespace) {
+        return null
+      }
+      return new LineListItem(leadingCharsAndWhitespace[0], leadingCharsAndWhitespace[1].charAt(0), leadingCharsAndWhitespace[1].length)
     } 
 
-    const leadingListItemRepeatingCharactersCount = (line, char) => {
-      const chars = line.match(new RegExp(`^\\${char}+`))
-      return chars ? chars[0].length : 0
-    } 
-
-    const delistifySelectedLines = (char) => {
-      const listItemLineCallback = (char, depth, line, leadingCharsWithWhitespaceLength) => {
-        editor.replaceRange('', {line: line, ch: 0}, {line: line, ch: leadingCharsWithWhitespaceLength})
+    const delistifySelectedLines = () => {
+      const listItemLineCallback = (char, depth, line, leadingCharsAndWhitespaceLength) => {
+        editor.replaceRange('', {line: line, ch: 0}, {line: line, ch: leadingCharsAndWhitespaceLength})
         return true
       }
-      performCallBackForSelectedListItemLines(editor, char, listItemLineCallback)
+      performCallBackForSelectedListItemLines(editor, listItemLineCallback)
     }
 
-    const performCallBackForSelectedListItemLines = (doc, char, callback) => {
+    const performCallBackForSelectedListItemLines = (doc, callback) => {
       let toLine = doc.getCursor('to').line
       let fromLine = doc.getCursor('from').line
       for (let line = toLine; line >= fromLine; line--) {
         const thisLineText = doc.getLine(line)
-        const leadingCharsWithWhitespace = leadingListItemRepeatingCharactersAndWhitespace(thisLineText, char)
-        if (leadingCharsWithWhitespace.length > 0) {
-          const depth = leadingListItemRepeatingCharactersCount(leadingCharsWithWhitespace, char)
-          const shouldContinue = callback(char, depth, line, leadingCharsWithWhitespace.length)
+        const lineListItem = leadingListItemRepeatingCharactersAndWhitespace(thisLineText)
+        if (lineListItem) {
+          const depth = lineListItem.depth
+          const shouldContinue = callback(lineListItem.char, depth, line, lineListItem.leadingCharsAndWhitespace.length)
           if (!shouldContinue) {
             return
           }
@@ -719,8 +729,7 @@
           editor.replaceRange(char, {line: line, ch: 0})
           return true
         }
-        performCallBackForSelectedListItemLines(editor, '#', listItemLineCallback)
-        performCallBackForSelectedListItemLines(editor, '*', listItemLineCallback)
+        performCallBackForSelectedListItemLines(editor, listItemLineCallback)
       },
       decreaseIndentDepth: () => {
         const listItemLineCallback = (char, depth, line) => {
@@ -730,8 +739,7 @@
           editor.replaceRange('', {line: line, ch: 0}, {line: line, ch: 1})
           return true
         }
-        performCallBackForSelectedListItemLines(editor, '#', listItemLineCallback)
-        performCallBackForSelectedListItemLines(editor, '*', listItemLineCallback)
+        performCallBackForSelectedListItemLines(editor, listItemLineCallback)
       },
       textSize: (newSize) => {
         switch (newSize) {

--- a/www/codemirror/codemirror-index.html
+++ b/www/codemirror/codemirror-index.html
@@ -318,8 +318,7 @@
         result.push(buttonPayload('li', {depth: depth, ordered: (char === '#')}))
         return false // No need to continue (only need to send one 'li' message)
       }
-      performCallBackForSelectedListItemLines(doc, '#', listItemLineCallback)
-      performCallBackForSelectedListItemLines(doc, '*', listItemLineCallback)
+      performCallBackForSelectedListItemLines(doc, listItemLineCallback)
 
       return result
     }
@@ -537,42 +536,53 @@
     }
 
     const toggleListForSelectedLines = (char) => {
-       const listPayload = selectionPayloadForButton('li')
-       const isExistingListSelected = listPayload !== null
-       if (isExistingListSelected) {
-         delistifySelectedLines(char)
-         return
-       }
-       convertSelectedLinesToList(char)
+      const listPayload = selectionPayloadForButton('li')
+      const isExistingListSelected = listPayload !== null
+      if (isExistingListSelected) {
+        delistifySelectedLines()
+        if (char === '#' && listPayload.info.ordered) {
+          return
+        }
+        if (char === '*' && !listPayload.info.ordered) {
+          return
+        }
+      }
+      convertSelectedLinesToList(char)
     }
 
-    const leadingListItemRepeatingCharactersAndWhitespace = (line, char) => {
-      const leadingCharAndWhitespace = line.match(new RegExp(`^\\${char}+\\s*`))
-      return leadingCharAndWhitespace ? leadingCharAndWhitespace[0] : ''
+    class LineListItem {
+      constructor(leadingCharsAndWhitespace, char, depth) {
+        this.leadingCharsAndWhitespace = leadingCharsAndWhitespace
+        this.char = char
+        this.depth = depth
+      }
+    }
+
+    const leadingListItemRepeatingCharactersAndWhitespace = (line) => {
+      const leadingCharsAndWhitespace = line.match(new RegExp(`^(?:(\\*+|#+))\\s*`))
+      if (!leadingCharsAndWhitespace) {
+        return null
+      }
+      return new LineListItem(leadingCharsAndWhitespace[0], leadingCharsAndWhitespace[1].charAt(0), leadingCharsAndWhitespace[1].length)
     } 
 
-    const leadingListItemRepeatingCharactersCount = (line, char) => {
-      const chars = line.match(new RegExp(`^\\${char}+`))
-      return chars ? chars[0].length : 0
-    } 
-
-    const delistifySelectedLines = (char) => {
-      const listItemLineCallback = (char, depth, line, leadingCharsWithWhitespaceLength) => {
-        editor.replaceRange('', {line: line, ch: 0}, {line: line, ch: leadingCharsWithWhitespaceLength})
+    const delistifySelectedLines = () => {
+      const listItemLineCallback = (char, depth, line, leadingCharsAndWhitespaceLength) => {
+        editor.replaceRange('', {line: line, ch: 0}, {line: line, ch: leadingCharsAndWhitespaceLength})
         return true
       }
-      performCallBackForSelectedListItemLines(editor, char, listItemLineCallback)
+      performCallBackForSelectedListItemLines(editor, listItemLineCallback)
     }
 
-    const performCallBackForSelectedListItemLines = (doc, char, callback) => {
+    const performCallBackForSelectedListItemLines = (doc, callback) => {
       let toLine = doc.getCursor('to').line
       let fromLine = doc.getCursor('from').line
       for (let line = toLine; line >= fromLine; line--) {
         const thisLineText = doc.getLine(line)
-        const leadingCharsWithWhitespace = leadingListItemRepeatingCharactersAndWhitespace(thisLineText, char)
-        if (leadingCharsWithWhitespace.length > 0) {
-          const depth = leadingListItemRepeatingCharactersCount(leadingCharsWithWhitespace, char)
-          const shouldContinue = callback(char, depth, line, leadingCharsWithWhitespace.length)
+        const lineListItem = leadingListItemRepeatingCharactersAndWhitespace(thisLineText)
+        if (lineListItem) {
+          const depth = lineListItem.depth
+          const shouldContinue = callback(lineListItem.char, depth, line, lineListItem.leadingCharsAndWhitespace.length)
           if (!shouldContinue) {
             return
           }
@@ -719,8 +729,7 @@
           editor.replaceRange(char, {line: line, ch: 0})
           return true
         }
-        performCallBackForSelectedListItemLines(editor, '#', listItemLineCallback)
-        performCallBackForSelectedListItemLines(editor, '*', listItemLineCallback)
+        performCallBackForSelectedListItemLines(editor, listItemLineCallback)
       },
       decreaseIndentDepth: () => {
         const listItemLineCallback = (char, depth, line) => {
@@ -730,8 +739,7 @@
           editor.replaceRange('', {line: line, ch: 0}, {line: line, ch: 1})
           return true
         }
-        performCallBackForSelectedListItemLines(editor, '#', listItemLineCallback)
-        performCallBackForSelectedListItemLines(editor, '*', listItemLineCallback)
+        performCallBackForSelectedListItemLines(editor, listItemLineCallback)
       },
       textSize: (newSize) => {
         switch (newSize) {


### PR DESCRIPTION
For example, when you select an `ordered` list, and you tap the `unordered` list button.