### PR TITLE
Fix edit toolbar constraints on various devices

### DIFF
--- a/Wikipedia/Code/DefaultEditToolbarView.xib
+++ b/Wikipedia/Code/DefaultEditToolbarView.xib
@@ -27,13 +27,13 @@
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="ajR-7a-Sik" userLabel="Main Stack View">
-                                            <rect key="frame" x="0.0" y="0.0" width="355" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BWO-2h-I64" userLabel="Default View">
-                                                    <rect key="frame" x="0.0" y="0.0" width="167.5" height="44"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="177.5" height="44"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="g2p-oh-oje" userLabel="Default Stack View">
-                                                            <rect key="frame" x="16" y="0.0" width="143.5" height="44"/>
+                                                            <rect key="frame" x="16" y="0.0" width="153.5" height="44"/>
                                                             <subviews>
                                                                 <button opaque="NO" tag="28" contentMode="scaleToFill" horizontalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="t52-tF-NuA" userLabel="Format Text Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
                                                                     <rect key="frame" x="0.0" y="11" width="27" height="22"/>
@@ -43,43 +43,43 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="29" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yVB-pz-I3S" userLabel="Format Text Style Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="29" y="11" width="30" height="22"/>
+                                                                    <rect key="frame" x="30.5" y="11" width="30" height="22"/>
                                                                     <state key="normal" image="text-formatting-style"/>
                                                                     <connections>
                                                                         <action selector="formatTextStyle:" destination="iN0-l3-epB" eventType="touchUpInside" id="1Zw-wT-rnd"/>
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="jlu-Wy-agF" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="61.5" y="12" width="1" height="20"/>
+                                                                    <rect key="frame" x="64.5" y="12" width="1" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="9" contentMode="scaleToFill" horizontalCompressionResistancePriority="752" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Do1-By-Bqb" userLabel="Citation Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="64.5" y="11" width="14" height="22"/>
+                                                                    <rect key="frame" x="69" y="11" width="14" height="22"/>
                                                                     <state key="normal" image="text-formatting-add-citation"/>
                                                                     <connections>
                                                                         <action selector="toggleCitation:" destination="iN0-l3-epB" eventType="touchUpInside" id="RWg-r0-cOq"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="6" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="usu-sH-MMC" userLabel="Link Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="81" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="86.5" y="11" width="18" height="22"/>
                                                                     <state key="normal" image="text-formatting-link"/>
                                                                     <connections>
                                                                         <action selector="toggleLink:" destination="iN0-l3-epB" eventType="touchUpInside" id="sdE-HW-jkI"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="10" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IXZ-uI-C7O" userLabel="Template Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="101" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="108" y="11" width="18" height="22"/>
                                                                     <state key="normal" image="text-formatting-curly-brackets"/>
                                                                     <connections>
                                                                         <action selector="toggleTemplate:" destination="iN0-l3-epB" eventType="touchUpInside" id="RWl-f2-2Vd"/>
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="sz5-NF-B4w" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="121.5" y="12" width="1" height="20"/>
+                                                                    <rect key="frame" x="130" y="12" width="1" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="27" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8GD-c3-cxB" userLabel="Find In Page Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="124.5" y="9.5" width="19" height="25"/>
+                                                                    <rect key="frame" x="134.5" y="9.5" width="19" height="25"/>
                                                                     <state key="normal" image="find-in-page"/>
                                                                     <connections>
                                                                         <action selector="showFindInPage:" destination="iN0-l3-epB" eventType="touchUpInside" id="OPh-Dx-Itg"/>
@@ -96,10 +96,10 @@
                                                     </constraints>
                                                 </view>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="51i-1d-Lli" userLabel="Secondary View">
-                                                    <rect key="frame" x="187.5" y="0.0" width="167.5" height="44"/>
+                                                    <rect key="frame" x="197.5" y="0.0" width="177.5" height="44"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="1bz-lo-Qsh" userLabel="Secondary Stack View">
-                                                            <rect key="frame" x="16" y="0.0" width="143.5" height="44"/>
+                                                            <rect key="frame" x="16" y="0.0" width="153.5" height="44"/>
                                                             <subviews>
                                                                 <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ycB-mS-qZ3" userLabel="Unordered List Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
                                                                     <rect key="frame" x="0.0" y="11" width="18" height="22"/>
@@ -110,7 +110,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MjG-se-XpY" userLabel="Ordered List Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="19" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="20" y="11" width="18" height="22"/>
                                                                     <state key="normal" image="text-formatting-ordered-list"/>
                                                                     <connections>
                                                                         <action selector="increaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="iOK-bK-63R"/>
