### PR TITLE
Fix search links from Siri and search state restoration

### DIFF
--- a/Wikipedia/Code/NavigationStateController.swift
+++ b/Wikipedia/Code/NavigationStateController.swift
@@ -84,9 +84,7 @@ final class NavigationStateController: NSObject {
                 }
                 savedViewController.toggleCurrentView(currentSavedViewRawValue)
             case let searchViewController as SearchViewController:
-                searchViewController.setSearchVisible(true, animated: false)
-                searchViewController.searchTerm = info.searchTerm
-                searchViewController.search()
+                searchViewController.searchAndMakeResultsVisibleForSearchTerm(info.searchTerm, animated: false)
             case let exploreViewController as ExploreViewController:
                 exploreViewController.presentedContentGroupKey = info.presentedContentGroupKey
                 exploreViewController.shouldRestoreScrollPosition = true

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -87,7 +87,7 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
         }
     }
     
-    @objc var searchTerm: String? {
+    var searchTerm: String? {
         set {
             searchBar.text = newValue
         }
@@ -106,8 +106,15 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
             _siteURL = newValue
         }
     }
+    
+    @objc func searchAndMakeResultsVisibleForSearchTerm(_ term: String?, animated: Bool) {
+        shouldAnimateSearchBar = animated
+        searchTerm = term
+        search(for: searchTerm, suggested: false)
+        searchBar.becomeFirstResponder()
+    }
 
-    @objc func search() {
+    func search() {
         search(for: searchTerm, suggested: false)
     }
     
@@ -286,7 +293,7 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
 
     var searchLanguageBarViewController: SearchLanguagesBarViewController?
     private var _isSearchVisible: Bool = false
-    func setSearchVisible(_ visible: Bool, animated: Bool) {
+    private func setSearchVisible(_ visible: Bool, animated: Bool) {
         _isSearchVisible = visible
         navigationBar.isAdjustingHidingFromContentInsetChangesEnabled  = false
         let completion = { (finished: Bool) in

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1279,9 +1279,8 @@ static const NSString *kvo_SavedArticlesFetcher_progress = @"kvo_SavedArticlesFe
             break;
         case WMFUserActivityTypeSearchResults:
             [self dismissPresentedViewControllers];
-            [self switchToSearchAnimated:YES];
-            [self.searchViewController setSearchTerm:[activity wmf_searchTerm]];
-            [self.searchViewController search];
+            [self.searchViewController searchAndMakeResultsVisibleForSearchTerm:[activity wmf_searchTerm] animated:animated];
+            [self switchToSearchAnimated:animated];
             break;
         case WMFUserActivityTypeSettings:
             [self dismissPresentedViewControllers];


### PR DESCRIPTION
- Fix grayed out cancel button on search state restoration and search results deep link
- Fix hidden search results on search results deep link


Deep link repro steps:
- Use OS-wide search to find one of your saved articles
- Tap "Search in app"

Restoration repo steps:
- Force quit the app while on the search tab
- Reopen the app