### PR TITLE
fix code mirror leading space (on a line) color

### DIFF
--- a/Wikipedia/assets/codemirror/codemirror-common.css
+++ b/Wikipedia/assets/codemirror/codemirror-common.css
@@ -51,3 +51,7 @@ body {
 .cm-searching-focus {
   background-color: #fc3 !important;
 }
+
+.cm-mw-skipformatting {
+    background-color: unset !important;
+}

--- a/www/codemirror/codemirror-common.css
+++ b/www/codemirror/codemirror-common.css
@@ -51,3 +51,7 @@ body {
 .cm-searching-focus {
   background-color: #fc3 !important;
 }
+
+.cm-mw-skipformatting {
+    background-color: unset !important;
+}


### PR DESCRIPTION
was showing a weird blue - looked pretty bad on dark themes

| Before  | After |
| ------------- | ------------- |
| <img width="593" alt="screen shot 2019-01-31 at 12 28 17 pm" src="https://user-images.githubusercontent.com/3143487/52083237-c5a5c700-2553-11e9-8faf-9c54354cf9c1.png"> | <img width="593" alt="screen shot 2019-01-31 at 12 27 39 pm" src="https://user-images.githubusercontent.com/3143487/52083241-ca6a7b00-2553-11e9-9449-af8caa212e51.png"> | 