@@ -118,50 +118,50 @@
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="bkM-bA-d3o" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="38" y="12" width="1" height="20"/>
+                                                                    <rect key="frame" x="40.5" y="12" width="1" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="21" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M2s-Up-JEt" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="40" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="43.5" y="11" width="18" height="22"/>
                                                                     <state key="normal" image="text-formatting-decrease-indent"/>
                                                                     <connections>
                                                                         <action selector="decreaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="bGk-wN-Y56"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="22" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dRI-FL-20t" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="59" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="63.5" y="11" width="18" height="22"/>
                                                                     <state key="normal" image="text-formatting-increase-indent"/>
                                                                     <connections>
                                                                         <action selector="increaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="chF-z3-SBA"/>
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="zrK-Kd-SnN" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="78.5" y="12" width="1" height="20"/>
+                                                                    <rect key="frame" x="84" y="12" width="1" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="23" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bcH-OJ-MDT" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="80.5" y="11" width="19" height="22"/>
+                                                                    <rect key="frame" x="87" y="11" width="19" height="22"/>
                                                                     <state key="normal" image="directionUp"/>
                                                                     <connections>
                                                                         <action selector="moveCursorUp:" destination="iN0-l3-epB" eventType="touchUpInside" id="SvW-C1-J2E"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="24" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r2W-3b-3SP" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="100.5" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="108" y="11" width="18" height="22"/>
                                                                     <state key="normal" image="directionDown"/>
                                                                     <connections>
                                                                         <action selector="moveCursorDown:" destination="iN0-l3-epB" eventType="touchUpInside" id="i1T-s3-dx4"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="25" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G3W-Xz-reX" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="119.5" y="11" width="12" height="22"/>
+                                                                    <rect key="frame" x="128.5" y="11" width="12" height="22"/>
                                                                     <state key="normal" image="directionLeft"/>
                                                                     <connections>
                                                                         <action selector="moveCursorLeft:" destination="iN0-l3-epB" eventType="touchUpInside" id="8ZI-Dx-nTQ"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="26" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nSf-Yo-A6r" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="132.5" y="11" width="11" height="22"/>
+                                                                    <rect key="frame" x="142.5" y="11" width="11" height="22"/>
                                                                     <state key="normal" image="directionRight"/>
                                                                     <connections>
                                                                         <action selector="moveCursorRight:" destination="iN0-l3-epB" eventType="touchUpInside" id="cxG-ce-e4c"/>
@@ -191,7 +191,7 @@
                                     </subviews>
                                     <constraints>
                                         <constraint firstAttribute="bottom" secondItem="ajR-7a-Sik" secondAttribute="bottom" id="24Z-8o-CkO"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="ajR-7a-Sik" secondAttribute="trailing" id="J5g-me-4g4"/>
+                                        <constraint firstAttribute="trailing" secondItem="ajR-7a-Sik" secondAttribute="trailing" id="J5g-me-4g4"/>
                                         <constraint firstItem="ajR-7a-Sik" firstAttribute="top" secondItem="vhM-bx-p7p" secondAttribute="top" id="dzU-Tm-IPJ"/>
                                         <constraint firstItem="ajR-7a-Sik" firstAttribute="leading" secondItem="vhM-bx-p7p" secondAttribute="leading" id="tfq-kw-aLq"/>
                                         <constraint firstAttribute="height" constant="44" id="wwE-a6-akA"/>

--- a/Wikipedia/Code/DefaultEditToolbarView.xib
+++ b/Wikipedia/Code/DefaultEditToolbarView.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="ipad9_7" orientation="portrait">
+    <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -21,65 +21,65 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                     <subviews>
                         <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZnR-ux-s6T">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                            <rect key="frame" x="0.0" y="0.0" width="321" height="44"/>
                             <subviews>
                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="375" placeholderIntrinsicHeight="44" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vhM-bx-p7p" userLabel="Stack View Container">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="650" height="44"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="ajR-7a-Sik" userLabel="Main Stack View">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="650" height="44"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BWO-2h-I64" userLabel="Default View">
-                                                    <rect key="frame" x="0.0" y="0.0" width="177.5" height="44"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="321" height="44"/>
                                                     <subviews>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="g2p-oh-oje" userLabel="Default Stack View">
-                                                            <rect key="frame" x="16" y="0.0" width="153.5" height="44"/>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="g2p-oh-oje" userLabel="Default Stack View">
+                                                            <rect key="frame" x="16" y="0.0" width="297" height="44"/>
                                                             <subviews>
                                                                 <button opaque="NO" tag="28" contentMode="scaleToFill" horizontalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="t52-tF-NuA" userLabel="Format Text Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="11" width="27" height="22"/>
