### PR TITLE
Fix incorrect empty view in Search results

### DIFF
--- a/Wikipedia/Code/UIViewController+WMFEmptyView.m
+++ b/Wikipedia/Code/UIViewController+WMFEmptyView.m
@@ -40,6 +40,7 @@ static const char *const WMFEmptyViewKey = "WMFEmptyView";
             break;
         case WMFEmptyViewTypeNoInternetConnection:
             view = [WMFEmptyView noInternetConnectionEmptyView];
+            break;
         case WMFEmptyViewTypeNoSelectedImageToInsert:
             view = [WMFEmptyView noSelectedImageToInsertEmptyView];
             break;


### PR DESCRIPTION
https://phabricator.wikimedia.org/T231680

Missing break was causing the case to fall through to `WMFEmptyViewTypeNoSelectedImageToInsert`, reproducible on airplane mode cause then the empty view type is `WMFEmptyViewTypeNoInternetConnection`, handled right above `WMFEmptyViewTypeNoSelectedImageToInsert `