### PR TITLE
Fix readability of panels on dark theme

### DIFF
--- a/Wikipedia/Code/Panels.swift
+++ b/Wikipedia/Code/Panels.swift
@@ -15,12 +15,7 @@ class AnnouncementPanelViewController : ScrollableEducationPanelViewController {
     }
 
     override func viewDidLoad() {
-        backgroundColor = theme.colors.cardBackground
-        primaryButtonBackgroundColor = theme.colors.cardButtonBackground
-        secondaryButtonTintColor = theme.colors.secondaryText
-        footerTextViewTextColor = theme.colors.secondaryText
         super.viewDidLoad()
-        isEffectsViewHidden = true
         subheadingHTML = announcement.text
         subheadingTextAlignment = .left
         primaryButtonTitle = announcement.actionTitle

--- a/Wikipedia/Code/ScrollableEducationPanelView.xib
+++ b/Wikipedia/Code/ScrollableEducationPanelView.xib
@@ -11,7 +11,6 @@
             <connections>
                 <outlet property="buttonTopSpacingConstraint" destination="wIB-c0-etL" id="kwm-yu-jPn"/>
                 <outlet property="closeButton" destination="BAe-h0-y6b" id="eXa-fB-phT"/>
-                <outlet property="effectsView" destination="i3Y-1u-tKd" id="O8S-b1-HYo"/>
                 <outlet property="footerTextView" destination="jJo-Ko-Gi1" id="Uaf-PG-xyV"/>
                 <outlet property="headingLabel" destination="Cta-dZ-grZ" id="rDC-RM-LOF"/>
                 <outlet property="imageView" destination="rFJ-kb-kte" id="Dmh-26-vvR"/>
@@ -35,14 +34,6 @@
                 <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qtK-Db-J92" userLabel="Rounded Corner Container">
                     <rect key="frame" x="9" y="20" width="280" height="489"/>
                     <subviews>
-                        <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i3Y-1u-tKd">
-                            <rect key="frame" x="0.0" y="0.0" width="280" height="489"/>
-                            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="OsN-uF-riJ">
-                                <rect key="frame" x="0.0" y="0.0" width="280" height="489"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                            </view>
-                            <blurEffect style="extraLight"/>
-                        </visualEffectView>
                         <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e3o-Ht-LDd">
                             <rect key="frame" x="0.0" y="0.0" width="280" height="489"/>
                             <subviews>
@@ -182,12 +173,8 @@
                         <constraint firstItem="e3o-Ht-LDd" firstAttribute="leading" secondItem="qtK-Db-J92" secondAttribute="leading" id="Ddf-FG-9Ec"/>
                         <constraint firstAttribute="width" constant="280" id="EvZ-1i-fo7"/>
                         <constraint firstItem="e3o-Ht-LDd" firstAttribute="top" secondItem="qtK-Db-J92" secondAttribute="top" id="LTF-k8-oqQ"/>
-                        <constraint firstAttribute="bottom" secondItem="i3Y-1u-tKd" secondAttribute="bottom" id="OP0-IS-QyH"/>
                         <constraint firstAttribute="trailing" secondItem="e3o-Ht-LDd" secondAttribute="trailing" id="Td2-3d-O5E"/>
-                        <constraint firstItem="i3Y-1u-tKd" firstAttribute="top" secondItem="qtK-Db-J92" secondAttribute="top" id="ZN6-Kj-6SM"/>
-                        <constraint firstItem="i3Y-1u-tKd" firstAttribute="leading" secondItem="qtK-Db-J92" secondAttribute="leading" id="hga-nf-cM1"/>
                         <constraint firstAttribute="bottom" secondItem="e3o-Ht-LDd" secondAttribute="bottom" id="kV7-O6-Yke"/>
-                        <constraint firstAttribute="trailing" secondItem="i3Y-1u-tKd" secondAttribute="trailing" id="ul6-GS-lp0"/>
                     </constraints>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="boolean" keyPath="masksToBounds" value="YES"/>

--- a/Wikipedia/Code/ScrollableEducationPanelViewController.swift
+++ b/Wikipedia/Code/ScrollableEducationPanelViewController.swift
@@ -380,6 +380,7 @@ class ScrollableEducationPanelViewController: UIViewController, Themeable {
         } else {
             roundedCornerContainer.layer.borderWidth = 0
         }
+        effectsView.effect = UIBlurEffect(style: theme.blurEffectStyle)
         roundedCornerContainer.backgroundColor = backgroundColor
         updateFooterHTML()
     }

