### PR TITLE
Fix deploy script

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -198,7 +198,7 @@ platform :ios do
     
     sh "xcodebuild -project \"#{project_dir}/#{project_name}.xcodeproj\" -scheme \"#{scheme_name}\" -archivePath \"#{build_dir}/#{product_name}.xcarchive\" -allowProvisioningUpdates WMF_APP_SEE_API_KEY=#{app_see_api_key} archive"
     sh "open \"#{build_dir}/#{product_name}.xcarchive\"" #import the build to xcode
-    sh "zip -rjq \"#{build_dir}/#{product_name}.xcarchive.zip\" \"#{build_dir}/#{product_name}.xcarchive\""
+    sh "zip -rq \"#{build_dir}/#{product_name}.xcarchive.zip\" \"#{build_dir}/#{product_name}.xcarchive\""
     sh "xcodebuild -exportArchive -exportOptionsPlist ExportOptions.plist -archivePath \"#{build_dir}/#{product_name}.xcarchive\" -exportPath \"#{build_dir}\" -allowProvisioningUpdates"
   end
   


### PR DESCRIPTION
- Remove j option (junk directories) because it doesn't work. xcarchive is a package, it's entire contents would be flattened and there are name conflicts.
- Add version and build number to resulting zip file