### PR TITLE
Keep input accessory view at bottom of screen when keyboard dismissed

### DIFF
--- a/Wikipedia/Code/SectionEditorInputViewsController.swift
+++ b/Wikipedia/Code/SectionEditorInputViewsController.swift
@@ -73,7 +73,7 @@ class SectionEditorInputViewsController: SectionEditorInputViewsSource, Themeabl
         }
     }
 
-    private var inputAccessoryView: UIView? {
+    public var inputAccessoryView: UIView? {
         guard let inputAccessoryViewType = inputAccessoryViewType else {
             return nil
         }

--- a/Wikipedia/Code/SectionEditorViewController.swift
+++ b/Wikipedia/Code/SectionEditorViewController.swift
@@ -164,6 +164,19 @@ class SectionEditorViewController: UIViewController {
         navigationController?.popViewController(animated: true)
         return true
     }
+    
+    // MARK: - Docking `inputAccessoryView` at bottom of screen when keyboard is hidden.
+
+    override var inputAccessoryView: UIView? {
+        // In conjunction with overriding `canBecomeFirstResponder` to be true, this override
+        // allows `inputViewsController.inputAccessoryView` to dock at bottom of screen when
+        // the keyboard is dismissed.
+        return inputViewsController.inputAccessoryView
+    }
+    
+    override var canBecomeFirstResponder: Bool {
+        return true
+    }
 }
 
 private var previousAdjustedContentInset = UIEdgeInsets.zero


### PR DESCRIPTION
https://phabricator.wikimedia.org/T213450

![11111111 mov](https://user-images.githubusercontent.com/3143487/51303498-6770d400-19ea-11e9-919f-d7f9e5b163c5.gif)

In this case keyboard dismissal occurs when the editor web view resigns 1st responder.
When this happens the system goes up the responder chain looking for a `UIResponder` subclass which wants to become 1st responder.

Making `SectionEditorViewController` able to become 1st responder means it's the first such item in the responder chain encountered when the keyboard is dismissed.

Making its `inputAccessoryView` return `inputViewsController.inputAccessoryView` means the accessory view shown will be the one which was previously shown atop the keyboard.

-----

Looking at how find in page docks its accessory view at bottom when keyboard hidden was helpful:
	https://github.com/wikimedia/wikipedia-ios/pull/794#discussion_r72737202
	https://github.com/wikimedia/wikipedia-ios/pull/794#discussion_r72865675
	https://github.com/wikimedia/wikipedia-ios/pull/794#issuecomment-236402422

These were useful too:
	https://robots.thoughtbot.com/input-accessorizing-uiviewcontroller
	https://developer.apple.com/documentation/uikit/uiresponder/1621119-inputaccessoryview

-----

Question for @carolynlimadeo - this fix doesn't yet keep `Style` or `TextFormatting` header from completely disappearing as seen below. It's pretty easy to fix (just need to move these headers in their own `inputAccessoryView's` too) but wanted to double-check you wanted that 1st.

![22222222 mov](https://user-images.githubusercontent.com/3143487/51303510-73f52c80-19ea-11e9-8874-abc59af758e5.gif)