+                                                                    <rect key="frame" x="0.0" y="11" width="47" height="22"/>
                                                                     <state key="normal" image="text-formatting"/>
                                                                     <connections>
                                                                         <action selector="formatText:" destination="iN0-l3-epB" eventType="touchUpInside" id="Cu4-x9-6NR"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="29" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yVB-pz-I3S" userLabel="Format Text Style Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="30.5" y="11" width="30" height="22"/>
+                                                                    <rect key="frame" x="53" y="11" width="52.5" height="22"/>
                                                                     <state key="normal" image="text-formatting-style"/>
                                                                     <connections>
                                                                         <action selector="formatTextStyle:" destination="iN0-l3-epB" eventType="touchUpInside" id="1Zw-wT-rnd"/>
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="jlu-Wy-agF" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="64.5" y="12" width="1" height="20"/>
+                                                                    <rect key="frame" x="111.5" y="12" width="2" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="9" contentMode="scaleToFill" horizontalCompressionResistancePriority="752" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Do1-By-Bqb" userLabel="Citation Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="69" y="11" width="14" height="22"/>
+                                                                    <rect key="frame" x="119.5" y="11" width="24.5" height="22"/>
                                                                     <state key="normal" image="text-formatting-add-citation"/>
                                                                     <connections>
                                                                         <action selector="toggleCitation:" destination="iN0-l3-epB" eventType="touchUpInside" id="RWg-r0-cOq"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="6" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="usu-sH-MMC" userLabel="Link Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="86.5" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="150" y="11" width="31" height="22"/>
                                                                     <state key="normal" image="text-formatting-link"/>
                                                                     <connections>
                                                                         <action selector="toggleLink:" destination="iN0-l3-epB" eventType="touchUpInside" id="sdE-HW-jkI"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="10" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IXZ-uI-C7O" userLabel="Template Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="108" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="187" y="11" width="31.5" height="22"/>
                                                                     <state key="normal" image="text-formatting-curly-brackets"/>
                                                                     <connections>
                                                                         <action selector="toggleTemplate:" destination="iN0-l3-epB" eventType="touchUpInside" id="RWl-f2-2Vd"/>
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="sz5-NF-B4w" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="130" y="12" width="1" height="20"/>
+                                                                    <rect key="frame" x="224.5" y="12" width="2" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="27" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8GD-c3-cxB" userLabel="Find In Page Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="134.5" y="9.5" width="19" height="25"/>
+                                                                    <rect key="frame" x="232.5" y="9.5" width="64.5" height="25"/>
                                                                     <state key="normal" image="find-in-page"/>
                                                                     <connections>
                                                                         <action selector="showFindInPage:" destination="iN0-l3-epB" eventType="touchUpInside" id="OPh-Dx-Itg"/>
@@ -96,13 +96,13 @@
                                                     </constraints>
                                                 </view>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="51i-1d-Lli" userLabel="Secondary View">
-                                                    <rect key="frame" x="197.5" y="0.0" width="177.5" height="44"/>
+                                                    <rect key="frame" x="329" y="0.0" width="321" height="44"/>
                                                     <subviews>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="1bz-lo-Qsh" userLabel="Secondary Stack View">
-                                                            <rect key="frame" x="16" y="0.0" width="153.5" height="44"/>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="1bz-lo-Qsh" userLabel="Secondary Stack View">
+                                                            <rect key="frame" x="16" y="0.0" width="297" height="44"/>
                                                             <subviews>
                                                                 <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ycB-mS-qZ3" userLabel="Unordered List Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="0.0" y="11" width="28.5" height="22"/>
                                                                     <state key="normal" image="text-formatting-unordered-list"/>
                                                                     <connections>
                                                                         <action selector="decreaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="5Pf-Sl-jzD"/>
@@ -110,7 +110,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MjG-se-XpY" userLabel="Ordered List Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="20" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="34.5" y="11" width="28.5" height="22"/>
                                                                     <state key="normal" image="text-formatting-ordered-list"/>
                                                                     <connections>
                                                                         <action selector="increaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="iOK-bK-63R"/>
