### PR TITLE
Track read status of talk page topics, Core Data thread safety fixes

### DIFF
--- a/WMF Framework/Wikipedia.xcdatamodeld/Wikipedia 2.xcdatamodel/contents
+++ b/WMF Framework/Wikipedia.xcdatamodeld/Wikipedia 2.xcdatamodel/contents
@@ -85,14 +85,22 @@
         <relationship name="topic" maxCount="1" deletionRule="Nullify" destinationEntity="TalkPageTopic" inverseName="replies" inverseEntity="TalkPageTopic" syncable="YES"/>
     </entity>
     <entity name="TalkPageTopic" representedClassName="TalkPageTopic" syncable="YES" codeGenerationType="class">
-        <attribute name="indicatorSha" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="isRead" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="relatedObjectsVersion" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="sectionID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="sort" attributeType="Integer 64" minValueString="0" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="textSha" attributeType="String" syncable="YES"/>
         <attribute name="title" attributeType="String" syncable="YES"/>
+        <relationship name="content" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TalkPageTopicContent" inverseName="topics" inverseEntity="TalkPageTopicContent" syncable="YES"/>
         <relationship name="replies" toMany="YES" deletionRule="Cascade" destinationEntity="TalkPageReply" inverseName="topic" inverseEntity="TalkPageReply" syncable="YES"/>
         <relationship name="talkPage" maxCount="1" deletionRule="Nullify" destinationEntity="TalkPage" inverseName="topics" inverseEntity="TalkPage" syncable="YES"/>
+    </entity>
+    <entity name="TalkPageTopicContent" representedClassName="TalkPageTopicContent" syncable="YES" codeGenerationType="class">
+        <attribute name="isRead" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="sha" attributeType="String" syncable="YES"/>
+        <relationship name="topics" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="TalkPageTopic" inverseName="content" inverseEntity="TalkPageTopic" syncable="YES"/>
+        <fetchIndex name="bySHAIndex">
+            <fetchIndexElement property="sha" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
     <entity name="WMFArticle" representedClassName="WMFArticle" syncable="YES">
         <attribute name="displayTitle" optional="YES" attributeType="String" syncable="YES"/>
@@ -208,6 +216,7 @@
         <element name="ReadingList" positionX="-54" positionY="135" width="128" height="300"/>
         <element name="ReadingListEntry" positionX="-27" positionY="153" width="128" height="180"/>
         <element name="TalkPage" positionX="-45" positionY="135" width="128" height="135"/>
+        <element name="TalkPageTopicContent" positionX="-36" positionY="135" width="128" height="90"/>
         <element name="TalkPageReply" positionX="-27" positionY="153" width="128" height="120"/>
         <element name="TalkPageTopic" positionX="-36" positionY="144" width="128" height="165"/>
         <element name="WMFArticle" positionX="-63" positionY="-18" width="128" height="480"/>

--- a/WMF Framework/Wikipedia.xcdatamodeld/Wikipedia 2.xcdatamodel/contents
+++ b/WMF Framework/Wikipedia.xcdatamodeld/Wikipedia 2.xcdatamodel/contents
@@ -216,9 +216,9 @@
         <element name="ReadingList" positionX="-54" positionY="135" width="128" height="300"/>
         <element name="ReadingListEntry" positionX="-27" positionY="153" width="128" height="180"/>
         <element name="TalkPage" positionX="-45" positionY="135" width="128" height="135"/>
-        <element name="TalkPageTopicContent" positionX="-36" positionY="135" width="128" height="90"/>
         <element name="TalkPageReply" positionX="-27" positionY="153" width="128" height="120"/>
         <element name="TalkPageTopic" positionX="-36" positionY="144" width="128" height="165"/>
+        <element name="TalkPageTopicContent" positionX="-36" positionY="135" width="128" height="90"/>
         <element name="WMFArticle" positionX="-63" positionY="-18" width="128" height="480"/>
         <element name="WMFContent" positionX="-63" positionY="135" width="128" height="75"/>
         <element name="WMFContentGroup" positionX="-63" positionY="99" width="128" height="345"/>

--- a/WMF Framework/Wikipedia.xcdatamodeld/Wikipedia 2.xcdatamodel/contents
+++ b/WMF Framework/Wikipedia.xcdatamodeld/Wikipedia 2.xcdatamodel/contents
@@ -86,7 +86,7 @@
     </entity>
     <entity name="TalkPageTopic" representedClassName="TalkPageTopic" syncable="YES" codeGenerationType="class">
         <attribute name="indicatorSha" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="isRead" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="isRead" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="sectionID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="sort" attributeType="Integer 64" minValueString="0" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="textSha" attributeType="String" syncable="YES"/>

--- a/WMF Framework/Wikipedia.xcdatamodeld/Wikipedia 2.xcdatamodel/contents
+++ b/WMF Framework/Wikipedia.xcdatamodeld/Wikipedia 2.xcdatamodel/contents
@@ -86,6 +86,7 @@
     </entity>
     <entity name="TalkPageTopic" representedClassName="TalkPageTopic" syncable="YES" codeGenerationType="class">
         <attribute name="indicatorSha" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isRead" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="sectionID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="sort" attributeType="Integer 64" minValueString="0" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="textSha" attributeType="String" syncable="YES"/>
@@ -208,7 +209,7 @@
         <element name="ReadingListEntry" positionX="-27" positionY="153" width="128" height="180"/>
         <element name="TalkPage" positionX="-45" positionY="135" width="128" height="135"/>
         <element name="TalkPageReply" positionX="-27" positionY="153" width="128" height="120"/>
-        <element name="TalkPageTopic" positionX="-36" positionY="144" width="128" height="150"/>
+        <element name="TalkPageTopic" positionX="-36" positionY="144" width="128" height="165"/>
         <element name="WMFArticle" positionX="-63" positionY="-18" width="128" height="480"/>
         <element name="WMFContent" positionX="-63" positionY="135" width="128" height="75"/>
         <element name="WMFContentGroup" positionX="-63" positionY="99" width="128" height="345"/>

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -970,6 +970,11 @@
 		8338AF8D21F7B33E000C4055 /* WMFLegacyFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 8338AF8B21F7B33E000C4055 /* WMFLegacyFetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8338AF8E21F7B33E000C4055 /* WMFLegacyFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 8338AF8C21F7B33E000C4055 /* WMFLegacyFetcher.m */; };
 		833D4FFB20A9E20800B44E7C /* String+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833D4FFA20A9E20800B44E7C /* String+HTML.swift */; };
