### PR TITLE
Consolidate summary handling, reduce dependence on MWKSearchResult

### DIFF
--- a/WMF Framework/RelatedSearchFetcher.swift
+++ b/WMF Framework/RelatedSearchFetcher.swift
@@ -2,54 +2,7 @@ import Foundation
 
 @objc(WMFRelatedSearchFetcher)
 final class RelatedSearchFetcher: Fetcher {
-    @objc static let MaxResultLimit = 20
-
-    private struct RelatedPages: Decodable {
-        let pages: [Page]?
-        struct Page: Decodable {
-            let id: Int?
-            let revision: String?
-            let index: Int?
-            let namespace: Int?
-            let title: String?
-            let displayTitle: String?
-            let description: String?
-            let extract: String?
-            let thumbnail: Image?
-            let coordinates: Coordinates?
-
-            enum CodingKeys: String, CodingKey {
-                case id = "pageid"
-                case revision
-                case index
-                case namespace = "ns"
-                case title
-                case displayTitle = "displaytitle"
-                case description
-                case extract
-                case thumbnail
-                case coordinates
-            }
-
-            struct Image: Decodable {
-                let source: String?
-
-                var url: URL? {
-                    guard let source = source else {
-                        return nil
-                    }
-                    return URL(string: source)
-                }
-            }
-
-            struct Coordinates: Decodable {
-                let lat: Double
-                let lon: Double
-            }
-        }
-    }
-
-    @objc func fetchRelatedArticles(forArticleWithURL articleURL: URL?, resultLimit: Int = RelatedSearchFetcher.MaxResultLimit, completion: @escaping (Error?, [MWKSearchResult]?) -> Void) {
+    @objc func fetchRelatedArticles(forArticleWithURL articleURL: URL?, completion: @escaping (Error?, ArticleSummariesByKey?) -> Void) {
         guard
             let articleURL = articleURL,
             let articleTitle = articleURL.wmf_titleWithUnderscores?.addingPercentEncoding(withAllowedCharacters: .wmf_articleTitlePathComponentAllowed)
@@ -58,61 +11,35 @@ final class RelatedSearchFetcher: Fetcher {
             return
         }
 
-        var resultLimit = resultLimit
-        if resultLimit > RelatedSearchFetcher.MaxResultLimit {
-            DDLogError("Illegal attempt to request \(resultLimit) articles, limiting to \(RelatedSearchFetcher.MaxResultLimit).")
-            resultLimit = RelatedSearchFetcher.MaxResultLimit
-        }
-
         let pathComponents = ["page", "related", articleTitle]
         guard let taskURL = configuration.wikipediaMobileAppsServicesAPIURLComponentsForHost(articleURL.host, appending: pathComponents).url else {
             completion(Fetcher.invalidParametersError, nil)
             return
         }
         
-        session.jsonDecodableTask(with: taskURL) { (relatedPages: RelatedPages?, response, error) in
+        session.getJSONDictionary(from: taskURL) { (result, response, error) in
             if let error = error {
                 completion(error, nil)
                 return
             }
 
-            guard
-                let response = response,
-                let httpResponse = response as? HTTPURLResponse
-            else {
+            guard let response = response else {
                 completion(Fetcher.unexpectedResponseError, nil)
                 return
             }
 
-            guard httpResponse.statusCode == 200 else {
-                let error = httpResponse.statusCode == 302 ? Fetcher.noNewDataError : Fetcher.unexpectedResponseError
+            guard response.statusCode == 200 else {
+                let error = response.statusCode == 302 ? Fetcher.noNewDataError : Fetcher.unexpectedResponseError
                 completion(error, nil)
                 return
             }
 
-            guard
-                let pages = relatedPages?.pages,
-                !pages.isEmpty
-            else {
-                completion(nil, nil)
+            guard let summaries = result?["pages"] as? [[String: Any]] else {
+                completion(Fetcher.unexpectedResponseError, nil)
                 return
             }
-
-            let results: [MWKSearchResult] = pages.compactMap { page in
-                guard
-                    let id = page.id,
-                    let revisionString = page.revision,
-                    let revision = Int(revisionString)
-                else {
-                    return nil
-                }
-                let index = page.index.flatMap { NSNumber(value: $0) }
-                let namespace = page.namespace.flatMap { NSNumber(value: $0) }
-                let location = page.coordinates.flatMap { CLLocation(latitude: $0.lat, longitude: $0.lon) }
-                return MWKSearchResult(articleID: id, revID: revision, title: page.title, displayTitle: page.displayTitle, displayTitleHTML: page.displayTitle, wikidataDescription: page.description, extract: page.extract, thumbnailURL: page.thumbnail?.url, index: index, titleNamespace: namespace, location: location)
-            }
-
-            completion(nil, results)
+            
+            completion(nil, summaries.articleSummariesByKey)
         }
     }
 }

--- a/Wikipedia/Code/RandomArticleFetcher.swift
+++ b/Wikipedia/Code/RandomArticleFetcher.swift
@@ -13,10 +13,7 @@ public final class RandomArticleFetcher: Fetcher {
                 completion(error, nil, nil)
                 return
             }
-            guard
-                let title = result?["title"] as? String,
-                let articleURL = siteURL.wmf_URL(withTitle: title)
-            else {
+            guard let articleURL = result?.articleSummaryURL else {
                 completion(Fetcher.unexpectedResponseError, nil, nil)
                 return
             }


### PR DESCRIPTION
In an ideal world `ArticleSummary` would be `Codable` - in the meantime, utilize the existing JSON dictionary summary handling code.

An `ArticleSummary` refactor could fit in with https://phabricator.wikimedia.org/T217411 - the summary functions on `Session` should probably move into a separate `SummaryFetcher` used by a `SummaryController` with persistence.