### PR TITLE
Fix views affected by Swift 5 compiler bug

### DIFF
--- a/Wikipedia/Code/AppearanceSettingsViewController.swift
+++ b/Wikipedia/Code/AppearanceSettingsViewController.swift
@@ -198,7 +198,7 @@ final class AppearanceSettingsViewController: SubSettingsViewController {
         } else if let spacerViewItem = sections[indexPath.section].items[indexPath.item] as? AppearanceSettingsSpacerViewItem {
             return spacerViewItem.spacing
         }
-        return UITableView.automaticDimension
+        return tableView.rowHeight
     }
     
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Wikipedia/Code/AppearanceSettingsViewController.swift
+++ b/Wikipedia/Code/AppearanceSettingsViewController.swift
@@ -198,7 +198,7 @@ final class AppearanceSettingsViewController: SubSettingsViewController {
         } else if let spacerViewItem = sections[indexPath.section].items[indexPath.item] as? AppearanceSettingsSpacerViewItem {
             return spacerViewItem.spacing
         }
-        return tableView.rowHeight
+        return UITableView.automaticDimension
     }
     
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Wikipedia/Code/AppearanceSettingsViewController.swift
+++ b/Wikipedia/Code/AppearanceSettingsViewController.swift
@@ -173,7 +173,8 @@ final class AppearanceSettingsViewController: SubSettingsViewController {
         return cell
     }
     
-    public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+    // keep @objc on UITableViewDelegate methods otherwise they aren't called on release builds
+    @objc public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         let item = sections[indexPath.section].items[indexPath.item]
         guard let customViewItem = item as? AppearanceSettingsCustomViewItem else {
             return
@@ -192,7 +193,7 @@ final class AppearanceSettingsViewController: SubSettingsViewController {
         NotificationCenter.default.post(name: Notification.Name(ReadingThemesControlsViewController.WMFUserDidSelectThemeNotification), object: nil, userInfo: userInfo)
     }
     
-    public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    @objc public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         if let customViewItem = sections[indexPath.section].items[indexPath.item] as? AppearanceSettingsCustomViewItem {
             return customViewItem.viewController.view.frame.height
         } else if let spacerViewItem = sections[indexPath.section].items[indexPath.item] as? AppearanceSettingsSpacerViewItem {
@@ -201,7 +202,7 @@ final class AppearanceSettingsViewController: SubSettingsViewController {
         return tableView.rowHeight
     }
     
-    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    @objc public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let item = sections[indexPath.section].items[indexPath.item] as? AppearanceSettingsCheckmarkItem else {
             return
         }
@@ -209,18 +210,18 @@ final class AppearanceSettingsViewController: SubSettingsViewController {
         tableView.reloadData()
     }
     
-    public func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+    @objc public func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         guard sections[indexPath.section].items[indexPath.item] is AppearanceSettingsCheckmarkItem else {
             return nil
         }
         return indexPath
     }
     
-    public func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+    @objc public func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
 
     }
     
-    public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+    @objc public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         let currentAppTheme = UserDefaults.wmf.wmf_appTheme
         
         if let checkmarkItem = sections[indexPath.section].items[indexPath.item] as? AppearanceSettingsCheckmarkItem {
@@ -256,11 +257,11 @@ final class AppearanceSettingsViewController: SubSettingsViewController {
         perform(selector, with: NSNumber(value: sender.isOn), afterDelay: CATransaction.animationDuration())
     }
     
-    public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    @objc public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return sections[section].headerTitle
     }
     
-    public func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+    @objc public func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         return sections[section].footerText
     }
 

--- a/Wikipedia/Code/AppearanceSettingsViewController.swift
+++ b/Wikipedia/Code/AppearanceSettingsViewController.swift
@@ -217,10 +217,6 @@ final class AppearanceSettingsViewController: SubSettingsViewController {
         return indexPath
     }
     
-    @objc public func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
-
-    }
-    
     @objc public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         let currentAppTheme = UserDefaults.wmf.wmf_appTheme
         

--- a/Wikipedia/Code/BaseExploreFeedSettingsViewController.swift
+++ b/Wikipedia/Code/BaseExploreFeedSettingsViewController.swift
@@ -244,12 +244,12 @@ extension BaseExploreFeedSettingsViewController {
         return sections.count
     }
 
-    override  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         let section = getSection(at: section)
         return section.items.count
     }
 
-    override  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: WMFSettingsTableViewCell.identifier, for: indexPath) as? WMFSettingsTableViewCell else {
             return UITableViewCell()
         }
@@ -268,12 +268,12 @@ extension BaseExploreFeedSettingsViewController {
 // MARK: - UITableViewDelegate
 
 extension BaseExploreFeedSettingsViewController {
-    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    @objc func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         let section = getSection(at: section)
         return section.headerTitle
     }
 
-    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    @objc func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         guard let footer = tableView.dequeueReusableHeaderFooterView(withIdentifier: WMFTableHeaderFooterLabelView.identifier) as? WMFTableHeaderFooterLabelView else {
             return nil
         }
@@ -286,7 +286,7 @@ extension BaseExploreFeedSettingsViewController {
         return footer
     }
 
-    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+    @objc func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         guard let _ = self.tableView(tableView, viewForFooterInSection: section) as? WMFTableHeaderFooterLabelView else {
             return 0
         }

--- a/Wikipedia/Code/ExploreFeedSettingsViewController.swift
+++ b/Wikipedia/Code/ExploreFeedSettingsViewController.swift
@@ -270,7 +270,7 @@ class ExploreFeedSettingsViewController: BaseExploreFeedSettingsViewController {
 // MARK: - UITableViewDelegate
 
 extension ExploreFeedSettingsViewController {
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    @objc func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard displayType == .multipleLanguages else {
             return
         }

--- a/Wikipedia/Code/NewsViewController.swift
+++ b/Wikipedia/Code/NewsViewController.swift
@@ -164,14 +164,14 @@ extension NewsViewController {
         }
     }
     
-    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+    @objc func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         guard let cell = cell as? NewsCollectionViewCell else {
             return
         }
         cell.selectionDelegate = self
     }
     
-    func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+    @objc func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         guard let cell = cell as? NewsCollectionViewCell else {
             return
         }

--- a/Wikipedia/Code/NotificationSettingsViewController.swift
+++ b/Wikipedia/Code/NotificationSettingsViewController.swift
@@ -156,7 +156,7 @@ class NotificationSettingsViewController: SubSettingsViewController {
         }
     }
 
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    @objc func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let header = WMFTableHeaderFooterLabelView.wmf_viewFromClassNib() else {
             return nil
         }