@@ -118,50 +118,50 @@
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="bkM-bA-d3o" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="40.5" y="12" width="1" height="20"/>
+                                                                    <rect key="frame" x="69" y="12" width="1.5" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="21" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M2s-Up-JEt" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="43.5" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="76.5" y="11" width="28.5" height="22"/>
                                                                     <state key="normal" image="text-formatting-decrease-indent"/>
                                                                     <connections>
                                                                         <action selector="decreaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="bGk-wN-Y56"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="22" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dRI-FL-20t" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="63.5" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="111" y="11" width="28.5" height="22"/>
                                                                     <state key="normal" image="text-formatting-increase-indent"/>
                                                                     <connections>
                                                                         <action selector="increaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="chF-z3-SBA"/>
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="zrK-Kd-SnN" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="84" y="12" width="1" height="20"/>
+                                                                    <rect key="frame" x="145.5" y="12" width="1.5" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="23" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bcH-OJ-MDT" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="87" y="11" width="19" height="22"/>
+                                                                    <rect key="frame" x="153" y="11" width="30" height="22"/>
                                                                     <state key="normal" image="directionUp"/>
                                                                     <connections>
                                                                         <action selector="moveCursorUp:" destination="iN0-l3-epB" eventType="touchUpInside" id="SvW-C1-J2E"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="24" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r2W-3b-3SP" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="108" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="189" y="11" width="28.5" height="22"/>
                                                                     <state key="normal" image="directionDown"/>
                                                                     <connections>
                                                                         <action selector="moveCursorDown:" destination="iN0-l3-epB" eventType="touchUpInside" id="i1T-s3-dx4"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="25" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G3W-Xz-reX" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="128.5" y="11" width="12" height="22"/>
+                                                                    <rect key="frame" x="223.5" y="11" width="19" height="22"/>
                                                                     <state key="normal" image="directionLeft"/>
                                                                     <connections>
                                                                         <action selector="moveCursorLeft:" destination="iN0-l3-epB" eventType="touchUpInside" id="8ZI-Dx-nTQ"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="26" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nSf-Yo-A6r" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="142.5" y="11" width="11" height="22"/>
+                                                                    <rect key="frame" x="248.5" y="11" width="48.5" height="22"/>
                                                                     <state key="normal" image="directionRight"/>
                                                                     <connections>
                                                                         <action selector="moveCursorRight:" destination="iN0-l3-epB" eventType="touchUpInside" id="cxG-ce-e4c"/>
@@ -231,8 +231,9 @@
                             </variation>
                         </scrollView>
                         <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="25k-rm-GLR">
-                            <rect key="frame" x="355" y="10" width="0.0" height="24"/>
+                            <rect key="frame" x="329" y="10" width="30" height="24"/>
                             <constraints>
+                                <constraint firstAttribute="width" constant="30" id="KBZ-Wb-t1T"/>
                                 <constraint firstAttribute="width" id="chZ-0u-nI7"/>
                                 <constraint firstAttribute="height" constant="24" id="rje-us-hjK"/>
                             </constraints>
@@ -255,6 +256,7 @@
                             </variation>
                             <variation key="heightClass=regular-widthClass=regular" hidden="YES">
                                 <mask key="constraints">
+                                    <exclude reference="KBZ-Wb-t1T"/>
                                     <include reference="chZ-0u-nI7"/>
                                 </mask>
                             </variation>

--- a/Wikipedia/Code/DefaultEditToolbarView.xib
+++ b/Wikipedia/Code/DefaultEditToolbarView.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_0" orientation="portrait">
+    <device id="retina6_5" orientation="landscape">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -18,68 +18,68 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="en8-Lh-EYg" userLabel="Content View">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                    <rect key="frame" x="0.0" y="-21" width="375" height="65"/>
                     <subviews>
                         <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZnR-ux-s6T">
-                            <rect key="frame" x="0.0" y="0.0" width="321" height="44"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                             <subviews>
                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="375" placeholderIntrinsicHeight="44" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vhM-bx-p7p" userLabel="Stack View Container">
-                                    <rect key="frame" x="0.0" y="0.0" width="650" height="44"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="ajR-7a-Sik" userLabel="Main Stack View">
-                                            <rect key="frame" x="0.0" y="0.0" width="650" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BWO-2h-I64" userLabel="Default View">
-                                                    <rect key="frame" x="0.0" y="0.0" width="321" height="44"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="177.66666666666666" height="44"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="g2p-oh-oje" userLabel="Default Stack View">
-                                                            <rect key="frame" x="16" y="0.0" width="297" height="44"/>
+                                                            <rect key="frame" x="60.000000000000007" y="0.0" width="109.66666666666669" height="44"/>
                                                             <subviews>
                                                                 <button opaque="NO" tag="28" contentMode="scaleToFill" horizontalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="t52-tF-NuA" userLabel="Format Text Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="11" width="47" height="22"/>
+                                                                    <rect key="frame" x="0.0" y="11" width="17.333333333333332" height="22"/>
                                                                     <state key="normal" image="text-formatting"/>
                                                                     <connections>
                                                                         <action selector="formatText:" destination="iN0-l3-epB" eventType="touchUpInside" id="Cu4-x9-6NR"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="29" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yVB-pz-I3S" userLabel="Format Text Style Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="53" y="11" width="52.5" height="22"/>
