### PR TITLE
T234369

### DIFF
--- a/WMF Framework/ExtensionViewController.swift
+++ b/WMF Framework/ExtensionViewController.swift
@@ -7,10 +7,12 @@ open class ExtensionViewController: UIViewController, Themeable {
         self.theme = theme
     }
     
-    open override func viewDidLoad() {
-        super.viewDidLoad()
-        updateThemeFromTraitCollection(force: true)
-        apply(theme: theme)
+    var isFirstLayout = true
+    
+    open override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        updateThemeFromTraitCollection(force: isFirstLayout)
+        isFirstLayout = false
     }
     
     private func updateThemeFromTraitCollection(force: Bool = false) {

--- a/WMF Framework/Theme.swift
+++ b/WMF Framework/Theme.swift
@@ -430,9 +430,9 @@ public class Theme: NSObject {
 
     @objc public static let blackDimmed = Theme(colors: .black, imageOpacity: Theme.dimmedImageOpacity, cardBorderWidthInPixels: Theme.defaultCardBorderWidthInPixels, cardShadowOpacity: 0, multiSelectIndicatorImage: Theme.darkMultiSelectIndicator, isDark: true, hasInputAccessoryShadow: false, name: "black-dimmed", displayName: Theme.black.displayName,  analyticsName: "black", webName: "dark")
 
-    @objc public static let widgetLight = Theme(colors: .widgetLight, imageOpacity: 1, cardBorderWidthInPixels: Theme.defaultCardBorderWidthInPixels, cardShadowOpacity: 0, multiSelectIndicatorImage: nil, isDark: false, hasInputAccessoryShadow: false, name: "", displayName: "", analyticsName: "", webName: "light")
+    @objc public static let widgetLight = Theme(colors: .widgetLight, imageOpacity: 1, cardBorderWidthInPixels: Theme.defaultCardBorderWidthInPixels, cardShadowOpacity: 0, multiSelectIndicatorImage: nil, isDark: false, hasInputAccessoryShadow: false, name: "widget-light", displayName: "", analyticsName: "", webName: "light")
     
-    @objc public static let widgetDark = Theme(colors: .widgetDark, imageOpacity: 1, cardBorderWidthInPixels: Theme.defaultCardBorderWidthInPixels, cardShadowOpacity: 0, multiSelectIndicatorImage: nil, isDark: false, hasInputAccessoryShadow: false, name: "", displayName: "", analyticsName: "", webName: "light")
+    @objc public static let widgetDark = Theme(colors: .widgetDark, imageOpacity: 1, cardBorderWidthInPixels: Theme.defaultCardBorderWidthInPixels, cardShadowOpacity: 0, multiSelectIndicatorImage: nil, isDark: false, hasInputAccessoryShadow: false, name: "widget-dark", displayName: "", analyticsName: "", webName: "black")
     
     public class func widgetThemeCompatible(with traitCollection: UITraitCollection) -> Theme {
         if #available(iOSApplicationExtension 12.0, *) {


### PR DESCRIPTION
Fix widget theme mismatch on iOS 13.1+

https://phabricator.wikimedia.org/T234369

It looks like my [assumption on #3229](https://github.com/wikimedia/wikipedia-ios/pull/3229#pullrequestreview-283868845) is no longer true for widget view controllers. The trait collection is incorrect on `viewDidLoad` and doesn't get a change notification.