### PR TITLE
Remove line-height adjustment

### DIFF
--- a/Wikipedia/Code/WKWebView+LoadAssetsHtml.swift
+++ b/Wikipedia/Code/WKWebView+LoadAssetsHtml.swift
@@ -91,7 +91,6 @@ extension WKWebView {
             <style type='text/css'>
                 body {
                     font-size: \(fontSize.intValue)%;
-                    line-height: \(fontSize.intValue)%;
                 }
             </style>
             <base href="\(baseURL.absoluteString)">

--- a/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.m
+++ b/Wikipedia/Code/WKWebView+WMFWebViewControllerJavascript.m
@@ -9,7 +9,7 @@ static int const kMinimumTextSelectionLength = 2;
 @implementation WKWebView (WMFWebViewControllerJavascript)
 
 - (void)wmf_setTextSize:(NSInteger)textSize {
-    [self evaluateJavaScript:[NSString stringWithFormat:@"window.wmf.windowResizeScroll.recordTopElementAndItsRelativeYOffset(); document.body.style['font-size'] = '%ld%%';document.body.style['line-height'] = '%ld%%';", (long)textSize, (long)textSize]
+    [self evaluateJavaScript:[NSString stringWithFormat:@"window.wmf.windowResizeScroll.recordTopElementAndItsRelativeYOffset(); document.body.style['font-size'] = '%ld%%';", (long)textSize]
            completionHandler:^(id _Nullable obj, NSError *_Nullable error) {
                [self evaluateJavaScript:@"window.wmf.windowResizeScroll.scrollToSamePlaceBeforeResize()" completionHandler:NULL];
            }];


### PR DESCRIPTION
Follow-up for https://github.com/wikimedia/wikipedia-ios/pull/3208

Line-height seems to be scaling proportionally w/o this.

# Before
![small - before](https://user-images.githubusercontent.com/3143487/64288882-09144980-cf18-11e9-85ad-6e223a2f5dfa.png)

# After
![small - after](https://user-images.githubusercontent.com/3143487/64288892-0e719400-cf18-11e9-9a08-f055917f456e.png)

# Before
![normal - before](https://user-images.githubusercontent.com/3143487/64288900-12051b00-cf18-11e9-9fce-fd0bfb296eb9.png)

# After
![normal - after](https://user-images.githubusercontent.com/3143487/64288907-16313880-cf18-11e9-819e-c1b11c868320.png)


# Before
![large - before](https://user-images.githubusercontent.com/3143487/64288916-19c4bf80-cf18-11e9-8127-3b7c3469bb2c.png)


# After
![large - after](https://user-images.githubusercontent.com/3143487/64288924-1cbfb000-cf18-11e9-98bf-62c0824bbf42.png)