### PR TITLE
Less invasive fix for empty SFSafariViewController bug

### DIFF
--- a/Wikipedia/Code/ArticleCollectionViewController.swift
+++ b/Wikipedia/Code/ArticleCollectionViewController.swift
@@ -33,6 +33,10 @@ class ArticleCollectionViewController: ColumnarCollectionViewController, Editabl
         editController.configureSwipeableCell(cell, forItemAt: indexPath, layoutOnly: layoutOnly)
     }
     
+    open func isExternalURL(at indexPath: IndexPath) -> Bool {
+        return false
+    }
+    
     open func articleURL(at indexPath: IndexPath) -> URL? {
         assert(false, "Subclassers should override this function")
         return nil
@@ -166,6 +170,10 @@ extension ArticleCollectionViewController {
             return
         }
         delegate?.articleCollectionViewController(self, didSelectArticleWithURL: articleURL, at: indexPath)
+        guard !isExternalURL(at: indexPath) else {
+            wmf_openExternalUrl(articleURL)
+            return
+        }
         wmf_pushArticle(with: articleURL, dataStore: dataStore, theme: theme, animated: true)
     }
     

--- a/Wikipedia/Code/SearchResultsViewController.swift
+++ b/Wikipedia/Code/SearchResultsViewController.swift
@@ -34,6 +34,10 @@ class SearchResultsViewController: ArticleCollectionViewController {
         return .search
     }
     
+    override func isExternalURL(at indexPath: IndexPath) -> Bool {
+        return results[indexPath.item].titleNamespace?.intValue ?? 0 != 0
+    }
+    
     override func articleURL(at indexPath: IndexPath) -> URL? {
         return results[indexPath.item].articleURL(forSiteURL: searchSiteURL)
     }

--- a/Wikipedia/Code/UIViewController+WMFOpenExternalUrl.m
+++ b/Wikipedia/Code/UIViewController+WMFOpenExternalUrl.m
@@ -19,18 +19,18 @@
 - (void)wmf_openExternalUrlModallyIfNeeded:(NSURL *)url forceSafari:(BOOL)forceSafari {
     url = url.wmf_URLByMakingiOSCompatibilityAdjustments;
 
-    //    if (forceSafari || [url.scheme.lowercaseString isEqualToString:@"mailto"]) {
-    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:NULL];
-    //    } else {
-    //        if (self.presentedViewController) {
-    //            [self dismissViewControllerAnimated:YES
-    //                                     completion:^{
-    //                                         [self wmf_presentExternalUrlWithinApp:url];
-    //                                     }];
-    //            return;
-    //        }
-    //        [self wmf_presentExternalUrlWithinApp:url];
-    //    }
+    if (forceSafari || [url.scheme.lowercaseString isEqualToString:@"mailto"]) {
+        [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:NULL];
+    } else {
+        if (self.presentedViewController) {
+            [self dismissViewControllerAnimated:YES
+                                     completion:^{
+                                         [self wmf_presentExternalUrlWithinApp:url];
+                                     }];
+            return;
+        }
+        [self wmf_presentExternalUrlWithinApp:url];
+    }
 }
 
 - (void)wmf_presentExternalUrlWithinApp:(NSURL *)url {

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1346,6 +1346,8 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
     [self fetchArticleForce:NO];
 }
 
+// Shows external URL as a child VC - works around an issue where pushing a SFSafariViewController
+// while removing this VC from the stack would put the app in a state where it needed to be force quit
 - (void)showExternalURL:(NSURL *)externalURL {
     SFSafariViewController *vc = [[SFSafariViewController alloc] initWithURL:externalURL];
     vc.delegate = self;
@@ -1777,8 +1779,9 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
 }
 
 - (void)showTalkPage {
-    SFSafariViewController *safariController = [[SFSafariViewController alloc] initWithURL:self.articleTalkPageURL];
-    [self.navigationController presentViewController:safariController animated:YES completion:nil];
+    // use wmf_openExternal instead of showExternalURL because this VC
+    // should be pushed on the stack instead of displayed here
+    [self wmf_openExternalUrl:self.articleTalkPageURL];
 }
 
 - (NSURL *)articleTalkPageURL {

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -22,7 +22,6 @@
 #import "UIViewController+WMFEmptyView.h"
 #import "UIBarButtonItem+WMFButtonConvenience.h"
 #import "UIScrollView+WMFContentOffsetUtils.h"
-#import "UIViewController+WMFOpenExternalUrl.h"
 #import "WMFArticleTextActivitySource.h"
 #import "UIImageView+WMFFaceDetectionBasedOnUIApplicationSharedApplication.h"
 #import "UIBarButtonItem+WMFButtonConvenience.h"


### PR DESCRIPTION
* Instead of doing a pop/push to replace the article vc with the `SFSafariViewController`, display the `SFSafariViewController` as a full screen child vc of the article vc 
* Use namespace returned by search to prevent pushing non-articles to the article vc in the first place

https://phabricator.wikimedia.org/T214690