### PR TITLE
Fix gap in search results after rotating

### DIFF
--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -53,6 +53,7 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
         super.viewWillTransition(to: size, with: coordinator)
         coordinator.animate(alongsideTransition: { (context) in
             self.view.setNeedsLayout()
+            self.resultsViewController.view.setNeedsLayout()
             self.view.layoutIfNeeded()
         })
     }


### PR DESCRIPTION
Not sure why but occasionally the resultsViewController wouldn't lay out after rotation, which is needed for it to pick up the new navigation bar visibleHeight and adjust the content inset. This feels like a bit of a band-aid but explicitly setting needs layout here fixes it.

https://phabricator.wikimedia.org/T215646