### PR TITLE
Fix Core Data crash when holding on to db during suspension

### DIFF
--- a/Wikipedia/Code/MWKDataStore.h
+++ b/Wikipedia/Code/MWKDataStore.h
@@ -60,6 +60,8 @@ extern NSString *const WMFViewContextDidSave;
 - (void)migrateToQuadKeyLocationIfNecessaryWithCompletion:(nonnull void (^)(NSError *nullable))completion;
 
 - (void)updateLocalConfigurationFromRemoteConfigurationWithCompletion:(nullable void (^)(NSError *nullable))completion;
+@property (readwrite, nonatomic) BOOL isLocalConfigUpdateAllowed;
+@property (readonly, nonatomic) BOOL failedToUpdateLocalConfig;
 
 @property (readonly, strong, nonatomic) MWKHistoryList *historyList;
 @property (readonly, strong, nonatomic) MWKSavedPageList *savedPageList;

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -60,6 +60,8 @@ static NSString *const MWKImageInfoFilename = @"ImageInfo.plist";
 
 @property (nonatomic, strong) NSURL *containerURL;
 
+@property (readwrite, nonatomic) BOOL failedToUpdateLocalConfig;
+
 @end
 
 @implementation MWKDataStore
@@ -1648,7 +1650,12 @@ static uint64_t bundleHash() {
                                         }
                                         NSDictionary *generalProps = [siteInfo valueForKeyPath:@"query.general"];
                                         NSDictionary *readingListsConfig = generalProps[@"readinglists-config"];
-                                        [self updateReadingListsLimits:readingListsConfig];
+                                        if (self.isLocalConfigUpdateAllowed) {
+                                            [self updateReadingListsLimits:readingListsConfig];
+                                            self.failedToUpdateLocalConfig = NO;
+                                        } else {
+                                            self.failedToUpdateLocalConfig = YES;
+                                        }
                                         [taskGroup leave];
                                     });
                                 }];
@@ -1664,7 +1671,12 @@ static uint64_t bundleHash() {
                                             [taskGroup leave];
                                             return;
                                         }
-                                        [self updateLocalConfigurationFromRemoteConfiguration:remoteConfigurationDictionary];
+                                        if (self.isLocalConfigUpdateAllowed) {
+                                            [self updateLocalConfigurationFromRemoteConfiguration:remoteConfigurationDictionary];
+                                            self.failedToUpdateLocalConfig = NO;
+                                        } else {
+                                            self.failedToUpdateLocalConfig = YES;
+                                        }
                                         [taskGroup leave];
                                     });
                                 }];

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -634,6 +634,34 @@ static const NSString *kvo_SavedArticlesFetcher_progress = @"kvo_SavedArticlesFe
     [self setBackgroundTaskIdentifier:identifier forKey:@"feed"];
 }
 
+- (UIBackgroundTaskIdentifier)remoteConfigCheckBackgroundTaskIdentifier {
+    return [self backgroundTaskIdentifierForKey:@"remoteConfigCheck"];
+}
+
+- (void)setRemoteConfigCheckBackgroundTaskIdentifier:(UIBackgroundTaskIdentifier)identifier {
+    [self setBackgroundTaskIdentifier:identifier forKey:@"remoteConfigCheck"];
+}
+
+- (void)startRemoteConfigCheckBackgroundTask:(dispatch_block_t)expirationHandler {
+    if (self.remoteConfigCheckBackgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+        return;
+    }
+    self.remoteConfigCheckBackgroundTaskIdentifier = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+        if (expirationHandler) {
+            expirationHandler();
+        }
+    }];
+}
+
+- (void)endRemoteConfigCheckBackgroundTask {
+    if (self.remoteConfigCheckBackgroundTaskIdentifier == UIBackgroundTaskInvalid) {
+        return;
+    }
+    UIBackgroundTaskIdentifier backgroundTaskToStop = self.remoteConfigCheckBackgroundTaskIdentifier;
+    self.remoteConfigCheckBackgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    [[UIApplication sharedApplication] endBackgroundTask:backgroundTaskToStop];
+}
+
 - (void)startHousekeepingBackgroundTask {
     if (self.housekeepingBackgroundTaskIdentifier != UIBackgroundTaskInvalid) {
         return;
@@ -1587,16 +1615,22 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
     self.checkingRemoteConfig = YES;
     CFAbsoluteTime lastCheckTime = (CFAbsoluteTime)[[self.dataStore.viewContext wmf_numberValueForKey:WMFLastRemoteAppConfigCheckAbsoluteTimeKey] doubleValue];
     CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
-    if (now - lastCheckTime >= WMFRemoteAppConfigCheckInterval) {
-        [self.dataStore updateLocalConfigurationFromRemoteConfigurationWithCompletion:^(NSError *error) {
-            if (!error) {
-                [self.dataStore.viewContext wmf_setValue:[NSNumber numberWithDouble:now] forKey:WMFLastRemoteAppConfigCheckAbsoluteTimeKey];
-            }
-            self.checkingRemoteConfig = NO;
-        }];
-    } else {
+    BOOL shouldCheckRemoteConfig = now - lastCheckTime >= WMFRemoteAppConfigCheckInterval || self.dataStore.failedToUpdateLocalConfig;
+    if (!shouldCheckRemoteConfig) {
         self.checkingRemoteConfig = NO;
+        return;
     }
+    self.dataStore.isLocalConfigUpdateAllowed = YES;
+    [self startRemoteConfigCheckBackgroundTask:^{
+        self.dataStore.isLocalConfigUpdateAllowed = NO;
+        [self endRemoteConfigCheckBackgroundTask];
+    }];
+    [self.dataStore updateLocalConfigurationFromRemoteConfigurationWithCompletion:^(NSError *error) {
+        if (!error && self.dataStore.isLocalConfigUpdateAllowed) {
+            [self.dataStore.viewContext wmf_setValue:[NSNumber numberWithDouble:now] forKey:WMFLastRemoteAppConfigCheckAbsoluteTimeKey];
+        }
+        self.checkingRemoteConfig = NO;
+    }];
 }
 
 #pragma mark - UITabBarControllerDelegate


### PR DESCRIPTION
This is the top crash in 6.3.2 and one of the top crashes in 6.3.1, 6.3 and possibly other versions. It happens in the background, during suspension: https://github.com/wikimedia/wikipedia-ios/blob/46c32220d4dcee06e02b908633b5bbb386a8be96/Wikipedia/Code/ReadingListsController.swift#L785.

The exception type is `SIGKILL` which means that the process was terminated by the system. The exception code `0xdead10cc` indicates that an application has been terminated by the OS because it held on to a file lock or sqlite database lock during suspension. https://developer.apple.com/library/archive/technotes/tn2151/_index.html

The recommendation is to request additional background time - we're doing that for housekeeping, library and feed updates.

Let me know if you think this is caused by something else and/or could be fixed in a better way.