### PR TITLE
Make 'maybe non-whitespace' string logic re-usable

### DIFF
--- a/WMF Framework/HasText.swift
+++ b/WMF Framework/HasText.swift
@@ -6,6 +6,16 @@ extension String {
     public var wmf_hasNonWhitespaceText: Bool {
         return wmf_hasText && !self.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
+
+    public static func wmf_maybeNonWhitespaceString(maybeString: String?) -> String? {
+        guard
+            let string = maybeString,
+            string.wmf_hasNonWhitespaceText
+            else {
+                return nil
+        }
+        return string
+    }
 }
 
 extension NSAttributedString {

--- a/Wikipedia/Code/PageHistoryCollectionViewCell.swift
+++ b/Wikipedia/Code/PageHistoryCollectionViewCell.swift
@@ -60,8 +60,7 @@ class PageHistoryCollectionViewCell: CollectionViewCell {
     func updateAccessibilityLabel() {
         let isMinorAccessibilityString = isMinor ? WMFLocalizedString("page-history-revision-minor-edit-accessibility-label", value: "Minor edit", comment: "Accessibility label text used if edit was minor") : ""
         accessibilityLabel = [timeLabel.accessibilityLabel, authorButton.accessibilityLabel, sizeDiffLabel.accessibilityLabel, isMinorAccessibilityString, commentLabel.accessibilityLabel]
-            .compactMap { $0 }
-            .filter { $0.wmf_hasNonWhitespaceText }
+            .compactMap(String.wmf_maybeNonWhitespaceString)
             .joined(separator: ", ") // Comma adds slight voice-over pause.
     }
     


### PR DESCRIPTION
For easy re-use by `compactMap`.

https://phabricator.wikimedia.org/T239176

https://github.com/wikimedia/wikipedia-ios/pull/3370#discussion_r351227356