### PR TITLE
Ensure basic edit funnels/event logging events are working

### DIFF
--- a/Wikipedia/Code/EditSaveViewController.swift
+++ b/Wikipedia/Code/EditSaveViewController.swift
@@ -113,8 +113,6 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
 
         mode = .preview
         
-        funnel?.logPreview()
-        
         minorEditLabel.text = WMFLocalizedStringWithDefaultValue("edit-minor-text", nil, nil, "This is a minor edit", "Text for minor edit label")
         minorEditButton.setTitle(WMFLocalizedStringWithDefaultValue("edit-minor-learn-more-text", nil, nil, "Learn more about minor edits", "Text for minor edits learn more button"), for: .normal)
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T215329

Not much to do here, all looks good.

Looks like there was a double preview log, one in `EditPreviewViewController` and another one in `EditSaveViewController`. Originally (looking at `releases/6.1.3`), this would get logged once in `PreviewAndSaveViewController`