### PR TITLE
Talk page - fix inset bug when returning from state restoration

### DIFF
--- a/Wikipedia/Code/NavigationStateController.swift
+++ b/Wikipedia/Code/NavigationStateController.swift
@@ -128,6 +128,7 @@ final class NavigationStateController: NSObject {
                 let talkPageContainerVC = TalkPageContainerViewController(title: title, siteURL: siteURL, type: type, dataStore: dataStore)
                 talkPageContainerVC.apply(theme: theme)
                 navigationController.isNavigationBarHidden = true
+                talkPageContainerVC.fromNavigationStateRestoration = true
                 navigationController.pushViewController(talkPageContainerVC, animated: false)
             case (.talkPageReplyList, let info?):
                 guard

--- a/Wikipedia/Code/TalkPageContainerViewController.swift
+++ b/Wikipedia/Code/TalkPageContainerViewController.swift
@@ -83,6 +83,7 @@ class TalkPageContainerViewController: ViewController, HintPresenting {
     @objc static let WMFTopicPublishedNotificationName = "WMFTopicPublishedNotificationName"
     
     var hintController: HintController?
+    var fromNavigationStateRestoration: Bool = false
     
     lazy private(set) var fakeProgressController: FakeProgressController = {
         let progressController = FakeProgressController(progress: navigationBar, delegate: navigationBar)
@@ -231,6 +232,8 @@ private extension TalkPageContainerViewController {
         if topicListViewController == nil {
             topicListViewController = TalkPageTopicListViewController(dataStore: dataStore, talkPageTitle: talkPageTitle, talkPage: talkPage, siteURL: siteURL, type: type, talkPageSemanticContentAttribute: talkPageSemanticContentAttribute)
             topicListViewController?.apply(theme: theme)
+            topicListViewController?.fromNavigationStateRestoration = fromNavigationStateRestoration
+            fromNavigationStateRestoration = false
             let belowView: UIView = wmf_emptyView ?? navigationBar
             wmf_add(childController: topicListViewController, andConstrainToEdgesOfContainerView: view, belowSubview: belowView)
             topicListViewController?.delegate = self

--- a/Wikipedia/Code/TalkPageTopicListViewController.swift
+++ b/Wikipedia/Code/TalkPageTopicListViewController.swift
@@ -27,6 +27,8 @@ class TalkPageTopicListViewController: ColumnarCollectionViewController {
     private let talkPageSemanticContentAttribute: UISemanticContentAttribute
 
     private var completedActivityType: UIActivity.ActivityType?
+    
+    var fromNavigationStateRestoration: Bool = false
 
     required init(dataStore: MWKDataStore, talkPageTitle: String, talkPage: TalkPage, siteURL: URL, type: TalkPageType, talkPageSemanticContentAttribute: UISemanticContentAttribute) {
         self.dataStore = dataStore
@@ -57,6 +59,17 @@ class TalkPageTopicListViewController: ColumnarCollectionViewController {
         setupToolbar()
 
         NotificationCenter.default.addObserver(self, selector: #selector(didBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        if fromNavigationStateRestoration {
+            navigationBar.setNeedsLayout()
+            navigationBar.layoutIfNeeded()
+            updateScrollViewInsets()
+            fromNavigationStateRestoration = false
+        }
     }
 
     deinit {

--- a/Wikipedia/Code/TalkPageTopicListViewController.swift
+++ b/Wikipedia/Code/TalkPageTopicListViewController.swift
@@ -64,6 +64,7 @@ class TalkPageTopicListViewController: ColumnarCollectionViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
+        //T226732 - workaround for when navigation bar maxY doesn't include top safe area height when returning from state restoration which results in a scroll view inset bug
         if fromNavigationStateRestoration {
             navigationBar.setNeedsLayout()
             navigationBar.layoutIfNeeded()


### PR DESCRIPTION
https://phabricator.wikimedia.org/T226732

For some reason the navigation bar maxY doesn't include the safe area height when returning from state restoration. Not sure why but low risk fix is to relayout the navigation bar & recalculate the scroll view insets on appearance when coming from state restoration.

Before:
![before](https://user-images.githubusercontent.com/3620196/60282230-15eb4000-98cc-11e9-9ddb-32d9321d986a.gif)

After:
![after](https://user-images.githubusercontent.com/3620196/60282239-1a175d80-98cc-11e9-9df0-cd548c91439e.gif)