+		833D6B48229EE872003CB650 /* TalkPageTopic+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833D6B47229EE872003CB650 /* TalkPageTopic+Extensions.swift */; };
+		833D6B49229EE872003CB650 /* TalkPageTopic+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833D6B47229EE872003CB650 /* TalkPageTopic+Extensions.swift */; };
+		833D6B4A229EE872003CB650 /* TalkPageTopic+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833D6B47229EE872003CB650 /* TalkPageTopic+Extensions.swift */; };
+		833D6B4B229EE872003CB650 /* TalkPageTopic+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833D6B47229EE872003CB650 /* TalkPageTopic+Extensions.swift */; };
+		833D6B4C229EE872003CB650 /* TalkPageTopic+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833D6B47229EE872003CB650 /* TalkPageTopic+Extensions.swift */; };
 		834400AE20B33498005F087D /* NSAttributedString+WMFTrim.m in Sources */ = {isa = PBXBuildFile; fileRef = B0E804881C0CE0B40065EBC0 /* NSAttributedString+WMFTrim.m */; };
 		834400AF20B334A0005F087D /* NSAttributedString+WMFTrim.h in Headers */ = {isa = PBXBuildFile; fileRef = B0E804871C0CE0B40065EBC0 /* NSAttributedString+WMFTrim.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		834400B020B3368A005F087D /* NSCharacterSet+WMFExtras.m in Sources */ = {isa = PBXBuildFile; fileRef = B0E8048C1C0CE0B40065EBC0 /* NSCharacterSet+WMFExtras.m */; };
@@ -3909,6 +3914,7 @@
 		8338AF8B21F7B33E000C4055 /* WMFLegacyFetcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WMFLegacyFetcher.h; sourceTree = "<group>"; };
 		8338AF8C21F7B33E000C4055 /* WMFLegacyFetcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WMFLegacyFetcher.m; sourceTree = "<group>"; };
 		833D4FFA20A9E20800B44E7C /* String+HTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTML.swift"; sourceTree = "<group>"; };
+		833D6B47229EE872003CB650 /* TalkPageTopic+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TalkPageTopic+Extensions.swift"; sourceTree = "<group>"; };
 		834CC34A21075B7600F62818 /* UITabBar+Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBar+Theme.swift"; sourceTree = "<group>"; };
 		8350FC4B20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleLocationAuthorizationCollectionViewCell.swift; sourceTree = "<group>"; };
 		8351CE7720D4424100E32FC1 /* CollectionViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewHeader.swift; sourceTree = "<group>"; };
@@ -6400,6 +6406,7 @@
 			children = (
 				67E8B0A4226A64CB00537BC9 /* TalkPagesController.swift */,
 				6734116322739CA2005B31DA /* TalkPageLocalHandler.swift */,
+				833D6B47229EE872003CB650 /* TalkPageTopic+Extensions.swift */,
 				67E8B0782268F8F100537BC9 /* Views */,
 				67E8B0772268F8E300537BC9 /* View Controllers */,
 			);
@@ -8278,10 +8285,10 @@
 				D8733C911ECA16580011E379 /* UIView+SemanticContent.swift */,
 				D8733C931ECA16940011E379 /* HasText.swift */,
 				D88E0E1C1EBB5A97005B8E9E /* Bundle.swift */,
+				83E9A2111F56FE5E006EB091 /* FakeProgressController.swift */,
 				D8FB46A11E26BC6600F2620F /* QuadKey.swift */,
 				D8987E071E325EC500E75DA6 /* ArticleLocationController.swift */,
 				D8F36F021EEEBA130087D4DD /* Licenses.swift */,
-				83E9A2111F56FE5E006EB091 /* FakeProgressController.swift */,
 				D8CC94D62178972C007293E7 /* Core Data */,
 				D8EBD1B91FBB16F700AA7DA9 /* Dictionary+JSON.swift */,
 				D8650B7920350FEE0044DFFA /* NSString+SHA256.h */,
@@ -10820,6 +10827,7 @@
 				B0E805601C0CE0DC0065EBC0 /* UIViewController+WMFOpenExternalUrl.m in Sources */,
 				0EC044791C7917860033D773 /* WMFArticleTextActivitySource.m in Sources */,
 				D82E956A1F156F77007BD960 /* UIView+SubviewEnumeration.swift in Sources */,
+				833D6B48229EE872003CB650 /* TalkPageTopic+Extensions.swift in Sources */,
 				B010E1A81E723E3600CFE1CD /* WMFAuthLinkLabel.swift in Sources */,
 				BA4524241F32500C00439C42 /* TextSizeChangeExampleViewController.swift in Sources */,
 				BA7683C51F30D86A00A487AA /* ProminentSwitch.swift in Sources */,
@@ -11097,6 +11105,7 @@
 				BA45241C1F324C3100439C42 /* FontSizeSliderViewController.swift in Sources */,
 				D80ED2841EE57F4800CE8C50 /* WMFReferencePageBackgroundView.swift in Sources */,
 				D80ED2861EE57F4800CE8C50 /* UIApplication+RTL.swift in Sources */,
+				833D6B4C229EE872003CB650 /* TalkPageTopic+Extensions.swift in Sources */,
 				67E8B09B226A57EA00537BC9 /* TalkPageTopicNewViewController.swift in Sources */,
 				83E52BB81F681F940045E776 /* ShareAFactViewController.swift in Sources */,
 				D80ED2891EE57F4800CE8C50 /* WMFWelcomePanelViewController.swift in Sources */,
@@ -11960,6 +11969,7 @@
 				D8A42ACB1E815A9C00D8E281 /* WMFArticleTextActivitySource.m in Sources */,
 				D8A42ACC1E815A9C00D8E281 /* WMFAuthLinkLabel.swift in Sources */,
 				D82E956D1F156F77007BD960 /* UIView+SubviewEnumeration.swift in Sources */,
+				833D6B4B229EE872003CB650 /* TalkPageTopic+Extensions.swift in Sources */,
 				D818D3841ED7254D0076110D /* ColumnarCollectionViewController.swift in Sources */,
 				D8A42AD11E815A9C00D8E281 /* WMFPasswordResetter.swift in Sources */,
 				7A0161E31FE8B4CA00AEDC3D /* TagCollectionViewCell.swift in Sources */,
@@ -12245,6 +12255,7 @@
 				D82E956B1F156F77007BD960 /* UIView+SubviewEnumeration.swift in Sources */,
 				D8CE24F61E698E2400DAE2E0 /* WMFReferencePageBackgroundView.swift in Sources */,
 				B04C809B1EA6E2A100EDD2DE /* WKWebView+WMFWebViewControllerJavascript.swift in Sources */,
+				833D6B49229EE872003CB650 /* TalkPageTopic+Extensions.swift in Sources */,
 				67E8B086226A57E900537BC9 /* TalkPageTopicNewViewController.swift in Sources */,
 				83E52BB51F681F940045E776 /* ShareAFactViewController.swift in Sources */,
 				D8CE24F81E698E2400DAE2E0 /* UIApplication+RTL.swift in Sources */,
@@ -12650,6 +12661,7 @@
 				D8EC3DEA1E9BDA35006712EB /* WMFTableOfContentsAnimator.swift in Sources */,
 				B0432346210680A900A9A6B6 /* WMFContentGroupKind+FeedCustomization.swift in Sources */,
 				BA45241A1F324C3100439C42 /* FontSizeSliderViewController.swift in Sources */,
+				833D6B4A229EE872003CB650 /* TalkPageTopic+Extensions.swift in Sources */,
 				67E8B08D226A57E900537BC9 /* TalkPageTopicNewViewController.swift in Sources */,
 				D8EC3DED1E9BDA35006712EB /* WMFReferencePageBackgroundView.swift in Sources */,
 				83E52BB61F681F940045E776 /* ShareAFactViewController.swift in Sources */,

