### PR TITLE
[OTRS] Images that open in article view cannot be deleted from history

### DIFF
--- a/Wikipedia/Code/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.m
@@ -265,7 +265,7 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
 - (NSURL *)wmf_databaseKeyURL {
     NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:NO];
     components.host = [NSURLComponents wmf_hostWithDomain:self.wmf_domain language:self.wmf_language isMobile:NO];
-    components.path = [components.path stringByRemovingPercentEncoding];
+    components.path = [components.path stringByRemovingPercentEncoding] ?: components.path;
     components.fragment = nil;
     components.query = nil;
     components.scheme = @"https";

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.m
@@ -265,7 +265,7 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
 - (NSURL *)wmf_databaseKeyURL {
     NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:NO];
     components.host = [NSURLComponents wmf_hostWithDomain:self.wmf_domain language:self.wmf_language isMobile:NO];
-    components.path = [components.path stringByRemovingPercentEncoding] ?: components.path;
+    components.path = [components.path stringByRemovingPercentEncoding];
     components.fragment = nil;
     components.query = nil;
     components.scheme = @"https";

--- a/Wikipedia/Code/WMFArticleViewController.h
+++ b/Wikipedia/Code/WMFArticleViewController.h
@@ -11,16 +11,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const WMFEditPublishedNotification;
 
-@protocol WMFArticleViewControllerDelegate <NSObject>
-
-- (void)articleController:(WMFArticleViewController *)controller didUpdateArticleLoadProgress:(CGFloat)progress animated:(BOOL)animated;
-
-- (void)articleControllerDidLoadArticle:(WMFArticleViewController *)controller;
-
-- (void)articleControllerDidFailToLoadArticle:(WMFArticleViewController *)controller;
-
-@end
-
 @protocol WMFArticlePreviewingActionsDelegate <NSObject>
 
 - (void)readMoreArticlePreviewActionSelectedWithArticleController:(WMFArticleViewController *)articleController;
@@ -51,8 +41,6 @@ extern NSString *const WMFEditPublishedNotification;
 @property (nonatomic, strong, nullable) dispatch_block_t articleLoadCompletion;
 
 @property (nonatomic, strong, readonly, nullable) MWKArticle *article;
-
-@property (nonatomic, weak) id<WMFArticleViewControllerDelegate> delegate;
 
 @property (nonatomic) WMFTableOfContentsDisplayMode tableOfContentsDisplayMode;
 @property (nonatomic) WMFTableOfContentsDisplaySide tableOfContentsDisplaySide;

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -683,8 +683,6 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
         return;
     }
     [self.navigationBar setProgress:progress animated:animated];
-
-    [self.delegate articleController:self didUpdateArticleLoadProgress:progress animated:animated];
 }
 
 - (void)completeAndHideProgressWithCompletion:(nullable dispatch_block_t)completion {
@@ -1304,7 +1302,6 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
             DDLogError(@"Article Fetch Error: %@", [error localizedDescription]);
             [self endRefreshing];
             [self hideProgressViewAnimated:YES];
-            [self.delegate articleControllerDidLoadArticle:self];
 
             MWKArticle *cachedFallback = error.userInfo[WMFArticleFetcherErrorCachedFallbackArticleKey];
             if (cachedFallback) {
@@ -1380,7 +1377,6 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
                 [self articleDidLoad];
             } else {
                 [self hideProgressViewAnimated:YES];
-                [self.delegate articleControllerDidLoadArticle:self];
 
                 [self showExternalURL:articleURL];
 
@@ -1567,8 +1563,6 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
         [self setupTableOfContentsViewController];
         [self layoutForSize:self.view.bounds.size];
     }
-
-    [self.delegate articleControllerDidLoadArticle:self];
 }
 
 - (void)webViewController:(WebViewController *)controller didLoadArticleContent:(MWKArticle *)article {

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -223,14 +223,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
                                                    url = [NSURL wmf_URLWithSiteURL:self.article.url escapedDenormalizedInternalLink:href];
                                                }
                                                url = [url wmf_urlByPrependingSchemeIfSchemeless];
