### PR TITLE
Fix reading lists sync token

### DIFF
--- a/WMF Framework/Fetcher.swift
+++ b/WMF Framework/Fetcher.swift
@@ -43,16 +43,16 @@ open class Fetcher: NSObject {
             guard
                 let query = result?["query"] as? [String: Any],
                 let tokens = query["tokens"] as? [String: Any],
-                let token = tokens[type.stringValue + "token"] as? String
+                let tokenValue = tokens[type.stringValue + "token"] as? String
                 else {
                     completionHandler(FetcherResult.failure(RequestError.unexpectedResponse))
                     return
             }
-            guard !token.isEmpty else {
+            guard !tokenValue.isEmpty else {
                 completionHandler(FetcherResult.failure(RequestError.unexpectedResponse))
                 return
             }
-            completionHandler(FetcherResult.success(Token(token: token, type: type)))
+            completionHandler(FetcherResult.success(Token(value: tokenValue, type: type)))
         }
     }
     
@@ -79,7 +79,7 @@ open class Fetcher: NSObject {
                 self.untrack(taskFor: key)
             case .success(let token):
                 var mutableBodyParameters = bodyParameters ?? [:]
-                mutableBodyParameters[tokenType.parameterName] = token.token
+                mutableBodyParameters[tokenType.parameterName] = token.value
                 self.performMediaWikiAPIPOST(for: URL, with: mutableBodyParameters, cancellationKey: key, completionHandler: completionHandler)
             }
         }
@@ -190,13 +190,13 @@ public enum TokenType: Int {
 
 @objc(WMFToken)
 public class Token: NSObject {
-    @objc public var token: String
+    @objc public var value: String
     @objc public var type: TokenType
     public var isAuthorized: Bool
-    @objc init(token: String, type: TokenType) {
-        self.token = token
+    @objc init(value: String, type: TokenType) {
+        self.value = value
         self.type = type
-        self.isAuthorized = token != "+\\"
+        self.isAuthorized = value != "+\\"
     }
 }
 

--- a/WMF Framework/ReadingListsAPIController.swift
+++ b/WMF Framework/ReadingListsAPIController.swift
@@ -146,7 +146,7 @@ class ReadingListsAPIController: Fetcher {
             case .failure(let error):
                 completion(nil, nil, error)
             case .success(let token):
-                let tokenQueryParameters = ["csrf_token": token]
+                let tokenQueryParameters = ["csrf_token": token.value]
                 var componentsWithToken = components
                 componentsWithToken.appendQueryParametersToPercentEncodedQuery(tokenQueryParameters)
                 let identifier =  UUID().uuidString

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -84,7 +84,7 @@ enum WikidataPublishingError: LocalizedError {
                                           "uselang": normalizedLanguage,
                                           "id": wikidataID,
                                           "value": newWikidataDescription,
-                                          "token": token.token]
+                                          "token": token.value]
                     self.session.jsonDecodableTask(with: components.url, method: .post, bodyParameters: bodyParameters, bodyEncoding: .form) { (result: WikidataAPIResult?, response, error) in
                         requestWithCSRFCompletion(result, response, token.isAuthorized, error)
                     }


### PR DESCRIPTION
Follow-up for https://phabricator.wikimedia.org/T217428#4999101

Initial reading lists setup fails because of `badtoken` response