### PR TITLE
fix editor dismissing upon background in iPadOS

### DIFF
--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1022,6 +1022,7 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
 
 - (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];
+
     [self updateTableOfContentsDisplayModeWithTraitCollection:newCollection];
     [self setupTableOfContentsViewController];
 }
@@ -1110,7 +1111,9 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
         case WMFTableOfContentsDisplayModeModal:
         default:
             self.tableOfContentsDisplayState = WMFTableOfContentsDisplayStateModalVisible;
-            [self presentViewController:self.tableOfContentsViewController animated:YES completion:NULL];
+            if (!self.presentedViewController) {
+                [self presentViewController:self.tableOfContentsViewController animated:YES completion:NULL];
+            }
     }
     [self updateToolbar];
 }

--- a/Wikipedia/Code/WMFTableOfContentsViewController.swift
+++ b/Wikipedia/Code/WMFTableOfContentsViewController.swift
@@ -224,8 +224,8 @@ open class WMFTableOfContentsViewController: UIViewController, UITableViewDelega
         tableOfContentsFunnel.logOpen()
     }
     
-    open override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
+    open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         deselectAllRows()
     }
     


### PR DESCRIPTION
& fix UITableViewAlertForLayoutOutsideViewHierarchy console warning

https://phabricator.wikimedia.org/T229494

I couldn't repro the freezing anymore but editor would dismiss if you had table of contents open in article > go to editor > background for 5-10 seconds. This is because oddly only in iPadOS willTransitionToTraitCollection in WMFArticleViewController is called twice upon background - the size classes switch to compact then switch back to what they were before. We try presenting table of contents again in this situation assuming the user is split screening which seems to automatically dismiss the editor. Fix is to make sure WMFArticleViewController isn't presenting anything like editor before attempting to present the table of contents.