### PR TITLE
Fix for fragments with percent encoding

### DIFF
--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -192,7 +192,7 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
     if (self) {
         NSString *fragment = [url fragment];
         if (![[fragment stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] isEqualToString:@""]) {
-            self.initialFragment = fragment;
+            self.initialFragment = [fragment stringByRemovingPercentEncoding];
         }
         self.restoreScrollPosition = fragment != nil;
         self.theme = theme;


### PR DESCRIPTION
Repro steps testwiki > bird article > tap Teoria della relativita section in bird... 2

note: there's inconsistent encoding on hrefs from mobileview. observe the issue with the links to sections here: https://test.m.wikipedia.org/w/index.php?title=Bird&oldid=402255