+                                                                    <rect key="frame" x="23.333333333333329" y="11" width="19.333333333333329" height="22"/>
                                                                     <state key="normal" image="text-formatting-style"/>
                                                                     <connections>
                                                                         <action selector="formatTextStyle:" destination="iN0-l3-epB" eventType="touchUpInside" id="1Zw-wT-rnd"/>
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="jlu-Wy-agF" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="111.5" y="12" width="2" height="20"/>
+                                                                    <rect key="frame" x="48.666666666666671" y="12" width="0.6666666666666643" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="9" contentMode="scaleToFill" horizontalCompressionResistancePriority="752" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Do1-By-Bqb" userLabel="Citation Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="119.5" y="11" width="24.5" height="22"/>
+                                                                    <rect key="frame" x="55.333333333333329" y="11" width="9" height="22"/>
                                                                     <state key="normal" image="text-formatting-add-citation"/>
                                                                     <connections>
                                                                         <action selector="toggleCitation:" destination="iN0-l3-epB" eventType="touchUpInside" id="RWg-r0-cOq"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="6" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="usu-sH-MMC" userLabel="Link Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="150" y="11" width="31" height="22"/>
+                                                                    <rect key="frame" x="70.333333333333343" y="11" width="11.666666666666671" height="22"/>
                                                                     <state key="normal" image="text-formatting-link"/>
                                                                     <connections>
                                                                         <action selector="toggleLink:" destination="iN0-l3-epB" eventType="touchUpInside" id="sdE-HW-jkI"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="10" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IXZ-uI-C7O" userLabel="Template Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="187" y="11" width="31.5" height="22"/>
+                                                                    <rect key="frame" x="88" y="11" width="9.6666666666666714" height="22"/>
                                                                     <state key="normal" image="text-formatting-curly-brackets"/>
                                                                     <connections>
                                                                         <action selector="toggleTemplate:" destination="iN0-l3-epB" eventType="touchUpInside" id="RWl-f2-2Vd"/>
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="sz5-NF-B4w" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="224.5" y="12" width="2" height="20"/>
+                                                                    <rect key="frame" x="103.66666666666666" y="12" width="0.0" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="27" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8GD-c3-cxB" userLabel="Find In Page Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="232.5" y="9.5" width="64.5" height="25"/>
+                                                                    <rect key="frame" x="109.66666666666666" y="9.3333333333333339" width="0.0" height="25.333333333333329"/>
                                                                     <state key="normal" image="find-in-page"/>
                                                                     <connections>
                                                                         <action selector="showFindInPage:" destination="iN0-l3-epB" eventType="touchUpInside" id="OPh-Dx-Itg"/>
@@ -96,13 +96,13 @@
                                                     </constraints>
                                                 </view>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="51i-1d-Lli" userLabel="Secondary View">
-                                                    <rect key="frame" x="329" y="0.0" width="321" height="44"/>
+                                                    <rect key="frame" x="197.66666666666663" y="0.0" width="177.33333333333337" height="44"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="1bz-lo-Qsh" userLabel="Secondary Stack View">
-                                                            <rect key="frame" x="16" y="0.0" width="297" height="44"/>
+                                                            <rect key="frame" x="15.999999999999993" y="0.0" width="109.33333333333331" height="44"/>
                                                             <subviews>
                                                                 <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ycB-mS-qZ3" userLabel="Unordered List Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="11" width="28.5" height="22"/>
+                                                                    <rect key="frame" x="0.0" y="11" width="10.333333333333334" height="22"/>
                                                                     <state key="normal" image="text-formatting-unordered-list"/>
                                                                     <connections>
                                                                         <action selector="decreaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="5Pf-Sl-jzD"/>
@@ -110,7 +110,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MjG-se-XpY" userLabel="Ordered List Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="34.5" y="11" width="28.5" height="22"/>
+                                                                    <rect key="frame" x="16.333333333333343" y="11" width="10.333333333333336" height="22"/>
                                                                     <state key="normal" image="text-formatting-ordered-list"/>
                                                                     <connections>
                                                                         <action selector="increaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="iOK-bK-63R"/>
@@ -118,50 +118,50 @@
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="bkM-bA-d3o" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="69" y="12" width="1.5" height="20"/>
+                                                                    <rect key="frame" x="32.666666666666686" y="12" width="0.6666666666666643" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="21" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M2s-Up-JEt" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="76.5" y="11" width="28.5" height="22"/>
+                                                                    <rect key="frame" x="39.333333333333343" y="11" width="10.666666666666664" height="22"/>
                                                                     <state key="normal" image="text-formatting-decrease-indent"/>
                                                                     <connections>
                                                                         <action selector="decreaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="bGk-wN-Y56"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="22" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dRI-FL-20t" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="111" y="11" width="28.5" height="22"/>
