### PR TITLE
Editing event logging: log revision id only only on section edit save, log missing actions

### DIFF
--- a/Wikipedia/Code/DescriptionEditViewController.swift
+++ b/Wikipedia/Code/DescriptionEditViewController.swift
@@ -32,9 +32,6 @@ import UIKit
     private var isAddingNewTitleDescription: Bool {
         return article?.entityDescription == nil
     }
-    private var articleRevision: Int? {
-        return article?.revisionId?.intValue
-    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -178,7 +175,7 @@ import UIKit
     }
 
     @IBAction private func publishDescriptionButton(withSender sender: UIButton) {
-        editFunnel?.logTitleDescriptionSaveAttempt(source: editFunnelSource, isAddingNewTitleDescription: isAddingNewTitleDescription, revision: articleRevision, language: article?.url.wmf_language)
+        editFunnel?.logTitleDescriptionSaveAttempt(source: editFunnelSource, isAddingNewTitleDescription: isAddingNewTitleDescription, language: article?.url.wmf_language)
         save()
     }
 
@@ -222,10 +219,10 @@ import UIKit
                 if let error = error {
                     let apiErrorCode = (error as? WikidataAPIResult.APIError)?.code
                     let errorText = apiErrorCode ?? "\((error as NSError).domain)-\((error as NSError).code)"
-                    self.editFunnel?.logTitleDescriptionSaveError(source: self.editFunnelSource, isAddingNewTitleDescription: self.isAddingNewTitleDescription, revision: self.articleRevision, language: article.url.wmf_language, errorText: errorText)
+                    self.editFunnel?.logTitleDescriptionSaveError(source: self.editFunnelSource, isAddingNewTitleDescription: self.isAddingNewTitleDescription, language: article.url.wmf_language, errorText: errorText)
                     WMFAlertManager.sharedInstance.showErrorAlert(error as NSError, sticky: true, dismissPreviousAlerts: true, tapCallBack: nil)
                 } else {
-                    self.editFunnel?.logTitleDescriptionSaved(source: self.editFunnelSource, isAddingNewTitleDescription: self.isAddingNewTitleDescription, revision: self.articleRevision, language: article.url.wmf_language)
+                    self.editFunnel?.logTitleDescriptionSaved(source: self.editFunnelSource, isAddingNewTitleDescription: self.isAddingNewTitleDescription, language: article.url.wmf_language)
                     self.delegate?.descriptionEditViewControllerEditSucceeded(self)
                     self.dismiss(animated: true) {
                         presentingVC?.wmf_showDescriptionPublishedPanelViewController(theme: self.theme)

--- a/Wikipedia/Code/EditFunnel.swift
+++ b/Wikipedia/Code/EditFunnel.swift
@@ -55,7 +55,7 @@
         }
     }
 
