### PR TITLE
Fix initial load experience when restoring scroll to a section

### DIFF
--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1551,10 +1551,15 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
             self.articleContentLoadCompletion = nil;
         }
         if (self.initialFragment) {
-            [self.webViewController scrollToFragment:self.initialFragment animated:NO completion:NULL];
+            [self.webViewController scrollToFragment:self.initialFragment
+                                            animated:NO
+                                          completion:^{
+                                              [self showWebView];
+                                          }];
             self.initialFragment = nil;
+        } else {
+            [self showWebView];
         }
-        [self showWebView];
     });
 }
 

--- a/Wikipedia/Code/WebViewController.h
+++ b/Wikipedia/Code/WebViewController.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)scrollToSection:(MWKSection *)section animated:(BOOL)animated;
 
-- (void)scrollToFragment:(NSString *)fragment animated:(BOOL)animated;
+- (void)scrollToFragment:(NSString *)fragment animated:(BOOL)animated completion:(nullable dispatch_block_t)completion;
 
 - (void)accessibilityCursorToSection:(MWKSection *)section;
 

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -759,24 +759,26 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
 #pragma mark - Scrolling
 
 - (void)scrollToFragment:(NSString *)fragment {
-    [self scrollToFragment:fragment animated:YES];
+    [self scrollToFragment:fragment animated:YES completion:NULL];
 }
 
-- (void)scrollToFragment:(NSString *)fragment animated:(BOOL)animated {
+- (void)scrollToFragment:(NSString *)fragment animated:(BOOL)animated completion:(nullable dispatch_block_t)completion {
     if (fragment.length == 0) {
         // No section so scroll to top. (Used when "Introduction" is selected.)
         [self.webView.scrollView scrollRectToVisible:CGRectMake(0, 1, 1, 1) animated:animated];
-    } else {
-        if (!animated) {
-            [self.webView wmf_scrollToFragment:fragment];
-            return;
+        if (completion) {
+            completion();
         }
+    } else {
         [self.webView getScrollViewRectForHtmlElementWithId:fragment
                                                  completion:^(CGRect rect) {
                                                      if (!CGRectIsNull(rect)) {
                                                          [self.webView.scrollView wmf_safeSetContentOffset:CGPointMake(self.webView.scrollView.contentOffset.x, rect.origin.y + [self.webView iOS12yOffsetHack] + self.delegate.navigationBar.hiddenHeight)
                                                                                                   animated:animated
                                                                                                 completion:^(BOOL finished){
+                                                                                                    if (completion) {
+                                                                                                        completion();
+                                                                                                    }
                                                                                                 }];
                                                      }
                                                  }];
@@ -784,7 +786,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
 }
 
 - (void)scrollToSection:(MWKSection *)section animated:(BOOL)animated {
-    [self scrollToFragment:section.anchor animated:animated];
+    [self scrollToFragment:section.anchor animated:animated completion:NULL];
     [self.delegate webViewController:self didScrollToSection:section];
 }
 


### PR DESCRIPTION
Before this change, there's a visible jump when the article loads and then scrolls to the section. After this change, the article doesn't become visible until after the section is scrolled into view.

Before:
![before](https://user-images.githubusercontent.com/741327/59769545-603d4300-9274-11e9-87de-3e3fb61cdd42.gif)

After:
![after](https://user-images.githubusercontent.com/741327/59769559-659a8d80-9274-11e9-8b41-95235a4e295e.gif)