+                                                                    <rect key="frame" x="56.000000000000028" y="11" width="10.333333333333329" height="22"/>
                                                                     <state key="normal" image="text-formatting-increase-indent"/>
                                                                     <connections>
                                                                         <action selector="increaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="chF-z3-SBA"/>
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="zrK-Kd-SnN" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="145.5" y="12" width="1.5" height="20"/>
+                                                                    <rect key="frame" x="72.333333333333343" y="12" width="0.6666666666666714" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="23" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bcH-OJ-MDT" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="153" y="11" width="30" height="22"/>
+                                                                    <rect key="frame" x="79.000000000000028" y="11" width="11" height="22"/>
                                                                     <state key="normal" image="directionUp"/>
                                                                     <connections>
                                                                         <action selector="moveCursorUp:" destination="iN0-l3-epB" eventType="touchUpInside" id="SvW-C1-J2E"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="24" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r2W-3b-3SP" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="189" y="11" width="28.5" height="22"/>
+                                                                    <rect key="frame" x="96.000000000000028" y="11" width="1.3333333333333286" height="22"/>
                                                                     <state key="normal" image="directionDown"/>
                                                                     <connections>
                                                                         <action selector="moveCursorDown:" destination="iN0-l3-epB" eventType="touchUpInside" id="i1T-s3-dx4"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="25" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G3W-Xz-reX" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="223.5" y="11" width="19" height="22"/>
+                                                                    <rect key="frame" x="103.33333333333334" y="11" width="0.0" height="22"/>
                                                                     <state key="normal" image="directionLeft"/>
                                                                     <connections>
                                                                         <action selector="moveCursorLeft:" destination="iN0-l3-epB" eventType="touchUpInside" id="8ZI-Dx-nTQ"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="26" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nSf-Yo-A6r" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="248.5" y="11" width="48.5" height="22"/>
+                                                                    <rect key="frame" x="109.33333333333334" y="11" width="0.0" height="22"/>
                                                                     <state key="normal" image="directionRight"/>
                                                                     <connections>
                                                                         <action selector="moveCursorRight:" destination="iN0-l3-epB" eventType="touchUpInside" id="cxG-ce-e4c"/>
@@ -231,7 +231,7 @@
                             </variation>
                         </scrollView>
                         <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="25k-rm-GLR">
-                            <rect key="frame" x="329" y="10" width="30" height="24"/>
+                            <rect key="frame" x="311" y="10" width="0.0" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="30" id="KBZ-Wb-t1T"/>
                                 <constraint firstAttribute="width" id="chZ-0u-nI7"/>
@@ -246,11 +246,13 @@
                             </variation>
                             <variation key="heightClass=compact-widthClass=compact" hidden="YES">
                                 <mask key="constraints">
+                                    <exclude reference="KBZ-Wb-t1T"/>
                                     <include reference="chZ-0u-nI7"/>
                                 </mask>
                             </variation>
                             <variation key="heightClass=compact-widthClass=regular" hidden="YES">
                                 <mask key="constraints">
+                                    <exclude reference="KBZ-Wb-t1T"/>
                                     <include reference="chZ-0u-nI7"/>
                                 </mask>
                             </variation>

--- a/Wikipedia/Code/DefaultEditToolbarView.xib
+++ b/Wikipedia/Code/DefaultEditToolbarView.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina5_5" orientation="portrait">
+    <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -21,19 +21,19 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                     <subviews>
                         <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZnR-ux-s6T">
-                            <rect key="frame" x="0.0" y="0.0" width="256" height="44"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                             <subviews>
                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="375" placeholderIntrinsicHeight="44" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vhM-bx-p7p" userLabel="Stack View Container">
-                                    <rect key="frame" x="0.0" y="0.0" width="528" height="44"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="ajR-7a-Sik" userLabel="Main Stack View">
-                                            <rect key="frame" x="0.0" y="0.0" width="520" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="355" height="44"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BWO-2h-I64" userLabel="Default View">
-                                                    <rect key="frame" x="0.0" y="0.0" width="256" height="44"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="167.5" height="44"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="g2p-oh-oje" userLabel="Default Stack View">
-                                                            <rect key="frame" x="16" y="0.0" width="232" height="44"/>
+                                                            <rect key="frame" x="16" y="0.0" width="143.5" height="44"/>
                                                             <subviews>
                                                                 <button opaque="NO" tag="28" contentMode="scaleToFill" horizontalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="t52-tF-NuA" userLabel="Format Text Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
                                                                     <rect key="frame" x="0.0" y="11" width="27" height="22"/>
