### PR TITLE
Tighten up ToC animation on iPhone

### DIFF
--- a/Wikipedia/Code/WMFArticleContainerViewController+TOC.swift
+++ b/Wikipedia/Code/WMFArticleContainerViewController+TOC.swift
@@ -51,7 +51,7 @@ extension WMFArticleViewController : WMFTableOfContentsViewControllerDelegate {
             }
             
             // Don't dismiss immediately - it looks jarring - let the user see the ToC selection before dismissing
-            dispatchOnMainQueueAfterDelayInSeconds(0.25) {
+            dispatchOnMainQueueAfterDelayInSeconds(0.15) {
                 self.dismiss(animated: true, completion: dismissVCCompletionHandler)
             }
         }        

--- a/Wikipedia/Code/WMFTableOfContentsAnimator.swift
+++ b/Wikipedia/Code/WMFTableOfContentsAnimator.swift
@@ -106,7 +106,7 @@ open class WMFTableOfContentsAnimator: UIPercentDrivenInteractiveTransition, UIV
 
     // MARK: - UIViewControllerAnimatedTransitioning
     open func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
-        return self.isPresenting ? 0.5 : 0.8
+        return 0.4
     }
     
     open func animateTransition(using transitionContext: UIViewControllerContextTransitioning)  {


### PR DESCRIPTION
Current duration feels like a loading delay rather than a slight delay to keep context. Extracted from #3230 