### PR TITLE
Revert "Keep input accessory view at bottom of screen when keyboard dismissed"

### DIFF
--- a/Wikipedia/Code/SectionEditorInputViewsController.swift
+++ b/Wikipedia/Code/SectionEditorInputViewsController.swift
@@ -73,7 +73,7 @@ class SectionEditorInputViewsController: SectionEditorInputViewsSource, Themeabl
         }
     }
 
-    public var inputAccessoryView: UIView? {
+    private var inputAccessoryView: UIView? {
         guard let inputAccessoryViewType = inputAccessoryViewType else {
             return nil
         }

--- a/Wikipedia/Code/SectionEditorViewController.swift
+++ b/Wikipedia/Code/SectionEditorViewController.swift
@@ -166,19 +166,6 @@ class SectionEditorViewController: UIViewController {
         navigationController?.popViewController(animated: true)
         return true
     }
-    
-    // MARK: - Docking `inputAccessoryView` at bottom of screen when keyboard is hidden.
-
-    override var inputAccessoryView: UIView? {
-        // In conjunction with overriding `canBecomeFirstResponder` to be true, this override
-        // allows `inputViewsController.inputAccessoryView` to dock at bottom of screen when
-        // the keyboard is dismissed.
-        return inputViewsController.inputAccessoryView
-    }
-    
-    override var canBecomeFirstResponder: Bool {
-        return true
-    }
 }
 
 private var previousAdjustedContentInset = UIEdgeInsets.zero


### PR DESCRIPTION
Reverts wikimedia/wikipedia-ios#2848