### PR TITLE
Log error code when logging Wikidata description editing errors

### DIFF
--- a/Wikipedia/Code/DescriptionEditViewController.swift
+++ b/Wikipedia/Code/DescriptionEditViewController.swift
@@ -223,7 +223,7 @@ class DescriptionEditViewController: WMFScrollViewController, Themeable, UITextV
                     return
                 }
                 let apiErrorCode = (error as? WikidataAPIResult.APIError)?.code
-                let errorText = apiErrorCode ?? (error as NSError).domain
+                let errorText = apiErrorCode ?? "\((error as NSError).domain)-\((error as NSError).code)"
                 self.editFunnel?.logWikidataDescriptionEditError(self.isEditingExistingDescription, language: language, errorText: errorText)
                 WMFAlertManager.sharedInstance.showErrorAlert(error as NSError, sticky: true, dismissPreviousAlerts: true, tapCallBack: nil)
             }

--- a/Wikipedia/Code/DescriptionEditViewController.swift
+++ b/Wikipedia/Code/DescriptionEditViewController.swift
@@ -222,7 +222,9 @@ class DescriptionEditViewController: WMFScrollViewController, Themeable, UITextV
                     }
                     return
                 }
-                self.editFunnel?.logWikidataDescriptionEditError(self.isEditingExistingDescription, language: language, errorText: error.localizedDescription)
+                let apiErrorCode = (error as? WikidataAPIResult.APIError)?.code
+                let errorText = apiErrorCode ?? (error as NSError).domain
+                self.editFunnel?.logWikidataDescriptionEditError(self.isEditingExistingDescription, language: language, errorText: errorText)
                 WMFAlertManager.sharedInstance.showErrorAlert(error as NSError, sticky: true, dismissPreviousAlerts: true, tapCallBack: nil)
             }
         }

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -16,12 +16,6 @@ struct MediaWikiSiteInfoResult: Decodable {
     let query: MediaWikiQueryResult
 }
 
-extension WikidataAPIResult.Error: LocalizedError {
-    var errorDescription: String? {
-        return info
-    }
-}
-
 extension WikidataAPIResult {
     var succeeded: Bool {
         return success == 1

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -1,8 +1,8 @@
-struct WikidataAPIResult: Decodable {
-    struct Error: Decodable {
-        let code, info: String?
+public struct WikidataAPIResult: Decodable {
+    public struct APIError: Error, Decodable {
+        public let code, info: String?
     }
-    let error: Error?
+    let error: APIError?
     let success: Int?
 }
 


### PR DESCRIPTION
Logs API error code or `NSError` domain as `errorText` instead of `localizedDescription`

https://phabricator.wikimedia.org/T210970#4935892