### PR TITLE
Fix missing completion when fragment is missing

### DIFF
--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -775,7 +775,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
                                                      if (!CGRectIsNull(rect)) {
                                                          [self.webView.scrollView wmf_safeSetContentOffset:CGPointMake(self.webView.scrollView.contentOffset.x, rect.origin.y + [self.webView iOS12yOffsetHack] + self.delegate.navigationBar.hiddenHeight)
                                                                                                   animated:animated
-                                                                                                completion:^(BOOL finished){
+                                                                                                completion:^(BOOL finished) {
                                                                                                     if (completion) {
                                                                                                         completion();
                                                                                                     }
@@ -863,7 +863,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
     CGFloat marginWidth = [self marginWidthForSize:self.view.bounds.size];
 
     SchemeHandler *handler = [SchemeHandler shared];
-    [handler cacheSectionDataForArticle: self.article];
+    [handler cacheSectionDataForArticle:self.article];
 
     [self.webView loadHTML:@"" baseURL:self.article.url withAssetsFile:@"index.html" scrolledToFragment:self.articleURL.fragment padding:UIEdgeInsetsMake(headerHeight, marginWidth, 0, marginWidth) theme:self.theme];
 }

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -780,6 +780,8 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
                                                                                                         completion();
                                                                                                     }
                                                                                                 }];
+                                                     } else if (completion) {
+                                                         completion();
                                                      }
                                                  }];
     }


### PR DESCRIPTION
Causes an empty view when loading an article with a fragment that can't be found