### PR TITLE
Link handling bug fixes

### DIFF
--- a/Wikipedia/Code/NSURL+WMFLinkParsing.h
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.h
@@ -178,7 +178,7 @@ extern NSString *const WMFEditPencil;
 
 @property (nonatomic, copy, readonly, nullable) NSString *wmf_titleWithUnderscores;
 
-@property (nonatomic, copy, readonly, nullable) NSURL *wmf_databaseURL; // canonical URL
+@property (nonatomic, copy, readonly, nullable) NSURL *wmf_canonicalURL; // canonical URL
 
 @property (nonatomic, copy, readonly, nullable) NSString *wmf_databaseKey; // string suitable for using as a unique key for any wiki page
 

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.m
@@ -230,6 +230,14 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
     }
 }
 
+- (NSURL *)wmf_canonicalURL {
+    NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:NO];
+    components.host = [NSURLComponents wmf_hostWithDomain:self.wmf_domain language:self.wmf_language isMobile:NO];
+    components.path = [components.path stringByRemovingPercentEncoding] ?: components.path;
+    components.scheme = @"https";
+    return components.URL;
+}
+
 - (NSURL *)wmf_databaseURL {
     NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:NO];
     components.host = [NSURLComponents wmf_hostWithDomain:self.wmf_domain language:self.wmf_language isMobile:NO];

--- a/Wikipedia/Code/SearchLanguagesBarViewController.swift
+++ b/Wikipedia/Code/SearchLanguagesBarViewController.swift
@@ -117,7 +117,7 @@ class SearchLanguagesBarViewController: UIViewController, WMFPreferredLanguagesV
             let button = languageButtons[index]
             button.setTitle(language.localizedName, for: .normal)
             if let selectedLanguage = currentlySelectedSearchLanguage {
-                button.isSelected = language.isEqual(to: selectedLanguage)
+                button.isSelected = language.languageCode == selectedLanguage.languageCode
             }else{
                 assertionFailure("selectedLanguage should have been set at this point")
                 button.isSelected = false

--- a/Wikipedia/Code/URL+WMFLinkParsing.swift
+++ b/Wikipedia/Code/URL+WMFLinkParsing.swift
@@ -83,7 +83,7 @@ extension URL {
     }
     
     public var canonical: URL {
-        return (self as NSURL).wmf_database ?? self
+        return (self as NSURL).wmf_canonical ?? self
     }
     
     public var wikiResourcePath: String? {


### PR DESCRIPTION
- Fix removal of fragment when navigating (repro with testwiki > Bird > Goat section link)
- Fix assertion failure in the searchVC after adding a new language (add new language in settings, go to search). This wasn't introduced by link handling, but makes testing the fragment issue more difficult.