### PR TITLE
applied replace dialog closing bug fix to replace all

### DIFF
--- a/Wikipedia/assets/codemirror/resources/addon/search/search.js
+++ b/Wikipedia/assets/codemirror/resources/addon/search/search.js
@@ -262,7 +262,9 @@
       var query = cm.state.query;
       query = parseQuery(query);
       replaceText = parseString(replaceText);
+      cm.isReplacing = true;
       replaceAll(cm, query, replaceText);
+      cm.isReplacing = false;
 
       //resets count to 0/0
       let state = getSearchState(cm);


### PR DESCRIPTION
https://github.com/wikimedia/wikipedia-ios-codemirror/pull/10

I had already added this workaround for replacing a single instance after the wrap around. Now applying it to replace all.

https://github.com/wikimedia/wikipedia-ios/pull/2980/files#r266941627