### PR TITLE
talk page - added superscript and subscript handling

### DIFF
--- a/InTheNewsNotification/WMFInTheNewsNotificationViewController.swift
+++ b/InTheNewsNotification/WMFInTheNewsNotificationViewController.swift
@@ -59,7 +59,7 @@ class WMFInTheNewsNotificationViewController: UIViewController, UNNotificationCo
                 let html = newsStory.storyHTML  {
                 let font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.footnote, compatibleWith: nil)
                 let linkFont = UIFont.boldSystemFont(ofSize: font.pointSize)
-                let attributedString = html.wmf_attributedStringFromHTML(with: font, boldFont: linkFont, italicFont: font, boldItalicFont: linkFont, color:nil, linkColor:nil, handlingLists: false, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: ["a":"b"], additionalTagAttributes:nil).wmf_trim()
+                let attributedString = html.wmf_attributedStringFromHTML(with: font, boldFont: linkFont, italicFont: font, boldItalicFont: linkFont, color:nil, linkColor:nil, handlingLists: false, handlingSuperSubscripts: false, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: ["a":"b"], additionalTagAttributes:nil).wmf_trim()
                 summaryLabel.attributedText = attributedString
             }
         } catch let error as NSError {

--- a/WMF Framework/String+HTML.swift
+++ b/WMF Framework/String+HTML.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 extension String {
-    public func byAttributingHTML(with textStyle: DynamicTextStyle, boldWeight: UIFont.Weight = .semibold, matching traitCollection: UITraitCollection, withBoldedString: String? = nil, color: UIColor? = nil, linkColor: UIColor? = nil, handlingLists: Bool = false, tagMapping: [String: String]? = nil, additionalTagAttributes: [String: [NSAttributedString.Key: Any]]? = nil) -> NSMutableAttributedString {
+    public func byAttributingHTML(with textStyle: DynamicTextStyle, boldWeight: UIFont.Weight = .semibold, matching traitCollection: UITraitCollection, withBoldedString: String? = nil, color: UIColor? = nil, linkColor: UIColor? = nil, handlingLists: Bool = false, handlingSuperSubscripts: Bool = false, tagMapping: [String: String]? = nil, additionalTagAttributes: [String: [NSAttributedString.Key: Any]]? = nil) -> NSMutableAttributedString {
         let font = UIFont.wmf_font(textStyle, compatibleWithTraitCollection: traitCollection)
         let boldFont = UIFont.wmf_font(textStyle.with(weight: boldWeight), compatibleWithTraitCollection: traitCollection)
         let italicFont = UIFont.wmf_font(textStyle.with(traits: [.traitItalic]), compatibleWithTraitCollection: traitCollection)
         let boldItalicFont = UIFont.wmf_font(textStyle.with(weight: boldWeight, traits: [.traitItalic]), compatibleWithTraitCollection: traitCollection)
-        return (self as NSString).wmf_attributedStringFromHTML(with: font, boldFont: boldFont, italicFont: italicFont, boldItalicFont: boldItalicFont, color: color, linkColor: linkColor, handlingLists: handlingLists, withAdditionalBoldingForMatchingSubstring: withBoldedString, tagMapping: tagMapping, additionalTagAttributes: additionalTagAttributes)
+        return (self as NSString).wmf_attributedStringFromHTML(with: font, boldFont: boldFont, italicFont: italicFont, boldItalicFont: boldItalicFont, color: color, linkColor: linkColor, handlingLists: handlingLists, handlingSuperSubscripts: handlingSuperSubscripts, withAdditionalBoldingForMatchingSubstring: withBoldedString, tagMapping: tagMapping, additionalTagAttributes: additionalTagAttributes)
     }
 }

--- a/Wikipedia/Code/NSString+WMFHTMLParsing.h
+++ b/Wikipedia/Code/NSString+WMFHTMLParsing.h
@@ -74,6 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                               color:(nullable UIColor *)color
                                                           linkColor:(nullable UIColor *)color
                                                         handlingLists:(BOOL)handlingLists
+                                                        handlingSuperSubscripts:(BOOL)handlingSuperSubscripts
                           withAdditionalBoldingForMatchingSubstring:(nullable NSString *)stringToBold
                                                          tagMapping:(nullable NSDictionary<NSString *, NSString *> *)tagMapping
                                             additionalTagAttributes:(nullable NSDictionary<NSString *, NSDictionary<NSAttributedStringKey, id> *> *)additionalTagAttributes;
@@ -81,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * Convienence method for the method above.
  */
-- (NSMutableAttributedString *)wmf_attributedStringFromHTMLWithFont:(UIFont *)font boldFont:(nullable UIFont *)boldFont italicFont:(nullable UIFont *)italicFont boldItalicFont:(nullable UIFont *)boldItalicFont color:(nullable UIColor *) color linkColor:(nullable UIColor *) linkColor handlingLists:(BOOL)handlingLists withAdditionalBoldingForMatchingSubstring:(nullable NSString *)stringToBold;
+- (NSMutableAttributedString *)wmf_attributedStringFromHTMLWithFont:(UIFont *)font boldFont:(nullable UIFont *)boldFont italicFont:(nullable UIFont *)italicFont boldItalicFont:(nullable UIFont *)boldItalicFont color:(nullable UIColor *) color linkColor:(nullable UIColor *) linkColor handlingLists:(BOOL)handlingLists handlingSuperSubscripts:(BOOL)handlingSuperSubscripts withAdditionalBoldingForMatchingSubstring:(nullable NSString *)stringToBold;
 
 
 @end

--- a/Wikipedia/Code/NSString+WMFHTMLParsing.m
+++ b/Wikipedia/Code/NSString+WMFHTMLParsing.m
@@ -6,6 +6,7 @@
 #import <WMF/NSRegularExpression+HTML.h>
 #import <WMF/NSCharacterSet+WMFExtras.h>
 #import "WMF/WMFHTMLElement.h"
+@import CoreText;
 
 @implementation NSString (WMFHTMLParsing)
 
@@ -294,11 +295,11 @@
     return [self wmf_stringByRemovingHTMLWithParsingBlock:NULL];
 }
 
-- (NSMutableAttributedString *)wmf_attributedStringFromHTMLWithFont:(UIFont *)font boldFont:(nullable UIFont *)boldFont italicFont:(nullable UIFont *)italicFont boldItalicFont:(nullable UIFont *)boldItalicFont color:(nullable UIColor *)color linkColor:(nullable UIColor *)linkColor handlingLists:(BOOL)handlingLists withAdditionalBoldingForMatchingSubstring:(nullable NSString *)stringToBold {
-    return [self wmf_attributedStringFromHTMLWithFont:font boldFont:boldFont italicFont:italicFont boldItalicFont:boldItalicFont color:color linkColor:linkColor handlingLists:handlingLists withAdditionalBoldingForMatchingSubstring:stringToBold tagMapping:nil additionalTagAttributes:nil];
+- (NSMutableAttributedString *)wmf_attributedStringFromHTMLWithFont:(UIFont *)font boldFont:(nullable UIFont *)boldFont italicFont:(nullable UIFont *)italicFont boldItalicFont:(nullable UIFont *)boldItalicFont color:(nullable UIColor *)color linkColor:(nullable UIColor *)linkColor handlingLists:(BOOL)handlingLists handlingSuperSubscripts:(BOOL)handlingSuperSubscripts withAdditionalBoldingForMatchingSubstring:(nullable NSString *)stringToBold {
+    return [self wmf_attributedStringFromHTMLWithFont:font boldFont:boldFont italicFont:italicFont boldItalicFont:boldItalicFont color:color linkColor:linkColor handlingLists:handlingLists handlingSuperSubscripts: handlingSuperSubscripts withAdditionalBoldingForMatchingSubstring:stringToBold tagMapping:nil additionalTagAttributes:nil];
 }
 
-- (NSMutableAttributedString *)wmf_attributedStringFromHTMLWithFont:(UIFont *)font boldFont:(nullable UIFont *)boldFont italicFont:(nullable UIFont *)italicFont boldItalicFont:(nullable UIFont *)boldItalicFont color:(nullable UIColor *)color linkColor:(nullable UIColor *)linkColor handlingLists:(BOOL)handlingLists withAdditionalBoldingForMatchingSubstring:(nullable NSString *)stringToBold tagMapping:(nullable NSDictionary<NSString *, NSString *> *)tagMapping additionalTagAttributes:(nullable NSDictionary<NSString *, NSDictionary<NSAttributedStringKey, id> *> *)additionalTagAttributes {
+- (NSMutableAttributedString *)wmf_attributedStringFromHTMLWithFont:(UIFont *)font boldFont:(nullable UIFont *)boldFont italicFont:(nullable UIFont *)italicFont boldItalicFont:(nullable UIFont *)boldItalicFont color:(nullable UIColor *)color linkColor:(nullable UIColor *)linkColor handlingLists:(BOOL)handlingLists handlingSuperSubscripts:(BOOL)handlingSuperSubscripts withAdditionalBoldingForMatchingSubstring:(nullable NSString *)stringToBold tagMapping:(nullable NSDictionary<NSString *, NSString *> *)tagMapping additionalTagAttributes:(nullable NSDictionary<NSString *, NSDictionary<NSAttributedStringKey, id> *> *)additionalTagAttributes {
     boldFont = boldFont ?: font;
     italicFont = italicFont ?: font;
     boldItalicFont = boldItalicFont ?: font;
@@ -418,6 +419,8 @@
         NSSet *linksForRange = [links objectAtIndex:idx];
         BOOL isItalic = [tagsForRange containsObject:@"i"];
         BOOL isBold = [tagsForRange containsObject:@"b"];
+        BOOL isSubscript = [tagsForRange containsObject:@"sub"];
+        BOOL isSuperscript = [tagsForRange containsObject:@"sup"];
         BOOL isUnorderedList = [tagsForRange containsObject:@"ul"];
         BOOL isOrderedList = [tagsForRange containsObject:@"ol"];
         BOOL isList = isUnorderedList || isOrderedList;
@@ -433,6 +436,16 @@
             }
         } else if (isBold) {
             [attributedString addAttribute:NSFontAttributeName value:boldFont range:range];
+        }
+        
+        if (handlingSuperSubscripts) {
+            if (isSubscript) {
+                [attributedString addAttribute:(NSString *)kCTSuperscriptAttributeName value:[NSNumber numberWithInt: -1] range:range];
+            }
+            
+            if (isSuperscript) {
+                [attributedString addAttribute:(NSString *)kCTSuperscriptAttributeName value:[NSNumber numberWithInt: 1] range:range];
+            }
         }
 
         if (handlingLists) {

--- a/Wikipedia/Code/NewsCollectionViewCell.swift
+++ b/Wikipedia/Code/NewsCollectionViewCell.swift
@@ -25,7 +25,7 @@ public class NewsCollectionViewCell: SideScrollingCollectionViewCell {
             descriptionLabel.text = nil
             return
         }
-        let attributedString = descriptionHTML.wmf_attributedStringFromHTML(with: descriptionFont, boldFont: descriptionLinkFont, italicFont: descriptionFont, boldItalicFont: descriptionLinkFont, color: descriptionLabel.textColor, linkColor: nil, handlingLists: false,  withAdditionalBoldingForMatchingSubstring:nil, tagMapping: ["a":"b"], additionalTagAttributes: nil).wmf_trim()
+        let attributedString = descriptionHTML.wmf_attributedStringFromHTML(with: descriptionFont, boldFont: descriptionLinkFont, italicFont: descriptionFont, boldItalicFont: descriptionLinkFont, color: descriptionLabel.textColor, linkColor: nil, handlingLists: false, handlingSuperSubscripts: false, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: ["a":"b"], additionalTagAttributes: nil).wmf_trim()
         descriptionLabel.attributedText = attributedString
     }
     

--- a/Wikipedia/Code/TalkPageHeaderView.swift
+++ b/Wikipedia/Code/TalkPageHeaderView.swift
@@ -102,7 +102,7 @@ class TalkPageHeaderView: SizeThatFitsReusableView {
         
         let titleFont = UIFont.wmf_font(.boldTitle1, compatibleWithTraitCollection: traitCollection)
         
-        if let titleAttributedString = viewModel.title.wmf_attributedStringFromHTML(with: titleFont, boldFont: titleFont, italicFont: titleFont, boldItalicFont: titleFont, color: titleTextView.textColor, linkColor:theme?.colors.link, handlingLists: false, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: nil, additionalTagAttributes: nil).wmf_trim() {
+        if let titleAttributedString = viewModel.title.wmf_attributedStringFromHTML(with: titleFont, boldFont: titleFont, italicFont: titleFont, boldItalicFont: titleFont, color: titleTextView.textColor, linkColor:theme?.colors.link, handlingLists: false, handlingSuperSubscripts: true, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: nil, additionalTagAttributes: nil).wmf_trim() {
             titleTextView.attributedText = titleAttributedString
         }
         
@@ -110,7 +110,7 @@ class TalkPageHeaderView: SizeThatFitsReusableView {
         let boldIntroFont = UIFont.wmf_font(.semiboldFootnote, compatibleWithTraitCollection: traitCollection)
         let italicIntroFont = UIFont.wmf_font(.italicFootnote, compatibleWithTraitCollection: traitCollection)
         
-        if let introAttributedString = viewModel.intro?.wmf_attributedStringFromHTML(with: introFont, boldFont: boldIntroFont, italicFont: italicIntroFont, boldItalicFont: boldIntroFont, color: introTextView.textColor, linkColor:theme?.colors.link, handlingLists: true, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: nil, additionalTagAttributes: nil).wmf_trim() {
+        if let introAttributedString = viewModel.intro?.wmf_attributedStringFromHTML(with: introFont, boldFont: boldIntroFont, italicFont: italicIntroFont, boldItalicFont: boldIntroFont, color: introTextView.textColor, linkColor:theme?.colors.link, handlingLists: true, handlingSuperSubscripts: true, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: nil, additionalTagAttributes: nil).wmf_trim() {
             introTextView.attributedText = introAttributedString
         }
     }

--- a/Wikipedia/Code/TalkPageReplyCell.swift
+++ b/Wikipedia/Code/TalkPageReplyCell.swift
@@ -70,7 +70,7 @@ class TalkPageReplyCell: CollectionViewCell {
         let font = UIFont.wmf_font(.body, compatibleWithTraitCollection: traitCollection)
         let boldFont = UIFont.wmf_font(.semiboldBody, compatibleWithTraitCollection: traitCollection)
         let italicfont = UIFont.wmf_font(.italicBody, compatibleWithTraitCollection: traitCollection)
-        if let attributedString = title.wmf_attributedStringFromHTML(with: font, boldFont: boldFont, italicFont: italicfont, boldItalicFont: boldFont, color: titleTextView.textColor, linkColor:theme?.colors.link, handlingLists: true, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: nil, additionalTagAttributes: nil).wmf_trim() {
+        if let attributedString = title.wmf_attributedStringFromHTML(with: font, boldFont: boldFont, italicFont: italicfont, boldItalicFont: boldFont, color: titleTextView.textColor, linkColor:theme?.colors.link, handlingLists: true, handlingSuperSubscripts: true, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: nil, additionalTagAttributes: nil).wmf_trim() {
             setupTitle(for: attributedString)
         }
         setNeedsLayout()

--- a/Wikipedia/Code/TalkPageTopicCell.swift
+++ b/Wikipedia/Code/TalkPageTopicCell.swift
@@ -51,7 +51,7 @@ class TalkPageTopicCell: CollectionViewCell {
         let boldFont = UIFont.wmf_font(.semiboldBody, compatibleWithTraitCollection: traitCollection)
         let italicfont = UIFont.wmf_font(.italicBody, compatibleWithTraitCollection: traitCollection)
         
-        if let attributedString = title.wmf_attributedStringFromHTML(with: font, boldFont: boldFont, italicFont: italicfont, boldItalicFont: boldFont, color: titleLabel.textColor, linkColor:nil, handlingLists: false, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: ["a": "b"], additionalTagAttributes: nil).wmf_trim() {
+        if let attributedString = title.wmf_attributedStringFromHTML(with: font, boldFont: boldFont, italicFont: italicfont, boldItalicFont: boldFont, color: titleLabel.textColor, linkColor:nil, handlingLists: false, handlingSuperSubscripts: true, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: ["a": "b"], additionalTagAttributes: nil).wmf_trim() {
             titleLabel.attributedText = attributedString
         }
     }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T222729 - superscript and subscript support

Endpoint currently seems to strip it out but here is native handling for it.

`let newTitle = "Testing with superscript<sup>test</sup> and subscript<sub>test</sub>."`

![Simulator Screen Shot - iPhone X - 2019-05-29 at 16 27 34](https://user-images.githubusercontent.com/3620196/58593026-7e90bf80-822f-11e9-9e58-9f2e9e0fc217.png)

`let newTitle = "Testing with superscript<sup><a href=\"http://www.google.com\">test</a></sup> and subscript<a href=\"http://www.google.com\"><sub>test</sub></a>."`

![Simulator Screen Shot - iPhone X - 2019-05-29 at 16 29 12](https://user-images.githubusercontent.com/3620196/58593033-8486a080-822f-11e9-88da-b81c78560ba8.png)
