### PR TITLE
Show Wikidata API error message

### DIFF
--- a/Wikipedia/Code/DescriptionEditViewController.swift
+++ b/Wikipedia/Code/DescriptionEditViewController.swift
@@ -218,8 +218,8 @@ import UIKit
         }
         
         dataStore.wikidataDescriptionEditingController.publish(newWikidataDescription: descriptionToSave, from: article.descriptionSource, forWikidataID: wikidataID, language: language) { error in
-            let presentingVC = self.presentingViewController
             DispatchQueue.main.async {
+                let presentingVC = self.presentingViewController
                 self.enableProgressiveButton(true)
                 if let error = error {
                     let apiErrorCode = (error as? WikidataAPIResult.APIError)?.code

--- a/Wikipedia/Code/WikidataDescriptionEditingController.swift
+++ b/Wikipedia/Code/WikidataDescriptionEditingController.swift
@@ -1,6 +1,10 @@
 public struct WikidataAPIResult: Decodable {
     public struct APIError: Error, Decodable {
         public let code, info: String?
+
+        public var localizedDescription: String {
+            return info ?? CommonStrings.unknownError
+        }
     }
     let error: APIError?
     let success: Int?


### PR DESCRIPTION
https://phabricator.wikimedia.org/T233168

I wasn't able to reproduce the reported case but it'd make sense to show the error messages from the API, the errors should be localized according to https://www.mediawiki.org/wiki/Wikibase/API#Possible_errors