### PR TITLE
Fix for "...internet not available" showing up in theme popup

### DIFF
--- a/Wikipedia/Third Party Code/RMessage/RMessageView.m
+++ b/Wikipedia/Third Party Code/RMessage/RMessageView.m
@@ -137,6 +137,9 @@ static NSMutableDictionary *globalDesignDictionary;
     do {
         presentedViewController = viewController.presentedViewController;
         if (presentedViewController) {
+            if (presentedViewController.popoverPresentationController != nil) {
+                break;
+            }
             viewController = presentedViewController;
         }
     } while (presentedViewController != nil);


### PR DESCRIPTION
This seems to address the issue of the internet not available showing up in the theme popup while not breaking other states.