### PR TITLE
Fix bold and italic markup behavior

### DIFF
--- a/Wikipedia/assets/codemirror/codemirror-index.html
+++ b/Wikipedia/assets/codemirror/codemirror-index.html
@@ -602,21 +602,9 @@
         if ((info.openDistance == 0 && info.closeDistance == 0) || info.selectionLength == 0) {
           unwrapSelectionWith(info.openMatch, info.closeMatch)
         } else if (info.openDistance == 0 && info.closeDistance > 0) { // slide opening markup to the right
-          const selectedText = editor.getSelection()
-          const selectionRange = getSelectionRange(editor)
-          const replacement = `${selectedText}${info.openMatch}`
-          const line = selectionRange.line
-          const from = { line: line, ch: selectionRange.start - info.openMatch.length }
-          const to = { line: line, ch: selectionRange.end }
-          editor.replaceRange(replacement, from, to)
-        } else if (info.openDistance >= 0 && info.closeDistance == 0) { // slide closing markup to the left
-          const selectedText = editor.getSelection()
-          const selectionRange = getSelectionRange(editor)
-          const replacement = `${info.closeMatch}${selectedText}`
-          const line = selectionRange.line
-          const from = { line: line, ch: selectionRange.start }
-          const to = { line: line, ch: selectionRange.end + info.closeMatch.length }
-          editor.replaceRange(replacement, from, to)
+          slideMarkupRight(info.openMatch)
+        } else if (info.openDistance > 0 && info.closeDistance == 0) { // slide closing markup to the left
+          slideMarkupLeft(info.closeMatch)
         } else {
           wrapSelectionWith(defaultClosingMarkup, defaultOpeningMarkup)
         }

--- a/Wikipedia/assets/codemirror/codemirror-index.html
+++ b/Wikipedia/assets/codemirror/codemirror-index.html
@@ -543,13 +543,49 @@
       const info = identicalMarkupSelectionWrapInfo(markup)
       return info.selectionLength == 0 ? info.beforeIndex >= 0 && info.afterIndex >= 0 : info.beforeIndex == 0 && info.afterIndex == 0
     }
