### PR TITLE
Ensure callback is always on the main thread

### DIFF
--- a/Wikipedia/Code/ArticleSummaryController.swift
+++ b/Wikipedia/Code/ArticleSummaryController.swift
@@ -13,13 +13,12 @@ public class ArticleSummaryController: NSObject {
     @discardableResult public func updateOrCreateArticleSummaryForArticle(withKey articleKey: String, completion: ((WMFArticle?, Error?) -> Void)? = nil) -> String? {
         
         let cancellationKey = fetcher.fetchSummaryForArticle(with: articleKey) { [weak self] (articleSummary, urlResponse, error) in
-            guard let articleSummary = articleSummary,
-                error == nil else {
-                completion?(nil, error)
-                return
-            }
-            
             DispatchQueue.main.async {
+                guard let articleSummary = articleSummary,
+                    error == nil else {
+                    completion?(nil, error)
+                    return
+                }
                 self?.processSummaryResponses(with: [articleKey: articleSummary]) { (result, error) in
                     completion?(result[articleKey], error)
                 }


### PR DESCRIPTION
Fixes UI access on the main thread crash in 6.5.0 beta

```
Last Exception Backtrace:
0   CoreFoundation                	0x1a7ef180c __exceptionPreprocess + 220 (NSException.m:199)
1   libobjc.A.dylib               	0x1a7c19fa4 objc_exception_throw + 56 (objc-exception.mm:565)
2   Foundation                    	0x1a83c7f1c _AssertAutolayoutOnAllowedThreadsOnly + 320 (NSISEngine.m:0)
3   Foundation                    	0x1a81c906c -[NSISEngine withBehaviors:performModifications:] + 32 (NSISEngine.m:1904)
4   UIKitCore                     	0x1ac31fe58 -[UIView(AdditionalLayoutSupport) _switchToLayoutEngine:] + 188 (NSLayoutConstraint_UIKitAdditions.m:4060)
5   UIKitCore                     	0x1ac3da540 __45-[UIView(Hierarchy) _postMovedFromSuperview:]_block_invoke + 100 (UIView.m:11532)
6   UIKitCore                     	0x1ac3da450 -[UIView(Hierarchy) _postMovedFromSuperview:] + 748 (UIView.m:437)
7   UIKitCore                     	0x1ac3d8738 __UIViewWasRemovedFromSuperview + 172 (UIView.m:10909)
8   UIKitCore                     	0x1ac3d8218 -[UIView(Hierarchy) removeFromSuperview] + 380 (UIView.m:10961)
9   UIKitCore                     	0x1ac1e33c8 -[UITextSelectionView removeFromSuperview] + 428 (UITextSelectionView.m:489)
10  UIKitCore                     	0x1ac1ce798 -[UITextInteractionAssistant(UITextInteractionAssistant_Internal) deactivateSelection] + 48 (UITextInteractionAssistant.m:301)
11  WebKit                        	0x1af986564 -[WKContentView(WKInteractionPreview) contextMenuInteraction:previewForHighlightingMenuWithConfig... + 32 (WKContentViewInteraction.mm:8465)
12  UIKitCore                     	0x1ac474ad4 -[UIContextMenuInteraction _delegate_previewForHighlightingForConfiguration:] + 92 (UIContextMenuInteraction.m:1008)
13  UIKitCore                     	0x1ac471744 -[UIContextMenuInteraction clickPresentationInteraction:previewForHighlightingAtLocation:] + 72 (UIContextMenuInteraction.m:362)
14  UIKitCore                     	0x1abecf094 -[_UIClickPresentationInteraction _prepareInteractionEffect] + 156 (_UIClickPresentationInteraction.m:1104)
15  UIKitCore                     	0x1abeccbc0 -[_UIClickPresentationInteraction highlightEffectForClickInteraction:] + 128 (_UIClickPresentationInteraction.m:520)
16  UIKitCore                     	0x1abbf7954 -[_UIClickInteraction _beginInteraction] + 120 (_UIClickInteraction.m:153)
17  UIKitCore                     	0x1abbf8384 -[_UIClickInteraction clickDriver:didPerformEvent:] + 340 (_UIClickInteraction.m:0)
18  UIKitCore                     	0x1ab88bb88 __58-[_UILongPressClickInteractionDriver _prepareStateMachine]_block_invoke + 68 (_UILongPressClickInteractionDriver.m:121)
19  UIKitCore                     	0x1abfe2594 -[_UIStateMachine handleEvent:withContext:] + 412 (_UIStateMachine.m:162)
20  UIKitCore                     	0x1ab88c528 -[_UILongPressClickInteractionDriver _asyncGestureBegan] + 100 (_UILongPressClickInteractionDriver.m:297)
21  UIKitCore                     	0x1ab88c4b4 __63-[_UILongPressClickInteractionDriver _handleGestureRecognizer:]_block_invoke + 60 (_UILongPressClickInteractionDriver.m:0)
22  UIKitCore                     	0x1ac4749dc __73-[UIContextMenuInteraction _interactionShouldBeginAtLocation:completion:]_block_invoke + 304 (UIContextMenuInteraction.m:0)
23  WebKit                        	0x1af989390 -[WKContentView(WKInteractionPreview) continueContextMenuInteraction:]::$_43::operator()(UIContex... + 136 (BlockPtr.h:184)
24  Wikipedia                     	0x100045540 __89-[WMFArticleViewController webView:contextMenuConfigurationForElement:completionHandler:]_blo... + 52 (WMFArticleViewController.m:2111)
25  Wikipedia                     	0x1001cc8f8 closure #1 in ArticlePeekPreviewViewController.fetchArticle(_:) + 72 (<compiler-generated>:39)
26  WMF                           	0x100bcd0b0 closure #1 in ArticleSummaryController.updateOrCreateArticleSummaryForArticle(withKey:completion:) + 176 (ArticleSummaryController.swift:18)
27  WMF                           	0x100b7a840 closure #1 in ArticleSummaryFetcher.fetchSummaryForArticle(with:priority:completion:) + 64 (ArticleSummaryFetcher.swift:119)
28  WMF                           	0x100a88bf8 thunk for @escaping @callee_guaranteed (@guaranteed ArticleSummary?, @guaranteed NSURLResponse?, ... + 24 (<compiler-generated>:0)
29  WMF                           	0x100aaf554 specialized closure #1 in Fetcher.performMobileAppsServicesGET<A>(for:pathComponents:priority:can... + 88 (Fetcher.swift:121)
30  WMF                           	0x100b52e38 specialized closure #1 in Session.jsonDecodableTask<A>(with:method:bodyParameters:bodyEncoding:he... + 1080 (Session.swift:327)
31  WMF                           	0x100b4cf40 thunk for @escaping @callee_guaranteed (@guaranteed Data?, @guaranteed NSURLResponse?, @guarantee... + 148 (<compiler-generated>:0)
32  CFNetwork                     	0x1ab151724 __40-[__NSURLSessionLocal taskForClassInfo:]_block_invoke + 308 (LocalSession.mm:718)
33  CFNetwork                     	0x1ab161c9c __49-[__NSCFLocalSessionTask _task_onqueue_didFinish]_block_invoke + 216 (LocalSessionTask.mm:566)
34  Foundation                    	0x1a82b6430 __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__ + 16 (NSOperation.m:1541)
35  Foundation                    	0x1a81c0168 -[NSBlockOperation main] + 100 (NSOperation.m:1560)
36  Foundation                    	0x1a82b86b8 __NSOPERATION_IS_INVOKING_MAIN__ + 20 (NSOperation.m:2184)
37  Foundation                    	0x1a81bfe00 -[NSOperation start] + 732 (NSOperation.m:2201)
38  Foundation                    	0x1a82b90b0 __NSOPERATIONQUEUE_IS_STARTING_AN_OPERATION__ + 20 (NSOperation.m:2215)
39  Foundation                    	0x1a82b8b7c __NSOQSchedule_f + 180 (NSOperation.m:2226)
40  libdispatch.dylib             	0x1a7b717dc _dispatch_block_async_invoke2 + 104 (queue.c:525)
41  libdispatch.dylib             	0x1a7bbf184 _dispatch_client_callout + 16 (object.m:495)
42  libdispatch.dylib             	0x1a7b6b404 _dispatch_lane_serial_drain$VARIANT$mp + 608 (inline_internal.h:2484)
43  libdispatch.dylib             	0x1a7b6be28 _dispatch_lane_invoke$VARIANT$mp + 468 (queue.c:3863)
44  libdispatch.dylib             	0x1a7b75314 _dispatch_workloop_worker_thread + 588 (queue.c:6445)
45  libsystem_pthread.dylib       	0x1a7c0ef88 _pthread_wqthread + 276 (pthread.c:2323)
46  libsystem_pthread.dylib       	0x1a7c11ad4 start_wqthread + 8
```