--- a/Wikipedia/Code/TalkPageContainerViewController.swift
+++ b/Wikipedia/Code/TalkPageContainerViewController.swift
@@ -86,9 +86,11 @@ private extension TalkPageContainerViewController {
             self.fakeProgressController.stop()
             
             switch result {
-            case .success(let talkPage):
-                self.talkPage = talkPage
-                self.setupTopicListViewControllerIfNeeded(with: talkPage)
+            case .success(let talkPageID):
+                self.talkPage = self.dataStore.viewContext.object(with: talkPageID) as? TalkPage
+                if let talkPage = self.talkPage {
+                    self.setupTopicListViewControllerIfNeeded(with: talkPage)
+                }
             case .failure(let error):
                 print("error! \(error)")
             }

--- a/Wikipedia/Code/TalkPageContainerViewController.swift
+++ b/Wikipedia/Code/TalkPageContainerViewController.swift
@@ -154,14 +154,6 @@ extension TalkPageContainerViewController: TalkPageTopicListDelegate {
     }
     
     func tappedTopic(_ topic: TalkPageTopic, viewController: TalkPageTopicListViewController) {
-        if !topic.isRead {
-            topic.isRead = true
-            do {
-                try topic.managedObjectContext?.save()
-            } catch let error {
-                DDLogError("Error saving after marking topic as read: \(error)")
-            }
-        }
         let replyVC = TalkPageReplyListViewController(dataStore: dataStore, topic: topic)
         replyVC.delegate = self
         replyVC.apply(theme: theme)

--- a/Wikipedia/Code/TalkPageContainerViewController.swift
+++ b/Wikipedia/Code/TalkPageContainerViewController.swift
@@ -87,7 +87,7 @@ private extension TalkPageContainerViewController {
             
             switch result {
             case .success(let talkPageID):
-                self.talkPage = self.dataStore.viewContext.object(with: talkPageID) as? TalkPage
+                self.talkPage = try? self.dataStore.viewContext.existingObject(with: talkPageID) as? TalkPage
                 if let talkPage = self.talkPage {
                     self.setupTopicListViewControllerIfNeeded(with: talkPage)
                 }

--- a/Wikipedia/Code/TalkPageContainerViewController.swift
+++ b/Wikipedia/Code/TalkPageContainerViewController.swift
@@ -152,7 +152,14 @@ extension TalkPageContainerViewController: TalkPageTopicListDelegate {
     }
     
     func tappedTopic(_ topic: TalkPageTopic, viewController: TalkPageTopicListViewController) {
-        
+        if !topic.isRead {
+            topic.isRead = true
+            do {
+                try topic.managedObjectContext?.save()
+            } catch let error {
+                DDLogError("Error saving after marking topic as read: \(error)")
+            }
+        }
         let replyVC = TalkPageReplyListViewController(dataStore: dataStore, topic: topic)
         replyVC.delegate = self
         replyVC.apply(theme: theme)

--- a/Wikipedia/Code/TalkPageContainerViewController.swift
+++ b/Wikipedia/Code/TalkPageContainerViewController.swift
@@ -116,7 +116,7 @@ extension TalkPageContainerViewController: TalkPageTopicNewViewControllerDelegat
         }
         
         viewController.postDidBegin()
-        controller.addTopic(to: talkPage, title: talkPageTitle, host: host, languageCode: languageCode, subject: subject, body: body) { [weak self] (result) in
+        controller.addTopic(toTalkPageWith: talkPage.objectID, title: talkPageTitle, host: host, languageCode: languageCode, subject: subject, body: body) { [weak self] (result) in
             
             viewController.postDidEnd()
             

--- a/Wikipedia/Code/TalkPageFetcher.swift
+++ b/Wikipedia/Code/TalkPageFetcher.swift
@@ -95,7 +95,7 @@ enum TalkPageType {
 }
 
 enum TalkPageFetcherError: Error {
-    case TalkPageDoesNotExist
+    case talkPageDoesNotExist
 }
 
 class TalkPageFetcher: Fetcher {
@@ -160,7 +160,7 @@ class TalkPageFetcher: Fetcher {
             
             if let statusCode = (response as? HTTPURLResponse)?.statusCode,
                 statusCode == 404 {
-                completion(.failure(TalkPageFetcherError.TalkPageDoesNotExist))
+                completion(.failure(TalkPageFetcherError.talkPageDoesNotExist))
                 return
             }
             

--- a/Wikipedia/Code/TalkPageLocalHandler.swift
+++ b/Wikipedia/Code/TalkPageLocalHandler.swift
@@ -16,11 +16,8 @@ extension NSManagedObjectContext {
     }
     
     func createEmptyTalkPage(with url: URL, languageCode: String, displayTitle: String) -> TalkPage? {
-        guard let talkPageEntityDesc = NSEntityDescription.entity(forEntityName: "TalkPage", in: self) else {
-                return nil
-        }
         
-        let talkPage = TalkPage(entity: talkPageEntityDesc, insertInto: self)
+        let talkPage = TalkPage(context: self)
         talkPage.key = url.wmf_talkPageDatabaseKey
         talkPage.languageCode = languageCode
         talkPage.displayTitle = displayTitle
@@ -36,12 +33,11 @@ extension NSManagedObjectContext {
     
     func createTalkPage(with networkTalkPage: NetworkTalkPage) -> TalkPage? {
         
-        guard let revisionID = networkTalkPage.revisionId,
-            let talkPageEntityDesc = NSEntityDescription.entity(forEntityName: "TalkPage", in: self) else {
+        guard let revisionID = networkTalkPage.revisionId else {
             return nil
         }
         
-        let talkPage = TalkPage(entity: talkPageEntityDesc, insertInto: self)
+        let talkPage = TalkPage(context: self)
         talkPage.key = networkTalkPage.url.wmf_talkPageDatabaseKey
         talkPage.revisionId = NSNumber(value: revisionID)
         talkPage.languageCode = networkTalkPage.languageCode

--- a/Wikipedia/Code/TalkPageLocalHandler.swift
+++ b/Wikipedia/Code/TalkPageLocalHandler.swift
@@ -170,7 +170,7 @@ private extension NSManagedObjectContext {
             if let sort = networkTopic.sort, localTopic.sort != sort {
                 localTopic.sort = Int64(sort)
             } else {
-                assertionFailure("Network topic is missing sort.")
+                assert(networkTopic.sort != nil, "Network topic is missing sort.")
             }
             
             let sectionID = Int64(networkTopic.sectionID)

--- a/Wikipedia/Code/TalkPageLocalHandler.swift
+++ b/Wikipedia/Code/TalkPageLocalHandler.swift
@@ -52,7 +52,8 @@ extension NSManagedObjectContext {
             try addTalkPageTopics(to: talkPage, with: networkTalkPage)
             try save()
             return talkPage
-        } catch {
+        } catch let error {
+            DDLogError("error creating talk page: \(error)")
             delete(talkPage)
             return nil
         }
@@ -111,7 +112,7 @@ extension NSManagedObjectContext {
         }
         let request: NSFetchRequest<TalkPageTopicContent> = TalkPageTopicContent.fetchRequest()
         request.predicate = NSPredicate(format: "sha == %@", sha)
-        let results = try request.execute()
+        let results = try fetch(request)
         var content = results.first
         if content == nil {
             content = TalkPageTopicContent(context: self)

--- a/Wikipedia/Code/TalkPageLocalHandler.swift
+++ b/Wikipedia/Code/TalkPageLocalHandler.swift
@@ -167,10 +167,15 @@ private extension NSManagedObjectContext {
         
         for (localTopic, networkTopic) in zippedTopics {
             
-            if let sort = networkTopic.sort {
+            if let sort = networkTopic.sort, localTopic.sort != sort {
                 localTopic.sort = Int64(sort)
             } else {
-                 assertionFailure("Network topic is missing sort.")
+                assertionFailure("Network topic is missing sort.")
+            }
+            
+            let sectionID = Int64(networkTopic.sectionID)
+            if localTopic.sectionID != sectionID {
+                localTopic.sectionID = sectionID
             }
 
             try fetchOrCreateTalkPageTopicContent(with: networkTopic.shas.indicator, for: localTopic)

--- a/Wikipedia/Code/TalkPageLocalHandler.swift
+++ b/Wikipedia/Code/TalkPageLocalHandler.swift
@@ -2,6 +2,14 @@
 import Foundation
 
 extension NSManagedObjectContext {
+    func talkPage(with managedObjectID: NSManagedObjectID) -> TalkPage? {
+        return try? existingObject(with: managedObjectID) as? TalkPage
+    }
+    
+    func talkPageTopic(with managedObjectID: NSManagedObjectID) -> TalkPageTopic? {
+        return try? existingObject(with: managedObjectID) as? TalkPageTopic
+    }
+
     func talkPage(for taskURL: URL) throws -> TalkPage? {
         
         guard let databaseKey = taskURL.wmf_talkPageDatabaseKey else {

--- a/Wikipedia/Code/TalkPageLocalHandler.swift
+++ b/Wikipedia/Code/TalkPageLocalHandler.swift
@@ -234,7 +234,7 @@ private extension TalkPageLocalHandler {
         }
         
         topic.textSha = networkTopic.shas.text
-        topic.isRead = true
+        topic.isRead = false
         topic.indicatorSha = networkTopic.shas.indicator
         
         for reply in networkTopic.replies {

--- a/Wikipedia/Code/TalkPageLocalHandler.swift
+++ b/Wikipedia/Code/TalkPageLocalHandler.swift
@@ -148,17 +148,13 @@ private extension TalkPageLocalHandler {
             } else {
                  assertionFailure("Network topic is missing sort.")
             }
-            
-            if localTopic.indicatorSha != networkTopic.shas.indicator {
-                localTopic.isRead = false
+
+            guard localTopic.indicatorSha != networkTopic.shas.indicator else {
+                return
             }
             
-            //todo possible performance, at one point we thought maybe having a 3rd separate "replies" at the topic level sha that represents only the replies text of a topic could improve performance here. Keeping it out now for simplicity but we could bring it back if we find it improves things.
-            //if replies have not changed in any manner, no need to dig into replies diffing
-//            guard localTopic.repliesSha != networkTopic.shas.replies else {
-//                continue
-//            }
-            
+            localTopic.isRead = false
+
             guard let replyShas = (localTopic.replies as? Set<TalkPageReply>)?.compactMap ({ return $0.sha }) else {
                 continue
             }

--- a/Wikipedia/Code/TalkPageLocalHandler.swift
+++ b/Wikipedia/Code/TalkPageLocalHandler.swift
@@ -149,6 +149,10 @@ private extension TalkPageLocalHandler {
                  assertionFailure("Network topic is missing sort.")
             }
             
+            if localTopic.indicatorSha != networkTopic.shas.indicator {
+                localTopic.isRead = false
+            }
+            
             //todo possible performance, at one point we thought maybe having a 3rd separate "replies" at the topic level sha that represents only the replies text of a topic could improve performance here. Keeping it out now for simplicity but we could bring it back if we find it improves things.
             //if replies have not changed in any manner, no need to dig into replies diffing
 //            guard localTopic.repliesSha != networkTopic.shas.replies else {
@@ -234,6 +238,7 @@ private extension TalkPageLocalHandler {
         }
         
         topic.textSha = networkTopic.shas.text
+        topic.isRead = true
         topic.indicatorSha = networkTopic.shas.indicator
         
         for reply in networkTopic.replies {

--- a/Wikipedia/Code/TalkPageReplyListViewController.swift
+++ b/Wikipedia/Code/TalkPageReplyListViewController.swift
@@ -98,6 +98,18 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
         collectionView.keyboardDismissMode = .interactive
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if !topic.isRead {
+            topic.isRead = true
+            do {
+                try dataStore.viewContext.save()
+            } catch let error {
+                DDLogError("Error saving after marking topic as read: \(error)")
+            }
+        }
+    }
+    
     func postDidBegin() {
         fakeProgressController.start()
         publishButton.isEnabled = false

--- a/Wikipedia/Code/TalkPageTopic+Extensions.swift
+++ b/Wikipedia/Code/TalkPageTopic+Extensions.swift
@@ -1,0 +1,11 @@
+extension TalkPageTopic {
+    var isRead: Bool {
+        get {
+            return content?.isRead ?? false
+        }
+        set {
+            content?.isRead = newValue
+            relatedObjectsVersion += 1 // triggers an update of any NSFetchedResultsController observing this topic
+        }
+    }
+}

--- a/Wikipedia/Code/TalkPageTopicCell.swift
+++ b/Wikipedia/Code/TalkPageTopicCell.swift
@@ -41,7 +41,8 @@ class TalkPageTopicCell: CollectionViewCell {
         return CGSize(width: size.width, height: finalHeight)
     }
     
-    func configure(title: String) {
+    func configure(title: String, isRead: Bool = true) {
+        unreadView.isHidden = isRead
         configureTitleLabel(title: title)
     }
     

--- a/Wikipedia/Code/TalkPageTopicListViewController.swift
+++ b/Wikipedia/Code/TalkPageTopicListViewController.swift
@@ -30,6 +30,7 @@ class TalkPageTopicListViewController: ColumnarCollectionViewController {
         
         let request: NSFetchRequest<TalkPageTopic> = TalkPageTopic.fetchRequest()
         request.predicate = NSPredicate(format: "talkPage == %@",  talkPage)
+        request.relationshipKeyPathsForPrefetching = ["content"]
         request.sortDescriptors = [NSSortDescriptor(key: "sort", ascending: true)]
         self.fetchedResultsController = NSFetchedResultsController(fetchRequest: request, managedObjectContext: dataStore.viewContext, sectionNameKeyPath: nil, cacheName: nil)
         

--- a/Wikipedia/Code/TalkPageTopicListViewController.swift
+++ b/Wikipedia/Code/TalkPageTopicListViewController.swift
@@ -241,11 +241,12 @@ private extension TalkPageTopicListViewController {
     }
     
     func configure(cell: TalkPageTopicCell, at indexPath: IndexPath) {
-        guard let title = fetchedResultsController.object(at: indexPath).title else {
+        let topic = fetchedResultsController.object(at: indexPath)
+        guard let title = topic.title else {
             return
         }
         
-        cell.configure(title: title)
+        cell.configure(title: title, isRead: topic.isRead)
         cell.layoutMargins = layout.itemLayoutMargins
         cell.apply(theme: theme)
     }

--- a/Wikipedia/Code/TalkPagesController.swift
+++ b/Wikipedia/Code/TalkPagesController.swift
@@ -13,12 +13,12 @@ enum TalkPageError: Error {
     case talkPageTitleCreationFailure
     case createUrlTitleStringFailure
     case freshFetchTaskGroupFailure
+    case topicMissingTalkPageRelationship
 }
 
 enum TalkPageAppendSuccessResult {
     case missingRevisionIDInResult
     case refreshFetchFailed
-    case topicMissingTalkPageRelationship
     case success
 }
 
@@ -91,7 +91,7 @@ class TalkPageController {
     }
     
     func createTalkPage(with urlTitle: String, taskURL: URL, in moc: NSManagedObjectContext, completion: ((Result<TalkPage, Error>) -> Void)? = nil) {
-        //If no local talk page to reference, fetch latest revision ID & latest talk page in a grouped calls.
+        //If no local talk page to reference, fetch latest revision ID & latest talk page in grouped calls.
         //Update network talk page with latest revision & save to db
         
         let taskGroup = WMFTaskGroup()
@@ -122,7 +122,7 @@ class TalkPageController {
                 networkTalkPage = resultNetworkTalkPage
             case .failure(let error):
                 if let talkPageFetcherError = error as? TalkPageFetcherError,
-                    talkPageFetcherError == .TalkPageDoesNotExist {
+                    talkPageFetcherError == .talkPageDoesNotExist {
                     talkPageDoesNotExist = true
                 }
             }
@@ -203,7 +203,7 @@ class TalkPageController {
         let wrappedBody = "<p>\n\n" + body + " ~~~~</p>"
         guard let talkPageObjectID = topic.talkPage?.objectID else {
             DispatchQueue.main.async {
-                completion(.success(.topicMissingTalkPageRelationship))
+                completion(.failure(TalkPageError.topicMissingTalkPageRelationship))
             }
             return
         }

--- a/Wikipedia/Code/TalkPagesController.swift
+++ b/Wikipedia/Code/TalkPagesController.swift
@@ -74,32 +74,23 @@ class TalkPageController {
         //If we already have a local talk page, chain revision & talk page calls.
         //If revision indicates we already have the latest, no need to fetch talk page.
         if let localTalkPage = localTalkPage {
-            
-            if let localRevisionID = localTalkPage.revisionId?.intValue {
-                fetchLatestRevisionID(endingWithRevision: localRevisionID, urlTitle: urlTitle) { (result) in
-                    switch result {
-                    case .success(let lastRevisionID):
-                        
-                        //if latest revision ID is the same return local talk page. else forward revision ID onto talk page fetcher
-                        if localTalkPage.revisionId == NSNumber(value: lastRevisionID) {
-                            DispatchQueue.main.async {
-                                completion?(.success(localTalkPage))
-                            }
-                        } else {
-                            self.fetchAndUpdate(localTalkPage: localTalkPage, revisionID: lastRevisionID, completion: completion)
-                        }
-                    case .failure(let error):
+            let localRevisionID = localTalkPage.revisionId?.intValue
+            fetchLatestRevisionID(endingWithRevision: localRevisionID, urlTitle: urlTitle) { (result) in
+                switch result {
+                case .success(let lastRevisionID):
+                    
+                    //if latest revision ID is the same return local talk page. else forward revision ID onto talk page fetcher
+                    if localRevisionID == lastRevisionID {
                         DispatchQueue.main.async {
-                            completion?(.failure(error))
+                            completion?(.success(localTalkPage))
                         }
+                    } else {
+                        self.fetchAndUpdate(localTalkPage: localTalkPage, revisionID: lastRevisionID, completion: completion)
                     }
-                }
-            } else {
-                
-                //can get into this state with a local talk page with no revision if talk page doesn't exist
-                //skip revision checking and return local talk page
-                DispatchQueue.main.async {
-                    completion?(.success(localTalkPage))
+                case .failure(let error):
+                    DispatchQueue.main.async {
+                        completion?(.failure(error))
+                    }
                 }
             }
             

--- a/Wikipedia/Code/TalkPagesController.swift
+++ b/Wikipedia/Code/TalkPagesController.swift
@@ -24,8 +24,8 @@ enum TalkPageAppendSuccessResult {
 
 class TalkPageController {
     let fetcher: TalkPageFetcher
-    let localHandler: TalkPageLocalHandler
     let articleRevisionFetcher: WMFArticleRevisionFetcher
+    weak var dataStore: MWKDataStore!
     let title: String
     let host: String
     let languageCode: String
@@ -36,16 +36,10 @@ class TalkPageController {
         return type.displayTitle(for: title, titleIncludesPrefix: titleIncludesPrefix)
     }
     
-    required init(fetcher: TalkPageFetcher = TalkPageFetcher(), articleRevisionFetcher: WMFArticleRevisionFetcher = WMFArticleRevisionFetcher(), localHandler: TalkPageLocalHandler? = nil, dataStore: MWKDataStore, title: String, host: String, languageCode: String, titleIncludesPrefix: Bool, type: TalkPageType) {
+    required init(fetcher: TalkPageFetcher = TalkPageFetcher(), articleRevisionFetcher: WMFArticleRevisionFetcher = WMFArticleRevisionFetcher(), dataStore: MWKDataStore, title: String, host: String, languageCode: String, titleIncludesPrefix: Bool, type: TalkPageType) {
         self.fetcher = fetcher
         self.articleRevisionFetcher = articleRevisionFetcher
-        
-        if let localHandler = localHandler {
-            self.localHandler = localHandler
-        } else {
-            self.localHandler = TalkPageLocalHandler(dataStore: dataStore)
-        }
-        
+        self.dataStore = dataStore
         self.title = title
         self.host = host
         self.languageCode = languageCode
@@ -54,50 +48,49 @@ class TalkPageController {
     }
     
     func fetchTalkPage(completion: ((Result<TalkPage, Error>) -> Void)? = nil) {
-        
         guard let urlTitle = type.urlTitle(for: title, titleIncludesPrefix: titleIncludesPrefix),
             let taskURL = fetcher.taskURL(for: urlTitle, host: host) else {
             completion?(.failure(TalkPageError.createTaskURLFailure))
             return
         }
         
-        var localTalkPage: TalkPage?
-        localHandler.dataStore.viewContext.performAndWait {
+        let moc = dataStore.viewContext
+        moc.perform {
             do {
-                localTalkPage = try localHandler.talkPage(for: taskURL)
+                guard let localTalkPage = try moc.talkPage(for: taskURL) else {
+                    self.createTalkPage(with: urlTitle, taskURL: taskURL, in: moc, completion: completion)
+                    return
+                }
+                let localObjectID = localTalkPage.objectID
+                let localRevisionID = localTalkPage.revisionId?.intValue
+                self.fetchLatestRevisionID(endingWithRevision: localRevisionID, urlTitle: urlTitle) { (result) in
+                    switch result {
+                    case .success(let lastRevisionID):
+                        //if latest revision ID is the same return local talk page. else forward revision ID onto talk page fetcher
+                        if localRevisionID == lastRevisionID {
+                            DispatchQueue.main.async {
+                                completion?(.success(localTalkPage))
+                            }
+                        } else {
+                            self.fetchAndUpdateLocalTalkPage(with: localObjectID, revisionID: lastRevisionID, completion: completion)
+                        }
+                    case .failure(let error):
+                        DispatchQueue.main.async {
+                            completion?(.failure(error))
+                        }
+                    }
+                }
+                
             } catch {
-                completion?(.failure(TalkPageError.fetchLocalTalkPageFailure))
+                DispatchQueue.main.async {
+                    completion?(.failure(TalkPageError.fetchLocalTalkPageFailure))
+                }
                 return
             }
         }
-        
-        //If we already have a local talk page, chain revision & talk page calls.
-        //If revision indicates we already have the latest, no need to fetch talk page.
-        if let localTalkPage = localTalkPage {
-            let localRevisionID = localTalkPage.revisionId?.intValue
-            fetchLatestRevisionID(endingWithRevision: localRevisionID, urlTitle: urlTitle) { (result) in
-                switch result {
-                case .success(let lastRevisionID):
-                    
-                    //if latest revision ID is the same return local talk page. else forward revision ID onto talk page fetcher
-                    if localRevisionID == lastRevisionID {
-                        DispatchQueue.main.async {
-                            completion?(.success(localTalkPage))
-                        }
-                    } else {
-                        self.fetchAndUpdate(localTalkPage: localTalkPage, revisionID: lastRevisionID, completion: completion)
-                    }
-                case .failure(let error):
-                    DispatchQueue.main.async {
-                        completion?(.failure(error))
-                    }
-                }
-            }
-            
-            return
-            
-        }
-        
+    }
+    
+    func createTalkPage(with urlTitle: String, taskURL: URL, in moc: NSManagedObjectContext, completion: ((Result<TalkPage, Error>) -> Void)? = nil) {
         //If no local talk page to reference, fetch latest revision ID & latest talk page in a grouped calls.
         //Update network talk page with latest revision & save to db
         
@@ -138,10 +131,9 @@ class TalkPageController {
         }
         
         taskGroup.waitInBackground {
-            
-            self.localHandler.dataStore.viewContext.perform {
+            moc.perform {
                 if talkPageDoesNotExist {
-                    if let newLocalTalkPage = self.localHandler.createEmptyTalkPage(with: taskURL, languageCode: self.languageCode, displayTitle: self.displayTitle) {
+                    if let newLocalTalkPage = moc.createEmptyTalkPage(with: taskURL, languageCode: self.languageCode, displayTitle: self.displayTitle) {
                         completion?(.success(newLocalTalkPage))
                     } else {
                         completion?(.failure(TalkPageError.createLocalTalkPageFailure))
@@ -150,12 +142,12 @@ class TalkPageController {
                     
                     guard let revisionID = revisionID,
                         let networkTalkPage = networkTalkPage else {
-                        completion?(.failure(TalkPageError.freshFetchTaskGroupFailure))
-                        return
+                            completion?(.failure(TalkPageError.freshFetchTaskGroupFailure))
+                            return
                     }
                     
                     networkTalkPage.revisionId = revisionID
-                    if let newLocalTalkPage = self.localHandler.createTalkPage(with: networkTalkPage) {
+                    if let newLocalTalkPage = moc.createTalkPage(with: networkTalkPage) {
                         completion?(.success(newLocalTalkPage))
                     } else {
                         completion?(.failure(TalkPageError.createLocalTalkPageFailure))
@@ -165,7 +157,7 @@ class TalkPageController {
         }
     }
     
-    func addTopic(to talkPage: TalkPage, title: String, host: String, languageCode: String, subject: String, body: String, completion: @escaping (Result<TalkPageAppendSuccessResult, Error>) -> Void) {
+    func addTopic(toTalkPageWith talkPageObjectID: NSManagedObjectID, title: String, host: String, languageCode: String, subject: String, body: String, completion: @escaping (Result<TalkPageAppendSuccessResult, Error>) -> Void) {
         
         guard let title = type.urlTitle(for: title, titleIncludesPrefix: titleIncludesPrefix) else {
             completion(.failure(TalkPageError.createUrlTitleStringFailure))
@@ -174,7 +166,6 @@ class TalkPageController {
         
         //todo: conditional signature
         let wrappedBody = "<p>\n\n" + body + " ~~~~</p>"
-        
         fetcher.addTopic(to: title, host: host, languageCode: languageCode, subject: subject, body: wrappedBody) { (result) in
             switch result {
             case .success(let result):
@@ -185,7 +176,7 @@ class TalkPageController {
                     return
                 }
                 
-                self.fetchAndUpdate(localTalkPage: talkPage, revisionID: newRevisionID, completion: { (result) in
+                self.fetchAndUpdateLocalTalkPage(with: talkPageObjectID, revisionID: newRevisionID, completion: { (result) in
                     switch result {
                     case .success:
                         completion(.success(.success))
@@ -210,6 +201,12 @@ class TalkPageController {
         
         //todo: conditional signature
         let wrappedBody = "<p>\n\n" + body + " ~~~~</p>"
+        guard let talkPageObjectID = topic.talkPage?.objectID else {
+            DispatchQueue.main.async {
+                completion(.success(.topicMissingTalkPageRelationship))
+            }
+            return
+        }
         
         fetcher.addReply(to: topic, title: title, host: host, languageCode: languageCode, body: wrappedBody) { (result) in
             switch result {
@@ -220,15 +217,7 @@ class TalkPageController {
                     }
                     return
                 }
-                
-                guard let talkPage = topic.talkPage else {
-                    DispatchQueue.main.async {
-                        completion(.success(.topicMissingTalkPageRelationship))
-                    }
-                    return
-                }
-                
-                self.fetchAndUpdate(localTalkPage: talkPage, revisionID: newRevisionID, completion: { (result) in
+                self.fetchAndUpdateLocalTalkPage(with: talkPageObjectID, revisionID: newRevisionID, completion: { (result) in
                     switch result {
                     case .success:
                         completion(.success(.success))
@@ -290,21 +279,34 @@ private extension TalkPageController {
         fetcher.fetchTalkPage(urlTitle: urlTitle, displayTitle: displayTitle, host: host, languageCode: languageCode, revisionID: revisionID, completion: completion)
     }
     
-    func fetchAndUpdate(localTalkPage: TalkPage, revisionID: Int, completion: ((Result<TalkPage, Error>) -> Void)? = nil) {
-        
+    func fetchAndUpdateLocalTalkPage(with moid: NSManagedObjectID, revisionID: Int, completion: ((Result<TalkPage, Error>) -> Void)? = nil) {
         fetchTalkPage(revisionID: revisionID) { (result) in
             DispatchQueue.main.async {
-                self.localHandler.dataStore.viewContext.perform {
-                    switch result {
-                    case .success(let networkTalkPage):
-                        assert(networkTalkPage.revisionId != nil, "Expecting network talk page to have a revision ID here so it can pass it into the local talk page.")
-                        if let updatedLocalTalkPage = self.localHandler.updateTalkPage(localTalkPage, with: networkTalkPage) {
-                            completion?(.success(updatedLocalTalkPage))
-                        } else {
-                            completion?(.failure(TalkPageError.updateLocalTalkPageFailure))
+                let moc = self.dataStore.viewContext
+                moc.perform {
+                    do {
+                        guard let localTalkPage = try moc.existingObject(with: moid) as? TalkPage else {
+                            DispatchQueue.main.async {
+                                completion?(.failure(TalkPageError.fetchLocalTalkPageFailure))
+                            }
+                            return
                         }
-                    case .failure(let error):
-                        completion?(.failure(error))
+                        switch result {
+                        case .success(let networkTalkPage):
+                            assert(networkTalkPage.revisionId != nil, "Expecting network talk page to have a revision ID here so it can pass it into the local talk page.")
+                            if let updatedLocalTalkPage = moc.updateTalkPage(localTalkPage, with: networkTalkPage) {
+                                completion?(.success(updatedLocalTalkPage))
+                            } else {
+                                completion?(.failure(TalkPageError.updateLocalTalkPageFailure))
+                            }
+                        case .failure(let error):
+                            completion?(.failure(error))
+                        }
+                        
+                    } catch {
+                        DispatchQueue.main.async {
+                            completion?(.failure(TalkPageError.fetchLocalTalkPageFailure))
+                        }
                     }
                 }
             }

--- a/WikipediaUnitTests/Code/TalkPageControllerTests.swift
+++ b/WikipediaUnitTests/Code/TalkPageControllerTests.swift
@@ -209,7 +209,7 @@ class TalkPageControllerTests: XCTestCase {
             initialFetchCallback.fulfill()
             
             switch result {
-            case .success(let dbTalkPage):
+            case .success(let dbTalkPageID):
                 
                 //fetch from db again, confirm count is 1 and matches returned talk page
                 let fetchRequest: NSFetchRequest<TalkPage> = TalkPage.fetchRequest()
@@ -220,7 +220,7 @@ class TalkPageControllerTests: XCTestCase {
                 }
                 
                 XCTAssertEqual(results.count, 1, "Expected one talk page in DB")
-                XCTAssertEqual(results.first, dbTalkPage)
+                XCTAssertEqual(results.first?.objectID, dbTalkPageID)
                 
             case .failure:
                 XCTFail("TalkPageController fetchTalkPage failure")

--- a/WikipediaUnitTests/Code/TalkPageControllerTests.swift
+++ b/WikipediaUnitTests/Code/TalkPageControllerTests.swift
@@ -68,7 +68,7 @@ class TalkPageControllerTests: XCTestCase {
         tempDataStore = MWKDataStore.temporary()
         talkPageFetcher = MockTalkPageFetcher(session: Session.shared, configuration: Configuration.current)
         articleRevisionFetcher = MockArticleRevisionFetcher()
-        talkPageController = TalkPageController(fetcher: talkPageFetcher, articleRevisionFetcher: articleRevisionFetcher, dataStore: tempDataStore, title: "Username1", host: Configuration.Domain.englishWikipedia, languageCode: "en", titleIncludesPrefix: false, type: .user)
+        talkPageController = TalkPageController(fetcher: talkPageFetcher, articleRevisionFetcher: articleRevisionFetcher, moc: tempDataStore.viewContext, title: "Username1", host: Configuration.Domain.englishWikipedia, languageCode: "en", titleIncludesPrefix: false, type: .user)
         MockArticleRevisionFetcher.revisionId = 894272715
         
     }
@@ -231,7 +231,7 @@ class TalkPageControllerTests: XCTestCase {
         
         //fetch again for ES language
         MockTalkPageFetcher.domain = "es.wikipedia.org"
-        talkPageController = TalkPageController(fetcher: talkPageFetcher, articleRevisionFetcher: articleRevisionFetcher, dataStore: tempDataStore, title: "Username1", host:"es.wikipedia.org", languageCode: "en", titleIncludesPrefix: false, type: .user)
+        talkPageController = TalkPageController(fetcher: talkPageFetcher, articleRevisionFetcher: articleRevisionFetcher, moc: tempDataStore.viewContext, title: "Username1", host:"es.wikipedia.org", languageCode: "en", titleIncludesPrefix: false, type: .user)
         
         let nextFetchCallback = expectation(description: "Waiting for next fetch callback")
         talkPageController.fetchTalkPage { (result) in
@@ -284,7 +284,7 @@ class TalkPageControllerTests: XCTestCase {
         
         //fetch again for ES language
         MockTalkPageFetcher.name = "Username2"
-        talkPageController = TalkPageController(fetcher: talkPageFetcher, articleRevisionFetcher: articleRevisionFetcher, dataStore: tempDataStore, title: "Username2", host:Configuration.Domain.englishWikipedia, languageCode: "en", titleIncludesPrefix: false, type: .user)
+        talkPageController = TalkPageController(fetcher: talkPageFetcher, articleRevisionFetcher: articleRevisionFetcher, moc: tempDataStore.viewContext, title: "Username2", host:Configuration.Domain.englishWikipedia, languageCode: "en", titleIncludesPrefix: false, type: .user)
         
         let nextFetchCallback = expectation(description: "Waiting for next fetch callback")
         talkPageController.fetchTalkPage { (result) in

--- a/WikipediaUnitTests/Code/TalkPageControllerTests.swift
+++ b/WikipediaUnitTests/Code/TalkPageControllerTests.swift
@@ -124,7 +124,7 @@ class TalkPageControllerTests: XCTestCase {
                     XCTFail("Failure fetching initial talk pages")
                     return
                 }
-                let dbTalkPage = try? self.tempDataStore.viewContext.existingObject(with: dbTalkPageID)
+                let dbTalkPage = try? self.tempDataStore.viewContext.existingObject(with: dbTalkPageID) as? TalkPage
                 XCTAssertEqual(results.count, 1, "Expected one talk page in DB")
                 XCTAssertEqual(results.first, dbTalkPage)
                 XCTAssertEqual(dbTalkPage?.revisionId?.intValue, MockArticleRevisionFetcher.revisionId)
@@ -329,10 +329,10 @@ class TalkPageControllerTests: XCTestCase {
             initialFetchCallback.fulfill()
             
             switch result {
-            case .success(let dbTalkPageId):
-                let dbTalkPage = try? self.tempDataStore.viewContext.existingObject(with: dbTalkPageID)
+            case .success(let dbTalkPageID):
+                let dbTalkPage = try? self.tempDataStore.viewContext.existingObject(with: dbTalkPageID) as? TalkPage
                 firstDBTalkPage = dbTalkPage
-                XCTAssertEqual(dbTalkPage.revisionId?.intValue, MockArticleRevisionFetcher.revisionId)
+                XCTAssertEqual(dbTalkPage?.revisionId?.intValue, MockArticleRevisionFetcher.revisionId)
                 XCTAssertTrue(self.talkPageFetcher.fetchCalled, "Expected fetcher to be called for initial fetch")
                 
             case .failure:
@@ -352,9 +352,9 @@ class TalkPageControllerTests: XCTestCase {
             
             switch result {
             case .success(let dbTalkPageID):
-                let dbTalkPage = try? self.tempDataStore.viewContext.existingObject(with: dbTalkPageID)
+                let dbTalkPage = try? self.tempDataStore.viewContext.existingObject(with: dbTalkPageID) as? TalkPage
                 XCTAssertEqual(firstDBTalkPage, dbTalkPage)
-                XCTAssertEqual(dbTalkPage.revisionId?.intValue, MockArticleRevisionFetcher.revisionId)
+                XCTAssertEqual(dbTalkPage?.revisionId?.intValue, MockArticleRevisionFetcher.revisionId)
                 XCTAssertFalse(self.talkPageFetcher.fetchCalled, "Expected fetcher to not be called for second fetch")
                 
             case .failure:

--- a/WikipediaUnitTests/Code/TalkPageControllerTests.swift
+++ b/WikipediaUnitTests/Code/TalkPageControllerTests.swift
@@ -115,7 +115,7 @@ class TalkPageControllerTests: XCTestCase {
             initialFetchCallback.fulfill()
             
             switch result {
-            case .success(let dbTalkPage):
+            case .success(let dbTalkPageID):
                 
                 //fetch from db again, confirm count is 1 and matches returned talk page
                 let fetchRequest: NSFetchRequest<TalkPage> = TalkPage.fetchRequest()
@@ -124,10 +124,10 @@ class TalkPageControllerTests: XCTestCase {
                     XCTFail("Failure fetching initial talk pages")
                     return
                 }
-                
+                let dbTalkPage = try? self.tempDataStore.viewContext.existingObject(with: dbTalkPageID)
                 XCTAssertEqual(results.count, 1, "Expected one talk page in DB")
                 XCTAssertEqual(results.first, dbTalkPage)
-                XCTAssertEqual(dbTalkPage.revisionId?.intValue, MockArticleRevisionFetcher.revisionId)
+                XCTAssertEqual(dbTalkPage?.revisionId?.intValue, MockArticleRevisionFetcher.revisionId)
                 
             case .failure:
                 XCTFail("TalkPageController fetchTalkPage failure")
@@ -329,7 +329,8 @@ class TalkPageControllerTests: XCTestCase {
             initialFetchCallback.fulfill()
             
             switch result {
-            case .success(let dbTalkPage):
+            case .success(let dbTalkPageId):
+                let dbTalkPage = try? self.tempDataStore.viewContext.existingObject(with: dbTalkPageID)
                 firstDBTalkPage = dbTalkPage
                 XCTAssertEqual(dbTalkPage.revisionId?.intValue, MockArticleRevisionFetcher.revisionId)
                 XCTAssertTrue(self.talkPageFetcher.fetchCalled, "Expected fetcher to be called for initial fetch")
@@ -350,8 +351,8 @@ class TalkPageControllerTests: XCTestCase {
             secondFetchCallback.fulfill()
             
             switch result {
-            case .success(let dbTalkPage):
-                
+            case .success(let dbTalkPageID):
+                let dbTalkPage = try? self.tempDataStore.viewContext.existingObject(with: dbTalkPageID)
                 XCTAssertEqual(firstDBTalkPage, dbTalkPage)
                 XCTAssertEqual(dbTalkPage.revisionId?.intValue, MockArticleRevisionFetcher.revisionId)
                 XCTAssertFalse(self.talkPageFetcher.fetchCalled, "Expected fetcher to not be called for second fetch")

--- a/WikipediaUnitTests/Code/TalkPageLocalHandlerTests.swift
+++ b/WikipediaUnitTests/Code/TalkPageLocalHandlerTests.swift
@@ -1,5 +1,6 @@
 
 import XCTest
+import CoreData
 @testable import Wikipedia
 
 class TalkPageLocalHandlerTests: XCTestCase {
@@ -9,12 +10,12 @@ class TalkPageLocalHandlerTests: XCTestCase {
     let urlString3 = "https://es.wikipedia.org/api/rest_v1/page/talk/Username1"
     
     var tempDataStore: MWKDataStore!
-    var talkPageLocalHandler: TalkPageLocalHandler!
+    var moc: NSManagedObjectContext!
     
     override func setUp() {
         super.setUp()
         tempDataStore = MWKDataStore.temporary()
-        talkPageLocalHandler = TalkPageLocalHandler(dataStore: tempDataStore)
+        moc = tempDataStore.viewContext
     }
     
     override func tearDown() {
@@ -42,7 +43,7 @@ class TalkPageLocalHandlerTests: XCTestCase {
         }
 
         //create db talk page
-        guard let dbTalkPage = talkPageLocalHandler.createTalkPage(with: talkPage) else {
+        guard let dbTalkPage = moc.createTalkPage(with: talkPage) else {
             XCTFail("Failure to create db talk page")
             return
         }
@@ -106,13 +107,13 @@ class TalkPageLocalHandlerTests: XCTestCase {
         }
         
         //create db talk page
-        guard let dbTalkPage = talkPageLocalHandler.createTalkPage(with: talkPage) else {
+        guard let dbTalkPage = moc.createTalkPage(with: talkPage) else {
             XCTFail("Failure to create db talk page")
             return
         }
         
         //confirm asking for existing talk page with key pulls same talk page
-        guard let existingTalkPage = try? talkPageLocalHandler.talkPage(for: URL(string: urlString1)!) else {
+        guard let existingTalkPage = try? moc.talkPage(for: URL(string: urlString1)!) else {
             XCTFail("Pull existing talk page fails")
             return
         }
@@ -121,7 +122,7 @@ class TalkPageLocalHandlerTests: XCTestCase {
         
         //confirm asking for urlString2 pulls nothing
         do {
-            let nonexistantTalkPage = try talkPageLocalHandler.talkPage(for: URL(string: urlString2)!)
+            let nonexistantTalkPage = try moc.talkPage(for: URL(string: urlString2)!)
             XCTAssertNil(nonexistantTalkPage)
         } catch {
             XCTFail("Pull existing talk page fails")
@@ -146,7 +147,7 @@ class TalkPageLocalHandlerTests: XCTestCase {
         }
         
         //create db talk page
-        guard let dbTalkPage = talkPageLocalHandler.createTalkPage(with: talkPage) else {
+        guard let dbTalkPage = moc.createTalkPage(with: talkPage) else {
             XCTFail("Failure to create db talk page")
             return
         }
@@ -164,7 +165,7 @@ class TalkPageLocalHandlerTests: XCTestCase {
             return
         }
         
-        guard let updatedDbTalkPage = talkPageLocalHandler.updateTalkPage(dbTalkPage, with: updatedTalkPage) else {
+        guard let updatedDbTalkPage = moc.updateTalkPage(dbTalkPage, with: updatedTalkPage) else {
             XCTFail("Failure updating existing local talk page")
             return
         }

--- a/WikipediaUnitTests/Code/TalkPageTestHelpers.swift
+++ b/WikipediaUnitTests/Code/TalkPageTestHelpers.swift
@@ -65,7 +65,7 @@ class TalkPageTestHelpers {
                             ],
                             "shas": {
                                 "text": "5a5bd8e",
-                                "indicator": "asdfgjl"
+                                "indicator": "not_asdfgjl"
                             },
                             "sort": 0
                         }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T222726

bc843fe ensures `NSManagedObject`s are only accessed within the `NSManagedObjectContext` perform block they were fetched in so they aren't accessed on any other queue and can't be deleted before being re-accessed on the same queue. Also removes some of the dependence on the `viewContext`, allowing for backgrounding of update operations in the future. Open to suggestions for different approaches.