### PR TITLE
NonBeta label test for xcode-select nonbeta

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+def IS_BETA = false
+
 pipeline {
   agent any
   
@@ -6,6 +8,9 @@ pipeline {
   }
   stages {
     stage('Test') {
+      environment {
+         IS_BETA = "${env.CHANGE_ID && pullRequest.labels.contains('Beta') ? true : false}"
+      }
       steps {
         sh '''rm -rf build/reports
         export LANG=en_US.UTF-8
@@ -13,7 +18,7 @@ pipeline {
         export LC_ALL=en_US.UTF-8
         eval "$(rbenv init -)"
         bundle install
-        bundle exec fastlane verify_pull_request
+        bundle exec fastlane verify_pull_request beta:${IS_BETA}
         '''
       }
       post {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -80,7 +80,12 @@ platform :ios do
   end
 
   desc "Runs tests on select platforms for verifying pull requests"
-  lane :verify_pull_request do
+  lane :verify_pull_request do |options|
+    if options[:beta]
+      xcode_select("/Applications/Xcode-beta.app")
+    else
+      xcode_select("/Applications/Xcode.app")
+    end
     verify({configurations: configurations_to_test_on_pull})
   end
 


### PR DESCRIPTION
With this verify-pull-requests will run on XCode_beta.app on the build server if the PR has a Beta label. I'm open to other alternatives - my first thought was check the branch name for xcodebeta/ prefix but this seemed a little cleaner.