### PR TITLE
Speed up talk page requests

### DIFF
--- a/Wikipedia/Code/NavigationStateController.swift
+++ b/Wikipedia/Code/NavigationStateController.swift
@@ -107,7 +107,8 @@ final class NavigationStateController: NSObject {
                 }
                 let articleVC = WMFArticleViewController(articleURL: articleURL, dataStore: dataStore, theme: theme)
                 articleVC.shouldRequestLatestRevisionOnInitialLoad = false
-                pushOrPresent(articleVC, navigationController: navigationController, presentation: viewController.presentation)
+                // never present an article modal, the nav bar disappears
+                pushOrPresent(articleVC, navigationController: navigationController, presentation: .push)
             case (.themeableNavigationController, _):
                 let themeableNavigationController = WMFThemeableNavigationController()
                 pushOrPresent(themeableNavigationController, navigationController: navigationController, presentation: viewController.presentation)

--- a/Wikipedia/Code/TalkPageFetcher.swift
+++ b/Wikipedia/Code/TalkPageFetcher.swift
@@ -188,13 +188,11 @@ class TalkPageFetcher: Fetcher {
                 }
             }
             
-            // all of this can be removed afer https://gerrit.wikimedia.org/r/#/c/mediawiki/services/mobileapps/+/545375/
-            // is deployed
+            // all of this can be removed after
+            // https://gerrit.wikimedia.org/r/#/c/mediawiki/services/mobileapps/+/545375/ is deployed
             let revision: Int
             if let networkRev = networkBase.revision {
                 revision = networkRev
-            } else if let requestedRev = revisionID {
-                revision = requestedRev
             } else {
                 guard
                     let etag = (response as? HTTPURLResponse)?.allHeaderFields["Etag"] as? String,

--- a/Wikipedia/Code/TalkPagesController.swift
+++ b/Wikipedia/Code/TalkPagesController.swift
@@ -98,7 +98,8 @@ class TalkPageController {
                             let fetchResult = FetchResult(objectID: localObjectID, isInitialLocalResult: false)
                             completion?(.success(fetchResult))
                         } else {
-                            self.fetchAndUpdateLocalTalkPage(with: localObjectID, revisionID: lastRevisionID, completion: { (result) in
+                            // we just want the latest revision, so don't pass revisionID
+                            self.fetchAndUpdateLocalTalkPage(with: localObjectID, revisionID: nil, completion: { (result) in
                                 switch result {
                                 case .success(let response):
                                     let fetchResult = FetchResult(objectID: response, isInitialLocalResult: false)
@@ -315,7 +316,7 @@ private extension TalkPageController {
         }
     }
     
-    func fetchAndUpdateLocalTalkPage(with moid: NSManagedObjectID, revisionID: Int, completion: ((Result<NSManagedObjectID, Error>) -> Void)? = nil) {
+    func fetchAndUpdateLocalTalkPage(with moid: NSManagedObjectID, revisionID: Int?, completion: ((Result<NSManagedObjectID, Error>) -> Void)? = nil) {
         fetchTalkPage(revisionID: revisionID) { (result) in
             self.moc.perform {
                 do {

--- a/Wikipedia/Code/TalkPagesController.swift
+++ b/Wikipedia/Code/TalkPagesController.swift
@@ -98,7 +98,7 @@ class TalkPageController {
                             let fetchResult = FetchResult(objectID: localObjectID, isInitialLocalResult: false)
                             completion?(.success(fetchResult))
                         } else {
-                            // we just want the latest revision, so don't pass revisionID
+                            // Omit the revisionID to get the latest revision. Including a revision bypasses the cache and slows down the response
                             self.fetchAndUpdateLocalTalkPage(with: localObjectID, revisionID: nil, completion: { (result) in
                                 switch result {
                                 case .success(let response):


### PR DESCRIPTION
Only the latest revision is cached and requesting a specific revision bypasses the cache. Removing the revision from the request should speed up talk page responses. Revision [will be added to the response](https://gerrit.wikimedia.org/r/#/c/mediawiki/services/mobileapps/+/545375/), but use the revision passed down in the etag in the meantime.

Also fixes a bug where if state was saved while an article was being previewed (effectively a modal presentation of WMFArticleViewController), the article would be restored without a nav bar. Fixed this by never presenting WMFArticleViewController modally in state restoration.