### PR TITLE
Fixes an issue where links we didn't want to preview were previewed (like edit pencils)

### DIFF
--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -2029,7 +2029,12 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
     UIViewController *peekParentVC = [self peekViewControllerForURL:updatedLinkURL];
     UIViewController *peekVC = [peekParentVC wmf_PeekableChildViewController];
     if (!peekParentVC) {
-        completionHandler(nil);
+        UIContextMenuConfiguration *nullConfig = [UIContextMenuConfiguration configurationWithIdentifier:nil previewProvider:^UIViewController * _Nullable{
+            return nil;
+        } actionProvider:^UIMenu * _Nullable(NSArray<UIMenuElement *> * _Nonnull suggestedActions) {
+            return nil;
+        }];
+        completionHandler(nullConfig);
         return;
     }
 


### PR DESCRIPTION
Return a config with a nil VC and menu instead of nil config

https://phabricator.wikimedia.org/T237045