+    
+    const slideMarkupLeft = (markup) => {
+      const selectedText = editor.getSelection()
+      const selectionRange = getSelectionRange(editor)
+      const replacement = `${markup}${selectedText}`
+      const line = selectionRange.line
+      const from = { line: line, ch: selectionRange.start }
+      const to = { line: line, ch: selectionRange.end + markup.length }
+      editor.replaceRange(replacement, from, to)
+    }
+    
+    const slideMarkupRight = (markup) => {
+      const selectedText = editor.getSelection()
+      const selectionRange = getSelectionRange(editor)
+      const replacement = `${selectedText}${markup}`
+      const line = selectionRange.line
+      const from = { line: line, ch: selectionRange.start - markup.length }
+      const to = { line: line, ch: selectionRange.end }
+      editor.replaceRange(replacement, from, to)
+    }
   
     const toggleIdenticalMarkup = (button, markup) => {
       const info = identicalMarkupSelectionWrapInfo(markup)
-      if (info.selectionLength == 0 || (info.beforeIndex == 0 && info.afterIndex == 0))  {
-        unwrapSelectionWith(markup)
+      if (info.beforeIndex >= 0 && info.afterIndex >= 0) {
+        if (info.selectionLength == 0 || (info.beforeIndex == 0 && info.afterIndex == 0)) {
+          unwrapSelectionWith(markup, markup)
+        } else if (info.beforeIndex == 0 && info.afterIndex > 0) { // slide opening markup to the right
+          slideMarkupRight(markup)
+        } else if (info.beforeIndex > 0 && info.afterIndex == 0) { // slide closing markup to the left
+          slideMarkupLeft(markup)
+        } else {
+          wrapSelectionWith(markup, markup)
+        }
+      } else if (info.beforeIndex == 0 && info.afterIndex == 0)  {
+        unwrapSelectionWith(markup, markup)
       } else {
-        wrapSelectionWith(markup)
+        if (info.afterIndex == 0) {
+          slideMarkupLeft(markup)
+        } else if (info.beforeIndex == 0) {
+          slideMarkupRight(markup)
+        } else {
+          wrapSelectionWith(markup, markup)
+        }
       }
     }
     

--- a/Wikipedia/assets/codemirror/codemirror-index.html
+++ b/Wikipedia/assets/codemirror/codemirror-index.html
@@ -577,7 +577,9 @@
           wrapSelectionWith(markup, markup)
         }
       } else {
-        if (info.afterIndex == 0) {
+        if (info.selectionLength == 0) {
+          wrapSelectionWith(markup, markup)
+        } else if (info.afterIndex == 0) {
           slideMarkupLeft(markup)
         } else if (info.beforeIndex == 0) {
           slideMarkupRight(markup)
@@ -609,8 +611,14 @@
           wrapSelectionWith(defaultClosingMarkup, defaultOpeningMarkup)
         }
       } else { // not wrapped with markup
-        if (info.priorCloseDistance == 0 && info.nextOpenDistance == 0) {
+        if (info.selectionLength == 0) {
+          wrapSelectionWith(defaultOpeningMarkup, defaultClosingMarkup)
+        } else if (info.priorCloseDistance == 0 && info.nextOpenDistance == 0) {
           unwrapSelectionWith(info.priorCloseMatch, info.nextOpenMatch)
+        } else if (info.nextOpenDistance == 0) {
+          slideMarkupLeft(info.nextOpenMatch)
+        } else if (info.priorCloseDistance == 0) {
+          slideMarkupRight(info.priorCloseMatch)
         } else {
           wrapSelectionWith(defaultOpeningMarkup, defaultClosingMarkup)
         }

--- a/Wikipedia/assets/codemirror/codemirror-index.html
+++ b/Wikipedia/assets/codemirror/codemirror-index.html
@@ -576,8 +576,6 @@
         } else {
           wrapSelectionWith(markup, markup)
         }
-      } else if (info.beforeIndex == 0 && info.afterIndex == 0)  {
-        unwrapSelectionWith(markup, markup)
       } else {
         if (info.afterIndex == 0) {
           slideMarkupLeft(markup)

--- a/www/codemirror/codemirror-index.html
+++ b/www/codemirror/codemirror-index.html
@@ -602,21 +602,9 @@
         if ((info.openDistance == 0 && info.closeDistance == 0) || info.selectionLength == 0) {
           unwrapSelectionWith(info.openMatch, info.closeMatch)
         } else if (info.openDistance == 0 && info.closeDistance > 0) { // slide opening markup to the right
-          const selectedText = editor.getSelection()
-          const selectionRange = getSelectionRange(editor)
-          const replacement = `${selectedText}${info.openMatch}`
-          const line = selectionRange.line
-          const from = { line: line, ch: selectionRange.start - info.openMatch.length }
-          const to = { line: line, ch: selectionRange.end }
-          editor.replaceRange(replacement, from, to)
-        } else if (info.openDistance >= 0 && info.closeDistance == 0) { // slide closing markup to the left
-          const selectedText = editor.getSelection()
-          const selectionRange = getSelectionRange(editor)
-          const replacement = `${info.closeMatch}${selectedText}`
-          const line = selectionRange.line
-          const from = { line: line, ch: selectionRange.start }
-          const to = { line: line, ch: selectionRange.end + info.closeMatch.length }
-          editor.replaceRange(replacement, from, to)
+          slideMarkupRight(info.openMatch)
+        } else if (info.openDistance > 0 && info.closeDistance == 0) { // slide closing markup to the left
+          slideMarkupLeft(info.closeMatch)
         } else {
           wrapSelectionWith(defaultClosingMarkup, defaultOpeningMarkup)
         }

--- a/www/codemirror/codemirror-index.html
+++ b/www/codemirror/codemirror-index.html
@@ -543,13 +543,49 @@
       const info = identicalMarkupSelectionWrapInfo(markup)
       return info.selectionLength == 0 ? info.beforeIndex >= 0 && info.afterIndex >= 0 : info.beforeIndex == 0 && info.afterIndex == 0
     }
+    
+    const slideMarkupLeft = (markup) => {
+      const selectedText = editor.getSelection()
+      const selectionRange = getSelectionRange(editor)
+      const replacement = `${markup}${selectedText}`
+      const line = selectionRange.line
+      const from = { line: line, ch: selectionRange.start }
+      const to = { line: line, ch: selectionRange.end + markup.length }
+      editor.replaceRange(replacement, from, to)
+    }
+    
+    const slideMarkupRight = (markup) => {
+      const selectedText = editor.getSelection()
+      const selectionRange = getSelectionRange(editor)
+      const replacement = `${selectedText}${markup}`
+      const line = selectionRange.line
+      const from = { line: line, ch: selectionRange.start - markup.length }
+      const to = { line: line, ch: selectionRange.end }
+      editor.replaceRange(replacement, from, to)
+    }
   
     const toggleIdenticalMarkup = (button, markup) => {
       const info = identicalMarkupSelectionWrapInfo(markup)
-      if (info.selectionLength == 0 || (info.beforeIndex == 0 && info.afterIndex == 0))  {
-        unwrapSelectionWith(markup)
+      if (info.beforeIndex >= 0 && info.afterIndex >= 0) {
+        if (info.selectionLength == 0 || (info.beforeIndex == 0 && info.afterIndex == 0)) {
+          unwrapSelectionWith(markup, markup)
+        } else if (info.beforeIndex == 0 && info.afterIndex > 0) { // slide opening markup to the right
+          slideMarkupRight(markup)
+        } else if (info.beforeIndex > 0 && info.afterIndex == 0) { // slide closing markup to the left
+          slideMarkupLeft(markup)
+        } else {
+          wrapSelectionWith(markup, markup)
+        }
+      } else if (info.beforeIndex == 0 && info.afterIndex == 0)  {
+        unwrapSelectionWith(markup, markup)
       } else {
-        wrapSelectionWith(markup)
+        if (info.afterIndex == 0) {
+          slideMarkupLeft(markup)
+        } else if (info.beforeIndex == 0) {
+          slideMarkupRight(markup)
+        } else {
+          wrapSelectionWith(markup, markup)
+        }
       }
     }
     

--- a/www/codemirror/codemirror-index.html
+++ b/www/codemirror/codemirror-index.html
@@ -577,7 +577,9 @@
           wrapSelectionWith(markup, markup)
         }
       } else {
-        if (info.afterIndex == 0) {
+        if (info.selectionLength == 0) {
+          wrapSelectionWith(markup, markup)
+        } else if (info.afterIndex == 0) {
           slideMarkupLeft(markup)
         } else if (info.beforeIndex == 0) {
           slideMarkupRight(markup)
@@ -609,8 +611,14 @@
           wrapSelectionWith(defaultClosingMarkup, defaultOpeningMarkup)
         }
       } else { // not wrapped with markup
-        if (info.priorCloseDistance == 0 && info.nextOpenDistance == 0) {
+        if (info.selectionLength == 0) {
+          wrapSelectionWith(defaultOpeningMarkup, defaultClosingMarkup)
+        } else if (info.priorCloseDistance == 0 && info.nextOpenDistance == 0) {
           unwrapSelectionWith(info.priorCloseMatch, info.nextOpenMatch)
+        } else if (info.nextOpenDistance == 0) {
+          slideMarkupLeft(info.nextOpenMatch)
+        } else if (info.priorCloseDistance == 0) {
+          slideMarkupRight(info.priorCloseMatch)
         } else {
           wrapSelectionWith(defaultOpeningMarkup, defaultClosingMarkup)
         }

--- a/www/codemirror/codemirror-index.html
+++ b/www/codemirror/codemirror-index.html
@@ -576,8 +576,6 @@
         } else {
           wrapSelectionWith(markup, markup)
         }
-      } else if (info.beforeIndex == 0 && info.afterIndex == 0)  {
-        unwrapSelectionWith(markup, markup)
       } else {
         if (info.afterIndex == 0) {
           slideMarkupLeft(markup)


### PR DESCRIPTION
Missed some things bringing back the 6.2 implementation for identical markup. This fix properly reverts to the 6.2 implementation and clarifies slide left/right behavior.

Fix for bug found in design review on https://phabricator.wikimedia.org/T211617