### PR TITLE
Percent encode `=` characters in query items

### DIFF
--- a/WMF Framework/NSCharacterSet+WMFLinkParsing.h
+++ b/WMF Framework/NSCharacterSet+WMFLinkParsing.h
@@ -3,6 +3,5 @@
 @interface NSCharacterSet (WMFLinkParsing)
 
 + (NSCharacterSet *)wmf_URLArticleTitlePathComponentAllowedCharacterSet;
-+ (NSCharacterSet *)wmf_URLQueryAllowedCharacterSet;
 
 @end

--- a/WMF Framework/NSCharacterSet+WMFLinkParsing.m
+++ b/WMF Framework/NSCharacterSet+WMFLinkParsing.m
@@ -13,15 +13,4 @@
     return wmf_URLArticleTitleAllowedCharacterSet;
 }
 
-+ (NSCharacterSet *)wmf_URLQueryAllowedCharacterSet {
-    static dispatch_once_t onceToken;
-    static NSCharacterSet *wmf_URLQueryAllowedCharacterSet;
-    dispatch_once(&onceToken, ^{
-        NSMutableCharacterSet *queryAllowedCharacterSet = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
-        [queryAllowedCharacterSet removeCharactersInString:@"+&"];
-        wmf_URLQueryAllowedCharacterSet = [queryAllowedCharacterSet copy];
-    });
-    return wmf_URLQueryAllowedCharacterSet;
-}
-
 @end

--- a/WMF Framework/URLComponents+Extensions.swift
+++ b/WMF Framework/URLComponents+Extensions.swift
@@ -14,8 +14,8 @@ extension URLComponents {
         var query = ""
         for (name, value) in queryParameters {
             guard
-                let encodedName = name.addingPercentEncoding(withAllowedCharacters: CharacterSet.wmf_urlQueryAllowed),
-                let encodedValue = String(describing: value).addingPercentEncoding(withAllowedCharacters: CharacterSet.wmf_urlQueryAllowed) else {
+                let encodedName = name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryComponentAllowed),
+                let encodedValue = String(describing: value).addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryComponentAllowed) else {
                     continue
             }
             if query != "" {

--- a/Wikipedia/Code/URL+WMFLinkParsing.swift
+++ b/Wikipedia/Code/URL+WMFLinkParsing.swift
@@ -5,9 +5,11 @@ extension CharacterSet {
         return NSCharacterSet.wmf_URLArticleTitlePathComponentAllowed()
     }
 
-    static var wmf_urlQueryAllowed: CharacterSet {
-        return NSCharacterSet.wmf_URLQueryAllowed()
-    }
+    static let urlQueryComponentAllowed: CharacterSet = {
+        var characterSet = CharacterSet.urlQueryAllowed
+        characterSet.remove(charactersIn: "+&=")
+        return characterSet
+    }()
 }
 
 extension URL {


### PR DESCRIPTION
This is working fine as it was - searches containing `=` work even though they produce query strings like `srsearch==`. However, it seems that according to [RFC 3986](https://tools.ietf.org/html/rfc3986#section-2.1) and the [Mozilla dev docs](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding), `=` should be encoded.

This character set and the manual encoding of the query parameters exist[ so that `+` is encoded](https://phabricator.wikimedia.org/T178947#3753564) in query item components - something `URLComponents` doesn't handle by default.