### PR TITLE
saved articles sync - pass original articleURL to didFetchArticle for task removal

### DIFF
--- a/Wikipedia/Code/SavedArticlesFetcher.m
+++ b/Wikipedia/Code/SavedArticlesFetcher.m
@@ -288,7 +288,7 @@ static SavedArticlesFetcher *_articleFetcher = nil;
                         failure(error);
                     });
                 }
-                success:^(MWKArticle *_Nonnull article, NSURL *_Nonnull articleURL) {
+                success:^(MWKArticle *_Nonnull article, NSURL *_Nonnull fetchedURL) {
                     dispatch_async(self.accessQueue, ^{
                         [self downloadImageDataForArticle:article
                             failure:^(NSError *error) {


### PR DESCRIPTION
Might be contributing to some of the syncing issues - https://phabricator.wikimedia.org/T225466.