### PR TITLE
Somewhat fix peek preview animation on iOS 13.2

### DIFF
--- a/Wikipedia/Code/ArticlePeekPreviewViewController.swift
+++ b/Wikipedia/Code/ArticlePeekPreviewViewController.swift
@@ -22,7 +22,6 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
     
     fileprivate func fetchArticle() {
         guard let article = dataStore.fetchArticle(with: articleURL) else {
-            updatePreferredContentSize(for: view.bounds.width)
             guard let key = articleURL.wmf_databaseKey else {
                 return
             }
@@ -72,7 +71,10 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
         expandedArticleView.isHidden = true
         view.addSubview(expandedArticleView)
         expandedArticleView.updateFonts(with: traitCollection)
-        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         fetchArticle()
     }
 

--- a/Wikipedia/Code/ArticlePeekPreviewViewController.swift
+++ b/Wikipedia/Code/ArticlePeekPreviewViewController.swift
@@ -22,6 +22,7 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
     
     fileprivate func fetchArticle() {
         guard let article = dataStore.fetchArticle(with: articleURL) else {
+            updatePreferredContentSize(for: view.bounds.width)
             guard let key = articleURL.wmf_databaseKey else {
                 return
             }
@@ -71,10 +72,7 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
         expandedArticleView.isHidden = true
         view.addSubview(expandedArticleView)
         expandedArticleView.updateFonts(with: traitCollection)
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+        
         fetchArticle()
     }
 

--- a/Wikipedia/Code/UIViewController+Peekable.swift
+++ b/Wikipedia/Code/UIViewController+Peekable.swift
@@ -14,6 +14,10 @@ extension UIViewController {
         articlePeekPreviewViewController.didMove(toParent: self)
     }
     
+    @objc var wmf_PeekableChildViewController: UIViewController? {
+        return children.first(where: { $0 is Peekable })
+    }
+    
     @objc func wmf_removePeekableChildViewControllers() {
         for vc in children {
             guard vc is Peekable else {

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -2029,6 +2029,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
     UIViewController *peekVC = [self peekViewControllerForURL:updatedLinkURL];
     if (!peekVC) {
         completionHandler(nil);
+        return;
     }
     [self.webViewController hideFindInPageWithCompletion:nil];
     UIContextMenuConfiguration *config = [UIContextMenuConfiguration configurationWithIdentifier:updatedLinkURL

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -2026,20 +2026,29 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
 
 - (void)webView:(WKWebView *)webView contextMenuConfigurationForElement:(WKContextMenuElementInfo *)elementInfo completionHandler:(void (^)(UIContextMenuConfiguration *_Nullable))completionHandler API_AVAILABLE(ios(13.0)) {
     NSURL *updatedLinkURL = [self updatedLinkURLForPreviewingLinkURL:elementInfo.linkURL];
-    UIViewController *peekVC = [self peekViewControllerForURL:updatedLinkURL];
-    if (!peekVC) {
+    UIViewController *peekParentVC = [self peekViewControllerForURL:updatedLinkURL];
+    UIViewController *peekVC = [peekParentVC wmf_PeekableChildViewController];
+    if (!peekParentVC) {
         completionHandler(nil);
         return;
     }
+
     [self.webViewController hideFindInPageWithCompletion:nil];
     UIContextMenuConfiguration *config = [UIContextMenuConfiguration configurationWithIdentifier:updatedLinkURL
         previewProvider:^UIViewController *_Nullable {
-            return peekVC;
+            return peekParentVC;
         }
         actionProvider:^UIMenu *_Nullable(NSArray<UIMenuElement *> *_Nonnull suggestedActions) {
-            return [self previewMenuElementsForPreviewViewController:peekVC suggestedActions:suggestedActions];
+            return [self previewMenuElementsForPreviewViewController:peekParentVC suggestedActions:suggestedActions];
         }];
-    completionHandler(config);
+    if (peekVC && [peekVC isKindOfClass:[WMFArticlePeekPreviewViewController class]]) {
+        WMFArticlePeekPreviewViewController *peekPreviewVC = (WMFArticlePeekPreviewViewController *)peekVC;
+        [peekPreviewVC fetchArticle:^{
+            completionHandler(config);
+        }];
+    } else {
+        completionHandler(config);
+    }
 }
 
 - (void)webView:(WKWebView *)webView contextMenuForElement:(WKContextMenuElementInfo *)elementInfo willCommitWithAnimator:(id<UIContextMenuInteractionCommitAnimating>)animator API_AVAILABLE(ios(13.0)) {


### PR DESCRIPTION
Fetching the article before calling the completion handler improves the appearance animation by having a determined content size available in viewWillAppear.

There are still some odd rotation animations but this fixes the issue where the box itself would resize without animation.

This also fixes a crash caused by the completion handler being called twice.