### PR TITLE
Fix scrolling cursor into view when scrolled to bottom of wikitext

### DIFF
--- a/Wikipedia/assets/codemirror/codemirror-index.html
+++ b/Wikipedia/assets/codemirror/codemirror-index.html
@@ -635,7 +635,7 @@
     }
 
     let adjustedContentInset = {top: 0, left: 0, bottom: 0, right: 0}
-    const webViewHeightNotCoveredByKeyboard = () => window.innerHeight - adjustedContentInset.bottom
+    const webViewHeightNotCoveredByKeyboard = () => document.documentElement.clientHeight - adjustedContentInset.bottom
     const cursorOffsetFromTopOfWebView = () => editor.cursorCoords(true, 'window').top
     const cursorOffsetFromTopOfKeyboard = () => editor.cursorCoords(false, 'window').bottom - webViewHeightNotCoveredByKeyboard()
 

--- a/www/codemirror/codemirror-index.html
+++ b/www/codemirror/codemirror-index.html
@@ -635,7 +635,7 @@
     }
 
     let adjustedContentInset = {top: 0, left: 0, bottom: 0, right: 0}
-    const webViewHeightNotCoveredByKeyboard = () => window.innerHeight - adjustedContentInset.bottom
+    const webViewHeightNotCoveredByKeyboard = () => document.documentElement.clientHeight - adjustedContentInset.bottom
     const cursorOffsetFromTopOfWebView = () => editor.cursorCoords(true, 'window').top
     const cursorOffsetFromTopOfKeyboard = () => editor.cursorCoords(false, 'window').bottom - webViewHeightNotCoveredByKeyboard()
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T213452

For some reason `window.innerHeight` changes when scrolled almost all the way to the bottom, which threw off the scroll offset calculation.


Repro steps:

- load wikitext for a long section
- scroll all the way to the bottom
- tap around to relocate cursor
- things scrolled crazily and unnecessarily