### PR TITLE
Fix image gallery dismissal by no longer wrapping it in a UINavigationController

### DIFF
--- a/Wikipedia/Code/SinglePageWebViewController.swift
+++ b/Wikipedia/Code/SinglePageWebViewController.swift
@@ -65,6 +65,10 @@ class SinglePageWebViewController: ViewController {
     var fetched = false
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        if navigationController?.viewControllers.first === self {
+            let closeButton = UIBarButtonItem.wmf_buttonType(WMFButtonType.X, target: self, action: #selector(closeButtonTapped(_:)))
+            navigationItem.leftBarButtonItem = closeButton
+        }
         guard !fetched else {
             return
         }
@@ -104,6 +108,10 @@ class SinglePageWebViewController: ViewController {
     
     @objc func wButtonTapped(_ sender: UIButton) {
         navigationController?.popToRootViewController(animated: true)
+    }
+    
+    @objc func closeButtonTapped(_ sender: UIButton) {
+        navigationController?.dismiss(animated: true)
     }
 }
 

--- a/Wikipedia/Code/ViewControllerRouter.swift
+++ b/Wikipedia/Code/ViewControllerRouter.swift
@@ -17,6 +17,20 @@ class ViewControllerRouter: NSObject {
             completion()
             return false
         }
+        
+        let theme = appViewController.theme
+        
+        let present = { (viewController: UIViewController) in
+            defer {
+                completion()
+            }
+            if let presented = navigationController.presentedViewController {
+                let wrapper = WMFThemeableNavigationController(rootViewController: viewController, theme:theme, style: .gallery)
+                presented.present(wrapper, animated: true)
+            } else {
+                navigationController.pushViewController(viewController, animated: true)
+            }
+        }
 
         do {
             let destination = try router.destination(for: url)
@@ -30,8 +44,7 @@ class ViewControllerRouter: NSObject {
                 return true
             case .articleHistory(let linkURL, let articleTitle):
                 let pageHistoryVC = PageHistoryViewController(pageTitle: articleTitle, pageURL: linkURL)
-                navigationController.pushViewController(pageHistoryVC, animated: true)
-                completion()
+                present(pageHistoryVC)
                 return true
             case .articleDiffCompare(let linkURL, let fromRevID, let toRevID):
                 guard let siteURL = linkURL.wmf_site,
@@ -39,10 +52,8 @@ class ViewControllerRouter: NSObject {
                     completion()
                     return false
                 }
-                
-                let diffContainerVC = DiffContainerViewController(siteURL: siteURL, theme: appViewController.theme, fromRevisionID: fromRevID, toRevisionID: toRevID, type: .compare, articleTitle: nil, hidesHistoryBackTitle: true)
-                navigationController.pushViewController(diffContainerVC, animated: true)
-                completion()
+                let diffContainerVC = DiffContainerViewController(siteURL: siteURL, theme: theme, fromRevisionID: fromRevID, toRevisionID: toRevID, type: .compare, articleTitle: nil, hidesHistoryBackTitle: true)
+                present(diffContainerVC)
                 return true
             case .articleDiffSingle(let linkURL, let fromRevID, let toRevID):
                 guard let siteURL = linkURL.wmf_site,
@@ -50,22 +61,20 @@ class ViewControllerRouter: NSObject {
                     completion()
                     return false
                 }
-                
-                let diffContainerVC = DiffContainerViewController(siteURL: siteURL, theme: appViewController.theme, fromRevisionID: fromRevID, toRevisionID: toRevID, type: .single, articleTitle: nil, hidesHistoryBackTitle: true)
-                navigationController.pushViewController(diffContainerVC, animated: true)
-                completion()
+                let diffContainerVC = DiffContainerViewController(siteURL: siteURL, theme: theme, fromRevisionID: fromRevID, toRevisionID: toRevID, type: .single, articleTitle: nil, hidesHistoryBackTitle: true)
+                present(diffContainerVC)
                 return true
             case .inAppLink(let linkURL):
-                let singlePageVC = SinglePageWebViewController(url: linkURL, theme: appViewController.theme)
-                navigationController.pushViewController(singlePageVC, animated: true)
-                completion()
+                let singlePageVC = SinglePageWebViewController(url: linkURL, theme: theme)
+                present(singlePageVC)
                 return true
             case .userTalk(let linkURL):
-                guard let talkPageVC = TalkPageContainerViewController.userTalkPageContainer(url: linkURL, dataStore: appViewController.dataStore, theme: appViewController.theme) else {
+                guard let talkPageVC = TalkPageContainerViewController.userTalkPageContainer(url: linkURL, dataStore: appViewController.dataStore, theme: theme) else {
                     completion()
                     return false
                 }
-                navigationController.pushViewController(talkPageVC, animated: true)
+                present(talkPageVC)
+                return true
             default:
                 completion()
                 return false

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1984,8 +1984,12 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 }
 
 - (nullable UINavigationController *)currentNavigationController {
-    if ([self.presentedViewController isKindOfClass:[UINavigationController class]]) {
-        return (UINavigationController *)self.presentedViewController;
+    UIViewController *presented = self.presentedViewController;
+    while (presented.presentedViewController != nil) {
+        presented = presented.presentedViewController;
+    }
+    if ([presented isKindOfClass:[UINavigationController class]]) {
+        return (UINavigationController *)presented;
     } else {
         return self.navigationController;
     }

--- a/Wikipedia/Code/WMFArticleViewController.m
+++ b/Wikipedia/Code/WMFArticleViewController.m
@@ -1597,7 +1597,7 @@ NSString *const WMFEditPublishedNotification = @"WMFEditPublishedNotification";
     MWKImage *selectedImage = [[MWKImage alloc] initWithArticle:self.article sourceURL:imageSourceURL];
     WMFArticleImageGalleryViewController *fullscreenGallery = [[WMFArticleImageGalleryViewController alloc] initWithArticle:self.article selectedImage:selectedImage theme:self.theme overlayViewTopBarHidden:NO];
     if (fullscreenGallery != nil) {
-        [self presentViewControllerEmbeddedInNavigationController:fullscreenGallery style:WMFThemeableNavigationControllerStyleGallery];
+        [self presentViewController:fullscreenGallery animated:YES completion:NULL];
     }
 }
 
@@ -1875,7 +1875,7 @@ static const CGFloat WMFArticleViewControllerTableOfContentsSectionUpdateScrollD
     WMFArticleImageGalleryViewController *fullscreenGallery = [[WMFArticleImageGalleryViewController alloc] initWithArticle:self.article theme:self.theme overlayViewTopBarHidden:NO];
     //    fullscreenGallery.referenceViewDelegate = self;
     if (fullscreenGallery != nil) {
-        [self presentViewControllerEmbeddedInNavigationController:fullscreenGallery style:WMFThemeableNavigationControllerStyleGallery];
+        [self presentViewController:fullscreenGallery animated:YES completion:NULL];
     }
 }
 

--- a/Wikipedia/Code/WMFContentGroup+DetailViewControllers.swift
+++ b/Wikipedia/Code/WMFContentGroup+DetailViewControllers.swift
@@ -17,8 +17,7 @@ extension WMFContentGroup {
             guard let date = self.date else {
                 return nil
             }
-            let potd = WMFPOTDImageGalleryViewController(dates: [date], theme: theme, overlayViewTopBarHidden: false)
-            return WMFThemeableNavigationController(rootViewController: potd, theme: theme, style: .gallery)
+            return WMFPOTDImageGalleryViewController(dates: [date], theme: theme, overlayViewTopBarHidden: false)
         case .story, .event:
             return detailViewControllerWithDataStore(dataStore, theme: theme)
         default:


### PR DESCRIPTION
Work around the link-from-gallery issue (the original reason for wrapping the gallery) by presenting a `UINavigationController` from the gallery controller