### PR TITLE
Fix navbarless state

### DIFF
--- a/Wikipedia/Code/NavigationStateController.swift
+++ b/Wikipedia/Code/NavigationStateController.swift
@@ -107,7 +107,8 @@ final class NavigationStateController: NSObject {
                 }
                 let articleVC = WMFArticleViewController(articleURL: articleURL, dataStore: dataStore, theme: theme)
                 articleVC.shouldRequestLatestRevisionOnInitialLoad = false
-                pushOrPresent(articleVC, navigationController: navigationController, presentation: viewController.presentation)
+                // never present an article modal, the nav bar disappears
+                pushOrPresent(articleVC, navigationController: navigationController, presentation: .push)
             case (.themeableNavigationController, _):
                 let themeableNavigationController = WMFThemeableNavigationController()
                 pushOrPresent(themeableNavigationController, navigationController: navigationController, presentation: viewController.presentation)


### PR DESCRIPTION
Fixes a bug where if state was saved while an article was being previewed (effectively a modal presentation of WMFArticleViewController), the article would be restored without a nav bar. Fixed this by never presenting WMFArticleViewController modally in state restoration.