### PR TITLE
Focused fix for T232022 that preserves ToC animation

### DIFF
--- a/Wikipedia/Code/UIScrollView+WMFContentOffsetUtils.m
+++ b/Wikipedia/Code/UIScrollView+WMFContentOffsetUtils.m
@@ -28,9 +28,7 @@
                               delay:0.0f
                             options:UIViewAnimationOptionBeginFromCurrentState
                          animations:^{
-                             CGPoint safeOffset = CGPointMake(offset.x, MAX(0 - self.contentInset.top, MIN(self.contentSize.height - self.bounds.size.height, offset.y)));
-
-                             self.contentOffset = safeOffset;
+                             self.contentOffset = offset;
                          }
                          completion:completion];
     } else {


### PR DESCRIPTION
- Don't limit the content offset based on the content size or inset. The values are incorrect in some cases but the scroll view ends up in the correct place when set. I confirmed the app doesn't crash on iOS 11 or 13 when set to a value that's out of bounds