### PR TITLE
Header labels are thrown off on rotation

### DIFF
--- a/Wikipedia/Code/CollectionViewHeader.swift
+++ b/Wikipedia/Code/CollectionViewHeader.swift
@@ -90,6 +90,11 @@ class CollectionViewHeader: SizeThatFitsReusableView {
         button.titleLabel?.font = UIFont.wmf_font(buttonTextStyle, compatibleWithTraitCollection: traitCollection)
     }
     
+    override func layoutMarginsDidChange() {
+        super.layoutMarginsDidChange()
+        setNeedsLayout()
+    }
+    
     override func sizeThatFits(_ size: CGSize, apply: Bool) -> CGSize {
         let additionalMargins: UIEdgeInsets
         switch style {


### PR DESCRIPTION
This is a work-in progress attempting to fix a bug where the title label in collection view headers can be misaligned after device rotation. It fixes the bug, but I’m not very confident in the solution because 1) I still don’t fully understand the reasons the bug happens and 2) I’m not sure if the solution is performant and also how it doesn’t cause draw() and layoutSubviews() to infinitely call each other.

   When it comes to the bug, I found some strange behavior. After `CollectionViewHeader.sizeThatFits()` and `wmf_preferredHeight` are called, the titleLabel’s position (frame.origin.x) is adjusted and correctly set . However, on-screen, the titleLabel will still be at the location it was at pre-rotation. Just to re-iterate, at this point, the frame is correct, but the screen is not reflecting that. 

 When you scroll the collection view up, and the titleLabel starts to leave the screen, the titleLabel redraws and moves to the correct position (the position that its frame was already set at, just not drawn at) 

 Since the frame was already correctly set, I’m trying to find a way to trigger it to get redrawn or relayouted to reflect it. 

 I’d be very interested to get some feedback or help understanding how the frame is being set but not being reflected, and how this solution could be improved to avoid redundant calls to layout and draw.