### PR TITLE
Remove Hausa (ha) from RTL languages

### DIFF
--- a/Wikipedia/Code/MWLanguageInfo.m
+++ b/Wikipedia/Code/MWLanguageInfo.m
@@ -29,7 +29,7 @@
     static dispatch_once_t onceToken;
     static NSSet *rtlLanguages;
     dispatch_once(&onceToken, ^{
-        rtlLanguages = [NSSet setWithObjects:@"arc", @"arz", @"ar", @"azb", @"bcc", @"bqi", @"ckb", @"dv", @"fa", @"glk", @"lrc", @"ha", @"he", @"khw", @"ks", @"mzn", @"nqo", @"pnb", @"ps", @"sd", @"ug", @"ur", @"yi", nil];
+        rtlLanguages = [NSSet setWithObjects:@"arc", @"arz", @"ar", @"azb", @"bcc", @"bqi", @"ckb", @"dv", @"fa", @"glk", @"lrc", @"he", @"khw", @"ks", @"mzn", @"nqo", @"pnb", @"ps", @"sd", @"ug", @"ur", @"yi", nil];
     });
     return rtlLanguages;
 }


### PR DESCRIPTION
This is a LTR wiki: 
Bug reported on Phabricator: [T237808](https://phabricator.wikimedia.org/T237808)