### PR TITLE
Utilize cached article responses when restoring navigation stack

### DIFF
--- a/ContinueReadingWidget/WMFTodayContinueReadingWidgetViewController.swift
+++ b/ContinueReadingWidget/WMFTodayContinueReadingWidgetViewController.swift
@@ -126,7 +126,7 @@ class WMFTodayContinueReadingWidgetViewController: UIViewController, NCWidgetPro
             self.textLabel.text = nil
         }
         
-        if let date = UserDefaults.wmf.wmf_appResignActiveDate() {
+        if let date = article.viewedDate {
             self.daysAgoView.isHidden = false
             self.daysAgoLabel.text = (date as NSDate).wmf_localizedRelativeDateStringFromLocalDateToNow()
         } else {

--- a/Wikipedia/Code/NavigationStateController.swift
+++ b/Wikipedia/Code/NavigationStateController.swift
@@ -25,10 +25,8 @@ final class NavigationStateController: NSObject {
         guard let navigationState = moc.navigationState else {
             return
         }
-        WMFAuthenticationManager.sharedInstance.attemptLogin {
-            for viewController in navigationState.viewControllers {
-                self.restore(viewController: viewController, for: tabBarController, navigationController: navigationController, in: moc)
-            }
+        for viewController in navigationState.viewControllers {
+            self.restore(viewController: viewController, for: tabBarController, navigationController: navigationController, in: moc)
         }
     }
 

--- a/Wikipedia/Code/NavigationStateController.swift
+++ b/Wikipedia/Code/NavigationStateController.swift
@@ -100,6 +100,7 @@ final class NavigationStateController: NSObject {
                     return
                 }
                 let articleVC = WMFArticleViewController(articleURL: articleURL, dataStore: dataStore, theme: theme)
+                articleVC.shouldRequestLatestRevisionOnInitialLoad = false
                 pushOrPresent(articleVC, navigationController: navigationController, presentation: viewController.presentation)
             case (.themeableNavigationController, _):
                 let themeableNavigationController = WMFThemeableNavigationController()

--- a/Wikipedia/Code/WMFArticleFetcher.h
+++ b/Wikipedia/Code/WMFArticleFetcher.h
@@ -22,32 +22,24 @@ extern NSString *const WMFArticleFetcherErrorCachedFallbackArticleKey;
 - (nullable NSURLSessionTask *)fetchArticleForURL:(NSURL *)articleURL saveToDisk:(BOOL)saveToDisk priority:(float)priority failure:(WMFErrorHandler)failure success:(WMFArticleHandler)success;
 
 /**
- *  Fetch the latest version of @c URL, if the locally stored revision is not the latest.
- *
- *  @param title    The title to fetch.
- *
- *  @param failure block If there was a cached article, and an error was encountered,
- *          the error's @c userInfo will contain the cached article for the key @c WMFArticleFetcherErrorCachedFallbackArticleKey
- *  @param success block
- */
-- (nullable NSURLSessionTask *)fetchLatestVersionOfArticleWithURLIfNeeded:(NSURL *)URL saveToDisk:(BOOL)saveToDisk priority:(float)priority failure:(WMFErrorHandler)failure success:(WMFArticleHandler)success;
-
-/**
  *  Fetch the latest version of @c URL, if the locally stored revision is not the latest. If forceDownload is passed, the latest version is always downloaded ignoring any cahced data
  *
- *  @param title    The title to fetch.
+ *  @param URL    The article URL to fetch.
  *  @param forceDownload If YES, the article will be downloaded even if it is already cached.
- *
+ *  @param checkForNewerRevision If YES, the fetcher will make a network call to verify the revision is the newest, and if it isn't will fetch the newer revision
+ *  @param saveToDisk If YES, the fetcher will save the article to disk
+ *  @param priority value between 0.0 and 1.0 (inclusive), where 0.0 is considered the lowest priority and 1.0 is considered the highest
  *  @param failure block If there was a cached article, and an error was encountered,
  *          the error's @c userInfo will contain the cached article for the key @c WMFArticleFetcherErrorCachedFallbackArticleKey
  *  @param success block
  */
-- (nullable NSURLSessionTask *)fetchLatestVersionOfArticleWithURL:(NSURL *)URL
-                                                    forceDownload:(BOOL)forceDownload
-                                                       saveToDisk:(BOOL)saveToDisk
-                                                         priority:(float)priority
-                                                          failure:(WMFErrorHandler)failure
-                                                          success:(WMFArticleHandler)success;
+- (nullable NSURLSessionTask *)fetchArticleWithURL:(NSURL *)URL
+                                     forceDownload:(BOOL)forceDownload
+                             checkForNewerRevision:(BOOL)checkForNewerRevision
+                                        saveToDisk:(BOOL)saveToDisk
+                                          priority:(float)priority
+                                           failure:(WMFErrorHandler)failure
+                                           success:(WMFArticleHandler)success;
 
 @property (nonatomic, assign, readonly) BOOL isFetching;
 

--- a/Wikipedia/Code/WMFArticleFetcher.m
+++ b/Wikipedia/Code/WMFArticleFetcher.m
@@ -205,8 +205,9 @@ NSString *const WMFArticleFetcherErrorCachedFallbackArticleKey = @"WMFArticleFet
     }
 }
 
-- (nullable NSURLSessionTask *)fetchLatestVersionOfArticleWithURL:(NSURL *)url
+- (nullable NSURLSessionTask *)fetchArticleWithURL:(NSURL *)url
                                                     forceDownload:(BOOL)forceDownload
+                                            checkForNewerRevision:(BOOL)checkForNewerRevision
                                                        saveToDisk:(BOOL)saveToDisk
                                                          priority:(float)priority
                                                           failure:(WMFErrorHandler)failure
@@ -262,7 +263,7 @@ NSString *const WMFArticleFetcherErrorCachedFallbackArticleKey = @"WMFArticleFet
             DDLogInfo(@"Cached article for main page: %@, fetching immediately.", url);
         }
         task = [self fetchArticleForURL:url saveToDisk:saveToDisk priority:priority failure:failure success:success];
