### PR TITLE
Fix cell separator not stretching full width on iOS 13

### DIFF
--- a/Wikipedia/Code/TextFormattingTableViewCell.swift
+++ b/Wikipedia/Code/TextFormattingTableViewCell.swift
@@ -12,7 +12,7 @@ class TextFormattingTableViewCell: UITableViewCell {
 
     private func addSeparator() {
         topSeparator.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(topSeparator)
+        addSubview(topSeparator)
     }
 
     private func configureSeparator() {

--- a/Wikipedia/Code/TextFormattingTableViewCell.swift
+++ b/Wikipedia/Code/TextFormattingTableViewCell.swift
@@ -1,6 +1,5 @@
 class TextFormattingTableViewCell: UITableViewCell {
     let topSeparator = UIView()
-    let bottomSeparator = UIView()
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)


### PR DESCRIPTION
On iOS 13 something changed about the default UITableViewCell's contentView - adding a separator view to contentView and constraining it to trailingAnchor no longer works on iOS 13

**Before**
iOS 13
![Simulator Screen Shot - iPhone Xʀ - 2019-09-12 at 14 44 58](https://user-images.githubusercontent.com/9299317/64811767-eb745f00-d56b-11e9-99c7-fa3f1b06b76d.png)

**After**
iOS 13
![Simulator Screen Shot - iPhone Xʀ - 2019-09-12 at 14 36 48](https://user-images.githubusercontent.com/9299317/64811261-e6fb7680-d56a-11e9-91bd-7435b47f5ddc.png)

iOS 11
![Simulator Screen Shot - iPhone SE - 2019-09-12 at 14 39 26](https://user-images.githubusercontent.com/9299317/64811378-22964080-d56b-11e9-9241-9393179070be.png)

iOS 12
![Simulator Screen Shot - iPhone 6 Plus - 2019-09-12 at 14 42 13](https://user-images.githubusercontent.com/9299317/64811565-8882c800-d56b-11e9-8fdc-68f16095aaf6.png)
