### PR TITLE
[Regression] Add missing button border in panels

### DIFF
--- a/Wikipedia/Code/Panels.swift
+++ b/Wikipedia/Code/Panels.swift
@@ -32,6 +32,7 @@ class AnnouncementPanelViewController : ScrollableEducationPanelViewController {
         buttonCornerRadius = 8
         buttonTopSpacing = 10
         primaryButtonTitleEdgeInsets = UIEdgeInsets(top: 14, left: 14, bottom: 14, right: 14)
+        primaryButtonBorderWidth = 0
         dismissWhenTappedOutside = true
         contentHorizontalPadding = 20
     }

--- a/Wikipedia/Code/ScrollableEducationPanelViewController.swift
+++ b/Wikipedia/Code/ScrollableEducationPanelViewController.swift
@@ -186,6 +186,11 @@ class ScrollableEducationPanelViewController: UIViewController, Themeable {
 
     var backgroundColor: UIColor?
     var primaryButtonBackgroundColor: UIColor?
+    var primaryButtonBorderWidth: CGFloat = 1 {
+        didSet {
+            primaryButton?.layer.borderWidth = primaryButtonBorderWidth
+        }
+    }
     var secondaryButtonTintColor: UIColor?
     var footerTextViewTextColor: UIColor?
     var isEffectsViewHidden: Bool = false {
@@ -366,7 +371,6 @@ class ScrollableEducationPanelViewController: UIViewController, Themeable {
         closeButton.tintColor = theme.colors.primaryText
         primaryButton?.tintColor = theme.colors.link
         secondaryButton?.tintColor = secondaryButtonTintColor ?? theme.colors.link
-        primaryButton?.layer.borderWidth = 0
         primaryButton?.layer.borderColor = theme.colors.link.cgColor
         primaryButton.backgroundColor = primaryButtonBackgroundColor
 


### PR DESCRIPTION
I messed this up when I was working on the announcement card. The primary button is missing a border in all the non-announcement panels -
![Simulator Screen Shot - iPhone 8 Plus - 2019-11-13 at 15 13 34](https://user-images.githubusercontent.com/9299317/68803895-9cf84500-062e-11ea-9ac4-333893856c4f.png)

Fixed -
![Simulator Screen Shot - iPhone 8 Plus - 2019-11-13 at 16 02 14](https://user-images.githubusercontent.com/9299317/68804105-024c3600-062f-11ea-8eec-bb18d4c62f9d.png)