@@ -43,43 +43,43 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="29" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yVB-pz-I3S" userLabel="Format Text Style Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="42" y="11" width="30" height="22"/>
+                                                                    <rect key="frame" x="29" y="11" width="30" height="22"/>
                                                                     <state key="normal" image="text-formatting-style"/>
                                                                     <connections>
                                                                         <action selector="formatTextStyle:" destination="iN0-l3-epB" eventType="touchUpInside" id="1Zw-wT-rnd"/>
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="jlu-Wy-agF" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="86.666666666666671" y="12" width="1" height="20"/>
+                                                                    <rect key="frame" x="61.5" y="12" width="1" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="9" contentMode="scaleToFill" horizontalCompressionResistancePriority="752" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Do1-By-Bqb" userLabel="Citation Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="102.66666666666667" y="11" width="14" height="22"/>
+                                                                    <rect key="frame" x="64.5" y="11" width="14" height="22"/>
                                                                     <state key="normal" image="text-formatting-add-citation"/>
                                                                     <connections>
                                                                         <action selector="toggleCitation:" destination="iN0-l3-epB" eventType="touchUpInside" id="RWg-r0-cOq"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="6" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="usu-sH-MMC" userLabel="Link Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="131.33333333333334" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="81" y="11" width="18" height="22"/>
                                                                     <state key="normal" image="text-formatting-link"/>
                                                                     <connections>
                                                                         <action selector="toggleLink:" destination="iN0-l3-epB" eventType="touchUpInside" id="sdE-HW-jkI"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="10" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IXZ-uI-C7O" userLabel="Template Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="164.33333333333334" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="101" y="11" width="18" height="22"/>
                                                                     <state key="normal" image="text-formatting-curly-brackets"/>
                                                                     <connections>
                                                                         <action selector="toggleTemplate:" destination="iN0-l3-epB" eventType="touchUpInside" id="RWl-f2-2Vd"/>
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="sz5-NF-B4w" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="197" y="12" width="1" height="20"/>
+                                                                    <rect key="frame" x="121.5" y="12" width="1" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="27" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8GD-c3-cxB" userLabel="Find In Page Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="213" y="9.6666666666666643" width="19" height="25"/>
+                                                                    <rect key="frame" x="124.5" y="9.5" width="19" height="25"/>
                                                                     <state key="normal" image="find-in-page"/>
                                                                     <connections>
                                                                         <action selector="showFindInPage:" destination="iN0-l3-epB" eventType="touchUpInside" id="OPh-Dx-Itg"/>
@@ -96,10 +96,10 @@
                                                     </constraints>
                                                 </view>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="51i-1d-Lli" userLabel="Secondary View">
-                                                    <rect key="frame" x="264" y="0.0" width="256" height="44"/>
+                                                    <rect key="frame" x="187.5" y="0.0" width="167.5" height="44"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="1bz-lo-Qsh" userLabel="Secondary Stack View">
-                                                            <rect key="frame" x="16" y="0.0" width="232" height="44"/>
+                                                            <rect key="frame" x="16" y="0.0" width="143.5" height="44"/>
                                                             <subviews>
                                                                 <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ycB-mS-qZ3" userLabel="Unordered List Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
                                                                     <rect key="frame" x="0.0" y="11" width="18" height="22"/>
@@ -110,7 +110,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MjG-se-XpY" userLabel="Ordered List Button" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="29" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="19" y="11" width="18" height="22"/>
                                                                     <state key="normal" image="text-formatting-ordered-list"/>
                                                                     <connections>
                                                                         <action selector="increaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="iOK-bK-63R"/>
@@ -118,50 +118,50 @@
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="bkM-bA-d3o" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="57.666666666666686" y="12" width="1" height="20"/>
+                                                                    <rect key="frame" x="38" y="12" width="1" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="21" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M2s-Up-JEt" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="69.666666666666686" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="40" y="11" width="18" height="22"/>
                                                                     <state key="normal" image="text-formatting-decrease-indent"/>
                                                                     <connections>
                                                                         <action selector="decreaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="bGk-wN-Y56"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="22" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dRI-FL-20t" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="98.666666666666686" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="59" y="11" width="18" height="22"/>
                                                                     <state key="normal" image="text-formatting-increase-indent"/>
                                                                     <connections>
                                                                         <action selector="increaseIndentation:" destination="iN0-l3-epB" eventType="touchUpInside" id="chF-z3-SBA"/>
                                                                     </connections>
                                                                 </button>
                                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="1" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="zrK-Kd-SnN" customClass="ToolbarSeparatorView" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="127.33333333333331" y="12" width="1" height="20"/>
+                                                                    <rect key="frame" x="78.5" y="12" width="1" height="20"/>
                                                                     <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </view>
                                                                 <button opaque="NO" tag="23" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bcH-OJ-MDT" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="139.33333333333331" y="11" width="19" height="22"/>
