### PR TITLE
Implement accessibilityPerformEscape for VCs presented modally

### DIFF
--- a/Wikipedia/Code/AddArticlesToReadingListViewController.swift
+++ b/Wikipedia/Code/AddArticlesToReadingListViewController.swift
@@ -61,6 +61,11 @@ class AddArticlesToReadingListViewController: ViewController {
         readingListsViewController.createReadingList(with: articles, moveFromReadingList: moveFromReadingList)
     }
 
+    override func accessibilityPerformEscape() -> Bool {
+        closeButtonPressed()
+        return true
+    }
+
     private var isCreateNewReadingListButtonViewHidden: Bool = false {
         didSet {
             if isCreateNewReadingListButtonViewHidden {

--- a/Wikipedia/Code/CreateReadingListViewController.swift
+++ b/Wikipedia/Code/CreateReadingListViewController.swift
@@ -40,6 +40,11 @@ class CreateReadingListViewController: WMFScrollViewController, UITextFieldDeleg
     override func viewWillDisappear(_ animated: Bool) {
         view.endEditing(false)
     }
+
+    override func accessibilityPerformEscape() -> Bool {
+        dismiss(animated: true)
+        return true
+    }
     
     init(theme: Theme, articles: [WMFArticle], moveFromReadingList: ReadingList? = nil) {
         self.theme = theme

--- a/Wikipedia/Code/InsertLinkViewController.swift
+++ b/Wikipedia/Code/InsertLinkViewController.swift
@@ -59,6 +59,11 @@ class InsertLinkViewController: UIViewController {
     @objc private func delegateCloseButtonTap(_ sender: UIBarButtonItem) {
         delegate?.insertLinkViewController(self, didTapCloseButton: sender)
     }
+
+    override func accessibilityPerformEscape() -> Bool {
+        delegate?.insertLinkViewController(self, didTapCloseButton: closeButton)
+        return true
+    }
 }
 
 extension InsertLinkViewController: ArticleCollectionViewControllerDelegate {

--- a/Wikipedia/Code/InsertMediaViewController.swift
+++ b/Wikipedia/Code/InsertMediaViewController.swift
@@ -202,6 +202,11 @@ final class InsertMediaViewController: ViewController {
             completion?()
         })
     }
+
+    override func accessibilityPerformEscape() -> Bool {
+        delegate?.insertMediaViewController(self, didTapCloseButton: closeButton)
+        return true
+    }
 }
 
 extension InsertMediaViewController: InsertMediaSearchViewControllerDelegate {

--- a/Wikipedia/Code/PageHistoryViewController.m
+++ b/Wikipedia/Code/PageHistoryViewController.m
@@ -59,6 +59,11 @@
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
+- (BOOL)accessibilityPerformEscape {
+    [self closeButtonPressed];
+    return YES;
+}
+
 - (void)getPageHistoryData {
     self.isLoadingData = YES;
 

--- a/Wikipedia/Code/SectionEditorViewController.swift
+++ b/Wikipedia/Code/SectionEditorViewController.swift
@@ -340,7 +340,7 @@ class SectionEditorViewController: UIViewController {
     // MARK: - Accessibility
     
     override func accessibilityPerformEscape() -> Bool {
-        navigationController?.popViewController(animated: true)
+        delegate?.sectionEditorDidFinishEditing(self, withChanges: false)
         return true
     }
     

--- a/Wikipedia/Code/SubSettingsViewController.swift
+++ b/Wikipedia/Code/SubSettingsViewController.swift
@@ -11,6 +11,11 @@ class SubSettingsViewController: ViewController {
     override var nibName: String? {
         return "SubSettingsViewController"
     }
+
+    override func accessibilityPerformEscape() -> Bool {
+        dismiss(animated: true)
+        return true
+    }
 }
 
 extension SubSettingsViewController: UITableViewDataSource {

--- a/Wikipedia/Code/WMFAccountCreationViewController.swift
+++ b/Wikipedia/Code/WMFAccountCreationViewController.swift
@@ -33,7 +33,7 @@ class WMFAccountCreationViewController: WMFScrollViewController, WMFCaptchaViewC
     
     fileprivate lazy var captchaViewController: WMFCaptchaViewController? = WMFCaptchaViewController.wmf_initialViewControllerFromClassStoryboard()
     
-    @objc func closeButtonPushed(_ : UIBarButtonItem) {
+    @objc func closeButtonPushed(_ : UIBarButtonItem?) {
         dismiss(animated: true, completion: nil)
     }
 
@@ -59,6 +59,11 @@ class WMFAccountCreationViewController: WMFScrollViewController, WMFCaptchaViewC
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         startDate = Date()
+    }
+
+    override func accessibilityPerformEscape() -> Bool {
+        closeButtonPushed(nil)
+        return true
     }
     
     override func viewDidLoad() {

--- a/Wikipedia/Code/WMFLoginViewController.swift
+++ b/Wikipedia/Code/WMFLoginViewController.swift
@@ -31,13 +31,18 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
         
     }
 
-    @objc func closeButtonPushed(_ : UIBarButtonItem) {
+    @objc func closeButtonPushed(_ : UIBarButtonItem?) {
         dismiss(animated: true, completion: nil)
         loginDismissedCompletion?()
     }
 
     @IBAction fileprivate func loginButtonTapped(withSender sender: UIButton) {
         save()
+    }
+
+    override func accessibilityPerformEscape() -> Bool {
+        closeButtonPushed(nil)
+        return true
     }
 
     override func viewDidLoad() {

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -176,6 +176,11 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
     return cell;
 }
 
+- (BOOL)accessibilityPerformEscape {
+    [self closeButtonPressed];
+    return YES;
+}
+
 - (void)disclosureSwitchChanged:(UISwitch *)disclosureSwitch {
     WMFSettingsMenuItemType type = (WMFSettingsMenuItemType)disclosureSwitch.tag;
     [self updateStateForMenuItemType:type isSwitchOnValue:disclosureSwitch.isOn];


### PR DESCRIPTION
Implementing `accessibilityPerformEscape` allows VoiceOver users to dismiss a VC with a two-finger Z-shaped gesture