### PR TITLE
Fix commits cherrypicked into 6.2.3

### DIFF
--- a/Wikipedia/Code/SectionEditorViewController.swift
+++ b/Wikipedia/Code/SectionEditorViewController.swift
@@ -251,13 +251,11 @@ class SectionEditorViewController: UIViewController {
         webView.becomeFirstResponder()
         messagingController.focus {
             assert(Thread.isMainThread)
-            self.delegate?.sectionEditorDidFinishLoadingWikitext(self)
-            
             guard let didFocusWebViewCompletion = self.didFocusWebViewCompletion else {
                 return
             }
             didFocusWebViewCompletion()
-            self?.didFocusWebViewCompletion = nil
+            self.didFocusWebViewCompletion = nil
         }
     }
     


### PR DESCRIPTION
Forgot to fix these 2 issues when cherry picking from develop into 6.2.3, `self` is not weak so it's not optional and `sectionEditorDidFinishLoadingWikitext` was added for Find & Replace tests