-                                               // If stringByRemovingPercentEncoding succeeds, we will be able to create a correct wmf_databaseKeyURL
-                                               // and use it to create an article url. If it fails, wmf_databaseKeyURL will be incorrect and we'll fail to
-                                               // create a correct article url.
-                                               if ([url.path stringByRemovingPercentEncoding]) {
-                                                   [(self).delegate webViewController:(self) didTapOnLinkForArticleURL:url];
-                                               } else if (url) {
-                                                   [self wmf_openExternalUrl:url];
-                                               }
+                                               [(self).delegate webViewController:(self) didTapOnLinkForArticleURL:url];
                                            } else {
                                                // A standard external link, either explicitly http(s) or left protocol-relative on web meaning http(s)
                                                if ([href hasPrefix:@"#"]) {

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -223,7 +223,13 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
                                                    url = [NSURL wmf_URLWithSiteURL:self.article.url escapedDenormalizedInternalLink:href];
                                                }
                                                url = [url wmf_urlByPrependingSchemeIfSchemeless];
-                                               [(self).delegate webViewController:(self) didTapOnLinkForArticleURL:url];
+                                               [self.article.dataStore.articleSummaryController.fetcher fetchSummaryForArticleWithKey:[url wmf_databaseKey] priority:NSURLSessionTaskPriorityHigh completion:^(WMFArticleSummary * _Nullable summary, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+                                                   if (summary.namespace.number.integerValue == PageNamespaceMain) {
+                                                       [(self).delegate webViewController:(self) didTapOnLinkForArticleURL:url];
+                                                   } else {
+                                                       [self wmf_openExternalUrl:url];
+                                                   }
+                                               }];
                                            } else {
                                                // A standard external link, either explicitly http(s) or left protocol-relative on web meaning http(s)
                                                if ([href hasPrefix:@"#"]) {

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -223,7 +223,14 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
                                                    url = [NSURL wmf_URLWithSiteURL:self.article.url escapedDenormalizedInternalLink:href];
                                                }
                                                url = [url wmf_urlByPrependingSchemeIfSchemeless];
-                                               [(self).delegate webViewController:(self) didTapOnLinkForArticleURL:url];
+                                               // If stringByRemovingPercentEncoding succeeds, we will be able to create a correct wmf_databaseKeyURL
+                                               // and use it to create an article url. If it fails, wmf_databaseKeyURL will be incorrect and we'll fail to
+                                               // create a correct article url.
+                                               if ([url.path stringByRemovingPercentEncoding]) {
+                                                   [(self).delegate webViewController:(self) didTapOnLinkForArticleURL:url];
+                                               } else if (url) {
+                                                   [self wmf_openExternalUrl:url];
+                                               }
                                            } else {
                                                // A standard external link, either explicitly http(s) or left protocol-relative on web meaning http(s)
                                                if ([href hasPrefix:@"#"]) {

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -223,13 +223,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
                                                    url = [NSURL wmf_URLWithSiteURL:self.article.url escapedDenormalizedInternalLink:href];
                                                }
                                                url = [url wmf_urlByPrependingSchemeIfSchemeless];
-                                               [self.article.dataStore.articleSummaryController.fetcher fetchSummaryForArticleWithKey:[url wmf_databaseKey] priority:NSURLSessionTaskPriorityHigh completion:^(WMFArticleSummary * _Nullable summary, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-                                                   if (summary.namespace.number.integerValue == PageNamespaceMain) {
-                                                       [(self).delegate webViewController:(self) didTapOnLinkForArticleURL:url];
-                                                   } else {
-                                                       [self wmf_openExternalUrl:url];
-                                                   }
-                                               }];
+                                               [(self).delegate webViewController:(self) didTapOnLinkForArticleURL:url];
                                            } else {
                                                // A standard external link, either explicitly http(s) or left protocol-relative on web meaning http(s)
                                                if ([href hasPrefix:@"#"]) {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T229141

Per documentation, `stringByRemovingPercentEncoding` that we're using to construct `wmf_databaseKeyURL` returns _nil if the receiver contains an invalid percent-encoding sequence_ (https://developer.apple.com/documentation/foundation/nsstring/1409569-stringbyremovingpercentencoding?language=objc).

Some titles include "%" characters that are not part of a percent-encoded sequence ("LED_Filament_CloseUp_at_5_%_power" or "%s") - calling `stringByRemovingPercentEncoding` will result in a `nil` return. In practice, `wmf_databaseKey` will be incorrect and we won't be able to construct a correct article url to either view the article in ArticleVC or interact with it (toggle saved state, delete).

For articles like "%s" that are in the main namespace and can come up in search results, we could modify `wmf_databaseKeyURL` to include a fallback for `path` if `stringByRemovingPercentEncoding` fails.

Test case
1. Search for "%"
2. Select "%s"
3. Go to History
4. Attempt to view "%s" or delete it