-    } else {
+    } else if (checkForNewerRevision) {
         task = [self.revisionFetcher fetchLatestRevisionsForArticleURL:url
                                                            resultLimit:1
                                                     endingWithRevision:cachedArticle.revisionId
@@ -283,17 +284,13 @@ NSString *const WMFArticleFetcherErrorCachedFallbackArticleKey = @"WMFArticleFet
                                                                        }
                                                                    });
                                                                }];
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            success(cachedArticle, url);
+        });
     }
     task.priority = priority;
     return task;
-}
-
-- (nullable NSURLSessionTask *)fetchLatestVersionOfArticleWithURLIfNeeded:(NSURL *)url
-                                                               saveToDisk:(BOOL)saveToDisk
-                                                                 priority:(float)priority
-                                                                  failure:(WMFErrorHandler)failure
-                                                                  success:(WMFArticleHandler)success {
-    return [self fetchLatestVersionOfArticleWithURL:url forceDownload:NO saveToDisk:saveToDisk priority:priority failure:failure success:success];
 }
 
 @end

--- a/Wikipedia/Code/WMFArticleViewController.h
+++ b/Wikipedia/Code/WMFArticleViewController.h
@@ -65,6 +65,7 @@ extern NSString *const WMFEditPublishedNotification;
 @property (nonatomic, getter=isSavingOpenArticleTitleEnabled) BOOL savingOpenArticleTitleEnabled;
 @property (nonatomic, getter=isAddingArticleToHistoryListEnabled) BOOL addingArticleToHistoryListEnabled;
 @property (nonatomic, getter=isPeekingAllowed) BOOL peekingAllowed;
+@property (nonatomic, getter=shouldRequestLatestRevisionOnInitialLoad) BOOL requestLatestRevisionOnInitialLoad;
 
 @property (weak, nonatomic, nullable) id<WMFArticlePreviewingActionsDelegate> articlePreviewingActionsDelegate;
 

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1282,11 +1282,12 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
     [self showProgressViewAnimated:YES];
 
     @weakify(self);
