### PR TITLE
set preferredContentSize of ArticlePeekPreview parent

### DIFF
--- a/Wikipedia/Code/ArticlePeekPreviewViewController.swift
+++ b/Wikipedia/Code/ArticlePeekPreviewViewController.swift
@@ -39,6 +39,7 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
     public func updatePreferredContentSize(for contentWidth: CGFloat) {
         var updatedContentSize = expandedArticleView.sizeThatFits(CGSize(width: contentWidth, height: UIView.noIntrinsicMetric), apply: true)
         updatedContentSize.width = contentWidth // extra protection to ensure this stays == width
+        parent?.preferredContentSize = updatedContentSize
         preferredContentSize = updatedContentSize
     }
     


### PR DESCRIPTION
For https://phabricator.wikimedia.org/T229142

Seems like this started with the code change in https://github.com/wikimedia/wikipedia-ios/pull/3068.