### PR TITLE
Manually add ku to supported languages in localization script

### DIFF
--- a/scripts/localization.swift
+++ b/scripts/localization.swift
@@ -385,6 +385,7 @@ let locales: Set<String> =  {
         let additional = filenames.compactMap { $0.components(separatedBy: ".").first?.lowercased() }
         identifiers += additional
     }
+    identifiers += ["ku"] // iOS 13 added support for ku but macOS 10.14 doesn't include it, add it manually
     return Set<String>(identifiers)
 }()
 

--- a/scripts/localization.swift
+++ b/scripts/localization.swift
@@ -385,7 +385,7 @@ let locales: Set<String> =  {
         let additional = filenames.compactMap { $0.components(separatedBy: ".").first?.lowercased() }
         identifiers += additional
     }
-    identifiers += ["ku"] // iOS 13 added support for ku but macOS 10.14 doesn't include it, add it manually
+    identifiers += ["ku"] // iOS 13 added support for ku but macOS 10.14 doesn't include it, add it manually. This line can be removed when macOS 10.15 ships.
     return Set<String>(identifiers)
 }()
 


### PR DESCRIPTION
Fixes discrepancy between macOS 10.14, macOS 10.15, and iOS 13