### PR TITLE
Tag build before uploading to the app store

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -293,6 +293,10 @@ platform :ios do
       project: "Wikipedia"
     )
     
+    tag(
+      prefix: tag_prefix,
+      build_number: build_number
+    )
     
     pilot(
       ipa: ipa_path,
@@ -301,11 +305,6 @@ platform :ios do
       distribute_external: false,
       app_identifier:  app_identifier,
       beta_app_feedback_email: "mobile-ios-wikipedia@wikimedia.org"
-    )
-    
-    tag(
-      prefix: tag_prefix,
-      build_number: build_number
     )
     
     if wait_for_build_processing #dsyms are only available if we wait


### PR DESCRIPTION
Ensures there's always a beta tag even if waiting for processing exits early