### PR TITLE
T151979 - To scroll via arrow keys on iPad hardware keyboard, need to tap into page content first to set focus

### DIFF
--- a/Wikipedia/Code/AboutViewController.plist
+++ b/Wikipedia/Code/AboutViewController.plist
@@ -144,6 +144,7 @@ THE SOFTWARE.</string>
 		<string>bart-kneepkens</string>
 		<string>Bernd Sitzmann</string>
 		<string>Boris Dušek</string>
+		<string>brett ohland</string>
 		<string>Brian Gerstle</string>
 		<string>Brion Vibber</string>
 		<string>Carolyn Li-Madeo</string>

--- a/Wikipedia/Code/WebViewController.m
+++ b/Wikipedia/Code/WebViewController.m
@@ -398,6 +398,8 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
     [self resetFindInPageWithCompletion:^{
         [[self findInPageKeyboardBar] hide];
         [self resignFirstResponder];
+        // Allows the webview to respond to keyboard events once again after the search bar has disappeared.
+        [self.webView becomeFirstResponder];
         if (completion) {
             completion();
         }
@@ -714,6 +716,14 @@ typedef NS_ENUM(NSUInteger, WMFFindInPageScrollDirection) {
     if (!self.indexHTMLDocumentLoadedFired && self.article && self.articleURL) {
         [self setArticle:self.article articleURL:self.articleURL];
     }
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    // Allows keyboard events from an external keyboard to scroll the webview without
+    // needing to first tap onto the webview.
+    [self.webView becomeFirstResponder];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T151979

- Sets web view to be first responder on viewDidAppear.
- Sets web view to be first reponder after search bar resigns first responder.

✅ Verified all automated tests still pass.