### PR TITLE
Fix Insert Media constraint crash

### DIFF
--- a/Wikipedia/Code/SectionEditorViewController.swift
+++ b/Wikipedia/Code/SectionEditorViewController.swift
@@ -581,7 +581,10 @@ extension SectionEditorViewController: SectionEditorInputViewsControllerDelegate
     func sectionEditorInputViewsControllerDidTapMediaInsert(_ sectionEditorInputViewsController: SectionEditorInputViewsController) {
         let insertMediaViewController = InsertMediaViewController(articleTitle: section?.article?.displaytitle, siteURL: section?.article?.url.wmf_site)
         insertMediaViewController.delegate = self
-        present(insertMediaViewController, animated: true)
+        insertMediaViewController.apply(theme: theme)
+        let navigationController = UINavigationController(rootViewController: insertMediaViewController)
+        navigationController.isNavigationBarHidden = true
+        present(navigationController, animated: true)
     }
 
     func showLinkWizard() {


### PR DESCRIPTION
`showsNavigationBar` in `viewWillAppear` of `ViewController` (superclass of `InsertMediaViewController`) is set to false because `navigationController` is nil

https://github.com/wikimedia/wikipedia-ios/blob/c080d88d30ce9146de4dfcf98c0bbd7c01a03195/Wikipedia/Code/ViewController.swift#L181

which causes a "no common ancestor" crash in `InsertMediaViewController`'s `viewWillAppear`

https://github.com/wikimedia/wikipedia-ios/blob/dbbaccf5fe088fa73eb76cb3f2ae27c08b1fbf89/Wikipedia/Code/InsertMediaViewController.swift#L72