### PR TITLE
talk page - make intro text tappable into reply thread

### DIFF
--- a/WMF Framework/Wikipedia.xcdatamodeld/Wikipedia 2.xcdatamodel/contents
+++ b/WMF Framework/Wikipedia.xcdatamodeld/Wikipedia 2.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14490.99" systemVersion="18E226" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14490.99" systemVersion="18F203" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ReadingList" representedClassName="WMF.ReadingList" syncable="YES">
         <attribute name="canonicalName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="color" optional="YES" attributeType="String" syncable="YES"/>
@@ -71,7 +71,6 @@
     </entity>
     <entity name="TalkPage" representedClassName="TalkPage" syncable="YES" codeGenerationType="class">
         <attribute name="displayTitle" attributeType="String" syncable="YES"/>
-        <attribute name="introText" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="key" attributeType="String" syncable="YES"/>
         <attribute name="revisionId" optional="YES" attributeType="Integer 64" minValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="topics" toMany="YES" deletionRule="Cascade" destinationEntity="TalkPageTopic" inverseName="talkPage" inverseEntity="TalkPageTopic" syncable="YES"/>
@@ -84,6 +83,7 @@
         <relationship name="topic" maxCount="1" deletionRule="Nullify" destinationEntity="TalkPageTopic" inverseName="replies" inverseEntity="TalkPageTopic" syncable="YES"/>
     </entity>
     <entity name="TalkPageTopic" representedClassName="TalkPageTopic" syncable="YES" codeGenerationType="class">
+        <attribute name="isIntro" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="relatedObjectsVersion" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="sectionID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="sort" attributeType="Integer 64" minValueString="0" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
@@ -215,9 +215,9 @@
     <elements>
         <element name="ReadingList" positionX="-54" positionY="135" width="128" height="300"/>
         <element name="ReadingListEntry" positionX="-27" positionY="153" width="128" height="180"/>
-        <element name="TalkPage" positionX="-45" positionY="135" width="128" height="120"/>
+        <element name="TalkPage" positionX="-45" positionY="135" width="128" height="105"/>
         <element name="TalkPageReply" positionX="-27" positionY="153" width="128" height="120"/>
-        <element name="TalkPageTopic" positionX="-36" positionY="144" width="128" height="165"/>
+        <element name="TalkPageTopic" positionX="-36" positionY="144" width="128" height="180"/>
         <element name="TalkPageTopicContent" positionX="-36" positionY="135" width="128" height="90"/>
         <element name="WMFArticle" positionX="-63" positionY="-18" width="128" height="495"/>
         <element name="WMFContent" positionX="-63" positionY="135" width="128" height="75"/>

--- a/Wikipedia/Code/TalkPageFetcher.swift
+++ b/Wikipedia/Code/TalkPageFetcher.swift
@@ -4,14 +4,12 @@ class NetworkTalkPage {
     let topics: [NetworkTopic]
     var revisionId: Int?
     let displayTitle: String
-    let introText: String?
     
-    init(url: URL, topics: [NetworkTopic], revisionId: Int?, displayTitle: String, introText: String?) {
+    init(url: URL, topics: [NetworkTopic], revisionId: Int?, displayTitle: String) {
         self.url = url
         self.topics = topics
         self.revisionId = revisionId
         self.displayTitle = displayTitle
-        self.introText = introText
     }
 }
 
@@ -188,16 +186,7 @@ class TalkPageFetcher: Fetcher {
                 }
             }
 
-            var introText: String?
-            if let firstTopic = networkBase.topics.first,
-                firstTopic.html.count == 0,
-                let firstReply = firstTopic.replies.first,
-                firstReply.html.count > 0 {
-                introText = firstReply.html
-            }
-            
-            let filteredTopics = networkBase.topics.filter { $0.html.count > 0 }
-            let talkPage = NetworkTalkPage(url: taskURLWithoutRevID, topics: filteredTopics, revisionId: revisionID, displayTitle: displayTitle, introText: introText)
+            let talkPage = NetworkTalkPage(url: taskURLWithoutRevID, topics: networkBase.topics, revisionId: revisionID, displayTitle: displayTitle)
             completion(.success(talkPage))
         }
     }

