### PR TITLE
Fetcher - pass along correct error object from result + tests

### DIFF
--- a/WMF Framework/Fetcher.swift
+++ b/WMF Framework/Fetcher.swift
@@ -103,7 +103,8 @@ open class Fetcher: NSObject {
         let components = configuration.mediaWikiAPIURForHost(URL?.host, with: queryParameters)
         let key = cancellationKey ?? UUID().uuidString
         let task = session.getJSONDictionary(from: components.url) { (result, response, error) in
-            completionHandler(result, response, error)
+            let returnError = error ?? WMFErrorForApiErrorObject(result?["error"] as? [AnyHashable : Any])
+            completionHandler(result, response, returnError)
             self.untrack(taskFor: key)
         }
         track(task: task, for: key)

--- a/WikipediaUnitTests/Code/ArticleFetcherTests.m
+++ b/WikipediaUnitTests/Code/ArticleFetcherTests.m
@@ -39,50 +39,47 @@
     return [[NSProcessInfo processInfo] wmf_isTravis] ? @[] : [super testInvocations];
 }
 
--(void)testMissingTitleReturnsExpectedError {
+- (void)testMissingTitleReturnsExpectedError {
     NSURL *siteURL = [NSURL wmf_URLWithDefaultSiteAndlanguage:@"en"];
     NSURL *dummyArticleURL = [siteURL wmf_URLWithTitle:@"Foo"];
     NSURL *url = [NSURL wmf_desktopAPIURLForURL:siteURL];
-    
+
     NSData *json = [[self wmf_bundle] wmf_dataFromContentsOfFile:@"missing-title" ofType:@"json"];
-    
-    // TODO: refactor into convenience method
+
     NSRegularExpression *anyRequestFromTestSite =
-    [NSRegularExpression regularExpressionWithPattern:
-     [NSString stringWithFormat:@"%@.*", [url absoluteString]]
-                                              options:0
-                                                error:nil];
-    
+        [NSRegularExpression regularExpressionWithPattern:
+                                 [NSString stringWithFormat:@"%@.*", [url absoluteString]]
+                                                  options:0
+                                                    error:nil];
+
     stubRequest(@"GET", anyRequestFromTestSite)
-    .andReturn(200)
-    .withHeaders(@{@"Content-Type": @"application/json"})
-    .withBody(json);
-    
+        .andReturn(200)
+        .withHeaders(@{@"Content-Type": @"application/json"})
+        .withBody(json);
+
     NSRegularExpression *anySummaryRequest =
-    [NSRegularExpression regularExpressionWithPattern:@".*v1/page/summary/.*"
-                                              options:0
-                                                error:nil];
+        [NSRegularExpression regularExpressionWithPattern:@".*v1/page/summary/.*"
+                                                  options:0
+                                                    error:nil];
     stubRequest(@"GET", anySummaryRequest).andReturn(404);
 
     WMFArticleFetcher *fetcher = self.articleFetcher;
-    
+
     XCTestExpectation *expectation = [self expectationWithDescription:@"Fetching article"];
-    
+
     [fetcher fetchArticleForURL:dummyArticleURL
-                     saveToDisk:YES
-                       priority:NSURLSessionTaskPriorityHigh
-                        failure:^(NSError *error) {
-                            
-                            XCTAssertEqual(error.domain, WMFNetworkingErrorDomain);
-                            XCTAssertEqual(error.code, WMFNetworkingError_APIError);
-                            XCTAssertTrue([error.userInfo[NSLocalizedFailureReasonErrorKey] isEqualToString:@"missingtitle"]);
-                            
-                            [expectation fulfill];
-                        }
-                        success:^(MWKArticle *article, NSURL *articleURL) {
-                            
-                            XCTFail(@"Recieved success");
-                        }];
+        saveToDisk:YES
+        priority:NSURLSessionTaskPriorityHigh
+        failure:^(NSError *error) {
+            XCTAssertEqual(error.domain, WMFNetworkingErrorDomain);
+            XCTAssertEqual(error.code, WMFNetworkingError_APIError);
+            XCTAssertTrue([error.userInfo[NSLocalizedFailureReasonErrorKey] isEqualToString:@"missingtitle"]);
+
+            [expectation fulfill];
+        }
+        success:^(MWKArticle *article, NSURL *articleURL) {
+            XCTFail(@"Recieved success");
+        }];
     [self waitForExpectationsWithTimeout:WMFDefaultExpectationTimeout
                                  handler:nil];
 }

--- a/WikipediaUnitTests/Fixtures/missing-title.json
+++ b/WikipediaUnitTests/Fixtures/missing-title.json
@@ -1,0 +1,8 @@
+{
+	"error": {
+		"code": "missingtitle",
+		"info": "The page you specified doesn't exist.",
+		"*": "See https://fr.wikipedia.org/w/api.php for API usage. Subscribe to the mediawiki-api-announce mailing list at &lt;https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce&gt; for notice of API deprecations and breaking changes."
+	},
+	"servedby": "mw1287"
+}


### PR DESCRIPTION
- Fixes saved article sync loop when article is deleted on server

https://phabricator.wikimedia.org/T225822