### PR TITLE
Fix outdated Settings subpage theming when interface style updates

### DIFF
--- a/Wikipedia/Code/AboutViewController.m
+++ b/Wikipedia/Code/AboutViewController.m
@@ -351,6 +351,8 @@ static NSString *const kWMFContributorsKey = @"contributors";
         return;
     }
     self.view.backgroundColor = theme.colors.paperBackground;
+    [self.webView wmf_setTextFontColor:theme];
+    [self.webView wmf_setLogoStyleWithTheme:theme];
 }
 
 @end

--- a/Wikipedia/Code/AboutViewController.plist
+++ b/Wikipedia/Code/AboutViewController.plist
@@ -155,6 +155,7 @@ THE SOFTWARE.</string>
 		<string>Dan Garry</string>
 		<string>Daniel McGlinchey</string>
 		<string>David Xia</string>
+		<string>Deepak Mantena</string>
 		<string>Dmitry Brant</string>
 		<string>Elena Tonkovidova</string>
 		<string>Ethan Holshouser</string>

--- a/Wikipedia/Code/BaseExploreFeedSettingsViewController.swift
+++ b/Wikipedia/Code/BaseExploreFeedSettingsViewController.swift
@@ -253,6 +253,7 @@ class BaseExploreFeedSettingsViewController: SubSettingsViewController {
         }
         view.backgroundColor = theme.colors.baseBackground
         tableView.backgroundColor = theme.colors.baseBackground
+        tableView.reloadData()
     }
 
 }

--- a/Wikipedia/Code/SearchSettingsViewController.swift
+++ b/Wikipedia/Code/SearchSettingsViewController.swift
@@ -48,6 +48,7 @@ final class SearchSettingsViewController: SubSettingsViewController {
         }
         view.backgroundColor = theme.colors.baseBackground
         tableView.backgroundColor = theme.colors.baseBackground
+        tableView.reloadData()
     }
 }
 

--- a/Wikipedia/Code/StorageAndSyncingSettingsViewController.swift
+++ b/Wikipedia/Code/StorageAndSyncingSettingsViewController.swift
@@ -176,6 +176,7 @@ class StorageAndSyncingSettingsViewController: SubSettingsViewController {
         view.backgroundColor = theme.colors.baseBackground
         tableView.backgroundColor = theme.colors.baseBackground
         eraseSavedArticlesView?.apply(theme: theme)
+        tableView.reloadData()
     }
 }
 


### PR DESCRIPTION
Currently, updating the system's light/dark interface style while viewing some Settings subpages results in that subpage failing to update to reflect the new style. The affected Settings subpages I noticed were Search, Explore feed, Article storage and syncing, and About the app. `AppearanceSettingsViewController` and `NotificationSettingsViewController` don't exhibit this issue because they reload table data when `apply(theme: ...)` is called. This PR addresses the affected pages by using this same approach where appropriate.

As a user, I might encounter this if I 1) backgrounded the app while in an affected Settings subpage and changed my device's appearance mode explicitly or 2) had my device's appearance mode change automatically via iOS's appearance schedule.

### REPRO STEPS

One way to reproduce this issue in the Simulator on the current `develop` branch:
1. Build and run the app, then navigate to Settings > Search.
2. Use Xcode's Environment Override to switch the interface style.
3. Note that the table cells are still styled per the original interface style.
 
![settings_theme_bug](https://user-images.githubusercontent.com/5652327/73895949-300fd800-4836-11ea-9c9c-10bdcef08c8c.gif)


### NOTES

A generalized alternative might be to handle this in the parent class. Since there's an expectation that `SubSettingsViewController`s have a `UITableView`, might be worth including something like this there:
```swift
override func apply(theme: Theme) {
    super.apply(theme: theme)
    if let tableView = tableView {
        tableView.reloadData()
    }
}
```

But it's probably more desirable keeping `SubSettingsViewController` itself as generic as possible, and letting its subclasses handle applying theme changes in context specific ways themselves. The `AboutViewController` is a great example of why keeping `SubSettingsViewController` generic is probably the better approach. 

Another area for improvement is only performing expensive operations like `reloadData()` if the incoming theme is different that the currently applied one. Better yet, only updating the theme for visible cells and accessory views instead of reloading the entire table.

Hope this helps!