--- a/Wikipedia/Code/TalkPageHeaderView.swift
+++ b/Wikipedia/Code/TalkPageHeaderView.swift
@@ -2,7 +2,8 @@
 import UIKit
 
 protocol TalkPageHeaderViewDelegate: class {
-    func tappedLink(_ url: URL, cell: TalkPageHeaderView)
+    func tappedLink(_ url: URL, headerView: TalkPageHeaderView)
+    func tappedIntro(headerView: TalkPageHeaderView)
 }
 
 class TalkPageHeaderView: UIView {
@@ -31,6 +32,14 @@ class TalkPageHeaderView: UIView {
     
     private var hasIntroText: Bool {
         return viewModel?.intro != nil
+    }
+    
+    private var hasTitleText: Bool {
+        if let viewModel = viewModel {
+            return viewModel.title.count > 0
+        }
+        
+        return false
     }
     
     var semanticContentAttributeOverride: UISemanticContentAttribute = .unspecified {
@@ -81,6 +90,8 @@ class TalkPageHeaderView: UIView {
         introTextView.textContainer.lineBreakMode = .byTruncatingTail
         introTextView.textContainerInset = UIEdgeInsets.zero
         introTextView.textContainer.lineFragmentPadding = 0
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(tappedIntro(sender:)))
+        introTextView.addGestureRecognizer(tapGestureRecognizer)
     }
     
     func configure(viewModel: ViewModel) {
@@ -96,9 +107,14 @@ class TalkPageHeaderView: UIView {
         
         headerLabel.text = viewModel.header
         
-        let titleFont = UIFont.wmf_font(.boldTitle1, compatibleWithTraitCollection: traitCollection)
-        let titleAttributedString = viewModel.title.wmf_attributedStringFromHTML(with: titleFont, boldFont: titleFont, italicFont: titleFont, boldItalicFont: titleFont, color: titleTextView.textColor, linkColor:theme?.colors.link, handlingLists: false, handlingSuperSubscripts: true, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: nil, additionalTagAttributes: nil)
-        titleTextView.attributedText = titleAttributedString
+        if hasTitleText {
+            let titleFont = UIFont.wmf_font(.boldTitle1, compatibleWithTraitCollection: traitCollection)
+            let titleAttributedString = viewModel.title.wmf_attributedStringFromHTML(with: titleFont, boldFont: titleFont, italicFont: titleFont, boldItalicFont: titleFont, color: titleTextView.textColor, linkColor:theme?.colors.link, handlingLists: false, handlingSuperSubscripts: true, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: nil, additionalTagAttributes: nil)
+            titleTextView.attributedText = titleAttributedString
+            titleTextView.isHidden = false
+        } else {
+            titleTextView.isHidden = true
+        }
         
         if let intro = viewModel.intro {
             introTextView.isHidden = false
@@ -109,16 +125,15 @@ class TalkPageHeaderView: UIView {
     }
     
     private func setupIntro(text: String) {
-        if hasIntroText {
-            
-            let introFont = UIFont.wmf_font(.footnote, compatibleWithTraitCollection: traitCollection)
-            let boldIntroFont = UIFont.wmf_font(.semiboldFootnote, compatibleWithTraitCollection: traitCollection)
-            let italicIntroFont = UIFont.wmf_font(.italicFootnote, compatibleWithTraitCollection: traitCollection)
-            
-            introTextView.attributedText = text.wmf_attributedStringFromHTML(with: introFont, boldFont: boldIntroFont, italicFont: italicIntroFont, boldItalicFont: boldIntroFont, color: introTextView.textColor, linkColor:theme?.colors.link, handlingLists: true, handlingSuperSubscripts: true, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: nil, additionalTagAttributes: nil)
-        } else {
-            introTextView.isHidden = true
-        }
+        let introFont = UIFont.wmf_font(.footnote, compatibleWithTraitCollection: traitCollection)
+        let boldIntroFont = UIFont.wmf_font(.semiboldFootnote, compatibleWithTraitCollection: traitCollection)
+        let italicIntroFont = UIFont.wmf_font(.italicFootnote, compatibleWithTraitCollection: traitCollection)
+        
+        introTextView.attributedText = text.wmf_attributedStringFromHTML(with: introFont, boldFont: boldIntroFont, italicFont: italicIntroFont, boldItalicFont: boldIntroFont, color: introTextView.textColor, linkColor:theme?.colors.link, handlingLists: true, handlingSuperSubscripts: true, withAdditionalBoldingForMatchingSubstring:nil, tagMapping: ["a": "b"], additionalTagAttributes: nil)
+    }
+    
+    @objc private func tappedIntro(sender: UITextView) {
+        delegate?.tappedIntro(headerView: self)
     }
     
     // MARK - Dynamic Type
@@ -170,7 +185,7 @@ extension TalkPageHeaderView: Themeable {
 
 extension TalkPageHeaderView: UITextViewDelegate {
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        delegate?.tappedLink(URL, cell: self)
+        delegate?.tappedLink(URL, headerView: self)
         return false
     }
 }

--- a/Wikipedia/Code/TalkPageLocalHandler.swift
+++ b/Wikipedia/Code/TalkPageLocalHandler.swift
@@ -28,7 +28,6 @@ extension NSManagedObjectContext {
         let talkPage = TalkPage(context: self)
         talkPage.key = url.wmf_talkPageDatabaseKey
         talkPage.displayTitle = displayTitle
-        talkPage.introText = nil
         
         do {
             try save()
@@ -48,7 +47,6 @@ extension NSManagedObjectContext {
         talkPage.key = networkTalkPage.url.wmf_talkPageDatabaseKey
         talkPage.revisionId = NSNumber(value: revisionID)
         talkPage.displayTitle = networkTalkPage.displayTitle
-        talkPage.introText = networkTalkPage.introText
         
         do {
             try addTalkPageTopics(to: talkPage, with: networkTalkPage)
@@ -68,7 +66,6 @@ extension NSManagedObjectContext {
         }
         
         localTalkPage.revisionId = NSNumber(value: revisionID)
-        localTalkPage.introText = networkTalkPage.introText
         
         guard let topicShas = (localTalkPage.topics as? Set<TalkPageTopic>)?.compactMap ({ return $0.textSha }) else {
             return nil
@@ -246,6 +243,7 @@ private extension NSManagedObjectContext {
         
         if let sort = networkTopic.sort {
             topic.sort = Int64(sort)
+            topic.isIntro = networkTopic.sort == 0 && networkTopic.html.count == 0
         } else {
             assertionFailure("Network topic is missing sort")
         }

--- a/Wikipedia/Code/TalkPageReplyListViewController.swift
+++ b/Wikipedia/Code/TalkPageReplyListViewController.swift
@@ -387,7 +387,11 @@ extension TalkPageReplyListViewController: ReplyButtonFooterViewDelegate {
 //MARK: TalkPageHeaderViewDelegate
 
 extension TalkPageReplyListViewController: TalkPageHeaderViewDelegate {
-    func tappedLink(_ url: URL, cell: TalkPageHeaderView) {
+    func tappedLink(_ url: URL, headerView: TalkPageHeaderView) {
         delegate?.tappedLink(url, viewController: self)
+    }
+    
+    func tappedIntro(headerView: TalkPageHeaderView) {
+        assertionFailure("Should not be able to tap intro text view from replies screen")
     }
 }

--- a/Wikipedia/Code/TalkPageTopicListViewController.swift
+++ b/Wikipedia/Code/TalkPageTopicListViewController.swift
@@ -37,7 +37,7 @@ class TalkPageTopicListViewController: ColumnarCollectionViewController {
         self.talkPageSemanticContentAttribute = talkPageSemanticContentAttribute
         
         let request: NSFetchRequest<TalkPageTopic> = TalkPageTopic.fetchRequest()
-        request.predicate = NSPredicate(format: "talkPage == %@",  talkPage)
+        request.predicate = NSPredicate(format: "talkPage == %@ && isIntro == NO",  talkPage)
         request.relationshipKeyPathsForPrefetching = ["content"]
         request.sortDescriptors = [NSSortDescriptor(key: "sort", ascending: true)]
         self.fetchedResultsController = NSFetchedResultsController(fetchRequest: request, managedObjectContext: dataStore.viewContext, sectionNameKeyPath: nil, cacheName: nil)

--- a/WikipediaUnitTests/Code/TalkPageTestHelpers.swift
+++ b/WikipediaUnitTests/Code/TalkPageTestHelpers.swift
@@ -90,7 +90,7 @@ class TalkPageTestHelpers {
                 }
             }
             
-            let talkPage = NetworkTalkPage(url: URL(string: urlString)!, topics: result.topics, revisionId: revisionId, displayTitle: "Username", introText: "Intro text")
+            let talkPage = NetworkTalkPage(url: URL(string: urlString)!, topics: result.topics, revisionId: revisionId, displayTitle: "Username")
 
             return talkPage
         } catch {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T224909

Depends on https://github.com/wikimedia/wikipedia-ios/pull/3125.

Note this requires changes to the core data model (topics now have isIntro boolean and removed introText field from talk page). The page does seem to lose the intro text if the user updates without reinstalling but fixes itself once a revision is made and the talk page is refetched.

develop: 
![Screen Shot 2019-06-13 at 1 34 55 PM](https://user-images.githubusercontent.com/3620196/59458692-985e0500-8de0-11e9-8c0a-26ab57f60992.png)

bug/T224909 without reinstalling:
![Screen Shot 2019-06-13 at 1 35 46 PM](https://user-images.githubusercontent.com/3620196/59458718-a875e480-8de0-11e9-9d09-e0f9a38fa44c.png)

bug/T224909 after revision:
![Screen Shot 2019-06-13 at 1 36 53 PM](https://user-images.githubusercontent.com/3620196/59458736-af9cf280-8de0-11e9-9569-3e312c3f1d02.png)

Before:
![before2](https://user-images.githubusercontent.com/3620196/59458765-c3e0ef80-8de0-11e9-94df-9a26e7179820.gif)

After:
![after2](https://user-images.githubusercontent.com/3620196/59458771-cb07fd80-8de0-11e9-99e8-ef056ff80afd.gif)

Before (FR):
![before1](https://user-images.githubusercontent.com/3620196/59458789-d529fc00-8de0-11e9-8eae-5b47ace95c65.gif)

After (FR):
![after1](https://user-images.githubusercontent.com/3620196/59458809-e1ae5480-8de0-11e9-8c37-1ac18e6faf92.gif)