-    private func event(action: Action, source: EditFunnelSource? = nil, sessionToken: String? = nil, wikidataDescriptionEdit: WikidataDescriptionEdit? = nil, editSummaryType: EditSummaryViewCannedButtonType? = nil, abuseFilterName: String? = nil, errorText: String? = nil, revision: Int?) -> Dictionary<String, Any> {
+    private func event(action: Action, source: EditFunnelSource? = nil, sessionToken: String? = nil, wikidataDescriptionEdit: WikidataDescriptionEdit? = nil, editSummaryType: EditSummaryViewCannedButtonType? = nil, abuseFilterName: String? = nil, errorText: String? = nil, revision: Int? = nil) -> Dictionary<String, Any> {
         var event: [String : Any] = ["action": action.rawValue]
 
         if let source = source, let stringValue = source.stringValue {
@@ -103,70 +103,71 @@
 
     // MARK: Start
 
-    @objc(logSectionEditingStartFromSource:revision:language:)
-    public func logSectionEditingStart(from source: EditFunnelSource, revision: Int, language: String) {
-        logStart(source: source, revision: revision, language: language)
+    @objc(logSectionEditingStartFromSource:language:)
+    public func logSectionEditingStart(from source: EditFunnelSource, language: String) {
+        logStart(source: source, language: language)
     }
 
-    @objc(logTitleDescriptionEditingStartFromSource:revision:language:)
-    public func logTitleDescriptionEditingStart(from source: EditFunnelSource, revision: Int, language: String) {
+    @objc(logTitleDescriptionEditingStartFromSource:language:)
+    public func logTitleDescriptionEditingStart(from source: EditFunnelSource, language: String) {
         let wikidataDescriptionEdit: WikidataDescriptionEdit
         if source == .titleDescription {
             wikidataDescriptionEdit = .new
         } else {
             wikidataDescriptionEdit = .existing
         }
-        logStart(source: source, wikidataDescriptionEdit: wikidataDescriptionEdit, revision: revision, language: language)
+        logStart(source: source, wikidataDescriptionEdit: wikidataDescriptionEdit, language: language)
     }
 
-    private func logStart(source: EditFunnelSource, wikidataDescriptionEdit: WikidataDescriptionEdit? = nil, revision: Int, language: String) {
+    private func logStart(source: EditFunnelSource, wikidataDescriptionEdit: WikidataDescriptionEdit? = nil, language: String) {
         // session token should be regenerated at every 'start' event
         sessionToken = singleUseUUID()
-        log(event(action: .start, source: source, sessionToken: sessionToken, wikidataDescriptionEdit: wikidataDescriptionEdit, revision: revision), language: language)
+        log(event(action: .start, source: source, sessionToken: sessionToken, wikidataDescriptionEdit: wikidataDescriptionEdit), language: language)
     }
 
     // MARK: Onboarding
 
-    @objc(logOnboardingPresentationInitiatedBySource:revision:language:)
-    public func logOnboardingPresentation(initiatedBy source: EditFunnelSource, revision: Int, language: String) {
-        logOnboardingPresentation(source: source, revision: revision, language: language)
+    @objc(logOnboardingPresentationInitiatedBySource:language:)
+    public func logOnboardingPresentation(initiatedBy source: EditFunnelSource, language: String) {
+        logOnboardingPresentation(source: source, language: language)
     }
 
-    private func logOnboardingPresentation(source: EditFunnelSource, revision: Int, language: String) {
-        log(event(action: .onboarding, source: source, revision: revision), language: language)
+    private func logOnboardingPresentation(source: EditFunnelSource, language: String) {
+        log(event(action: .onboarding, source: source), language: language)
     }
 
     // MARK: Ready
 
-    @objc(logTitleDescriptionReadyToEditFromSource:isAddingNewTitleDescription:revision:language:)
-    public func logTitleDescriptionReadyToEditFrom(from source: EditFunnelSource, isAddingNewTitleDescription: Bool, revision: Int, language: String) {
-        log(event(action: .ready, source: source, wikidataDescriptionEdit: WikidataDescriptionEdit(isAddingNewTitleDescription: isAddingNewTitleDescription), revision: revision), language: language)
+    @objc(logTitleDescriptionReadyToEditFromSource:isAddingNewTitleDescription:language:)
+    public func logTitleDescriptionReadyToEditFrom(from source: EditFunnelSource, isAddingNewTitleDescription: Bool, language: String) {
+        log(event(action: .ready, source: source, wikidataDescriptionEdit: WikidataDescriptionEdit(isAddingNewTitleDescription: isAddingNewTitleDescription)), language: language)
     }
 
-    public func logSectionReadyToEdit(from source: EditFunnelSource, revision: Int?, language: String?) {
-        log(event(action: .ready, source: source, revision: revision), language: language)
+    public func logSectionReadyToEdit(from source: EditFunnelSource, language: String?) {
+        log(event(action: .ready, source: source), language: language)
     }
 
     // MARK: Preview
 
-    public func logEditPreviewForArticle(withRevision revision: Int?, language: String?) {
-        log(event(action: .preview, revision: revision), language: language)
+    public func logEditPreviewForArticle(language: String?) {
+        log(event(action: .preview), language: language)
     }
 
     // MARK: Save attempt
 
-    public func logTitleDescriptionSaveAttempt(source: EditFunnelSource, isAddingNewTitleDescription: Bool, revision: Int?, language: String?) {
-        log(event(action: .saveAttempt, source: source, wikidataDescriptionEdit: WikidataDescriptionEdit(isAddingNewTitleDescription: isAddingNewTitleDescription), revision: revision), language: language)
+    public func logTitleDescriptionSaveAttempt(source: EditFunnelSource, isAddingNewTitleDescription: Bool, language: String?) {
+        log(event(action: .saveAttempt, source: source, wikidataDescriptionEdit: WikidataDescriptionEdit(isAddingNewTitleDescription: isAddingNewTitleDescription)), language: language)
     }
 
-    public func logSectionSaveAttempt(source: EditFunnelSource, revision: Int?, language: String?) {
-        log(event(action: .saveAttempt, source: source, revision: revision), language: language)
+    public func logSectionSaveAttempt(source: EditFunnelSource, language: String?) {
+        log(event(action: .saveAttempt, source: source), language: language)
     }
 
     // MARK: Saved
 
-    public func logTitleDescriptionSaved(source: EditFunnelSource, isAddingNewTitleDescription: Bool, revision: Int?, language: String?) {
-        log(event(action: .saved, source: source, wikidataDescriptionEdit: WikidataDescriptionEdit(isAddingNewTitleDescription: isAddingNewTitleDescription), revision: revision), language: language)
+    // check if we get revision after submitting a new wikidata description edit
+    public func logTitleDescriptionSaved(source: EditFunnelSource, isAddingNewTitleDescription: Bool, language: String?) {
+        log(event(action: .saved, source: source, wikidataDescriptionEdit: WikidataDescriptionEdit(isAddingNewTitleDescription: isAddingNewTitleDescription)), language: language)
     }
 
     public func logSectionSaved(source: EditFunnelSource, revision: Int?, language: String?) {
@@ -175,49 +176,49 @@
 
     // MARK: Error
 
-    public func logTitleDescriptionSaveError(source: EditFunnelSource, isAddingNewTitleDescription: Bool, revision: Int?, language: String?, errorText: String) {
-        log(event(action: .error, source: source, wikidataDescriptionEdit: WikidataDescriptionEdit(isAddingNewTitleDescription: isAddingNewTitleDescription), errorText: errorText, revision: revision), language: language)
+    public func logTitleDescriptionSaveError(source: EditFunnelSource, isAddingNewTitleDescription: Bool, language: String?, errorText: String) {
+        log(event(action: .error, source: source, wikidataDescriptionEdit: WikidataDescriptionEdit(isAddingNewTitleDescription: isAddingNewTitleDescription), errorText: errorText), language: language)
     }
 
-    public func logSectionSaveError(source: EditFunnelSource, revision: Int?, language: String?, errorText: String) {
-        log(event(action: .error, source: source, errorText: errorText, revision: revision), language: language)
+    public func logSectionSaveError(source: EditFunnelSource, language: String?, errorText: String) {
+        log(event(action: .error, source: source, errorText: errorText), language: language)
     }
 
-    public func logSectionHighlightToEditError(revision: Int?, language: String?) {
-        log(event(action: .error, source: .highlight, errorText: "non-editable", revision: revision), language: language)
+    public func logSectionHighlightToEditError(language: String?) {
+        log(event(action: .error, source: .highlight, errorText: "non-editable"), language: language)
     }
 
     // MARK: Section edit summary tap
 
-    public func logSectionEditSummaryTap(source: EditFunnelSource, editSummaryType: EditSummaryViewCannedButtonType, revision: Int?, language: String?) {
-        log(event(action: .editSummaryTap, source: source, editSummaryType: editSummaryType, revision: revision), language: language)
+    public func logSectionEditSummaryTap(source: EditFunnelSource, editSummaryType: EditSummaryViewCannedButtonType, language: String?) {
+        log(event(action: .editSummaryTap, source: source, editSummaryType: editSummaryType), language: language)
     }
 
     // MARK: Captcha
 
-    public func logCaptchaShownForSectionEdit(source: EditFunnelSource, revision: Int?, language: String?) {
-        log(event(action: .captchaShown, source: source, revision: revision), language: language)
+    public func logCaptchaShownForSectionEdit(source: EditFunnelSource, language: String?) {
+        log(event(action: .captchaShown, source: source), language: language)
     }
 
-    public func logCaptchaFailedForSectionEdit(source: EditFunnelSource, revision: Int?, language: String?) {
-        log(event(action: .captchaFailure, source: source, revision: revision), language: language)
+    public func logCaptchaFailedForSectionEdit(source: EditFunnelSource, language: String?) {
+        log(event(action: .captchaFailure, source: source), language: language)
     }
 
     // MARK: Abuse filter
 
-    public func logAbuseFilterWarningForSectionEdit(abuseFilterName: String, source: EditFunnelSource, revision: Int?, language: String?) {
-        log(event(action: .abuseFilterWarning, source: source, abuseFilterName: abuseFilterName, revision: revision), language: language)
+    public func logAbuseFilterWarningForSectionEdit(abuseFilterName: String, source: EditFunnelSource, language: String?) {
+        log(event(action: .abuseFilterWarning, source: source, abuseFilterName: abuseFilterName), language: language)
     }
 
-    public func logAbuseFilterWarningBackForSectionEdit(abuseFilterName: String, source: EditFunnelSource, revision: Int?, language: String?) {
-        log(event(action: .abuseFilterWarningBack, source: source, abuseFilterName: abuseFilterName, revision: revision), language: language)
+    public func logAbuseFilterWarningBackForSectionEdit(abuseFilterName: String, source: EditFunnelSource, language: String?) {
+        log(event(action: .abuseFilterWarningBack, source: source, abuseFilterName: abuseFilterName), language: language)
     }
 
-    public func logAbuseFilterWarningIgnoreForSectionEdit(abuseFilterName: String, source: EditFunnelSource, revision: Int?, language: String?) {
-        log(event(action: .abuseFilterWarningIgnore, source: source, abuseFilterName: abuseFilterName, revision: revision), language: language)
+    public func logAbuseFilterWarningIgnoreForSectionEdit(abuseFilterName: String, source: EditFunnelSource, language: String?) {
+        log(event(action: .abuseFilterWarningIgnore, source: source, abuseFilterName: abuseFilterName), language: language)
     }
 
-    public func logAbuseFilterErrorForSectionEdit(abuseFilterName: String, source: EditFunnelSource, revision: Int?, language: String?) {
-        log(event(action: .abuseFilterError, source: source, abuseFilterName: abuseFilterName, revision: revision), language: language)
+    public func logAbuseFilterErrorForSectionEdit(abuseFilterName: String, source: EditFunnelSource, language: String?) {
+        log(event(action: .abuseFilterError, source: source, abuseFilterName: abuseFilterName), language: language)
     }
 }

--- a/Wikipedia/Code/EditFunnel.swift
+++ b/Wikipedia/Code/EditFunnel.swift
@@ -165,7 +165,6 @@
 
     // MARK: Saved
 
-    // check if we get revision after submitting a new wikidata description edit
     public func logTitleDescriptionSaved(source: EditFunnelSource, isAddingNewTitleDescription: Bool, language: String?) {
         log(event(action: .saved, source: source, wikidataDescriptionEdit: WikidataDescriptionEdit(isAddingNewTitleDescription: isAddingNewTitleDescription)), language: language)
     }

--- a/Wikipedia/Code/EditFunnel.swift
+++ b/Wikipedia/Code/EditFunnel.swift
@@ -37,13 +37,13 @@
         case abuseFilterWarning
         case abuseFilterError
         case editSummaryTap
+        case editSummaryShown
         case abuseFilterWarningIgnore
         case abuseFilterWarningBack
         case saveAttempt
         case error
         case ready
         case onboarding
-        case editSummaryShown
     }
 
     private enum WikidataDescriptionEdit: String {
@@ -187,10 +187,14 @@
         log(event(action: .error, source: .highlight, errorText: "non-editable"), language: language)
     }
 
-    // MARK: Section edit summary tap
+    // MARK: Section edit summary
 
     public func logSectionEditSummaryTap(source: EditFunnelSource, editSummaryType: EditSummaryViewCannedButtonType, language: String?) {
         log(event(action: .editSummaryTap, source: source, editSummaryType: editSummaryType), language: language)
+    }
+
+    public func logSectionEditSummaryShown(source: EditFunnelSource, language: String?) {
+        log(event(action: .editSummaryShown, source: source), language: language)
     }
 
     // MARK: Captcha

--- a/Wikipedia/Code/EditPreviewViewController.swift
+++ b/Wikipedia/Code/EditPreviewViewController.swift
@@ -9,7 +9,7 @@ class EditPreviewViewController: UIViewController, Themeable, WMFOpenExternalLin
     var section: MWKSection?
     var wikitext = ""
     var editFunnel: EditFunnel?
-    var loggedEditActions: [EditFunnel.Action]?
+    var loggedEditActions: NSMutableSet?
     var savedPagesFunnel: SavedPagesFunnel?
     var theme: Theme = .standard
     
@@ -82,9 +82,9 @@ class EditPreviewViewController: UIViewController, Themeable, WMFOpenExternalLin
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: CommonStrings.nextTitle, style: .done, target: self, action: #selector(self.goForward))
         navigationItem.rightBarButtonItem?.tintColor = theme.colors.link
 
-        if var loggedEditActions = loggedEditActions, loggedEditActions.contains(.preview) {
+        if let loggedEditActions = loggedEditActions, !loggedEditActions.contains(EditFunnel.Action.preview) {
             editFunnel?.logEditPreviewForArticle(language: section?.articleLanguage)
-            loggedEditActions.append(.preview)
+            loggedEditActions.add(EditFunnel.Action.preview)
         }
         
         preview()

--- a/Wikipedia/Code/EditPreviewViewController.swift
+++ b/Wikipedia/Code/EditPreviewViewController.swift
@@ -83,7 +83,7 @@ class EditPreviewViewController: UIViewController, Themeable, WMFOpenExternalLin
         navigationItem.rightBarButtonItem?.tintColor = theme.colors.link
 
         if var loggedEditActions = loggedEditActions, loggedEditActions.contains(.preview) {
-            editFunnel?.logEditPreviewForArticle(withRevision: section?.article?.revisionId?.intValue, language: section?.articleLanguage)
+            editFunnel?.logEditPreviewForArticle(language: section?.articleLanguage)
             loggedEditActions.append(.preview)
         }
         

--- a/Wikipedia/Code/EditSaveViewController.swift
+++ b/Wikipedia/Code/EditSaveViewController.swift
@@ -24,9 +24,6 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
     var editFunnel: EditFunnel?
     var editFunnelSource: EditFunnelSource = .unknown
     var savedPagesFunnel: SavedPagesFunnel?
-    private var articleRevision: Int? {
-        return section?.article?.revisionId?.intValue
-    }
 
     private lazy var captchaViewController: WMFCaptchaViewController? = WMFCaptchaViewController.wmf_initialViewControllerFromClassStoryboard()
     @IBOutlet private var captchaContainer: UIView!
@@ -89,7 +86,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
 
     @objc private func goBack() {
         if mode == .abuseFilterWarning {
-            editFunnel?.logAbuseFilterWarningBackForSectionEdit(abuseFilterName: abuseFilterCode, source: editFunnelSource, revision: articleRevision, language: section?.articleLanguage)
+            editFunnel?.logAbuseFilterWarningBackForSectionEdit(abuseFilterName: abuseFilterCode, source: editFunnelSource, language: section?.articleLanguage)
         }
         
         navigationController?.popViewController(animated: true)
@@ -99,7 +96,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
         switch mode {
         case .abuseFilterWarning:
             save()
-            editFunnel?.logAbuseFilterWarningIgnoreForSectionEdit(abuseFilterName: abuseFilterCode, source: editFunnelSource, revision: articleRevision, language: section?.articleLanguage)
+            editFunnel?.logAbuseFilterWarningIgnoreForSectionEdit(abuseFilterName: abuseFilterCode, source: editFunnelSource, language: section?.articleLanguage)
         case .captcha:
             save()
         default:
@@ -224,7 +221,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
     private func save() {
         WMFAlertManager.sharedInstance.showAlert(WMFLocalizedString("wikitext-upload-save", value: "Publishing...", comment: "Alert text shown when changes to section wikitext are being published\n{{Identical|Publishing}}"), sticky: true, dismissPreviousAlerts: true, tapCallBack: nil)
 
-        editFunnel?.logSectionSaveAttempt(source: editFunnelSource, revision: articleRevision, language: section?.articleLanguage)
+        editFunnel?.logSectionSaveAttempt(source: editFunnelSource, language: section?.articleLanguage)
 
         if (savedPagesFunnel != nil) {
             savedPagesFunnel?.logEditAttempt(withArticleURL: section?.article?.url)
@@ -278,14 +275,14 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
         switch errorType {
         case .needsCaptcha:
             if mode == .captcha {
-                editFunnel?.logCaptchaFailedForSectionEdit(source: editFunnelSource, revision: articleRevision, language: section?.articleLanguage)
+                editFunnel?.logCaptchaFailedForSectionEdit(source: editFunnelSource, language: section?.articleLanguage)
             }
             
             let captchaUrl = URL(string: nsError.userInfo["captchaUrl"] as? String ?? "")
             let captchaId = nsError.userInfo["captchaId"] as? String ?? ""
             WMFAlertManager.sharedInstance.showErrorAlert(nsError, sticky: false, dismissPreviousAlerts: true, tapCallBack: nil)
             captchaViewController?.captcha = WMFCaptcha(captchaID: captchaId, captchaURL: captchaUrl!)
-            editFunnel?.logCaptchaShownForSectionEdit(source: editFunnelSource, revision: articleRevision, language: section?.articleLanguage)
+            editFunnel?.logCaptchaShownForSectionEdit(source: editFunnelSource, language: section?.articleLanguage)
             mode = .captcha
             highlightCaptchaSubmitButton(false)
             dispatchOnMainQueueAfterDelayInSeconds(0.1) { // Prevents weird animation.
@@ -300,12 +297,12 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
                 WMFAlertManager.sharedInstance.showErrorAlert(nsError, sticky: false, dismissPreviousAlerts: true, tapCallBack: nil)
                 mode = .abuseFilterDisallow
                 abuseFilterCode = nsError.userInfo["code"] as! String
-                editFunnel?.logAbuseFilterErrorForSectionEdit(abuseFilterName: abuseFilterCode, source: editFunnelSource, revision: articleRevision, language: section?.articleLanguage)
+                editFunnel?.logAbuseFilterErrorForSectionEdit(abuseFilterName: abuseFilterCode, source: editFunnelSource, language: section?.articleLanguage)
             } else {
                 WMFAlertManager.sharedInstance.showWarningAlert(nsError.localizedDescription, sticky: false, dismissPreviousAlerts: true, tapCallBack: nil)
                 mode = .abuseFilterWarning
                 abuseFilterCode = nsError.userInfo["code"] as! String
-                editFunnel?.logAbuseFilterWarningForSectionEdit(abuseFilterName: abuseFilterCode, source: editFunnelSource, revision: articleRevision, language: section?.articleLanguage)
+                editFunnel?.logAbuseFilterWarningForSectionEdit(abuseFilterName: abuseFilterCode, source: editFunnelSource, language: section?.articleLanguage)
             }
             
             let alertType: AbuseFilterAlertType = (errorType == .abuseFilterDisallowed) ? .disallow : .warning
@@ -313,10 +310,10 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
             
         case .server, .unknown:
             WMFAlertManager.sharedInstance.showErrorAlert(nsError, sticky: true, dismissPreviousAlerts: true, tapCallBack: nil)
-            editFunnel?.logSectionSaveError(source: editFunnelSource, revision: articleRevision, language: section?.articleLanguage, errorText: "other")
+            editFunnel?.logSectionSaveError(source: editFunnelSource, language: section?.articleLanguage, errorText: "other")
         default:
             WMFAlertManager.sharedInstance.showErrorAlert(nsError, sticky: true, dismissPreviousAlerts: true, tapCallBack: nil)
-            editFunnel?.logSectionSaveError(source: editFunnelSource, revision: articleRevision, language: section?.articleLanguage, errorText: "other")
+            editFunnel?.logSectionSaveError(source: editFunnelSource, language: section?.articleLanguage, errorText: "other")
         }
     }
     
@@ -407,7 +404,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
     }
     
     func cannedButtonTapped(type: EditSummaryViewCannedButtonType) {
-        editFunnel?.logSectionEditSummaryTap(source: editFunnelSource, editSummaryType: type, revision: articleRevision, language: section?.articleLanguage)
+        editFunnel?.logSectionEditSummaryTap(source: editFunnelSource, editSummaryType: type, language: section?.articleLanguage)
     }
     
     // Keep bottom divider and license/login labels at bottom of screen while remaining scrollable.

--- a/Wikipedia/Code/EditSaveViewController.swift
+++ b/Wikipedia/Code/EditSaveViewController.swift
@@ -24,6 +24,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
     var editFunnel: EditFunnel?
     var editFunnelSource: EditFunnelSource = .unknown
     var savedPagesFunnel: SavedPagesFunnel?
+    var loggedEditActions: NSMutableSet?
 
     private lazy var captchaViewController: WMFCaptchaViewController? = WMFCaptchaViewController.wmf_initialViewControllerFromClassStoryboard()
     @IBOutlet private var captchaContainer: UIView!
@@ -130,6 +131,11 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
         
         // TODO: show this once we figure out how to handle watchlists (T214749)
         addToWatchlistStackView.isHidden = true
+
+        if let loggedEditActions = loggedEditActions, !loggedEditActions.contains(EditFunnel.Action.editSummaryShown) {
+            editFunnel?.logSectionEditSummaryShown(source: editFunnelSource, language: section?.articleLanguage)
+            loggedEditActions.add(EditFunnel.Action.editSummaryShown)
+        }
         
         apply(theme: theme)
     }

--- a/Wikipedia/Code/SectionEditorViewController.swift
+++ b/Wikipedia/Code/SectionEditorViewController.swift
@@ -354,13 +354,13 @@ class SectionEditorViewController: UIViewController {
 
     // MARK: Event logging
 
-    private var loggedEditActions: [EditFunnel.Action] = []
+    private var loggedEditActions: NSMutableSet = []
     private func logSectionReadyToEdit() {
-        guard !loggedEditActions.contains(.ready) else {
+        guard !loggedEditActions.contains(EditFunnel.Action.ready) else {
             return
         }
         editFunnel.logSectionReadyToEdit(from: editFunnelSource, language: section?.articleLanguage)
-        loggedEditActions.append(.ready)
+        loggedEditActions.add(EditFunnel.Action.ready)
     }
 
     private var editFunnelSource: EditFunnelSource {
@@ -520,6 +520,7 @@ extension SectionEditorViewController: EditPreviewViewControllerDelegate {
         vc.theme = self.theme
         vc.editFunnel = self.editFunnel
         vc.editFunnelSource = editFunnelSource
+        vc.loggedEditActions = loggedEditActions
         self.navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/Wikipedia/Code/SectionEditorViewController.swift
+++ b/Wikipedia/Code/SectionEditorViewController.swift
@@ -234,7 +234,7 @@ class SectionEditorViewController: UIViewController {
     }
     
     private func showCouldNotFindSelectionInWikitextAlert() {
-        editFunnel.logSectionHighlightToEditError(revision: section?.article?.revisionId?.intValue, language: section?.articleLanguage)
+        editFunnel.logSectionHighlightToEditError(language: section?.articleLanguage)
         let alertTitle = WMFLocalizedString("edit-menu-item-could-not-find-selection-alert-title", value:"The text that you selected could not be located", comment:"Title for alert informing user their text selection could not be located in the article wikitext.")
         let alertMessage = WMFLocalizedString("edit-menu-item-could-not-find-selection-alert-message", value:"This might be because the text you selected is not editable (eg. article title or infobox titles) or the because of the length of the text that was highlighted", comment:"Description of possible reasons the user text selection could not be located in the article wikitext.")
         let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
@@ -359,7 +359,7 @@ class SectionEditorViewController: UIViewController {
         guard !loggedEditActions.contains(.ready) else {
             return
         }
-        editFunnel.logSectionReadyToEdit(from: editFunnelSource, revision: section?.article?.revisionId?.intValue, language: section?.articleLanguage)
+        editFunnel.logSectionReadyToEdit(from: editFunnelSource, language: section?.articleLanguage)
         loggedEditActions.append(.ready)
     }
 

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1797,9 +1797,8 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
 }
 
 - (void)showEditorForSection:(MWKSection *)section selectedTextEditInfo:(nullable SelectedTextEditInfo *)selectedTextEditInfo source:(EditFunnelSource)source {
-    int articleRevision = self.article.revisionId.intValue;
     NSString *articleLanguage = self.article.url.wmf_language;
-    [self.editFunnel logSectionEditingStartFromSource:source revision:articleRevision language:articleLanguage];
+    [self.editFunnel logSectionEditingStartFromSource:source language:articleLanguage];
 
     [self cancelWIconPopoverDisplay];
     WMFSectionEditorViewController *sectionEditVC = [[WMFSectionEditorViewController alloc] init];
@@ -1821,7 +1820,7 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
     @weakify(self);
     void (^showIntro)(void) = ^{
         @strongify(self);
-        [self.editFunnel logOnboardingPresentationInitiatedBySource:source revision:articleRevision language:articleLanguage];
+        [self.editFunnel logOnboardingPresentationInitiatedBySource:source language:articleLanguage];
         WMFEditingWelcomeViewController *editingWelcomeViewController = [[WMFEditingWelcomeViewController alloc] initWithTheme:self.theme
                                                                                                                     completion:^{
                                                                                                                         sectionEditVC.shouldFocusWebView = YES;
@@ -1849,9 +1848,8 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
 
 - (void)showTitleDescriptionEditor:(EditFunnelSource)source {
     BOOL isAddingNewTitleDescription = self.article.entityDescription == NULL;
-    int articleRevision = self.article.revisionId.intValue;
     NSString *articleLanguage = self.article.url.wmf_language;
-    [self.editFunnel logTitleDescriptionEditingStartFromSource:source revision:articleRevision language:articleLanguage];
+    [self.editFunnel logTitleDescriptionEditingStartFromSource:source language:articleLanguage];
 
     DescriptionEditViewController *editVC = [DescriptionEditViewController wmf_initialViewControllerFromClassStoryboard];
     editVC.delegate = self;
@@ -1874,10 +1872,10 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
     @weakify(navVC);
     void (^showIntro)(void) = ^{
         @strongify(self);
-        [self.editFunnel logOnboardingPresentationInitiatedBySource:source revision:articleRevision language:articleLanguage];
+        [self.editFunnel logOnboardingPresentationInitiatedBySource:source language:articleLanguage];
         DescriptionWelcomeInitialViewController *welcomeVC = [DescriptionWelcomeInitialViewController wmf_viewControllerFromDescriptionWelcomeStoryboard];
         welcomeVC.completionBlock = ^{
-            [self.editFunnel logTitleDescriptionReadyToEditFromSource:source isAddingNewTitleDescription:isAddingNewTitleDescription revision:articleRevision language:articleLanguage];
+            [self.editFunnel logTitleDescriptionReadyToEditFromSource:source isAddingNewTitleDescription:isAddingNewTitleDescription language:articleLanguage];
         };
         [welcomeVC applyTheme:self.theme];
         [navVC presentViewController:welcomeVC
@@ -1894,7 +1892,7 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
                          if (needsIntro) {
                              showIntro();
                          } else {
-                             [self.editFunnel logTitleDescriptionReadyToEditFromSource:source isAddingNewTitleDescription:isAddingNewTitleDescription revision:articleRevision language:articleLanguage];
+                             [self.editFunnel logTitleDescriptionReadyToEditFromSource:source isAddingNewTitleDescription:isAddingNewTitleDescription language:articleLanguage];
                          }
                      }];
 }


### PR DESCRIPTION
In my first pass, I logged revision id for all editing events, per Chelsy's comment (https://phabricator.wikimedia.org/T218933#5250606), we only want to log the new revision id on section edit save

Also, logs for `preview` and `editSummaryShown` were missing