### PR TITLE
Switch themes and syntax highlighting using classes

### DIFF
--- a/Wikipedia/assets/codemirror/codemirror-black.css
+++ b/Wikipedia/assets/codemirror/codemirror-black.css
@@ -1,94 +1,94 @@
-html, body, .CodeMirror {
+.cm-mw-black, .cm-mw-black .CodeMirror {
   background-color: #000;
   color: #FFF;
 }
 
-.CodeMirror-gutters {
+.cm-mw-black .CodeMirror-gutters {
   background-color: #000;
   border-right: 4px solid #000;
 }
 
-.CodeMirror-linenumber {
+.cm-mw-black .CodeMirror-linenumber {
   color: #C8CCD1;
   font-size: 0.8em;
 }
 
-.cm-mw-template {
+.cm-mw-black .cm-mw-template {
   color: #FFF; /* plain text color */
 }
 
-.cm-mw-link,
-.cm-mw-link-pagename,
-.cm-mw-link-tosection,
-.cm-mw-link-bracket,
-.cm-mw-link-delimiter,
-.cm-mw-extlink,
-.cm-mw-free-extlink,
-.cm-mw-extlink-protocol,
-.cm-mw-free-extlink-protocol,
-.cm-mw-extlink-bracket,
-.cm-mw-doubleUnderscore,
-.cm-mw-signature,
-.cm-mw-hr {
+.cm-mw-black .cm-mw-link,
+.cm-mw-black .cm-mw-link-pagename,
+.cm-mw-black .cm-mw-link-tosection,
+.cm-mw-black .cm-mw-link-bracket,
+.cm-mw-black .cm-mw-link-delimiter,
+.cm-mw-black .cm-mw-extlink,
+.cm-mw-black .cm-mw-free-extlink,
+.cm-mw-black .cm-mw-extlink-protocol,
+.cm-mw-black .cm-mw-free-extlink-protocol,
+.cm-mw-black .cm-mw-extlink-bracket,
+.cm-mw-black .cm-mw-doubleUnderscore,
+.cm-mw-black .cm-mw-signature,
+.cm-mw-black .cm-mw-hr {
   color: #6699FF;
   font-weight: normal;
 }
 
-.cm-mw-mnemonic,
-.cm-mw-exttag-name,
-.cm-mw-exttag-bracket,
-.cm-mw-exttag-attribute,
-.cm-mw-htmltag-name,
-.cm-mw-htmltag-bracket,
-.cm-mw-htmltag-attribute {
+.cm-mw-black .cm-mw-mnemonic,
+.cm-mw-black .cm-mw-exttag-name,
+.cm-mw-black .cm-mw-exttag-bracket,
+.cm-mw-black .cm-mw-exttag-attribute,
+.cm-mw-black .cm-mw-htmltag-name,
+.cm-mw-black .cm-mw-htmltag-bracket,
+.cm-mw-black .cm-mw-htmltag-attribute {
   color: #00AF89;
   font-weight: normal;
 }
 
-.cm-mw-parserfunction-name,
-.cm-mw-parserfunction-bracket,
-.cm-mw-parserfunction-delimiter { 
+.cm-mw-black .cm-mw-parserfunction-name,
+.cm-mw-black .cm-mw-parserfunction-bracket,
+.cm-mw-black .cm-mw-parserfunction-delimiter { 
   color: #FF6E6E;
 }
 
-.cm-mw-table-bracket,
-.cm-mw-table-delimiter,
-.cm-mw-table-definition { 
+.cm-mw-black .cm-mw-table-bracket,
+.cm-mw-black .cm-mw-table-delimiter,
+.cm-mw-black .cm-mw-table-definition { 
   color: #F06695; 
   font-weight: normal; 
 }
 
-.cm-mw-template-name,
-.cm-mw-template-argument-name,
-.cm-mw-template-delimiter,
-.cm-mw-template-bracket  {
+.cm-mw-black .cm-mw-template-name,
+.cm-mw-black .cm-mw-template-argument-name,
+.cm-mw-black .cm-mw-template-delimiter,
+.cm-mw-black .cm-mw-template-bracket  {
   color: #C180BB;
   font-weight: normal;
 }
 
-.cm-mw-list,
-.cm-mw-doubleUnderscore, 
-.cm-mw-signature, 
-.cm-mw-hr,
-.cm-mw-indenting,
-.cm-mw-apostrophes-bold, 
-.cm-mw-apostrophes-italic,
-.cm-mw-section-header,
-.cm-mw-templatevariable,
-.cm-mw-templatevariable-name,
-.cm-mw-templatevariable-bracket,
-.cm-mw-templatevariable-delimiter,
-.cm-mw-matching {
+.cm-mw-black .cm-mw-list,
+.cm-mw-black .cm-mw-doubleUnderscore, 
+.cm-mw-black .cm-mw-signature, 
+.cm-mw-black .cm-mw-hr,
+.cm-mw-black .cm-mw-indenting,
+.cm-mw-black .cm-mw-apostrophes-bold, 
+.cm-mw-black .cm-mw-apostrophes-italic,
+.cm-mw-black .cm-mw-section-header,
+.cm-mw-black .cm-mw-templatevariable,
+.cm-mw-black .cm-mw-templatevariable-name,
+.cm-mw-black .cm-mw-templatevariable-bracket,
+.cm-mw-black .cm-mw-templatevariable-delimiter,
+.cm-mw-black .cm-mw-matching {
   color: #FF9500;
   font-weight: normal;
 }
 
-.cm-mw-comment,
-.cm-mw-skipformatting {
+.cm-mw-black .cm-mw-comment,
+.cm-mw-black .cm-mw-skipformatting {
   color: #C8CCD1;
 }
 
-.cm-searching {
+.cm-mw-black .cm-searching {
   color: #000;
   background-color: rgba(247, 215, 121, 0.7);
   border-radius: 2px;

--- a/Wikipedia/assets/codemirror/codemirror-dark.css
+++ b/Wikipedia/assets/codemirror/codemirror-dark.css
@@ -1,94 +1,94 @@
-html, body, .CodeMirror {
+.cm-mw-dark, .cm-mw-dark .CodeMirror {
   background-color: #2E3136;
   color: #FFF;
 }
 
-.CodeMirror-gutters {
+.cm-mw-dark .CodeMirror-gutters {
   background-color: #2E3136;
   border-right: 4px solid #2E3136;
 }
 
-.CodeMirror-linenumber {
+.cm-mw-dark .CodeMirror-linenumber {
   color: #C8CCD1;
   font-size: 0.8em;
 }
 
-.cm-mw-template {
+.cm-mw-dark .cm-mw-template {
   color: #FFF; /* plain text color */
 }
 
-.cm-mw-link,
-.cm-mw-link-pagename,
-.cm-mw-link-tosection,
-.cm-mw-link-bracket,
-.cm-mw-link-delimiter,
-.cm-mw-extlink,
-.cm-mw-free-extlink,
-.cm-mw-extlink-protocol,
-.cm-mw-free-extlink-protocol,
-.cm-mw-extlink-bracket,
-.cm-mw-doubleUnderscore,
-.cm-mw-signature,
-.cm-mw-hr {
+.cm-mw-dark .cm-mw-link,
+.cm-mw-dark .cm-mw-link-pagename,
+.cm-mw-dark .cm-mw-link-tosection,
+.cm-mw-dark .cm-mw-link-bracket,
+.cm-mw-dark .cm-mw-link-delimiter,
+.cm-mw-dark .cm-mw-extlink,
+.cm-mw-dark .cm-mw-free-extlink,
+.cm-mw-dark .cm-mw-extlink-protocol,
+.cm-mw-dark .cm-mw-free-extlink-protocol,
+.cm-mw-dark .cm-mw-extlink-bracket,
+.cm-mw-dark .cm-mw-doubleUnderscore,
+.cm-mw-dark .cm-mw-signature,
+.cm-mw-dark .cm-mw-hr {
   color: #6699FF;
   font-weight: normal;
 }
 
-.cm-mw-mnemonic,
-.cm-mw-exttag-name,
-.cm-mw-exttag-bracket,
-.cm-mw-exttag-attribute,
-.cm-mw-htmltag-name,
-.cm-mw-htmltag-bracket,
-.cm-mw-htmltag-attribute {
+.cm-mw-dark .cm-mw-mnemonic,
+.cm-mw-dark .cm-mw-exttag-name,
+.cm-mw-dark .cm-mw-exttag-bracket,
+.cm-mw-dark .cm-mw-exttag-attribute,
+.cm-mw-dark .cm-mw-htmltag-name,
+.cm-mw-dark .cm-mw-htmltag-bracket,
+.cm-mw-dark .cm-mw-htmltag-attribute {
   color: #00AF89;
   font-weight: normal;
 }
 
-.cm-mw-parserfunction-name,
-.cm-mw-parserfunction-bracket,
-.cm-mw-parserfunction-delimiter { 
+.cm-mw-dark .cm-mw-parserfunction-name,
+.cm-mw-dark .cm-mw-parserfunction-bracket,
+.cm-mw-dark .cm-mw-parserfunction-delimiter { 
   color: #FF6E6E;
 }
 
-.cm-mw-table-bracket,
-.cm-mw-table-delimiter,
-.cm-mw-table-definition { 
+.cm-mw-dark .cm-mw-table-bracket,
+.cm-mw-dark .cm-mw-table-delimiter,
+.cm-mw-dark .cm-mw-table-definition { 
   color: #F06695; 
   font-weight: normal; 
 }
 
-.cm-mw-template-name,
-.cm-mw-template-argument-name,
-.cm-mw-template-delimiter,
-.cm-mw-template-bracket  {
+.cm-mw-dark .cm-mw-template-name,
+.cm-mw-dark .cm-mw-template-argument-name,
+.cm-mw-dark .cm-mw-template-delimiter,
+.cm-mw-dark .cm-mw-template-bracket  {
   color: #C180BB;
   font-weight: normal;
 }
 
-.cm-mw-list,
-.cm-mw-doubleUnderscore, 
-.cm-mw-signature, 
-.cm-mw-hr,
-.cm-mw-indenting,
-.cm-mw-apostrophes-bold, 
-.cm-mw-apostrophes-italic,
-.cm-mw-section-header,
-.cm-mw-templatevariable,
-.cm-mw-templatevariable-name,
-.cm-mw-templatevariable-bracket,
-.cm-mw-templatevariable-delimiter,
-.cm-mw-matching {
+.cm-mw-dark .cm-mw-list,
+.cm-mw-dark .cm-mw-doubleUnderscore, 
+.cm-mw-dark .cm-mw-signature, 
+.cm-mw-dark .cm-mw-hr,
+.cm-mw-dark .cm-mw-indenting,
+.cm-mw-dark .cm-mw-apostrophes-bold, 
+.cm-mw-dark .cm-mw-apostrophes-italic,
+.cm-mw-dark .cm-mw-section-header,
+.cm-mw-dark .cm-mw-templatevariable,
+.cm-mw-dark .cm-mw-templatevariable-name,
+.cm-mw-dark .cm-mw-templatevariable-bracket,
+.cm-mw-dark .cm-mw-templatevariable-delimiter,
+.cm-mw-dark .cm-mw-matching {
   color: #FF9500;
   font-weight: normal;
 }
 
-.cm-mw-comment,
-.cm-mw-skipformatting {
+.cm-mw-dark .cm-mw-comment,
+.cm-mw-dark .cm-mw-skipformatting {
   color: #C8CCD1;
 }
 
-.cm-searching {
+.cm-mw-dark .cm-searching {
   color: #000;
   background-color: rgba(247, 215, 121, 0.7);
   border-radius: 2px;

--- a/Wikipedia/assets/codemirror/codemirror-index.html
+++ b/Wikipedia/assets/codemirror/codemirror-index.html
@@ -9,9 +9,11 @@
   <script src="resources/mode/mediawiki/mediawiki.js"></script>
   <link rel="stylesheet" type="text/css" href="resources/mode/mediawiki/mediawiki.css">
   <link rel="stylesheet" type="text/css" href="codemirror-common.css">
-  <link rel="stylesheet" id="codemirror-theme" type="text/css" href="">
-  <link rel="stylesheet" id="codemirror-syntax-highlighting-off" type="text/css" href="">
-
+  <link rel="stylesheet" type="text/css" href="codemirror-light.css">
+  <link rel="stylesheet" type="text/css" href="codemirror-sepia.css">
+  <link rel="stylesheet" type="text/css" href="codemirror-dark.css">
+  <link rel="stylesheet" type="text/css" href="codemirror-black.css">
+  <link rel="stylesheet" type="text/css" href="codemirror-syntax-highlighting-off.css">
   <script src="resources/addon/search/search.js"></script>
   <script src="resources/addon/search/searchcursor.js"></script>
   <script src="resources/addon/search/match-highlighter.js"></script>
@@ -20,7 +22,7 @@
 </head>
 
 
-<body>
+<body class="cm-mw-light">
   <script>    
     let editor
 
@@ -372,13 +374,16 @@
     }
         
     const applyTheme = (themeName) => {
-      document.getElementById('codemirror-theme').setAttribute('href', `codemirror-${themeName}.css`)  
+      document.body.className = `cm-mw-${themeName}`  
     }
   
     const toggleSyntaxColors = () => {
-        var oldName = document.getElementById('codemirror-syntax-highlighting-off').getAttribute('href')
-        var newName = oldName.length > 0 ? '' : 'codemirror-syntax-highlighting-off.css'
-        document.getElementById('codemirror-syntax-highlighting-off').setAttribute('href', newName)
+      var elements = document.body.className.split(" ")
+      if (elements.length == 1) {
+        document.body.className = elements[0] + " cm-mw-off"
+      } else {
+        document.body.className = elements[0]
+      }
     }
   
     const scaleBodyText = (textSizeAdjustment) => {

--- a/Wikipedia/assets/codemirror/codemirror-light.css
+++ b/Wikipedia/assets/codemirror/codemirror-light.css
@@ -1,94 +1,94 @@
-html, body, .CodeMirror {
+.cm-mw-light, .cm-mw-light .CodeMirror {
   background-color: #FFF;
   color: #222;
 }
 
-.CodeMirror-gutters {
+.cm-mw-light .CodeMirror-gutters {
   background-color: #FFF;
   border-right: 4px solid #FFF;
 }
 
-.CodeMirror-linenumber {
+.cm-mw-light .CodeMirror-linenumber {
   color: #72777D;
   font-size: 0.8em;
 }
 
-.cm-mw-template {
+.cm-mw-light .cm-mw-template {
   color: #222; /* plain text color */
 }
 
-.cm-mw-link,
-.cm-mw-link-pagename,
-.cm-mw-link-tosection,
-.cm-mw-link-bracket,
-.cm-mw-link-delimiter,
-.cm-mw-extlink,
-.cm-mw-free-extlink,
-.cm-mw-extlink-protocol,
-.cm-mw-free-extlink-protocol,
-.cm-mw-extlink-bracket,
-.cm-mw-doubleUnderscore,
-.cm-mw-signature,
-.cm-mw-hr {
+.cm-mw-light .cm-mw-link,
+.cm-mw-light .cm-mw-link-pagename,
+.cm-mw-light .cm-mw-link-tosection,
+.cm-mw-light .cm-mw-link-bracket,
+.cm-mw-light .cm-mw-link-delimiter,
+.cm-mw-light .cm-mw-extlink,
+.cm-mw-light .cm-mw-free-extlink,
+.cm-mw-light .cm-mw-extlink-protocol,
+.cm-mw-light .cm-mw-free-extlink-protocol,
+.cm-mw-light .cm-mw-extlink-bracket,
+.cm-mw-light .cm-mw-doubleUnderscore,
+.cm-mw-light .cm-mw-signature,
+.cm-mw-light .cm-mw-hr {
   color: #36C;
   font-weight: normal;
 }
 
-.cm-mw-mnemonic,
-.cm-mw-exttag-name,
-.cm-mw-exttag-bracket,
-.cm-mw-exttag-attribute,
-.cm-mw-htmltag-name,
-.cm-mw-htmltag-bracket,
-.cm-mw-htmltag-attribute {
+.cm-mw-light .cm-mw-mnemonic,
+.cm-mw-light .cm-mw-exttag-name,
+.cm-mw-light .cm-mw-exttag-bracket,
+.cm-mw-light .cm-mw-exttag-attribute,
+.cm-mw-light .cm-mw-htmltag-name,
+.cm-mw-light .cm-mw-htmltag-bracket,
+.cm-mw-light .cm-mw-htmltag-attribute {
   color: #00AF89;
   font-weight: normal;
 }
 
-.cm-mw-parserfunction-name,
-.cm-mw-parserfunction-bracket,
-.cm-mw-parserfunction-delimiter { 
+.cm-mw-light .cm-mw-parserfunction-name,
+.cm-mw-light .cm-mw-parserfunction-bracket,
+.cm-mw-light .cm-mw-parserfunction-delimiter { 
   color: #B32424;
 }
 
-.cm-mw-table-bracket,
-.cm-mw-table-delimiter,
-.cm-mw-table-definition { 
+.cm-mw-light .cm-mw-table-bracket,
+.cm-mw-light .cm-mw-table-delimiter,
+.cm-mw-light .cm-mw-table-definition { 
   color: #E6275d; 
   font-weight: normal; 
 }
 
-.cm-mw-template-name,
-.cm-mw-template-argument-name,
-.cm-mw-template-delimiter,
-.cm-mw-template-bracket  {
+.cm-mw-light .cm-mw-template-name,
+.cm-mw-light .cm-mw-template-argument-name,
+.cm-mw-light .cm-mw-template-delimiter,
+.cm-mw-light .cm-mw-template-bracket  {
   color: #97498F;
   font-weight: normal;
 }
 
-.cm-mw-list,
-.cm-mw-doubleUnderscore, 
-.cm-mw-signature, 
-.cm-mw-hr,
-.cm-mw-indenting,
-.cm-mw-apostrophes-bold, 
-.cm-mw-apostrophes-italic,
-.cm-mw-section-header,
-.cm-mw-templatevariable,
-.cm-mw-templatevariable-name,
-.cm-mw-templatevariable-bracket,
-.cm-mw-templatevariable-delimiter,
-.cm-mw-matching {
+.cm-mw-light .cm-mw-list,
+.cm-mw-light .cm-mw-doubleUnderscore, 
+.cm-mw-light .cm-mw-signature, 
+.cm-mw-light .cm-mw-hr,
+.cm-mw-light .cm-mw-indenting,
+.cm-mw-light .cm-mw-apostrophes-bold, 
+.cm-mw-light .cm-mw-apostrophes-italic,
+.cm-mw-light .cm-mw-section-header,
+.cm-mw-light .cm-mw-templatevariable,
+.cm-mw-light .cm-mw-templatevariable-name,
+.cm-mw-light .cm-mw-templatevariable-bracket,
+.cm-mw-light .cm-mw-templatevariable-delimiter,
+.cm-mw-light .cm-mw-matching {
   color: #FF9500;
   font-weight: normal;
 }
 
-.cm-mw-comment,
-.cm-mw-skipformatting {
+.cm-mw-light .cm-mw-comment,
+.cm-mw-light .cm-mw-skipformatting {
   color: #72777D;
 }
 
-.cm-searching {
+.cm-mw-light .cm-searching {
   color: #000;
   background-color: rgba(255, 204, 51, 0.3);
   border-radius: 2px;

--- a/Wikipedia/assets/codemirror/codemirror-sepia.css
+++ b/Wikipedia/assets/codemirror/codemirror-sepia.css
@@ -1,94 +1,94 @@
-html, body, .CodeMirror {
+.cm-mw-sepia, .cm-mw-sepia .CodeMirror {
   background-color: #F8F1E3;
   color: #222;
 }
 
-.CodeMirror-gutters {
+.cm-mw-sepia .CodeMirror-gutters {
   background-color: #F8F1E3;
   border-right: 4px solid #F8F1E3;
 }
 
-.CodeMirror-linenumber {
+.cm-mw-sepia .CodeMirror-linenumber {
   color: #6C6760;
   font-size: 0.8em;
 }
 
-.cm-mw-template {
+.cm-mw-sepia .cm-mw-template {
   color: #222; /* plain text color */
 }
 
-.cm-mw-link,
-.cm-mw-link-pagename,
-.cm-mw-link-tosection,
-.cm-mw-link-bracket,
-.cm-mw-link-delimiter,
-.cm-mw-extlink,
-.cm-mw-free-extlink,
-.cm-mw-extlink-protocol,
-.cm-mw-free-extlink-protocol,
-.cm-mw-extlink-bracket,
-.cm-mw-doubleUnderscore,
-.cm-mw-signature,
-.cm-mw-hr {
+.cm-mw-sepia .cm-mw-link,
+.cm-mw-sepia .cm-mw-link-pagename,
+.cm-mw-sepia .cm-mw-link-tosection,
+.cm-mw-sepia .cm-mw-link-bracket,
+.cm-mw-sepia .cm-mw-link-delimiter,
+.cm-mw-sepia .cm-mw-extlink,
+.cm-mw-sepia .cm-mw-free-extlink,
+.cm-mw-sepia .cm-mw-extlink-protocol,
+.cm-mw-sepia .cm-mw-free-extlink-protocol,
+.cm-mw-sepia .cm-mw-extlink-bracket,
+.cm-mw-sepia .cm-mw-doubleUnderscore,
+.cm-mw-sepia .cm-mw-signature,
+.cm-mw-sepia .cm-mw-hr {
   color: #36C;
   font-weight: normal;
 }
 
-.cm-mw-mnemonic,
-.cm-mw-exttag-name,
-.cm-mw-exttag-bracket,
-.cm-mw-exttag-attribute,
-.cm-mw-htmltag-name,
-.cm-mw-htmltag-bracket,
-.cm-mw-htmltag-attribute {
+.cm-mw-sepia .cm-mw-mnemonic,
+.cm-mw-sepia .cm-mw-exttag-name,
+.cm-mw-sepia .cm-mw-exttag-bracket,
+.cm-mw-sepia .cm-mw-exttag-attribute,
+.cm-mw-sepia .cm-mw-htmltag-name,
+.cm-mw-sepia .cm-mw-htmltag-bracket,
+.cm-mw-sepia .cm-mw-htmltag-attribute {
   color: #00AF89;
   font-weight: normal;
 }
 
-.cm-mw-parserfunction-name,
-.cm-mw-parserfunction-bracket,
-.cm-mw-parserfunction-delimiter { 
+.cm-mw-sepia .cm-mw-parserfunction-name,
+.cm-mw-sepia .cm-mw-parserfunction-bracket,
+.cm-mw-sepia .cm-mw-parserfunction-delimiter { 
   color: #B32424;
 }
 
-.cm-mw-table-bracket,
-.cm-mw-table-delimiter,
-.cm-mw-table-definition { 
+.cm-mw-sepia .cm-mw-table-bracket,
+.cm-mw-sepia .cm-mw-table-delimiter,
+.cm-mw-sepia .cm-mw-table-definition { 
   color: #F06695; 
   font-weight: normal; 
 }
 
-.cm-mw-template-name,
-.cm-mw-template-argument-name,
-.cm-mw-template-delimiter,
-.cm-mw-template-bracket  {
+.cm-mw-sepia .cm-mw-template-name,
+.cm-mw-sepia .cm-mw-template-argument-name,
+.cm-mw-sepia .cm-mw-template-delimiter,
+.cm-mw-sepia .cm-mw-template-bracket  {
   color: #97498F;
   font-weight: normal;
 }
 
-.cm-mw-list,
-.cm-mw-doubleUnderscore, 
-.cm-mw-signature, 
-.cm-mw-hr,
-.cm-mw-indenting,
-.cm-mw-apostrophes-bold, 
-.cm-mw-apostrophes-italic,
-.cm-mw-section-header,
-.cm-mw-templatevariable,
-.cm-mw-templatevariable-name,
-.cm-mw-templatevariable-bracket,
-.cm-mw-templatevariable-delimiter,
-.cm-mw-matching {
+.cm-mw-sepia .cm-mw-list,
+.cm-mw-sepia .cm-mw-doubleUnderscore, 
+.cm-mw-sepia .cm-mw-signature, 
+.cm-mw-sepia .cm-mw-hr,
+.cm-mw-sepia .cm-mw-indenting,
+.cm-mw-sepia .cm-mw-apostrophes-bold, 
+.cm-mw-sepia .cm-mw-apostrophes-italic,
+.cm-mw-sepia .cm-mw-section-header,
+.cm-mw-sepia .cm-mw-templatevariable,
+.cm-mw-sepia .cm-mw-templatevariable-name,
+.cm-mw-sepia .cm-mw-templatevariable-bracket,
+.cm-mw-sepia .cm-mw-templatevariable-delimiter,
+.cm-mw-sepia .cm-mw-matching {
   color: #FF9500;
   font-weight: normal;
 }
 
-.cm-mw-comment,
-.cm-mw-skipformatting {
+.cm-mw-sepia .cm-mw-comment,
+.cm-mw-sepia .cm-mw-skipformatting {
   color: #6C6760;
 }
 
-.cm-searching {
+.cm-mw-sepia .cm-searching {
   color: #000;
   background-color: rgba(255, 204, 51, 0.3);
   border-radius: 2px;

--- a/Wikipedia/assets/codemirror/codemirror-syntax-highlighting-off.css
+++ b/Wikipedia/assets/codemirror/codemirror-syntax-highlighting-off.css
@@ -1,65 +1,47 @@
-.cm-mw-link,
-.cm-mw-link-pagename,
-.cm-mw-link-tosection,
-.cm-mw-link-bracket,
-.cm-mw-link-delimiter,
-.cm-mw-extlink,
-.cm-mw-free-extlink,
-.cm-mw-extlink-protocol,
-.cm-mw-free-extlink-protocol,
-.cm-mw-extlink-bracket,
-.cm-mw-doubleUnderscore,
-.cm-mw-signature,
-.cm-mw-hr {
-  color: inherit;
-}
-
-.cm-mw-mnemonic,
-.cm-mw-exttag-name,
-.cm-mw-exttag-bracket,
-.cm-mw-exttag-attribute,
-.cm-mw-htmltag-name,
-.cm-mw-htmltag-bracket,
-.cm-mw-htmltag-attribute {
-  color: inherit;
-}
-
-.cm-mw-parserfunction-name,
-.cm-mw-parserfunction-bracket,
-.cm-mw-parserfunction-delimiter { 
-  color: inherit;
-}
-
-.cm-mw-table-bracket,
-.cm-mw-table-delimiter,
-.cm-mw-table-definition { 
-  color: inherit;
-}
-
-.cm-mw-template-name,
-.cm-mw-template-argument-name,
-.cm-mw-template-delimiter,
-.cm-mw-template-bracket  {
-  color: inherit;
-}
-
-.cm-mw-list,
-.cm-mw-doubleUnderscore, 
-.cm-mw-signature, 
-.cm-mw-hr,
-.cm-mw-indenting,
-.cm-mw-apostrophes-bold, 
-.cm-mw-apostrophes-italic,
-.cm-mw-section-header,
-.cm-mw-templatevariable,
-.cm-mw-templatevariable-name,
-.cm-mw-templatevariable-bracket,
-.cm-mw-templatevariable-delimiter,
-.cm-mw-matching {
-  color: inherit;
-}
-
-.cm-mw-comment,
-.cm-mw-skipformatting {
+.cm-mw-off .cm-mw-link,
+.cm-mw-off .cm-mw-link-pagename,
+.cm-mw-off .cm-mw-link-tosection,
+.cm-mw-off .cm-mw-link-bracket,
+.cm-mw-off .cm-mw-link-delimiter,
+.cm-mw-off .cm-mw-extlink,
+.cm-mw-off .cm-mw-free-extlink,
+.cm-mw-off .cm-mw-extlink-protocol,
+.cm-mw-off .cm-mw-free-extlink-protocol,
+.cm-mw-off .cm-mw-extlink-bracket,
+.cm-mw-off .cm-mw-doubleUnderscore,
+.cm-mw-off .cm-mw-signature,
+.cm-mw-off .cm-mw-hr,
+.cm-mw-off .cm-mw-mnemonic,
+.cm-mw-off .cm-mw-exttag-name,
+.cm-mw-off .cm-mw-exttag-bracket,
+.cm-mw-off .cm-mw-exttag-attribute,
+.cm-mw-off .cm-mw-htmltag-name,
+.cm-mw-off .cm-mw-htmltag-bracket,
+.cm-mw-off .cm-mw-htmltag-attribute,
+.cm-mw-off .cm-mw-parserfunction-name,
+.cm-mw-off .cm-mw-parserfunction-bracket,
+.cm-mw-off .cm-mw-parserfunction-delimiter,
+.cm-mw-off .cm-mw-table-bracket,
+.cm-mw-off .cm-mw-table-delimiter,
+.cm-mw-off .cm-mw-table-definition,
+.cm-mw-off .cm-mw-template-name,
+.cm-mw-off .cm-mw-template-argument-name,
+.cm-mw-off .cm-mw-template-delimiter,
+.cm-mw-off .cm-mw-template-bracket,
+.cm-mw-off .cm-mw-list,
+.cm-mw-off .cm-mw-doubleUnderscore, 
+.cm-mw-off .cm-mw-signature, 
+.cm-mw-off .cm-mw-hr,
+.cm-mw-off .cm-mw-indenting,
+.cm-mw-off .cm-mw-apostrophes-bold, 
+.cm-mw-off .cm-mw-apostrophes-italic,
+.cm-mw-off .cm-mw-section-header,
+.cm-mw-off .cm-mw-templatevariable,
+.cm-mw-off .cm-mw-templatevariable-name,
+.cm-mw-off .cm-mw-templatevariable-bracket,
+.cm-mw-off .cm-mw-templatevariable-delimiter,
+.cm-mw-off .cm-mw-matching,
+.cm-mw-off .cm-mw-comment,
+.cm-mw-off .cm-mw-skipformatting {
   color: inherit;
 }

--- a/www/codemirror/codemirror-black.css
+++ b/www/codemirror/codemirror-black.css
@@ -1,94 +1,94 @@
-html, body, .CodeMirror {
+.cm-mw-black, .cm-mw-black .CodeMirror {
   background-color: #000;
   color: #FFF;
 }
 
-.CodeMirror-gutters {
+.cm-mw-black .CodeMirror-gutters {
   background-color: #000;
   border-right: 4px solid #000;
 }
 
-.CodeMirror-linenumber {
+.cm-mw-black .CodeMirror-linenumber {
   color: #C8CCD1;
   font-size: 0.8em;
 }
 
-.cm-mw-template {
+.cm-mw-black .cm-mw-template {
   color: #FFF; /* plain text color */
 }
 
-.cm-mw-link,
-.cm-mw-link-pagename,
-.cm-mw-link-tosection,
-.cm-mw-link-bracket,
-.cm-mw-link-delimiter,
-.cm-mw-extlink,
-.cm-mw-free-extlink,
-.cm-mw-extlink-protocol,
-.cm-mw-free-extlink-protocol,
-.cm-mw-extlink-bracket,
-.cm-mw-doubleUnderscore,
-.cm-mw-signature,
-.cm-mw-hr {
+.cm-mw-black .cm-mw-link,
+.cm-mw-black .cm-mw-link-pagename,
+.cm-mw-black .cm-mw-link-tosection,
+.cm-mw-black .cm-mw-link-bracket,
+.cm-mw-black .cm-mw-link-delimiter,
+.cm-mw-black .cm-mw-extlink,
+.cm-mw-black .cm-mw-free-extlink,
+.cm-mw-black .cm-mw-extlink-protocol,
+.cm-mw-black .cm-mw-free-extlink-protocol,
+.cm-mw-black .cm-mw-extlink-bracket,
+.cm-mw-black .cm-mw-doubleUnderscore,
+.cm-mw-black .cm-mw-signature,
+.cm-mw-black .cm-mw-hr {
   color: #6699FF;
   font-weight: normal;
 }
 
-.cm-mw-mnemonic,
-.cm-mw-exttag-name,
-.cm-mw-exttag-bracket,
-.cm-mw-exttag-attribute,
-.cm-mw-htmltag-name,
-.cm-mw-htmltag-bracket,
-.cm-mw-htmltag-attribute {
+.cm-mw-black .cm-mw-mnemonic,
+.cm-mw-black .cm-mw-exttag-name,
+.cm-mw-black .cm-mw-exttag-bracket,
+.cm-mw-black .cm-mw-exttag-attribute,
+.cm-mw-black .cm-mw-htmltag-name,
+.cm-mw-black .cm-mw-htmltag-bracket,
+.cm-mw-black .cm-mw-htmltag-attribute {
   color: #00AF89;
   font-weight: normal;
 }
 
-.cm-mw-parserfunction-name,
-.cm-mw-parserfunction-bracket,
-.cm-mw-parserfunction-delimiter { 
+.cm-mw-black .cm-mw-parserfunction-name,
+.cm-mw-black .cm-mw-parserfunction-bracket,
+.cm-mw-black .cm-mw-parserfunction-delimiter { 
   color: #FF6E6E;
 }
 
-.cm-mw-table-bracket,
-.cm-mw-table-delimiter,
-.cm-mw-table-definition { 
+.cm-mw-black .cm-mw-table-bracket,
+.cm-mw-black .cm-mw-table-delimiter,
+.cm-mw-black .cm-mw-table-definition { 
   color: #F06695; 
   font-weight: normal; 
 }
 
-.cm-mw-template-name,
-.cm-mw-template-argument-name,
-.cm-mw-template-delimiter,
-.cm-mw-template-bracket  {
+.cm-mw-black .cm-mw-template-name,
+.cm-mw-black .cm-mw-template-argument-name,
+.cm-mw-black .cm-mw-template-delimiter,
+.cm-mw-black .cm-mw-template-bracket  {
   color: #C180BB;
   font-weight: normal;
 }
 
-.cm-mw-list,
-.cm-mw-doubleUnderscore, 
-.cm-mw-signature, 
-.cm-mw-hr,
-.cm-mw-indenting,
-.cm-mw-apostrophes-bold, 
-.cm-mw-apostrophes-italic,
-.cm-mw-section-header,
-.cm-mw-templatevariable,
-.cm-mw-templatevariable-name,
-.cm-mw-templatevariable-bracket,
-.cm-mw-templatevariable-delimiter,
-.cm-mw-matching {
+.cm-mw-black .cm-mw-list,
+.cm-mw-black .cm-mw-doubleUnderscore, 
+.cm-mw-black .cm-mw-signature, 
+.cm-mw-black .cm-mw-hr,
+.cm-mw-black .cm-mw-indenting,
+.cm-mw-black .cm-mw-apostrophes-bold, 
+.cm-mw-black .cm-mw-apostrophes-italic,
+.cm-mw-black .cm-mw-section-header,
+.cm-mw-black .cm-mw-templatevariable,
+.cm-mw-black .cm-mw-templatevariable-name,
+.cm-mw-black .cm-mw-templatevariable-bracket,
+.cm-mw-black .cm-mw-templatevariable-delimiter,
+.cm-mw-black .cm-mw-matching {
   color: #FF9500;
   font-weight: normal;
 }
 
-.cm-mw-comment,
-.cm-mw-skipformatting {
+.cm-mw-black .cm-mw-comment,
+.cm-mw-black .cm-mw-skipformatting {
   color: #C8CCD1;
 }
 
-.cm-searching {
+.cm-mw-black .cm-searching {
   color: #000;
   background-color: rgba(247, 215, 121, 0.7);
   border-radius: 2px;

--- a/www/codemirror/codemirror-dark.css
+++ b/www/codemirror/codemirror-dark.css
@@ -1,94 +1,94 @@
-html, body, .CodeMirror {
+.cm-mw-dark, .cm-mw-dark .CodeMirror {
   background-color: #2E3136;
   color: #FFF;
 }
 
-.CodeMirror-gutters {
+.cm-mw-dark .CodeMirror-gutters {
   background-color: #2E3136;
   border-right: 4px solid #2E3136;
 }
 
-.CodeMirror-linenumber {
+.cm-mw-dark .CodeMirror-linenumber {
   color: #C8CCD1;
   font-size: 0.8em;
 }
 
-.cm-mw-template {
+.cm-mw-dark .cm-mw-template {
   color: #FFF; /* plain text color */
 }
 
-.cm-mw-link,
-.cm-mw-link-pagename,
-.cm-mw-link-tosection,
-.cm-mw-link-bracket,
-.cm-mw-link-delimiter,
-.cm-mw-extlink,
-.cm-mw-free-extlink,
-.cm-mw-extlink-protocol,
-.cm-mw-free-extlink-protocol,
-.cm-mw-extlink-bracket,
-.cm-mw-doubleUnderscore,
-.cm-mw-signature,
-.cm-mw-hr {
+.cm-mw-dark .cm-mw-link,
+.cm-mw-dark .cm-mw-link-pagename,
+.cm-mw-dark .cm-mw-link-tosection,
+.cm-mw-dark .cm-mw-link-bracket,
+.cm-mw-dark .cm-mw-link-delimiter,
+.cm-mw-dark .cm-mw-extlink,
+.cm-mw-dark .cm-mw-free-extlink,
+.cm-mw-dark .cm-mw-extlink-protocol,
+.cm-mw-dark .cm-mw-free-extlink-protocol,
+.cm-mw-dark .cm-mw-extlink-bracket,
+.cm-mw-dark .cm-mw-doubleUnderscore,
+.cm-mw-dark .cm-mw-signature,
+.cm-mw-dark .cm-mw-hr {
   color: #6699FF;
   font-weight: normal;
 }
 
-.cm-mw-mnemonic,
-.cm-mw-exttag-name,
-.cm-mw-exttag-bracket,
-.cm-mw-exttag-attribute,
-.cm-mw-htmltag-name,
-.cm-mw-htmltag-bracket,
-.cm-mw-htmltag-attribute {
+.cm-mw-dark .cm-mw-mnemonic,
+.cm-mw-dark .cm-mw-exttag-name,
+.cm-mw-dark .cm-mw-exttag-bracket,
+.cm-mw-dark .cm-mw-exttag-attribute,
+.cm-mw-dark .cm-mw-htmltag-name,
+.cm-mw-dark .cm-mw-htmltag-bracket,
+.cm-mw-dark .cm-mw-htmltag-attribute {
   color: #00AF89;
   font-weight: normal;
 }
 
-.cm-mw-parserfunction-name,
-.cm-mw-parserfunction-bracket,
-.cm-mw-parserfunction-delimiter { 
+.cm-mw-dark .cm-mw-parserfunction-name,
+.cm-mw-dark .cm-mw-parserfunction-bracket,
+.cm-mw-dark .cm-mw-parserfunction-delimiter { 
   color: #FF6E6E;
 }
 
-.cm-mw-table-bracket,
-.cm-mw-table-delimiter,
-.cm-mw-table-definition { 
+.cm-mw-dark .cm-mw-table-bracket,
+.cm-mw-dark .cm-mw-table-delimiter,
+.cm-mw-dark .cm-mw-table-definition { 
   color: #F06695; 
   font-weight: normal; 
 }
 
-.cm-mw-template-name,
-.cm-mw-template-argument-name,
-.cm-mw-template-delimiter,
-.cm-mw-template-bracket  {
+.cm-mw-dark .cm-mw-template-name,
+.cm-mw-dark .cm-mw-template-argument-name,
+.cm-mw-dark .cm-mw-template-delimiter,
+.cm-mw-dark .cm-mw-template-bracket  {
   color: #C180BB;
   font-weight: normal;
 }
 
-.cm-mw-list,
-.cm-mw-doubleUnderscore, 
-.cm-mw-signature, 
-.cm-mw-hr,
-.cm-mw-indenting,
-.cm-mw-apostrophes-bold, 
-.cm-mw-apostrophes-italic,
-.cm-mw-section-header,
-.cm-mw-templatevariable,
-.cm-mw-templatevariable-name,
-.cm-mw-templatevariable-bracket,
-.cm-mw-templatevariable-delimiter,
-.cm-mw-matching {
+.cm-mw-dark .cm-mw-list,
+.cm-mw-dark .cm-mw-doubleUnderscore, 
+.cm-mw-dark .cm-mw-signature, 
+.cm-mw-dark .cm-mw-hr,
+.cm-mw-dark .cm-mw-indenting,
+.cm-mw-dark .cm-mw-apostrophes-bold, 
+.cm-mw-dark .cm-mw-apostrophes-italic,
+.cm-mw-dark .cm-mw-section-header,
+.cm-mw-dark .cm-mw-templatevariable,
+.cm-mw-dark .cm-mw-templatevariable-name,
+.cm-mw-dark .cm-mw-templatevariable-bracket,
+.cm-mw-dark .cm-mw-templatevariable-delimiter,
+.cm-mw-dark .cm-mw-matching {
   color: #FF9500;
   font-weight: normal;
 }
 
-.cm-mw-comment,
-.cm-mw-skipformatting {
+.cm-mw-dark .cm-mw-comment,
+.cm-mw-dark .cm-mw-skipformatting {
   color: #C8CCD1;
 }
 
-.cm-searching {
+.cm-mw-dark .cm-searching {
   color: #000;
   background-color: rgba(247, 215, 121, 0.7);
   border-radius: 2px;

--- a/www/codemirror/codemirror-index.html
+++ b/www/codemirror/codemirror-index.html
@@ -9,9 +9,11 @@
   <script src="resources/mode/mediawiki/mediawiki.js"></script>
   <link rel="stylesheet" type="text/css" href="resources/mode/mediawiki/mediawiki.css">
   <link rel="stylesheet" type="text/css" href="codemirror-common.css">
-  <link rel="stylesheet" id="codemirror-theme" type="text/css" href="">
-  <link rel="stylesheet" id="codemirror-syntax-highlighting-off" type="text/css" href="">
-
+  <link rel="stylesheet" type="text/css" href="codemirror-light.css">
+  <link rel="stylesheet" type="text/css" href="codemirror-sepia.css">
+  <link rel="stylesheet" type="text/css" href="codemirror-dark.css">
+  <link rel="stylesheet" type="text/css" href="codemirror-black.css">
+  <link rel="stylesheet" type="text/css" href="codemirror-syntax-highlighting-off.css">
   <script src="resources/addon/search/search.js"></script>
   <script src="resources/addon/search/searchcursor.js"></script>
   <script src="resources/addon/search/match-highlighter.js"></script>
@@ -20,7 +22,7 @@
 </head>
 
 
-<body>
+<body class="cm-mw-light">
   <script>    
     let editor
 
@@ -372,13 +374,16 @@
     }
         
     const applyTheme = (themeName) => {
-      document.getElementById('codemirror-theme').setAttribute('href', `codemirror-${themeName}.css`)  
+      document.body.className = `cm-mw-${themeName}`  
     }
   
     const toggleSyntaxColors = () => {
-        var oldName = document.getElementById('codemirror-syntax-highlighting-off').getAttribute('href')
-        var newName = oldName.length > 0 ? '' : 'codemirror-syntax-highlighting-off.css'
-        document.getElementById('codemirror-syntax-highlighting-off').setAttribute('href', newName)
+      var elements = document.body.className.split(" ")
+      if (elements.length == 1) {
+        document.body.className = elements[0] + " cm-mw-off"
+      } else {
+        document.body.className = elements[0]
+      }
     }
   
     const scaleBodyText = (textSizeAdjustment) => {

--- a/www/codemirror/codemirror-light.css
+++ b/www/codemirror/codemirror-light.css
@@ -1,94 +1,94 @@
-html, body, .CodeMirror {
+.cm-mw-light, .cm-mw-light .CodeMirror {
   background-color: #FFF;
   color: #222;
 }
 
-.CodeMirror-gutters {
+.cm-mw-light .CodeMirror-gutters {
   background-color: #FFF;
   border-right: 4px solid #FFF;
 }
 
-.CodeMirror-linenumber {
+.cm-mw-light .CodeMirror-linenumber {
   color: #72777D;
   font-size: 0.8em;
 }
 
-.cm-mw-template {
+.cm-mw-light .cm-mw-template {
   color: #222; /* plain text color */
 }
 
-.cm-mw-link,
-.cm-mw-link-pagename,
-.cm-mw-link-tosection,
-.cm-mw-link-bracket,
-.cm-mw-link-delimiter,
-.cm-mw-extlink,
-.cm-mw-free-extlink,
-.cm-mw-extlink-protocol,
-.cm-mw-free-extlink-protocol,
-.cm-mw-extlink-bracket,
-.cm-mw-doubleUnderscore,
-.cm-mw-signature,
-.cm-mw-hr {
+.cm-mw-light .cm-mw-link,
+.cm-mw-light .cm-mw-link-pagename,
+.cm-mw-light .cm-mw-link-tosection,
+.cm-mw-light .cm-mw-link-bracket,
+.cm-mw-light .cm-mw-link-delimiter,
+.cm-mw-light .cm-mw-extlink,
+.cm-mw-light .cm-mw-free-extlink,
+.cm-mw-light .cm-mw-extlink-protocol,
+.cm-mw-light .cm-mw-free-extlink-protocol,
+.cm-mw-light .cm-mw-extlink-bracket,
+.cm-mw-light .cm-mw-doubleUnderscore,
+.cm-mw-light .cm-mw-signature,
+.cm-mw-light .cm-mw-hr {
   color: #36C;
   font-weight: normal;
 }
 
-.cm-mw-mnemonic,
-.cm-mw-exttag-name,
-.cm-mw-exttag-bracket,
-.cm-mw-exttag-attribute,
-.cm-mw-htmltag-name,
-.cm-mw-htmltag-bracket,
-.cm-mw-htmltag-attribute {
+.cm-mw-light .cm-mw-mnemonic,
+.cm-mw-light .cm-mw-exttag-name,
+.cm-mw-light .cm-mw-exttag-bracket,
+.cm-mw-light .cm-mw-exttag-attribute,
+.cm-mw-light .cm-mw-htmltag-name,
+.cm-mw-light .cm-mw-htmltag-bracket,
+.cm-mw-light .cm-mw-htmltag-attribute {
   color: #00AF89;
   font-weight: normal;
 }
 
-.cm-mw-parserfunction-name,
-.cm-mw-parserfunction-bracket,
-.cm-mw-parserfunction-delimiter { 
+.cm-mw-light .cm-mw-parserfunction-name,
+.cm-mw-light .cm-mw-parserfunction-bracket,
+.cm-mw-light .cm-mw-parserfunction-delimiter { 
   color: #B32424;
 }
 
-.cm-mw-table-bracket,
-.cm-mw-table-delimiter,
-.cm-mw-table-definition { 
+.cm-mw-light .cm-mw-table-bracket,
+.cm-mw-light .cm-mw-table-delimiter,
+.cm-mw-light .cm-mw-table-definition { 
   color: #E6275d; 
   font-weight: normal; 
 }
 
-.cm-mw-template-name,
-.cm-mw-template-argument-name,
-.cm-mw-template-delimiter,
-.cm-mw-template-bracket  {
+.cm-mw-light .cm-mw-template-name,
+.cm-mw-light .cm-mw-template-argument-name,
+.cm-mw-light .cm-mw-template-delimiter,
+.cm-mw-light .cm-mw-template-bracket  {
   color: #97498F;
   font-weight: normal;
 }
 
-.cm-mw-list,
-.cm-mw-doubleUnderscore, 
-.cm-mw-signature, 
-.cm-mw-hr,
-.cm-mw-indenting,
-.cm-mw-apostrophes-bold, 
-.cm-mw-apostrophes-italic,
-.cm-mw-section-header,
-.cm-mw-templatevariable,
-.cm-mw-templatevariable-name,
-.cm-mw-templatevariable-bracket,
-.cm-mw-templatevariable-delimiter,
-.cm-mw-matching {
+.cm-mw-light .cm-mw-list,
+.cm-mw-light .cm-mw-doubleUnderscore, 
+.cm-mw-light .cm-mw-signature, 
+.cm-mw-light .cm-mw-hr,
+.cm-mw-light .cm-mw-indenting,
+.cm-mw-light .cm-mw-apostrophes-bold, 
+.cm-mw-light .cm-mw-apostrophes-italic,
+.cm-mw-light .cm-mw-section-header,
+.cm-mw-light .cm-mw-templatevariable,
+.cm-mw-light .cm-mw-templatevariable-name,
+.cm-mw-light .cm-mw-templatevariable-bracket,
+.cm-mw-light .cm-mw-templatevariable-delimiter,
+.cm-mw-light .cm-mw-matching {
   color: #FF9500;
   font-weight: normal;
 }
 
-.cm-mw-comment,
-.cm-mw-skipformatting {
+.cm-mw-light .cm-mw-comment,
+.cm-mw-light .cm-mw-skipformatting {
   color: #72777D;
 }
 
-.cm-searching {
+.cm-mw-light .cm-searching {
   color: #000;
   background-color: rgba(255, 204, 51, 0.3);
   border-radius: 2px;

--- a/www/codemirror/codemirror-sepia.css
+++ b/www/codemirror/codemirror-sepia.css
@@ -1,94 +1,94 @@
-html, body, .CodeMirror {
+.cm-mw-sepia, .cm-mw-sepia .CodeMirror {
   background-color: #F8F1E3;
   color: #222;
 }
 
-.CodeMirror-gutters {
+.cm-mw-sepia .CodeMirror-gutters {
   background-color: #F8F1E3;
   border-right: 4px solid #F8F1E3;
 }
 
-.CodeMirror-linenumber {
+.cm-mw-sepia .CodeMirror-linenumber {
   color: #6C6760;
   font-size: 0.8em;
 }
 
-.cm-mw-template {
+.cm-mw-sepia .cm-mw-template {
   color: #222; /* plain text color */
 }
 
-.cm-mw-link,
-.cm-mw-link-pagename,
-.cm-mw-link-tosection,
-.cm-mw-link-bracket,
-.cm-mw-link-delimiter,
-.cm-mw-extlink,
-.cm-mw-free-extlink,
-.cm-mw-extlink-protocol,
-.cm-mw-free-extlink-protocol,
-.cm-mw-extlink-bracket,
-.cm-mw-doubleUnderscore,
-.cm-mw-signature,
-.cm-mw-hr {
+.cm-mw-sepia .cm-mw-link,
+.cm-mw-sepia .cm-mw-link-pagename,
+.cm-mw-sepia .cm-mw-link-tosection,
+.cm-mw-sepia .cm-mw-link-bracket,
+.cm-mw-sepia .cm-mw-link-delimiter,
+.cm-mw-sepia .cm-mw-extlink,
+.cm-mw-sepia .cm-mw-free-extlink,
+.cm-mw-sepia .cm-mw-extlink-protocol,
+.cm-mw-sepia .cm-mw-free-extlink-protocol,
+.cm-mw-sepia .cm-mw-extlink-bracket,
+.cm-mw-sepia .cm-mw-doubleUnderscore,
+.cm-mw-sepia .cm-mw-signature,
+.cm-mw-sepia .cm-mw-hr {
   color: #36C;
   font-weight: normal;
 }
 
-.cm-mw-mnemonic,
-.cm-mw-exttag-name,
-.cm-mw-exttag-bracket,
-.cm-mw-exttag-attribute,
-.cm-mw-htmltag-name,
-.cm-mw-htmltag-bracket,
-.cm-mw-htmltag-attribute {
+.cm-mw-sepia .cm-mw-mnemonic,
+.cm-mw-sepia .cm-mw-exttag-name,
+.cm-mw-sepia .cm-mw-exttag-bracket,
+.cm-mw-sepia .cm-mw-exttag-attribute,
+.cm-mw-sepia .cm-mw-htmltag-name,
+.cm-mw-sepia .cm-mw-htmltag-bracket,
+.cm-mw-sepia .cm-mw-htmltag-attribute {
   color: #00AF89;
   font-weight: normal;
 }
 
-.cm-mw-parserfunction-name,
-.cm-mw-parserfunction-bracket,
-.cm-mw-parserfunction-delimiter { 
+.cm-mw-sepia .cm-mw-parserfunction-name,
+.cm-mw-sepia .cm-mw-parserfunction-bracket,
+.cm-mw-sepia .cm-mw-parserfunction-delimiter { 
   color: #B32424;
 }
 
-.cm-mw-table-bracket,
-.cm-mw-table-delimiter,
-.cm-mw-table-definition { 
+.cm-mw-sepia .cm-mw-table-bracket,
+.cm-mw-sepia .cm-mw-table-delimiter,
+.cm-mw-sepia .cm-mw-table-definition { 
   color: #F06695; 
   font-weight: normal; 
 }
 
-.cm-mw-template-name,
-.cm-mw-template-argument-name,
-.cm-mw-template-delimiter,
-.cm-mw-template-bracket  {
+.cm-mw-sepia .cm-mw-template-name,
+.cm-mw-sepia .cm-mw-template-argument-name,
+.cm-mw-sepia .cm-mw-template-delimiter,
+.cm-mw-sepia .cm-mw-template-bracket  {
   color: #97498F;
   font-weight: normal;
 }
 
-.cm-mw-list,
-.cm-mw-doubleUnderscore, 
-.cm-mw-signature, 
-.cm-mw-hr,
-.cm-mw-indenting,
-.cm-mw-apostrophes-bold, 
-.cm-mw-apostrophes-italic,
-.cm-mw-section-header,
-.cm-mw-templatevariable,
-.cm-mw-templatevariable-name,
-.cm-mw-templatevariable-bracket,
-.cm-mw-templatevariable-delimiter,
-.cm-mw-matching {
+.cm-mw-sepia .cm-mw-list,
+.cm-mw-sepia .cm-mw-doubleUnderscore, 
+.cm-mw-sepia .cm-mw-signature, 
+.cm-mw-sepia .cm-mw-hr,
+.cm-mw-sepia .cm-mw-indenting,
+.cm-mw-sepia .cm-mw-apostrophes-bold, 
+.cm-mw-sepia .cm-mw-apostrophes-italic,
+.cm-mw-sepia .cm-mw-section-header,
+.cm-mw-sepia .cm-mw-templatevariable,
+.cm-mw-sepia .cm-mw-templatevariable-name,
+.cm-mw-sepia .cm-mw-templatevariable-bracket,
+.cm-mw-sepia .cm-mw-templatevariable-delimiter,
+.cm-mw-sepia .cm-mw-matching {
   color: #FF9500;
   font-weight: normal;
 }
 
-.cm-mw-comment,
-.cm-mw-skipformatting {
+.cm-mw-sepia .cm-mw-comment,
+.cm-mw-sepia .cm-mw-skipformatting {
   color: #6C6760;
 }
 
-.cm-searching {
+.cm-mw-sepia .cm-searching {
   color: #000;
   background-color: rgba(255, 204, 51, 0.3);
   border-radius: 2px;

--- a/www/codemirror/codemirror-syntax-highlighting-off.css
+++ b/www/codemirror/codemirror-syntax-highlighting-off.css
@@ -1,65 +1,47 @@
-.cm-mw-link,
-.cm-mw-link-pagename,
-.cm-mw-link-tosection,
-.cm-mw-link-bracket,
-.cm-mw-link-delimiter,
-.cm-mw-extlink,
-.cm-mw-free-extlink,
-.cm-mw-extlink-protocol,
-.cm-mw-free-extlink-protocol,
-.cm-mw-extlink-bracket,
-.cm-mw-doubleUnderscore,
-.cm-mw-signature,
-.cm-mw-hr {
-  color: inherit;
-}
-
-.cm-mw-mnemonic,
-.cm-mw-exttag-name,
-.cm-mw-exttag-bracket,
-.cm-mw-exttag-attribute,
-.cm-mw-htmltag-name,
-.cm-mw-htmltag-bracket,
-.cm-mw-htmltag-attribute {
-  color: inherit;
-}
-
-.cm-mw-parserfunction-name,
-.cm-mw-parserfunction-bracket,
-.cm-mw-parserfunction-delimiter { 
-  color: inherit;
-}
-
-.cm-mw-table-bracket,
-.cm-mw-table-delimiter,
-.cm-mw-table-definition { 
-  color: inherit;
-}
-
-.cm-mw-template-name,
-.cm-mw-template-argument-name,
-.cm-mw-template-delimiter,
-.cm-mw-template-bracket  {
-  color: inherit;
-}
-
-.cm-mw-list,
-.cm-mw-doubleUnderscore, 
-.cm-mw-signature, 
-.cm-mw-hr,
-.cm-mw-indenting,
-.cm-mw-apostrophes-bold, 
-.cm-mw-apostrophes-italic,
-.cm-mw-section-header,
-.cm-mw-templatevariable,
-.cm-mw-templatevariable-name,
-.cm-mw-templatevariable-bracket,
-.cm-mw-templatevariable-delimiter,
-.cm-mw-matching {
-  color: inherit;
-}
-
-.cm-mw-comment,
-.cm-mw-skipformatting {
+.cm-mw-off .cm-mw-link,
+.cm-mw-off .cm-mw-link-pagename,
+.cm-mw-off .cm-mw-link-tosection,
+.cm-mw-off .cm-mw-link-bracket,
+.cm-mw-off .cm-mw-link-delimiter,
+.cm-mw-off .cm-mw-extlink,
+.cm-mw-off .cm-mw-free-extlink,
+.cm-mw-off .cm-mw-extlink-protocol,
+.cm-mw-off .cm-mw-free-extlink-protocol,
+.cm-mw-off .cm-mw-extlink-bracket,
+.cm-mw-off .cm-mw-doubleUnderscore,
+.cm-mw-off .cm-mw-signature,
+.cm-mw-off .cm-mw-hr,
+.cm-mw-off .cm-mw-mnemonic,
+.cm-mw-off .cm-mw-exttag-name,
+.cm-mw-off .cm-mw-exttag-bracket,
+.cm-mw-off .cm-mw-exttag-attribute,
+.cm-mw-off .cm-mw-htmltag-name,
+.cm-mw-off .cm-mw-htmltag-bracket,
+.cm-mw-off .cm-mw-htmltag-attribute,
+.cm-mw-off .cm-mw-parserfunction-name,
+.cm-mw-off .cm-mw-parserfunction-bracket,
+.cm-mw-off .cm-mw-parserfunction-delimiter,
+.cm-mw-off .cm-mw-table-bracket,
+.cm-mw-off .cm-mw-table-delimiter,
+.cm-mw-off .cm-mw-table-definition,
+.cm-mw-off .cm-mw-template-name,
+.cm-mw-off .cm-mw-template-argument-name,
+.cm-mw-off .cm-mw-template-delimiter,
+.cm-mw-off .cm-mw-template-bracket,
+.cm-mw-off .cm-mw-list,
+.cm-mw-off .cm-mw-doubleUnderscore, 
+.cm-mw-off .cm-mw-signature, 
+.cm-mw-off .cm-mw-hr,
+.cm-mw-off .cm-mw-indenting,
+.cm-mw-off .cm-mw-apostrophes-bold, 
+.cm-mw-off .cm-mw-apostrophes-italic,
+.cm-mw-off .cm-mw-section-header,
+.cm-mw-off .cm-mw-templatevariable,
+.cm-mw-off .cm-mw-templatevariable-name,
+.cm-mw-off .cm-mw-templatevariable-bracket,
+.cm-mw-off .cm-mw-templatevariable-delimiter,
+.cm-mw-off .cm-mw-matching,
+.cm-mw-off .cm-mw-comment,
+.cm-mw-off .cm-mw-skipformatting {
   color: inherit;
 }


### PR DESCRIPTION
Follow up due to https://phabricator.wikimedia.org/T218303#5040430

Before this PR,  longer layouts (red bars) were triggered on theme change and when switching syntax highlighting on:
<img width="1146" alt="Screen Shot 2019-03-20 at 12 24 46 PM" src="https://user-images.githubusercontent.com/741327/54706708-ec28bd00-4b15-11e9-8351-cc9528760414.png">

After this change, it's quicker:
<img width="1130" alt="Screen Shot 2019-03-20 at 1 37 19 PM" src="https://user-images.githubusercontent.com/741327/54706715-efbc4400-4b15-11e9-9353-99a1e9b5cd8b.png">

Benchmarks taken on an iPhone X, "History" section of the SpaceX article