### PR TITLE
Fix typo

### DIFF
--- a/Wikipedia/Code/DiffContainerViewController.swift
+++ b/Wikipedia/Code/DiffContainerViewController.swift
@@ -669,7 +669,7 @@ class RevisionAuthorThankedHintVC: HintViewController {
     }
     override func configureSubviews() {
         viewType = .default
-        let thanksMessage = WMFLocalizedString("diff-thanks-sent", value: "Your 'Thanks' was set to %1$@", comment: "Message indicating thanks was sent. Parameters:\n* %1$@ - name of user who was thanked")
+        let thanksMessage = WMFLocalizedString("diff-thanks-sent", value: "Your 'Thanks' was sent to %1$@", comment: "Message indicating thanks was sent. Parameters:\n* %1$@ - name of user who was thanked")
         let thanksMessageWithRecipient = String.localizedStringWithFormat(thanksMessage, recipient)
         defaultImageView.image = UIImage(named: "selected")
         defaultLabel.text = thanksMessageWithRecipient

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -182,7 +182,7 @@
 "diff-thanks-send-button-title" = "Send 'Thanks'";
 "diff-thanks-send-subtitle" = "'Thanks' are an easy way to show appreciation for an editor's work on Wikipedia. 'Thanks' cannot be undone and are publicly viewable.";
 "diff-thanks-send-title" = "Publicly send 'Thanks'";
-"diff-thanks-sent" = "Your 'Thanks' was set to $1";
+"diff-thanks-sent" = "Your 'Thanks' was sent to $1";
 "diff-thanks-sent-already" = "You’ve already sent a ‘Thanks’ for this edit";
 "diff-thanks-sent-cannot-unsend" = "Thanks cannot be unsent";
 "diff-unedited-lines-format" = "{{PLURAL:$1|$1 line unedited|$1 lines unedited}}";


### PR DESCRIPTION
Thanks was set to » Thanks was se**n**t to

Reported by @Papuass in https://translatewiki.net/wiki/Thread:Support/Reporting_typo_in_source