@@ -167,7 +167,7 @@ class NotificationSettingsViewController: SubSettingsViewController {
         return header;
     }
     
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    @objc func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         guard let header = WMFTableHeaderFooterLabelView.wmf_viewFromClassNib() else {
             return 0
         }
@@ -175,7 +175,7 @@ class NotificationSettingsViewController: SubSettingsViewController {
         return header.height(withExpectedWidth: self.view.frame.width)
     }
     
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    @objc func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let item = sections[indexPath.section].items[indexPath.item] as? NotificationSettingsButtonItem else {
             return
         }
@@ -185,7 +185,7 @@ class NotificationSettingsViewController: SubSettingsViewController {
     }
     
     
-    func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+    @objc func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
         return sections[indexPath.section].items[indexPath.item] as? NotificationSettingsSwitchItem == nil
     }
     

--- a/Wikipedia/Code/OnThisDayViewController.swift
+++ b/Wikipedia/Code/OnThisDayViewController.swift
@@ -214,7 +214,7 @@ extension OnThisDayViewController {
         return header
     }
     
-    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+    @objc func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         guard let cell = cell as? OnThisDayCollectionViewCell else {
             return
         }
@@ -222,7 +222,7 @@ extension OnThisDayViewController {
         cell.pauseDotsAnimation = false
     }
     
-    func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+    @objc func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         guard let cell = cell as? OnThisDayCollectionViewCell else {
             return
         }
@@ -230,25 +230,25 @@ extension OnThisDayViewController {
         cell.pauseDotsAnimation = true
     }
     
-    func collectionView(_ collectionView: UICollectionView, willDisplaySupplementaryView view: UICollectionReusableView, forElementKind elementKind: String, at indexPath: IndexPath) {
+    @objc func collectionView(_ collectionView: UICollectionView, willDisplaySupplementaryView view: UICollectionReusableView, forElementKind elementKind: String, at indexPath: IndexPath) {
         guard indexPath.section == 0, elementKind == UICollectionView.elementKindSectionHeader else {
             return
         }
         isDateVisibleInTitle = false
     }
     
-    func collectionView(_ collectionView: UICollectionView, didEndDisplayingSupplementaryView view: UICollectionReusableView, forElementOfKind elementKind: String, at indexPath: IndexPath) {
+    @objc func collectionView(_ collectionView: UICollectionView, didEndDisplayingSupplementaryView view: UICollectionReusableView, forElementOfKind elementKind: String, at indexPath: IndexPath) {
         guard indexPath.section == 0, elementKind == UICollectionView.elementKindSectionHeader else {
             return
         }
         isDateVisibleInTitle = true
     }
     
-    func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
+    @objc func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
         return false
     }
     
-    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+    @objc func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         return false
     }
 }

--- a/Wikipedia/Code/SearchSettingsViewController.swift
+++ b/Wikipedia/Code/SearchSettingsViewController.swift
@@ -78,7 +78,7 @@ extension SearchSettingsViewController {
 }
 
 extension SearchSettingsViewController {
-    public func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+    @objc public func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         return getSection(at: section).footerTitle
     }
 }

--- a/Wikipedia/Code/StorageAndSyncingSettingsViewController.swift
+++ b/Wikipedia/Code/StorageAndSyncingSettingsViewController.swift
@@ -227,7 +227,7 @@ extension StorageAndSyncingSettingsViewController {
         return cell
     }
     
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    @objc func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let item = getItem(at: indexPath)
         switch item.type {
@@ -255,7 +255,7 @@ extension StorageAndSyncingSettingsViewController {
 // MARK: UITableViewDelegate
 
 extension StorageAndSyncingSettingsViewController {
-    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    @objc func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         guard let footer = tableView.dequeueReusableHeaderFooterView(withIdentifier: WMFTableHeaderFooterLabelView.identifier) as? WMFTableHeaderFooterLabelView else {
             return nil
         }
@@ -267,7 +267,7 @@ extension StorageAndSyncingSettingsViewController {
         return footer
     }
     
-    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+    @objc func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         guard let _ = self.tableView(tableView, viewForFooterInSection: section) as? WMFTableHeaderFooterLabelView else {
             return 0
         }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T221906
https://phabricator.wikimedia.org/T221683
https://phabricator.wikimedia.org/T220694

~~I couldn't reproduce this consistently so this might not be the ultimate fix. It looked like the row height was off - all the rows were 44. It would make sense cause `heightForRowAt` can be called before the cells are available, causing custom cells to have the default height of 44. That was preventing me from changing the theme.~~

~~Let me know if you've seen it behave differently (as in if you were unable to change the theme while the table view looked ok).~~