### PR TITLE
Fix missing headers

### DIFF
--- a/Wikipedia/Code/Session.swift
+++ b/Wikipedia/Code/Session.swift
@@ -211,7 +211,7 @@ import Foundation
         guard let url = url else {
             return nil
         }
-        guard let request = request(with: url, method: method, bodyParameters: bodyParameters, bodyEncoding: bodyEncoding) else {
+        guard let request = request(with: url, method: method, bodyParameters: bodyParameters, bodyEncoding: bodyEncoding, headers: headers) else {
             return nil
         }
         


### PR DESCRIPTION
Custom request headers weren't being passed on from the `dataTask` function to the `request` function