-    self.articleFetcherPromise = [self.articleFetcher fetchLatestVersionOfArticleWithURL:self.articleURL
-        forceDownload:force
-        saveToDisk:YES
-        priority:NSURLSessionTaskPriorityHigh
-        failure:^(NSError *_Nonnull error) {
+    self.articleFetcherPromise = [self.articleFetcher fetchArticleWithURL:self.articleURL
+                                                            forceDownload:force
+                                                    checkForNewerRevision:force
+                                                               saveToDisk:YES
+                                                                 priority:NSURLSessionTaskPriorityHigh
+                                                                  failure:^(NSError *_Nonnull error) {
             @strongify(self);
             DDLogError(@"Article Fetch Error: %@", [error localizedDescription]);
             [self endRefreshing];

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -213,6 +213,7 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
                                                                                  });
                                                                              }
                                                                          }];
+        self.requestLatestRevisionOnInitialLoad = YES;
         self.savingOpenArticleTitleEnabled = YES;
         self.addingArticleToHistoryListEnabled = YES;
         self.peekingAllowed = YES;
@@ -1284,7 +1285,7 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
     @weakify(self);
     self.articleFetcherPromise = [self.articleFetcher fetchArticleWithURL:self.articleURL
                                                             forceDownload:force
-                                                    checkForNewerRevision:force
+                                                    checkForNewerRevision:force || self.requestLatestRevisionOnInitialLoad
                                                                saveToDisk:YES
                                                                  priority:NSURLSessionTaskPriorityHigh
                                                                   failure:^(NSError *_Nonnull error) {
@@ -1342,6 +1343,7 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
         }
         success:^(MWKArticle *_Nonnull article, NSURL *_Nonnull articleURL) {
             @strongify(self);
+            self.requestLatestRevisionOnInitialLoad = NO;
             [self endRefreshing];
             [self updateProgress:[self totalProgressWithArticleFetcherProgress:1.0] animated:YES];
             self.articleURL = articleURL;

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1629,6 +1629,17 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
 
 - (void)webViewController:(WebViewController *)controller scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
     [self.navigationBarHider scrollViewDidEndDecelerating:scrollView];
+    [self.webViewController getCurrentVisibleSectionCompletion:^(MWKSection *visibleSection, NSError *error) {
+        if (error) {
+            // Reminder: an error is *expected* here when 1st loading an article. This is
+            // because 'saveOpenArticleTitleWithCurrentlyOnscreenFragment' is also called
+            // by 'viewDidAppear' (so the 'Continue reading' widget is kept up-to-date even
+            // when tapping the 'Back' button), but on 1st load the article is not yet
+            // fetched when this occurs.
+            return;
+        }
+        self.visibleSectionAnchor = visibleSection.anchor;
+    }];
 }
 
 - (void)webViewController:(WebViewController *)controller scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1284,11 +1284,11 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
 
     @weakify(self);
     self.articleFetcherPromise = [self.articleFetcher fetchArticleWithURL:self.articleURL
-                                                            forceDownload:force
-                                                    checkForNewerRevision:force || self.requestLatestRevisionOnInitialLoad
-                                                               saveToDisk:YES
-                                                                 priority:NSURLSessionTaskPriorityHigh
-                                                                  failure:^(NSError *_Nonnull error) {
+        forceDownload:force
+        checkForNewerRevision:force || self.requestLatestRevisionOnInitialLoad
+        saveToDisk:YES
+        priority:NSURLSessionTaskPriorityHigh
+        failure:^(NSError *_Nonnull error) {
             @strongify(self);
             DDLogError(@"Article Fetch Error: %@", [error localizedDescription]);
             [self endRefreshing];


### PR DESCRIPTION
- Add `checkForNewerRevision` parameter to article fetcher
- Add `requestLatestRevisionOnInitialLoad` to article VC
- Don't check for a newer revision when restoring the navigation stack, ensures quicker load on launch
- Fix missing section anchor, set it on `scrollViewDidEndDecelerating`