### PR TITLE
talk page - ensure only onscreen footer view is set for future resetting

### DIFF
--- a/Wikipedia/Code/TalkPageReplyListViewController.swift
+++ b/Wikipedia/Code/TalkPageReplyListViewController.swift
@@ -206,6 +206,7 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
             let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: TalkPageReplyFooterView.identifier, for: indexPath) as? TalkPageReplyFooterView {
             self.footerView = footer
             configure(footer: footer)
+            self.footerView = footer
             return footer
         }
         
@@ -335,7 +336,6 @@ private extension TalkPageReplyListViewController {
         footer.layoutMargins = layout.itemLayoutMargins
         footer.apply(theme: theme)
         footer.composeButtonIsDisabled = repliesAreDisabled
-        self.footerView = footer
     }
     
     func configure(cell: TalkPageReplyCell, at indexPath: IndexPath) {


### PR DESCRIPTION
Setting footerView in the footer configure method (where it's also called from `estimatedHeightForFooterInSection`) caused the incorrect footer view instance to get reset after publishing a reply. Moving to `viewForSupplementaryElementOfKind` fixes this.

Before:
![before](https://user-images.githubusercontent.com/3620196/59456403-dad11300-8ddb-11e9-8715-efb3ef3093db.gif)

After:
![after](https://user-images.githubusercontent.com/3620196/59456417-e0c6f400-8ddb-11e9-9d22-e52f0ef558ab.gif)
