### PR TITLE
Fix some incorrectly positioned reference highlights

### DIFF
--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -288,11 +288,9 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
 - (void)handleReferenceClickedScriptMessage:(NSDictionary *)messageDict {
     NSAssert(messageDict[@"referencesGroup"], @"Expected key 'referencesGroup' not found in script message dictionary");
     self.lastClickedReferencesGroup = [messageDict[@"referencesGroup"] wmf_map:^id(NSDictionary *referenceDict) {
-        CGFloat offset;
+        CGFloat offset = self.webView.scrollView.contentInset.top;
         if (@available(iOS 12.0, *)) {
-            offset = 0;
-        } else {
-            offset = self.webView.scrollView.contentInset.top;
+            offset += [self.webView iOS12yOffsetHack];
         }
         return [[WMFReference alloc] initWithScriptMessageDict:referenceDict yOffset:offset];
     }];
@@ -812,7 +810,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
                                                                        if (completion) {
                                                                            completion();
                                                                        }
-                                                                        [self.delegate webViewController:self didScrollToAnchor:anchor];
+                                                                       [self.delegate webViewController:self didScrollToAnchor:anchor];
                                                                    }];
                                                      } else if (completion) {
                                                          completion();

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -288,10 +288,7 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
 - (void)handleReferenceClickedScriptMessage:(NSDictionary *)messageDict {
     NSAssert(messageDict[@"referencesGroup"], @"Expected key 'referencesGroup' not found in script message dictionary");
     self.lastClickedReferencesGroup = [messageDict[@"referencesGroup"] wmf_map:^id(NSDictionary *referenceDict) {
-        CGFloat offset = self.webView.scrollView.contentInset.top;
-        if (@available(iOS 12.0, *)) {
-            offset += [self.webView iOS12yOffsetHack];
-        }
+        CGFloat offset = self.webView.scrollView.contentInset.top + [self.webView iOS12yOffsetHack];
         return [[WMFReference alloc] initWithScriptMessageDict:referenceDict yOffset:offset];
     }];
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T233472

Fixes this issue seen on iOS 12 & up:

![highlight mov](https://user-images.githubusercontent.com/3143487/66525167-7d0eb800-eaa9-11e9-904c-d651112a6ead.gif)
