### PR TITLE
diff - toolbar spacing tweaks

### DIFF
--- a/Wikipedia/Code/DiffToolbarView.swift
+++ b/Wikipedia/Code/DiffToolbarView.swift
@@ -38,11 +38,7 @@ class DiffToolbarView: UIView {
     lazy var shareButton: IconBarButtonItem = {
         let item = IconBarButtonItem(iconName: "share", target: self, action: #selector(tappedShare(_:)), for: .touchUpInside)
         item.accessibilityLabel = CommonStrings.accessibilityShareTitle
-        
-        if let button = item.customView as? UIButton {
-            button.contentEdgeInsets = UIEdgeInsets(top: -5, left: 0, bottom: 0, right: 0)
-        }
-        
+
         return item
     }()
 
@@ -50,10 +46,6 @@ class DiffToolbarView: UIView {
         let item = IconBarButtonItem(iconName: "diff-smile", target: self, action: #selector(tappedThank(_:)), for: .touchUpInside)
         item.accessibilityLabel = WMFLocalizedString("action-thank-user-accessibility", value: "Thank User", comment: "Accessibility title for the 'Thank User' action button when viewing a single revision diff.")
         
-        if let button = item.customView as? UIButton {
-            button.contentEdgeInsets = UIEdgeInsets(top: 5, left: 0, bottom: 0, right: 0)
-        }
-
         return item
     }()
     
@@ -114,12 +106,32 @@ class DiffToolbarView: UIView {
     }
 
     private func setItems() {
-        let marginSpacing = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
+        let trailingMarginSpacing = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
         switch (traitCollection.horizontalSizeClass, traitCollection.verticalSizeClass) {
         case (.regular, .regular):
-            marginSpacing.width = 50
+            if #available(iOS 13, *) {
+                trailingMarginSpacing.width = 58
+            } else {
+                trailingMarginSpacing.width = 36
+            }
         default:
-            marginSpacing.width = 0
+            if #available(iOS 13, *) {
+                trailingMarginSpacing.width = 24
+            } else {
+                trailingMarginSpacing.width = 8
+            }
+        }
+        
+        let leadingMarginSpacing = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
+        switch (traitCollection.horizontalSizeClass, traitCollection.verticalSizeClass) {
+        case (.regular, .regular):
+            if #available(iOS 13, *) {
+                leadingMarginSpacing.width = 42
+            } else {
+                leadingMarginSpacing.width = 24
+            }
+        default:
+            leadingMarginSpacing.width = 0
         }
         
         let largeFixedSize = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
@@ -127,7 +139,7 @@ class DiffToolbarView: UIView {
         
         let spacer = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         
-        toolbar.items = [nextButton, previousButton, spacer, thankButton, largeFixedSize, shareButton, marginSpacing]
+        toolbar.items = [leadingMarginSpacing, nextButton, previousButton, spacer, thankButton, largeFixedSize, shareButton, trailingMarginSpacing]
     }
     
     func setPreviousButtonState(isEnabled: Bool) {

--- a/Wikipedia/Code/DiffToolbarView.xib
+++ b/Wikipedia/Code/DiffToolbarView.xib
@@ -20,14 +20,16 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rSJ-XL-bDW">
-                    <rect key="frame" x="0.0" y="0.0" width="415" height="49"/>
+                    <rect key="frame" x="-8" y="0.0" width="423" height="49"/>
                     <items/>
                 </toolbar>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="rSJ-XL-bDW" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="4V5-oJ-dKb"/>
-                <constraint firstItem="rSJ-XL-bDW" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="MXc-HC-4ja"/>
+                <constraint firstItem="rSJ-XL-bDW" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="-8" id="MXc-HC-4ja">
+                    <variation key="heightClass=regular-widthClass=regular" constant="0.0"/>
+                </constraint>
                 <constraint firstItem="rSJ-XL-bDW" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="Ngq-3p-91Z"/>
                 <constraint firstAttribute="top" secondItem="rSJ-XL-bDW" secondAttribute="top" id="biU-b8-ytc"/>
             </constraints>


### PR DESCRIPTION
Margin / Spacing tweaks follow-on from https://github.com/wikimedia/wikipedia-ios/pull/3356 to better match mocks.

![Screen Shot 2019-11-25 at 11 56 38 PM](https://user-images.githubusercontent.com/3620196/69603483-76e48480-0fe0-11ea-8d4b-0a8ec93ae633.png)
![Screen Shot 2019-11-25 at 11 50 37 PM](https://user-images.githubusercontent.com/3620196/69603491-7ea42900-0fe0-11ea-8a85-ab58f6ed214b.png)
![Screen Shot 2019-11-25 at 11 56 12 PM](https://user-images.githubusercontent.com/3620196/69603517-91b6f900-0fe0-11ea-87dc-93192a776950.png)
![Screen Shot 2019-11-25 at 11 50 49 PM](https://user-images.githubusercontent.com/3620196/69603536-9c718e00-0fe0-11ea-86a2-6b3bd2916a22.png)
![Screen Shot 2019-11-25 at 11 50 11 PM](https://user-images.githubusercontent.com/3620196/69603543-a1ced880-0fe0-11ea-9c36-51c786827906.png)
![Screen Shot 2019-11-25 at 11 50 43 PM](https://user-images.githubusercontent.com/3620196/69603593-c034d400-0fe0-11ea-987a-f6ae3d3c3348.png)
![Screen Shot 2019-11-26 at 12 09 12 AM](https://user-images.githubusercontent.com/3620196/69603689-025e1580-0fe1-11ea-88b4-c300a26929e4.png)
![Screen Shot 2019-11-26 at 12 00 40 AM](https://user-images.githubusercontent.com/3620196/69603697-0722c980-0fe1-11ea-9e02-4220fcd3986a.png)
![Screen Shot 2019-11-25 at 11 58 17 PM](https://user-images.githubusercontent.com/3620196/69603720-10ac3180-0fe1-11ea-952a-d0445c1af76e.png)
![Screen Shot 2019-11-25 at 11 58 24 PM](https://user-images.githubusercontent.com/3620196/69603730-143fb880-0fe1-11ea-8634-2e77ff3b00ef.png)
![Screen Shot 2019-11-25 at 11 53 25 PM](https://user-images.githubusercontent.com/3620196/69603749-1b66c680-0fe1-11ea-862b-67fdb0b95b79.png)
![Screen Shot 2019-11-25 at 11 53 30 PM](https://user-images.githubusercontent.com/3620196/69603758-20c41100-0fe1-11ea-9a15-4a8c44511ea8.png)
