### PR TITLE
fatalError fix - no default reading list workaround

### DIFF
--- a/Wikipedia/Code/SavedArticlesCollectionViewController.swift
+++ b/Wikipedia/Code/SavedArticlesCollectionViewController.swift
@@ -5,8 +5,9 @@ class SavedArticlesCollectionViewController: ReadingListEntryCollectionViewContr
     //This is not a convenience initalizer because this allows us to not inherit
     //the super class initializer, so clients can't pass any arbitrary reading list to this
     //class
-    init(with dataStore: MWKDataStore) {
-        func fetchDefaultReadingListWithSortOrder() -> ReadingList {
+    
+    init?(with dataStore: MWKDataStore) {
+        func fetchDefaultReadingListWithSortOrder() -> ReadingList? {
             let fetchRequest: NSFetchRequest<ReadingList> = ReadingList.fetchRequest()
             fetchRequest.fetchLimit = 1
             fetchRequest.propertiesToFetch = ["sortOrder"]
@@ -15,11 +16,14 @@ class SavedArticlesCollectionViewController: ReadingListEntryCollectionViewContr
             guard let readingLists = try? dataStore.viewContext.fetch(fetchRequest),
                 let defaultReadingList = readingLists.first else {
                 assertionFailure("Failed to fetch default reading list with sort order")
-                fatalError()
+                return nil
             }
             return defaultReadingList
         }
-        let readingList = fetchDefaultReadingListWithSortOrder()
+        guard let readingList = fetchDefaultReadingListWithSortOrder() else {
+            return nil
+        }
+        
         super.init(for: readingList, with: dataStore)
         emptyViewType = .noSavedPages
     }

--- a/Wikipedia/Code/SavedViewController.swift
+++ b/Wikipedia/Code/SavedViewController.swift
@@ -11,7 +11,7 @@ protocol SavedViewControllerDelegate: NSObjectProtocol {
 @objc(WMFSavedViewController)
 class SavedViewController: ViewController {
 
-    private var savedArticlesViewController: SavedArticlesCollectionViewController!
+    private var savedArticlesViewController: SavedArticlesCollectionViewController?
     
     private lazy var readingListsViewController: ReadingListsViewController? = {
         guard let dataStore = dataStore else {
@@ -87,22 +87,25 @@ class SavedViewController: ViewController {
             switch currentView {
             case .savedArticles:
                 removeChild(readingListsViewController)
+                setSavedArticlesViewControllerIfNeeded()
                 addSavedChildViewController(savedArticlesViewController)
-                savedArticlesViewController.editController.navigationDelegate = self
+                savedArticlesViewController?.editController.navigationDelegate = self
                 readingListsViewController?.editController.navigationDelegate = nil
                 savedDelegate = savedArticlesViewController
-                scrollView = savedArticlesViewController.collectionView
+                scrollView = savedArticlesViewController?.collectionView
                 activeEditableCollection = savedArticlesViewController
                 extendedNavBarViewType = isCurrentViewEmpty ? .none : .search
+                evaluateEmptyState()
             case .readingLists :
                 readingListsViewController?.editController.navigationDelegate = self
-                savedArticlesViewController.editController.navigationDelegate = nil
+                savedArticlesViewController?.editController.navigationDelegate = nil
                 removeChild(savedArticlesViewController)
                 addSavedChildViewController(readingListsViewController)
                 scrollView = readingListsViewController?.collectionView
                 extendedNavBarViewType = .createNewReadingList
                 activeEditableCollection = readingListsViewController
                 extendedNavBarViewType = isCurrentViewEmpty ? .none : .createNewReadingList
+                evaluateEmptyState()
             }
         }
     }
@@ -196,9 +199,38 @@ class SavedViewController: ViewController {
         super.viewDidLoad()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        let savedArticlesWasNil = savedArticlesViewController == nil
+        setSavedArticlesViewControllerIfNeeded()
+        if let _ = savedArticlesViewController,
+            currentView == .savedArticles,
+            savedArticlesWasNil {
+            //reassign so activeEditableCollection gets reset
+            currentView = .savedArticles
+        }
+    }
+    
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         actionButton.titleLabel?.font = UIFont.wmf_font(.body, compatibleWithTraitCollection: traitCollection)
+    }
+    
+    private func setSavedArticlesViewControllerIfNeeded() {
+        if let dataStore = dataStore,
+            savedArticlesViewController == nil {
+            savedArticlesViewController = SavedArticlesCollectionViewController(with: dataStore)
+            savedArticlesViewController?.apply(theme: theme)
+        }
+    }
+    
+    private func evaluateEmptyState() {
+        if activeEditableCollection == nil {
+            wmf_showEmptyView(of: .noSavedPages, theme: theme, frame: view.bounds)
+        } else {
+            wmf_hideEmptyView()
+        }
     }
     
     // MARK: - Sorting and searching
@@ -237,7 +269,7 @@ class SavedViewController: ViewController {
         }
         view.backgroundColor = theme.colors.chromeBackground
         
-        savedArticlesViewController.apply(theme: theme)
+        savedArticlesViewController?.apply(theme: theme)
         readingListsViewController?.apply(theme: theme)
         savedProgressViewController?.apply(theme: theme)
 


### PR DESCRIPTION
Also tried to make it recoverable on viewWillAppear and on switching sub tabs in case it is a temporary state the user gets in. You can test by commenting out the assertionFailure and changing the predicate to return no lists the first few times it tries to init.

https://phabricator.wikimedia.org/T227146