### PR TITLE
Fix splash view

### DIFF
--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1484,46 +1484,12 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 
 #pragma mark - Splash
 
-- (UIImageView *)splashView {
-    if (!_splashView) {
-        _splashView = [[UIImageView alloc] init];
-        _splashView.contentMode = UIViewContentModeCenter;
-        if (UI_USER_INTERFACE_IDIOM() != UIUserInterfaceIdiomPad) {
-            [_splashView setImage:[UIImage imageNamed:@"splashscreen-background"]];
-        }
-        _splashView.backgroundColor = [UIColor whiteColor];
-        [self.view wmf_addSubviewWithConstraintsToEdges:_splashView];
-        UIImage *wordmark = [UIImage imageNamed:@"wikipedia-wordmark"];
-        UIImageView *wordmarkView = [[UIImageView alloc] initWithImage:wordmark];
-        wordmarkView.translatesAutoresizingMaskIntoConstraints = NO;
-        [_splashView addSubview:wordmarkView];
-        NSLayoutConstraint *centerXConstraint = [_splashView.centerXAnchor constraintEqualToAnchor:wordmarkView.centerXAnchor];
-        NSLayoutConstraint *centerYConstraint = [_splashView.centerYAnchor constraintEqualToAnchor:wordmarkView.centerYAnchor constant:12];
-        [_splashView addConstraints:@[centerXConstraint, centerYConstraint]];
-    }
-    return _splashView;
-}
-
 - (void)showSplashView {
-    self.splashView.hidden = NO;
-    self.splashView.alpha = 1.0;
+    [(WMFThemeableNavigationController *)self.navigationController showSplashView];
 }
 
 - (void)hideSplashViewAnimated:(BOOL)animated {
-    NSTimeInterval duration = animated ? 0.15 : 0.0;
-    [UIView animateWithDuration:duration
-        delay:0
-        options:UIViewAnimationOptionAllowUserInteraction
-        animations:^{
-            self.splashView.alpha = 0.0;
-        }
-        completion:^(BOOL finished) {
-            self.splashView.hidden = YES;
-        }];
-}
-
-- (BOOL)isShowingSplashView {
-    return self.splashView.hidden == NO;
+    [(WMFThemeableNavigationController *)self.navigationController hideSplashViewAnimated:animated];
 }
 
 #pragma mark - Explore VC

--- a/Wikipedia/Code/WMFThemeableNavigationController.h
+++ b/Wikipedia/Code/WMFThemeableNavigationController.h
@@ -9,6 +9,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithRootViewController:(UIViewController<WMFThemeable> *)rootViewController theme:(WMFTheme *)theme;
 
+- (void)showSplashView;
+- (void)hideSplashViewAnimated:(BOOL)animated;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFThemeableNavigationController.m
+++ b/Wikipedia/Code/WMFThemeableNavigationController.m
@@ -3,10 +3,12 @@
 @interface WMFThemeableNavigationController ()
 
 @property (nonatomic, strong) WMFTheme *theme;
+@property (nonatomic, readonly) UIImageView *splashView;
 @property (nonatomic, getter=isEditorStyle) BOOL editorStyle;
 @end
 
 @implementation WMFThemeableNavigationController
+@synthesize splashView = _splashView;
 
 - (instancetype)initWithRootViewController:(UIViewController<WMFThemeable> *)rootViewController theme:(WMFTheme *)theme isEditorStyle:(BOOL)isEditorStyle {
     self = [super initWithRootViewController:rootViewController];
@@ -44,6 +46,46 @@
     self.toolbar.translucent = NO;
     self.view.tintColor = theme.colors.link;
     [self setNeedsStatusBarAppearanceUpdate];
+}
+
+#pragma mark - Splash
+
+- (UIImageView *)splashView {
+    if (!_splashView) {
+        _splashView = [[UIImageView alloc] init];
+        _splashView.contentMode = UIViewContentModeCenter;
+        if (UI_USER_INTERFACE_IDIOM() != UIUserInterfaceIdiomPad) {
+            [_splashView setImage:[UIImage imageNamed:@"splashscreen-background"]];
+        }
+        _splashView.backgroundColor = [UIColor whiteColor];
+        [self.view wmf_addSubviewWithConstraintsToEdges:_splashView];
+        UIImage *wordmark = [UIImage imageNamed:@"wikipedia-wordmark"];
+        UIImageView *wordmarkView = [[UIImageView alloc] initWithImage:wordmark];
+        wordmarkView.translatesAutoresizingMaskIntoConstraints = NO;
+        [_splashView addSubview:wordmarkView];
+        NSLayoutConstraint *centerXConstraint = [_splashView.centerXAnchor constraintEqualToAnchor:wordmarkView.centerXAnchor];
+        NSLayoutConstraint *centerYConstraint = [_splashView.centerYAnchor constraintEqualToAnchor:wordmarkView.centerYAnchor constant:12];
+        [_splashView addConstraints:@[centerXConstraint, centerYConstraint]];
+    }
+    return _splashView;
+}
+
+- (void)showSplashView {
+    self.splashView.hidden = NO;
+    self.splashView.alpha = 1.0;
+}
+
+- (void)hideSplashViewAnimated:(BOOL)animated {
+    NSTimeInterval duration = animated ? 0.15 : 0.0;
+    [UIView animateWithDuration:duration
+                          delay:0
+                        options:UIViewAnimationOptionAllowUserInteraction
+                     animations:^{
+                         self.splashView.alpha = 0.0;
+                     }
+                     completion:^(BOOL finished) {
+                         self.splashView.hidden = YES;
+                     }];
 }
 
 @end


### PR DESCRIPTION
`WMFAppViewController` was changed to be the root VC of a `WMFThemeableNavigationController` but the splash view wasn't updated. As a result, the splash view was not visible due to the changed view hierarchy. This moves the splash view into `WMFThemeableNavigationController` so that it covers the content