### PR TITLE
iOS 13 and scale transforms for appearing and disappearing cells don't mix

### DIFF
--- a/WMF Framework/ColumnarCollectionViewLayout.swift
+++ b/WMF Framework/ColumnarCollectionViewLayout.swift
@@ -239,7 +239,6 @@ public class ColumnarCollectionViewLayout: UICollectionViewLayout {
                 return
             }
             attributes.zIndex = -1
-            attributes.transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
             attributes.alpha = 0
             return
         }
@@ -275,7 +274,6 @@ public class ColumnarCollectionViewLayout: UICollectionViewLayout {
             return attributes
         }
         attributes.zIndex = -1
-        attributes.transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
         attributes.alpha = 0
         return attributes
     }

--- a/WMF Framework/ColumnarCollectionViewLayout.swift
+++ b/WMF Framework/ColumnarCollectionViewLayout.swift
@@ -239,7 +239,7 @@ public class ColumnarCollectionViewLayout: UICollectionViewLayout {
                 return
             }
             attributes.zIndex = -1
-            attributes.transform = CGAffineTransform.init(scaleX: 0.75, y: 0.75)
+            attributes.transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
             attributes.alpha = 0
             return
         }
@@ -275,7 +275,7 @@ public class ColumnarCollectionViewLayout: UICollectionViewLayout {
             return attributes
         }
         attributes.zIndex = -1
-        attributes.transform = CGAffineTransform.init(scaleX: 0.75, y: 0.75)
+        attributes.transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
         attributes.alpha = 0
         return attributes
     }


### PR DESCRIPTION
Previously, the scale transform didn't affect the `bounds.size` of the cell. On iOS 13 it does and breaks the layout. Remove the scale transform for now.