### PR TITLE
Fix WebKit crash caused by a deallocation of a WKURLSchemeTask on a thread other than main

### DIFF
--- a/Wikipedia/Code/Session.swift
+++ b/Wikipedia/Code/Session.swift
@@ -402,7 +402,7 @@ public enum RequestError: Int, LocalizedError {
 }
 
 class SessionDelegate: NSObject, URLSessionDelegate, URLSessionDataDelegate {
-    let delegateDispatchQueue = DispatchQueue(label: "SessionDelegateDispatchQueue", qos: .default, attributes: [.concurrent], autoreleaseFrequency: .workItem, target: nil)
+    let delegateDispatchQueue = DispatchQueue(label: "SessionDelegateDispatchQueue", qos: .default, attributes: [], autoreleaseFrequency: .workItem, target: nil) // needs to be serial according the docs for NSURLSession
     let delegateQueue: OperationQueue
     var callbacks: [Int: Session.Callback] = [:]
     
@@ -412,14 +412,8 @@ class SessionDelegate: NSObject, URLSessionDelegate, URLSessionDataDelegate {
     }
     
     func addCallback(callback: Session.Callback, for task: URLSessionTask) {
-        delegateDispatchQueue.async(flags: .barrier) {
+        delegateDispatchQueue.async {
             self.callbacks[task.taskIdentifier] = callback
-        }
-    }
-    
-    func removeDataCallback(for task: URLSessionTask) {
-        delegateDispatchQueue.async(flags: .barrier) {
-            self.callbacks.removeValue(forKey: task.taskIdentifier)
         }
     }
     
@@ -441,12 +435,12 @@ class SessionDelegate: NSObject, URLSessionDelegate, URLSessionDataDelegate {
     }
     
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        defer {
-            removeDataCallback(for: task)
-        }
-        
         guard let callback = callbacks[task.taskIdentifier] else {
             return
+        }
+        
+        defer {
+            callbacks.removeValue(forKey: task.taskIdentifier)
         }
         
         if let error = error as NSError? {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T224113

- Ensures `WKURLSchemeTask` isn't captured by blocks that will be deallocated off the main thread 
- Use a serial queue for the `NSURLSession` queue to match [what the doc recommends](https://developer.apple.com/documentation/foundation/urlsession/1411597-init)
- Use an operation queue for cache operations in the scheme handler - while testing this I observed a state where a large number of concurrent cache operations (kicked off by loading and cancelling several article loads) caused every network request to hang