### PR TITLE
Design review updates: Link previews

### DIFF
--- a/Wikipedia/Code/ArticlePeekPreviewViewController.swift
+++ b/Wikipedia/Code/ArticlePeekPreviewViewController.swift
@@ -33,6 +33,12 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
         updateView(with: article)
     }
     
+    public func updatePreferredContentSize(for contentWidth: CGFloat) {
+        var updatedContentSize = expandedArticleView.sizeThatFits(CGSize(width: contentWidth, height: UIView.noIntrinsicMetric), apply: true)
+        updatedContentSize.width = contentWidth // extra protection to ensure this stays == width
+        preferredContentSize = updatedContentSize
+    }
+    
     fileprivate func updateView(with article: WMFArticle) {
         expandedArticleView.configure(article: article, displayType: .pageWithPreview, index: 0, theme: theme, layoutOnly: false)
         expandedArticleView.isSaveButtonHidden = true
@@ -43,10 +49,7 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
         expandedArticleView.isHidden = false
 
         activityIndicatorView.stopAnimating()
-        
-        let preferredSize = self.view.systemLayoutSizeFitting(CGSize(width: self.view.bounds.size.width, height: UIView.layoutFittingCompressedSize.height), withHorizontalFittingPriority: UILayoutPriority.required, verticalFittingPriority: UILayoutPriority.fittingSizeLevel)
-        self.preferredContentSize = expandedArticleView.sizeThatFits(preferredSize, apply: true)
-        self.parent?.preferredContentSize = self.preferredContentSize
+        view.setNeedsLayout()
     }
     
     override func viewDidLoad() {
@@ -70,6 +73,7 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
         super.viewDidLayoutSubviews()
         expandedArticleView.frame = view.bounds
         activityIndicatorView.center = CGPoint(x: view.bounds.midX, y: view.bounds.midY)
+        updatePreferredContentSize(for: view.bounds.width)
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Wikipedia/Code/EditPreviewInternalLinkViewController.swift
+++ b/Wikipedia/Code/EditPreviewInternalLinkViewController.swift
@@ -4,6 +4,7 @@ class EditPreviewInternalLinkViewController: UIViewController {
     @IBOutlet private weak var containerView: UIView!
     private var containerViewHeightConstraint: NSLayoutConstraint?
     @IBOutlet private weak var button: UIButton!
+    @IBOutlet private weak var tapGestureRecignizer: UITapGestureRecognizer!
 
     private let articleURL: URL
     private let dataStore: MWKDataStore
@@ -29,6 +30,7 @@ class EditPreviewInternalLinkViewController: UIViewController {
         button.layer.cornerRadius = 8
         button.setTitle(CommonStrings.okTitle, for: .normal)
         wmf_addPeekableChildViewController(for: articleURL, dataStore: dataStore, theme: theme, containerView: containerView)
+        tapGestureRecignizer.addTarget(self, action: #selector(dismissAnimated(_:)))
         apply(theme: theme)
     }
 

--- a/Wikipedia/Code/EditPreviewInternalLinkViewController.swift
+++ b/Wikipedia/Code/EditPreviewInternalLinkViewController.swift
@@ -4,6 +4,7 @@ class EditPreviewInternalLinkViewController: UIViewController {
     @IBOutlet private weak var containerView: UIView!
     private var containerViewHeightConstraint: NSLayoutConstraint?
     @IBOutlet private weak var button: UIButton!
+    @IBOutlet private weak var tapView: UIView!
     @IBOutlet private weak var tapGestureRecignizer: UITapGestureRecognizer!
 
     private let articleURL: URL
@@ -22,7 +23,7 @@ class EditPreviewInternalLinkViewController: UIViewController {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        button.titleLabel?.font = UIFont.wmf_font(.semiboldSubheadline, compatibleWithTraitCollection: traitCollection)
+        button.titleLabel?.font = UIFont.wmf_font(.title3, compatibleWithTraitCollection: traitCollection)
     }
 
     override func viewDidLoad() {
@@ -30,6 +31,7 @@ class EditPreviewInternalLinkViewController: UIViewController {
         button.layer.cornerRadius = 8
         button.setTitle(CommonStrings.okTitle, for: .normal)
         wmf_addPeekableChildViewController(for: articleURL, dataStore: dataStore, theme: theme, containerView: containerView)
+        tapGestureRecignizer.delegate = self
         tapGestureRecignizer.addTarget(self, action: #selector(dismissAnimated(_:)))
         apply(theme: theme)
     }
@@ -45,6 +47,12 @@ class EditPreviewInternalLinkViewController: UIViewController {
 
     @IBAction private func dismissAnimated(_ sender: UIButton) {
         dismiss(animated: true)
+    }
+}
+
+extension EditPreviewInternalLinkViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        return touch.view == tapView
     }
 }
 

--- a/Wikipedia/Code/EditPreviewInternalLinkViewController.xib
+++ b/Wikipedia/Code/EditPreviewInternalLinkViewController.xib
@@ -15,6 +15,7 @@
                 <outlet property="button" destination="Sce-E4-ZEM" id="poG-0c-bFU"/>
                 <outlet property="containerView" destination="LBy-N3-43n" id="9ar-tz-xOX"/>
                 <outlet property="tapGestureRecignizer" destination="NwK-NY-AW1" id="YmP-cs-COA"/>
+                <outlet property="tapView" destination="lP8-IR-vmI" id="Ky4-vL-OUy"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -90,7 +91,7 @@
                                 </mask>
                             </variation>
                             <connections>
-                                <outletCollection property="gestureRecognizers" destination="NwK-NY-AW1" appends="YES" id="jjR-Pw-yzR"/>
+                                <outletCollection property="gestureRecognizers" destination="NwK-NY-AW1" appends="YES" id="U02-ck-e4A"/>
                             </connections>
                         </view>
                     </subviews>

--- a/Wikipedia/Code/EditPreviewInternalLinkViewController.xib
+++ b/Wikipedia/Code/EditPreviewInternalLinkViewController.xib
@@ -31,7 +31,7 @@
                             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LBy-N3-43n">
-                                    <rect key="frame" x="12" y="284" width="390" height="328"/>
+                                    <rect key="frame" x="16" y="284" width="382" height="328"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="328" placeholder="YES" id="tg4-vm-hVM">
                                             <variation key="heightClass=compact" constant="100"/>
@@ -45,9 +45,9 @@
                                     </userDefinedRuntimeAttributes>
                                 </view>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sce-E4-ZEM">
-                                    <rect key="frame" x="12" y="624" width="390" height="42"/>
+                                    <rect key="frame" x="16" y="624" width="382" height="48"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <inset key="contentEdgeInsets" minX="24" minY="12" maxX="24" maxY="12"/>
+                                    <inset key="contentEdgeInsets" minX="24" minY="15" maxX="24" maxY="15"/>
                                     <state key="normal" title="Button"/>
                                     <connections>
                                         <action selector="dismissAnimated:" destination="-1" eventType="touchUpInside" id="dRw-nP-Rnz"/>
@@ -62,9 +62,9 @@
                                 <constraint firstItem="LBy-N3-43n" firstAttribute="centerY" secondItem="lP8-IR-vmI" secondAttribute="centerY" priority="999" id="VOb-BY-w6e"/>
                                 <constraint firstItem="LBy-N3-43n" firstAttribute="top" relation="greaterThanOrEqual" secondItem="0Qr-og-G0P" secondAttribute="top" constant="12" id="Zv5-nZ-JQD"/>
                                 <constraint firstItem="Sce-E4-ZEM" firstAttribute="top" secondItem="LBy-N3-43n" secondAttribute="bottom" constant="12" id="aKb-nf-tUW"/>
-                                <constraint firstItem="LBy-N3-43n" firstAttribute="leading" secondItem="0Qr-og-G0P" secondAttribute="leading" constant="12" id="cRo-gZ-Roi"/>
+                                <constraint firstItem="LBy-N3-43n" firstAttribute="leading" secondItem="0Qr-og-G0P" secondAttribute="leading" constant="16" id="cRo-gZ-Roi"/>
                                 <constraint firstItem="0Qr-og-G0P" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Sce-E4-ZEM" secondAttribute="bottom" constant="12" id="dVL-Ji-r8x"/>
-                                <constraint firstItem="0Qr-og-G0P" firstAttribute="trailing" secondItem="LBy-N3-43n" secondAttribute="trailing" constant="12" id="z80-nG-fHu"/>
+                                <constraint firstItem="0Qr-og-G0P" firstAttribute="trailing" secondItem="LBy-N3-43n" secondAttribute="trailing" constant="16" id="z80-nG-fHu"/>
                             </constraints>
                             <viewLayoutGuide key="safeArea" id="0Qr-og-G0P"/>
                             <variation key="heightClass=compact">

--- a/Wikipedia/Code/EditPreviewInternalLinkViewController.xib
+++ b/Wikipedia/Code/EditPreviewInternalLinkViewController.xib
@@ -14,6 +14,7 @@
             <connections>
                 <outlet property="button" destination="Sce-E4-ZEM" id="poG-0c-bFU"/>
                 <outlet property="containerView" destination="LBy-N3-43n" id="9ar-tz-xOX"/>
+                <outlet property="tapGestureRecignizer" destination="NwK-NY-AW1" id="YmP-cs-COA"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -52,6 +53,7 @@
                                     </connections>
                                 </button>
                             </subviews>
+                            <gestureRecognizers/>
                             <constraints>
                                 <constraint firstItem="Sce-E4-ZEM" firstAttribute="leading" secondItem="LBy-N3-43n" secondAttribute="leading" id="0ia-Tb-5cn"/>
                                 <constraint firstItem="LBy-N3-43n" firstAttribute="centerX" secondItem="lP8-IR-vmI" secondAttribute="centerX" priority="999" id="HWz-iP-BMQ"/>
@@ -87,6 +89,9 @@
                                     <exclude reference="cRo-gZ-Roi"/>
                                 </mask>
                             </variation>
+                            <connections>
+                                <outletCollection property="gestureRecognizers" destination="NwK-NY-AW1" appends="YES" id="jjR-Pw-yzR"/>
+                            </connections>
                         </view>
                     </subviews>
                     <constraints>
@@ -131,5 +136,6 @@
                 </mask>
             </variation>
         </view>
+        <tapGestureRecognizer id="NwK-NY-AW1"/>
     </objects>
 </document>

--- a/Wikipedia/Code/EditPreviewViewController.swift
+++ b/Wikipedia/Code/EditPreviewViewController.swift
@@ -46,6 +46,7 @@ class EditPreviewViewController: UIViewController, Themeable, WMFOpenExternalLin
                 return
             }
             let internalLinkViewController = EditPreviewInternalLinkViewController(articleURL: articleURL, dataStore: dataStore)
+            internalLinkViewController.preferredContentSize = CGSize(width: 10, height: 10)
             internalLinkViewController.modalPresentationStyle = .overCurrentContext
             internalLinkViewController.modalTransitionStyle = .crossDissolve
             internalLinkViewController.apply(theme: theme)

--- a/Wikipedia/Code/EditPreviewViewController.swift
+++ b/Wikipedia/Code/EditPreviewViewController.swift
@@ -46,7 +46,6 @@ class EditPreviewViewController: UIViewController, Themeable, WMFOpenExternalLin
                 return
             }
             let internalLinkViewController = EditPreviewInternalLinkViewController(articleURL: articleURL, dataStore: dataStore)
-            internalLinkViewController.preferredContentSize = CGSize(width: 10, height: 10)
             internalLinkViewController.modalPresentationStyle = .overCurrentContext
             internalLinkViewController.modalTransitionStyle = .crossDissolve
             internalLinkViewController.apply(theme: theme)


### PR DESCRIPTION
https://phabricator.wikimedia.org/T213753#5150195

Sizing question:

The VC that I'm presenting is in a xib (`EditPreviewInternalLinkViewController.xib`). When I lay out my subviews, I rely on the VC's view's bounds to figure out how much space I have available:

https://github.com/wikimedia/wikipedia-ios/blob/908bd09ae9e8c0907488512b149d5ce049c5a48d/Wikipedia/Code/ArticlePeekPreviewViewController.swift#L47

But at that time, the bounds are wrong so my `ArticleFullWidthImageCollectionViewCell` ends up thinking that it has more available width to lay out its labels than it actually does. I thought I could set `preferredContentSize` on the VC before presenting it and that would let it know what size it should shoot for but that doesn't affect the bounds. 😬  Is there a good way to let the VC how big its bounds should be before it's presented? 

To demonstrate the issue - here, I think, the title label thought that it had more width available so it told the cell that its height would be only ~30 when in fact it's more than that

![Simulator Screen Shot - iPhone X - 2019-05-01 at 16 45 08](https://user-images.githubusercontent.com/9299317/57041536-865d4400-6c30-11e9-8fc9-39d15daaaa8e.png)