+                                                                    <rect key="frame" x="80.5" y="11" width="19" height="22"/>
                                                                     <state key="normal" image="directionUp"/>
                                                                     <connections>
                                                                         <action selector="moveCursorUp:" destination="iN0-l3-epB" eventType="touchUpInside" id="SvW-C1-J2E"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="24" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r2W-3b-3SP" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="169.33333333333331" y="11" width="18" height="22"/>
+                                                                    <rect key="frame" x="100.5" y="11" width="18" height="22"/>
                                                                     <state key="normal" image="directionDown"/>
                                                                     <connections>
                                                                         <action selector="moveCursorDown:" destination="iN0-l3-epB" eventType="touchUpInside" id="i1T-s3-dx4"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="25" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G3W-Xz-reX" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="198" y="11" width="12" height="22"/>
+                                                                    <rect key="frame" x="119.5" y="11" width="12" height="22"/>
                                                                     <state key="normal" image="directionLeft"/>
                                                                     <connections>
                                                                         <action selector="moveCursorLeft:" destination="iN0-l3-epB" eventType="touchUpInside" id="8ZI-Dx-nTQ"/>
                                                                     </connections>
                                                                 </button>
                                                                 <button opaque="NO" tag="26" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nSf-Yo-A6r" customClass="TextFormattingButton" customModule="Wikipedia" customModuleProvider="target">
-                                                                    <rect key="frame" x="221" y="11" width="11" height="22"/>
+                                                                    <rect key="frame" x="132.5" y="11" width="11" height="22"/>
                                                                     <state key="normal" image="directionRight"/>
                                                                     <connections>
                                                                         <action selector="moveCursorRight:" destination="iN0-l3-epB" eventType="touchUpInside" id="cxG-ce-e4c"/>
@@ -186,6 +186,7 @@
                                             <gestureRecognizers/>
                                             <variation key="heightClass=compact-widthClass=compact" distribution="fillEqually" spacing="20"/>
                                             <variation key="heightClass=compact-widthClass=regular" distribution="fillEqually" spacing="20"/>
+                                            <variation key="heightClass=regular-widthClass=regular" distribution="fillEqually" spacing="20"/>
                                         </stackView>
                                     </subviews>
                                     <constraints>
@@ -222,9 +223,15 @@
                                     <exclude reference="yH6-Nh-KTL"/>
                                 </mask>
                             </variation>
+                            <variation key="heightClass=regular-widthClass=regular">
+                                <mask key="constraints">
+                                    <exclude reference="UqM-eZ-wld"/>
+                                    <exclude reference="yH6-Nh-KTL"/>
+                                </mask>
+                            </variation>
                         </scrollView>
                         <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="25k-rm-GLR">
-                            <rect key="frame" x="264" y="10" width="91" height="24"/>
+                            <rect key="frame" x="355" y="10" width="0.0" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="width" id="chZ-0u-nI7"/>
                                 <constraint firstAttribute="height" constant="24" id="rje-us-hjK"/>
@@ -242,6 +249,11 @@
                                 </mask>
                             </variation>
                             <variation key="heightClass=compact-widthClass=regular" hidden="YES">
+                                <mask key="constraints">
+                                    <include reference="chZ-0u-nI7"/>
+                                </mask>
+                            </variation>
+                            <variation key="heightClass=regular-widthClass=regular" hidden="YES">
                                 <mask key="constraints">
                                     <include reference="chZ-0u-nI7"/>
                                 </mask>
@@ -277,6 +289,13 @@
                         </mask>
                     </variation>
                     <variation key="heightClass=compact-widthClass=regular">
+                        <mask key="constraints">
+                            <include reference="Zlo-fb-zDB"/>
+                            <include reference="gEH-3O-D4m"/>
+                            <exclude reference="shr-1D-h3f"/>
+                        </mask>
+                    </variation>
+                    <variation key="heightClass=regular-widthClass=regular">
                         <mask key="constraints">
                             <include reference="Zlo-fb-zDB"/>
                             <include reference="gEH-3O-D4m"/>


### PR DESCRIPTION
Question for @carolynlimadeo - 

Paper maintains a visual separation of tool sets on landscape, do we want to do the same or merge all?

![img_3144](https://user-images.githubusercontent.com/9299317/52667949-3b108080-2ee0-11e9-9ed3-f0a25373dd6b.PNG)


![simulator screen shot - iphone xs max - 2019-02-12 at 16 05 51](https://user-images.githubusercontent.com/9299317/52667920-2af8a100-2ee0-11e9-9d9d-8f10c5aebf6e.png)