--- a/Wikipedia/Code/ScrollableEducationPanelViewController.swift
+++ b/Wikipedia/Code/ScrollableEducationPanelViewController.swift
@@ -381,6 +381,8 @@ class ScrollableEducationPanelViewController: UIViewController, Themeable {
             roundedCornerContainer.layer.borderWidth = 0
         }
         effectsView.effect = UIBlurEffect(style: theme.blurEffectStyle)
+        effectsView.backgroundColor = theme.colors.blurEffectBackground
+        
         roundedCornerContainer.backgroundColor = backgroundColor
         updateFooterHTML()
     }

--- a/Wikipedia/Code/ScrollableEducationPanelViewController.swift
+++ b/Wikipedia/Code/ScrollableEducationPanelViewController.swift
@@ -40,7 +40,6 @@ class ScrollableEducationPanelViewController: UIViewController, Themeable {
     @IBOutlet fileprivate weak var scrollViewContainer: UIView!
     @IBOutlet fileprivate weak var stackView: UIStackView!
     @IBOutlet fileprivate weak var roundedCornerContainer: UIView!
-    @IBOutlet fileprivate weak var effectsView: UIVisualEffectView!
 
     fileprivate var primaryButtonTapHandler: ScrollableEducationPanelButtonTapHandler?
     fileprivate var secondaryButtonTapHandler: ScrollableEducationPanelButtonTapHandler?
@@ -184,20 +183,12 @@ class ScrollableEducationPanelViewController: UIViewController, Themeable {
         footerTextView.attributedText = attributedText
     }
 
-    var backgroundColor: UIColor?
-    var primaryButtonBackgroundColor: UIColor?
     var primaryButtonBorderWidth: CGFloat = 1 {
         didSet {
             primaryButton?.layer.borderWidth = primaryButtonBorderWidth
         }
     }
-    var secondaryButtonTintColor: UIColor?
-    var footerTextViewTextColor: UIColor?
-    var isEffectsViewHidden: Bool = false {
-        didSet {
-            effectsView.isHidden = isEffectsViewHidden
-        }
-    }
+    
     var isUrgent: Bool = false
     var spacing: CGFloat = 14 {
         didSet {
@@ -367,12 +358,12 @@ class ScrollableEducationPanelViewController: UIViewController, Themeable {
         }
         headingLabel?.textColor = theme.colors.primaryText
         subheadingLabel?.textColor = theme.colors.primaryText
-        footerTextView?.textColor = footerTextViewTextColor ?? theme.colors.primaryText
+        footerTextView?.textColor = theme.colors.secondaryText
         closeButton.tintColor = theme.colors.primaryText
         primaryButton?.tintColor = theme.colors.link
-        secondaryButton?.tintColor = secondaryButtonTintColor ?? theme.colors.link
+        secondaryButton?.tintColor = theme.colors.secondaryText
         primaryButton?.layer.borderColor = theme.colors.link.cgColor
-        primaryButton.backgroundColor = primaryButtonBackgroundColor
+        primaryButton.backgroundColor = theme.colors.cardButtonBackground
 
         if isUrgent {
             roundedCornerContainer.layer.borderWidth = 3
@@ -380,10 +371,7 @@ class ScrollableEducationPanelViewController: UIViewController, Themeable {
         } else {
             roundedCornerContainer.layer.borderWidth = 0
         }
-        effectsView.effect = UIBlurEffect(style: theme.blurEffectStyle)
-        effectsView.backgroundColor = theme.colors.blurEffectBackground
-        
-        roundedCornerContainer.backgroundColor = backgroundColor
+        roundedCornerContainer.backgroundColor = theme.colors.cardBackground
         updateFooterHTML()
     }
 }


### PR DESCRIPTION
Utilize the new appearance for the in-article fundraising cards for all educational panels. Confirmed with @carolynlimadeo 
 
Before:
![IMG_0340](https://user-images.githubusercontent.com/741327/68875809-6cb5b280-06d1-11ea-82f5-68fbbd316c5c.PNG)

After:
![Simulator Screen Shot - iPhone 11 Pro - 2019-11-14 at 11 33 10](https://user-images.githubusercontent.com/741327/68876619-c4a0e900-06d2-11ea-9f07-cf9ed6fc211b.png)
