### PR TITLE
Fix continue reading layout, ensure URLs are unique

### DIFF
--- a/WMF Framework/WMFContentGroup+Extensions.h
+++ b/WMF Framework/WMFContentGroup+Extensions.h
@@ -61,7 +61,7 @@ typedef NS_ENUM(int16_t, WMFContentGroupUndoType) {
 - (void)updateDailySortPriorityWithSiteURLSortOrder:(nullable NSDictionary<NSString *, NSNumber *> *)siteURLSortOrder;
 
 + (nullable NSURL *)mainPageURLForSiteURL:(NSURL *)URL;
-+ (nullable NSURL *)continueReadingContentGroupURL;
++ (nullable NSURL *)continueReadingContentGroupURLForArticleURL:(NSURL *)articleURL;
 + (nullable NSURL *)relatedPagesContentGroupURLForArticleURL:(NSURL *)articleURL;
 + (nullable NSURL *)articleURLForRelatedPagesContentGroupURL:(nullable NSURL *)url;
 + (nullable NSURL *)announcementURLForSiteURL:(NSURL *)siteURL identifier:(NSString *)identifier;

--- a/WMF Framework/WMFContentGroup+Extensions.m
+++ b/WMF Framework/WMFContentGroup+Extensions.m
@@ -35,7 +35,7 @@
             assert(false);
             break;
         case WMFContentGroupKindContinueReading:
-            URL = [WMFContentGroup continueReadingContentGroupURL];
+            URL = [WMFContentGroup continueReadingContentGroupURLForArticleURL:self.articleURL];
             break;
         case WMFContentGroupKindMainPage:
             URL = [WMFContentGroup mainPageURLForSiteURL:self.siteURL];
@@ -360,8 +360,22 @@
     return theURL;
 }
 
-+ (nullable NSURL *)continueReadingContentGroupURL {
-    return [[self baseURL] URLByAppendingPathComponent:@"continue-reading"];
++ (nullable NSURL *)continueReadingContentGroupURLForArticleURL:(NSURL *)url {
+    NSParameterAssert(url);
+    NSString *title = url.wmf_title;
+    NSString *domain = url.wmf_domain;
+    NSString *language = url.wmf_language;
+    NSParameterAssert(title);
+    NSParameterAssert(domain);
+    NSParameterAssert(language);
+    if (!title || !domain || !language) {
+        return nil;
+    }
+    NSURLComponents *components = [NSURLComponents componentsWithURL:[self baseURL] resolvingAgainstBaseURL:NO];
+    NSString *encodedTitle = [title stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet wmf_URLArticleTitlePathComponentAllowedCharacterSet]];
+    NSString *path = [NSString pathWithComponents:@[@"/continue-reading", domain, language, encodedTitle]];
+    components.percentEncodedPath = path;
+    return components.URL;
 }
 
 + (nullable NSURL *)relatedPagesContentGroupURLForArticleURL:(NSURL *)url {

--- a/Wikipedia/Code/WMFContinueReadingContentSource.m
+++ b/Wikipedia/Code/WMFContinueReadingContentSource.m
@@ -34,7 +34,7 @@ static NSTimeInterval const WMFTimeBeforeDisplayingLastReadArticle = 60 * 60 * 2
 }
 
 - (void)loadNewContentInManagedObjectContext:(NSManagedObjectContext *)moc force:(BOOL)force completion:(nullable dispatch_block_t)completion {
-    NSURL *lastRead = [self.userDataStore.historyList mostRecentEntryInManagedObjectContext:moc].URL;
+    NSURL *lastRead = [moc wmf_openArticleURL] ?: [self.userDataStore.historyList mostRecentEntryInManagedObjectContext:moc].URL;
 
     if (!lastRead) {
         completion();
@@ -58,7 +58,7 @@ static NSTimeInterval const WMFTimeBeforeDisplayingLastReadArticle = 60 * 60 * 2
             }
             return;
         }
-        
+
         NSURL *savedURL = (NSURL *)groups.firstObject.contentPreview;
 
         if ([savedURL isEqual:lastRead]) {
@@ -76,11 +76,11 @@ static NSTimeInterval const WMFTimeBeforeDisplayingLastReadArticle = 60 * 60 * 2
             }
             return;
         }
-        
+
         for (WMFContentGroup *group in groups) {
             [moc removeContentGroup:group];
         }
-        
+
         NSURL *continueReadingURL = [WMFContentGroup continueReadingContentGroupURLForArticleURL:lastRead];
         [moc fetchOrCreateGroupForURL:continueReadingURL
                                ofKind:WMFContentGroupKindContinueReading


### PR DESCRIPTION
The content group URL for continue reading was the same no matter which article was displayed. Since this URL is used as the layout cache key, it would cause layout issues when the continue reading article changed.

https://phabricator.wikimedia.org/T219046