### PR TITLE
Make "Be kind.." view an input accessory view (Reply screen)

### DIFF
--- a/Wikipedia/Code/TalkPageReplyComposeView.swift
+++ b/Wikipedia/Code/TalkPageReplyComposeView.swift
@@ -9,8 +9,7 @@ protocol TalkPageReplyComposeViewDelegate: class {
 class TalkPageReplyComposeView: UIView {
     
     private(set) var composeTextViewFrame: CGRect?
-    private(set) var beKindViewFrame: CGRect?
-    
+
     lazy private(set) var composeTextView: ThemeableTextView = ThemeableTextView()
     lazy private var finePrintTextView: UITextView = UITextView()
     

--- a/Wikipedia/Code/TalkPageReplyComposeView.swift
+++ b/Wikipedia/Code/TalkPageReplyComposeView.swift
@@ -12,7 +12,6 @@ class TalkPageReplyComposeView: UIView {
     private(set) var beKindViewFrame: CGRect?
     
     lazy private(set) var composeTextView: ThemeableTextView = ThemeableTextView()
-    lazy private(set) var beKindView: InfoBannerView = InfoBannerView()
     lazy private var finePrintTextView: UITextView = UITextView()
     
     weak var delegate: TalkPageReplyComposeViewDelegate?
@@ -61,14 +60,9 @@ class TalkPageReplyComposeView: UIView {
         }
     }
     
-    func resetBeKindViewFrame() {
-        if let beKindViewFrame = beKindViewFrame {
-            beKindView.frame = beKindViewFrame
-        }
-    }
-    
     func sizeThatFits(_ size: CGSize, apply: Bool) -> CGSize {
-        
+        let inputAccessoryViewHeight: CGFloat = composeTextView.inputAccessoryView?.frame.height ?? 0
+
         let semanticContentAttribute: UISemanticContentAttribute = traitCollection.layoutDirection == .rightToLeft ? .forceRightToLeft : .forceLeftToRight
         
         let adjustedMargins = UIEdgeInsets(top: layoutMargins.top, left: layoutMargins.left + 7, bottom: layoutMargins.bottom, right: layoutMargins.right + 7)
@@ -81,25 +75,18 @@ class TalkPageReplyComposeView: UIView {
         
         
         let finePrintFrame = finePrintTextView.wmf_preferredFrame(at: finePrintTextViewOrigin, maximumWidth: finePrintTextViewWidth, minimumWidth: finePrintTextViewWidth, alignedBy: semanticContentAttribute, apply: false) //will apply below
-        
-        let beKindViewOrigin = CGPoint(x: 0, y: adjustedMargins.top)
-        beKindView.layoutMargins = layoutMargins
-        let beKindViewSize = beKindView.sizeThatFits(size, apply: apply)
-        let beKindViewFrame = CGRect(origin: beKindViewOrigin, size: beKindViewSize)
-        
-        let forcedComposeHeight = (delegate?.collectionViewFrame.size ?? size).height * 0.67 - (finePrintFrame.height + beKindViewFrame.height)
+
+        let forcedComposeHeight = (delegate?.collectionViewFrame.size ?? size).height * 0.67 - finePrintFrame.height - inputAccessoryViewHeight
         
         let composeTextViewFrame = CGRect(x: composeTextViewOrigin.x, y: composeTextViewOrigin.y, width: composeTextViewWidth, height: forcedComposeHeight)
         self.composeTextViewFrame = composeTextViewFrame
         
         if (apply) {
             composeTextView.frame = composeTextViewFrame
-            beKindView.frame = CGRect(x: 0, y: composeTextViewFrame.minY + composeTextViewFrame.height, width: size.width, height: beKindViewFrame.height)
-            self.beKindViewFrame = beKindView.frame
-            finePrintTextView.frame = CGRect(x: adjustedMargins.left, y: composeTextViewFrame.minY + composeTextViewFrame.height + beKindViewFrame.height, width: finePrintTextViewWidth, height: finePrintFrame.height)
+            finePrintTextView.frame = CGRect(x: adjustedMargins.left, y: composeTextViewFrame.minY + composeTextViewFrame.height, width: finePrintTextViewWidth, height: finePrintFrame.height)
         }
         
-        let finalHeight = adjustedMargins.top + composeTextViewFrame.size.height + beKindViewFrame.height + finePrintFrame.height + adjustedMargins.bottom
+        let finalHeight = adjustedMargins.top + composeTextViewFrame.size.height + finePrintFrame.height + adjustedMargins.bottom + inputAccessoryViewHeight
         return CGSize(width: size.width, height: finalHeight)
     }
     
@@ -150,8 +137,6 @@ private extension TalkPageReplyComposeView {
         insertSubview(finePrintTextView, belowSubview: composeTextView)
         finePrintTextView.isScrollEnabled = false
         finePrintTextView.attributedText = licenseTitleTextViewAttributedString
-        insertSubview(beKindView, aboveSubview: composeTextView)
-        beKindView.configure(iconName: "heart-icon", title: CommonStrings.talkPageNewBannerTitle, subtitle: CommonStrings.talkPageNewBannerSubtitle)
     }
 }
 
@@ -161,7 +146,6 @@ extension TalkPageReplyComposeView: Themeable {
     func apply(theme: Theme) {
         self.theme = theme
         composeTextView.apply(theme: theme)
-        beKindView.apply(theme: theme)
         backgroundColor = theme.colors.paperBackground
         finePrintTextView.backgroundColor = theme.colors.paperBackground
         finePrintTextView.textColor = theme.colors.secondaryText

--- a/Wikipedia/Code/TalkPageReplyFooterView.swift
+++ b/Wikipedia/Code/TalkPageReplyFooterView.swift
@@ -33,20 +33,12 @@ class TalkPageReplyFooterView: SizeThatFitsReusableView {
         return composeView.composeTextView
     }
     
-    var beKindView: InfoBannerView {
-        return composeView.beKindView
-    }
-    
     func resetCompose() {
         composeView.resetCompose()
     }
     
     func resetComposeTextViewFrame() {
         composeView.resetComposeTextViewFrame()
-    }
-    
-    func resetBeKindViewFrame() {
-        composeView.resetBeKindViewFrame()
     }
     
     override func sizeThatFits(_ size: CGSize, apply: Bool) -> CGSize {
@@ -75,8 +67,6 @@ class TalkPageReplyFooterView: SizeThatFitsReusableView {
             
             return CGSize(width: size.width, height: finalHeight)
         } else {
-            
-            
             let composeViewOrigin = CGPoint(x: 0, y: adjustedMargins.top + dividerHeight + divComposeSpacing)
             
             composeView.layoutMargins = layoutMargins

--- a/Wikipedia/Code/TalkPageReplyListViewController.swift
+++ b/Wikipedia/Code/TalkPageReplyListViewController.swift
@@ -17,6 +17,8 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
     private let reuseIdentifier = "TalkPageReplyCell"
     
     private var collectionViewUpdater: CollectionViewUpdater<TalkPageReply>!
+
+    private lazy var beKindInputAccessoryView: BeKindInputAccessoryView = BeKindInputAccessoryView.wmf_viewFromClassNib()
     
     private lazy var publishButton: UIBarButtonItem = {
         let publishButton = UIBarButtonItem(title: CommonStrings.publishTitle, style: .done, target: self, action: #selector(tappedPublish(_:)))
@@ -58,6 +60,7 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
                 navigationItem.rightBarButtonItem = replyBarButtonItem
                 navigationBar.updateNavigationItems()
             }
+            reloadInputViews()
         }
     }
     
@@ -95,6 +98,14 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
         
         collectionView.keyboardDismissMode = .onDrag
     }
+
+    override var canBecomeFirstResponder: Bool {
+        return true
+    }
+
+    override var inputAccessoryView: UIView? {
+        return showingCompose ? beKindInputAccessoryView : nil
+    }
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
@@ -128,7 +139,7 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
             
             //shift keyboard frame if necessary so compose view is in visible window
             let navBarHeight = navigationBar.visibleHeight
-            let newHeight = keyboardFrame.minY - navBarHeight - footerView.beKindView.frame.height
+            let newHeight = keyboardFrame.minY - navBarHeight
             
             convertedComposeTextViewFrame.origin.y = navBarHeight
             convertedComposeTextViewFrame.size.height = newHeight
@@ -142,7 +153,6 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
             
             UIView.animate(withDuration: duration, delay: 0.0, options: curve, animations: {
                 footerView.composeTextView.frame = newConvertedComposeTextViewFrame
-                footerView.beKindView.frame.origin.y = newConvertedComposeTextViewFrame.minY + newConvertedComposeTextViewFrame.height
             }, completion: nil)
         }
     }
@@ -161,7 +171,6 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
         
         UIView.animate(withDuration: duration, animations: {
             self.footerView?.resetComposeTextViewFrame()
-            self.footerView?.resetBeKindViewFrame()
         })
     }
     
@@ -262,6 +271,7 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
             return estimate
         }
         configure(footer: footer)
+        footer.composeTextView.inputAccessoryView = beKindInputAccessoryView
         estimate.height = footer.sizeThatFits(CGSize(width: columnWidth, height: UIView.noIntrinsicMetric), apply: false).height
         estimate.precalculated = true
         return estimate
@@ -270,6 +280,7 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
     override func apply(theme: Theme) {
         super.apply(theme: theme)
         view.backgroundColor = theme.colors.paperBackground
+        beKindInputAccessoryView.apply(theme: theme)
     }
 }
 


### PR DESCRIPTION
Now that "Be kind..." view is below "By saving changes..." view (https://github.com/wikimedia/wikipedia-ios/pull/3099), we'd want to keep the same order of views on the Reply screen.

Branched off https://github.com/wikimedia/wikipedia-ios/pull/3099.

Relevant commits:

- https://github.com/wikimedia/wikipedia-ios/commit/467a0d8d14d81c19b89bbc9d9dbc184fa63df603