### PR TITLE
Pass direction to codemirror config

### DIFF
--- a/Wikipedia/Code/CodemirrorSetupUserScript.swift
+++ b/Wikipedia/Code/CodemirrorSetupUserScript.swift
@@ -2,13 +2,17 @@ import Foundation
 
 // sets the theme using wmf.applyTheme atDocumentEnd
 class CodemirrorSetupUserScript: WKUserScript, WKScriptMessageHandler {
+    public enum CodemirrorDirection: String {
+        case ltr
+        case rtl
+    }
     let messageHandlerName = "wmfCodemirrorReady"
     let completion: () -> Void
     
-    init(language: String, theme: Theme, completion: @escaping () -> Void) {
+    init(language: String, direction: CodemirrorDirection, theme: Theme, completion: @escaping () -> Void) {
         self.completion = completion
         let source = """
-        wmf.setup('\(language)', '\(theme.webName)', () => {
+        wmf.setup('\(language)', '\(direction.rawValue)', '\(theme.webName)', () => {
             window.webkit.messageHandlers.\(messageHandlerName).postMessage({})
         })
         """

--- a/Wikipedia/Code/SectionEditorViewController.swift
+++ b/Wikipedia/Code/SectionEditorViewController.swift
@@ -78,7 +78,8 @@ class SectionEditorViewController: UIViewController {
         messagingController = SectionEditorWebViewMessagingController()
         messagingController.textSelectionDelegate = self
         messagingController.buttonSelectionDelegate = self
-        let setupUserScript = CodemirrorSetupUserScript(language: language, theme: theme) { [weak self] in
+        let languageInfo = MWLanguageInfo(forCode: language)
+        let setupUserScript = CodemirrorSetupUserScript(language: language, direction: CodemirrorSetupUserScript.CodemirrorDirection(rawValue: languageInfo.dir) ?? .ltr, theme: theme) { [weak self] in
             self?.isCodemirrorReady = true
         }
         

--- a/Wikipedia/assets/codemirror/codemirror-index.html
+++ b/Wikipedia/assets/codemirror/codemirror-index.html
@@ -368,23 +368,7 @@
     
     let cursorActivityScrollTimer
     
-    const setupCodemirrorWithConfig = (config, callback) => {
-      let codeMirrorSettings = {
-        mwConfig: config,
-        lineWrapping: true,
-        lineNumbers: true,
-        mode: "text/mediawiki",
-        matchBrackets: true,
-        extraKeys: {
-          // t.b.d.
-        }, 
-        inputStyle: 'contenteditable',
-        autocorrect: true,
-        autocapitalize: true,
-        spellcheck: false,
-        preventDefaultOnKeyPress: false,
-        viewportMargin: Infinity
-      }
+    const setupCodemirrorWithSettings = (codeMirrorSettings, callback) => {
       editor = CodeMirror(document.body, codeMirrorSettings)
       if (callback) {
         callback()
@@ -400,14 +384,32 @@
       })
     }
     
-    const setupCodemirror = (language, themeName, callback) => {
+    const setupCodemirror = (language, direction, themeName, callback) => {
       applyTheme(themeName)
       let xhr = new XMLHttpRequest()
       let url = `config/codemirror-config-${language}.json`
       xhr.open('GET', url, true)
       xhr.onload = () => {
-        let config = JSON.parse(xhr.responseText)
-        setupCodemirrorWithConfig(config['extCodeMirrorConfig'], callback)
+        let object = JSON.parse(xhr.responseText)
+        let mwConfig = object['extCodeMirrorConfig']
+        let codeMirrorSettings = {
+          mwConfig: mwConfig,
+          lineWrapping: true,
+          lineNumbers: true,
+          mode: "text/mediawiki",
+          matchBrackets: true,
+          extraKeys: {
+            // t.b.d.
+          }, 
+          inputStyle: 'contenteditable',
+          direction: direction,
+          autocorrect: true,
+          autocapitalize: true,
+          spellcheck: false,
+          preventDefaultOnKeyPress: false,
+          viewportMargin: Infinity
+        }
+        setupCodemirrorWithSettings(codeMirrorSettings, callback)
       };
       xhr.send()
     }
@@ -504,7 +506,7 @@
     
     wmf.getWikitext = () => editor.getValue()
     wmf.setWikitext = (wikitext) => editor.setValue(wikitext)
-    wmf.setup = (language, themeName, callback) => setupCodemirror(language, themeName, callback)
+    wmf.setup = (language, direction, themeName, callback) => setupCodemirror(language, direction, themeName, callback)
     wmf.applyTheme = (themeName) => applyTheme(themeName)
 
     const italicMarkup = "''"

--- a/www/codemirror/codemirror-index.html
+++ b/www/codemirror/codemirror-index.html
@@ -368,23 +368,7 @@
     
     let cursorActivityScrollTimer
     
-    const setupCodemirrorWithConfig = (config, callback) => {
-      let codeMirrorSettings = {
-        mwConfig: config,
-        lineWrapping: true,
-        lineNumbers: true,
-        mode: "text/mediawiki",
-        matchBrackets: true,
-        extraKeys: {
-          // t.b.d.
-        }, 
-        inputStyle: 'contenteditable',
-        autocorrect: true,
-        autocapitalize: true,
-        spellcheck: false,
-        preventDefaultOnKeyPress: false,
-        viewportMargin: Infinity
-      }
+    const setupCodemirrorWithSettings = (codeMirrorSettings, callback) => {
       editor = CodeMirror(document.body, codeMirrorSettings)
       if (callback) {
         callback()
@@ -400,14 +384,32 @@
       })
     }
     
-    const setupCodemirror = (language, themeName, callback) => {
+    const setupCodemirror = (language, direction, themeName, callback) => {
       applyTheme(themeName)
       let xhr = new XMLHttpRequest()
       let url = `config/codemirror-config-${language}.json`
       xhr.open('GET', url, true)
       xhr.onload = () => {
-        let config = JSON.parse(xhr.responseText)
-        setupCodemirrorWithConfig(config['extCodeMirrorConfig'], callback)
+        let object = JSON.parse(xhr.responseText)
+        let mwConfig = object['extCodeMirrorConfig']
+        let codeMirrorSettings = {
+          mwConfig: mwConfig,
+          lineWrapping: true,
+          lineNumbers: true,
+          mode: "text/mediawiki",
+          matchBrackets: true,
+          extraKeys: {
+            // t.b.d.
+          }, 
+          inputStyle: 'contenteditable',
+          direction: direction,
+          autocorrect: true,
+          autocapitalize: true,
+          spellcheck: false,
+          preventDefaultOnKeyPress: false,
+          viewportMargin: Infinity
+        }
+        setupCodemirrorWithSettings(codeMirrorSettings, callback)
       };
       xhr.send()
     }
@@ -504,7 +506,7 @@
     
     wmf.getWikitext = () => editor.getValue()
     wmf.setWikitext = (wikitext) => editor.setValue(wikitext)
-    wmf.setup = (language, themeName, callback) => setupCodemirror(language, themeName, callback)
+    wmf.setup = (language, direction, themeName, callback) => setupCodemirror(language, direction, themeName, callback)
     wmf.applyTheme = (themeName) => applyTheme(themeName)
 
     const italicMarkup = "''"


### PR DESCRIPTION
Now RTL languages work as expected (minus the line numbers):

![simulator screen shot - iphone x - 2019-01-18 at 12 31 55](https://user-images.githubusercontent.com/741327/51402979-101f5080-1b1d-11e9-8cdf-3b33c0549fff.png)
