### PR TITLE
Fix missing `Cancel` & `Done` buttons on reading list detail view

### DIFF
--- a/WMF Framework/NavigationBar.swift
+++ b/WMF Framework/NavigationBar.swift
@@ -82,6 +82,7 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
         if displayType == .largeTitle, let navigationItem = items.last {
             configureTitleBar(with: navigationItem)
         } else {
+            bar.setItems([], animated: false)
             bar.setItems(items, animated: false)
         }
         apply(theme: theme)

--- a/Wikipedia/Code/ReadingListDetailViewController.swift
+++ b/Wikipedia/Code/ReadingListDetailViewController.swift
@@ -179,6 +179,8 @@ extension ReadingListDetailViewController: CollectionViewEditControllerNavigatio
         default:
             break
         }
+        
+        navigationBar.updateNavigationItems()
     }
 }
 


### PR DESCRIPTION
Repro steps:
1. Open a reading list
2. Tap through to an article
3. Tap back
4. Tap title or description to edit OR tap on Edit in the top right

Expected:
Cancel / Done buttons are shown at the top for title/description editing, Cancel is shown for batch editing

Actual:
Buttons don't change

The `UINavigationBar` wasn't updating the buttons. In the debugger the navigation bar had the correct navigation items set with the right buttons, but the actual views were out of sync. It's likely this is due to using the standard `navigationItem` property as it puts our `NavigationBar` in conflict with the `UINavigationController`.