### PR TITLE
Remove yOffset hack for the reference rect

### DIFF
--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -952,9 +952,6 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
     CGRect windowCoordsRefGroupRect = [self windowCoordsReferenceGroupRect];
     UIView *firstPanel = [controller firstPanelView];
     if (!CGRectIsEmpty(windowCoordsRefGroupRect) && firstPanel && controller.backgroundView) {
-
-        windowCoordsRefGroupRect = CGRectOffset(windowCoordsRefGroupRect, 0, [self.webView iOS12yOffsetHack]);
-
         CGRect panelRectInWindowCoords = [firstPanel convertRect:firstPanel.bounds toView:nil];
         CGRect refGroupRectInWindowCoords = [controller.backgroundView convertRect:windowCoordsRefGroupRect toView:nil];
         if (CGRectIntersectsRect(windowCoordsRefGroupRect, panelRectInWindowCoords)) {


### PR DESCRIPTION
It looks like it's still needed elsewhere but not for the reference rect.

This is a regression when compared with the current app store build on iOS 12 and 13