### PR TITLE
mobile-html: Reference link and lead image bug fixes

### DIFF
--- a/WMF Framework/ArticleCacheController.swift
+++ b/WMF Framework/ArticleCacheController.swift
@@ -3,6 +3,7 @@ import Foundation
 
 public final class ArticleCacheController: CacheController {
     
+    #if DEBUG
     override public func add(url: URL, groupKey: CacheController.GroupKey, itemKey: CacheController.ItemKey? = nil, bypassGroupDeduping: Bool = false, itemCompletion: @escaping CacheController.ItemCompletionBlock, groupCompletion: @escaping CacheController.GroupCompletionBlock) {
         super.add(url: url, groupKey: groupKey, itemKey: itemKey, bypassGroupDeduping: bypassGroupDeduping, itemCompletion: itemCompletion, groupCompletion: groupCompletion)
         
@@ -20,6 +21,7 @@ public final class ArticleCacheController: CacheController {
             self.dbWriter.fetchAndPrintEachGroup()
         }
     }
+    #endif
 
     enum CacheFromMigrationError: Error {
         case noArticleFileWriter
@@ -38,7 +40,7 @@ public final class ArticleCacheController: CacheController {
             articleFileWriter.migrateCachedContent(content: content, itemKey: itemKey, mimeType: mimeType, success: {
                 
                 articleDBWriter.migratedCacheItemFile(itemKey: itemKey, success: {
-                    print("successfully migrated")
+                    DDLogDebug("successfully migrated")
                     completionHandler(nil)
 
                     DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 10) {

--- a/Wikipedia/Code/ArticleViewController+ArticleWebMessageHandling.swift
+++ b/Wikipedia/Code/ArticleViewController+ArticleWebMessageHandling.swift
@@ -73,7 +73,12 @@ extension ArticleViewController: ArticleWebMessageHandling {
         }
     }
     
-    func handleLeadImage(source: String, width: Int?, height: Int?) {
+    func handleLeadImage(source: String?, width: Int?, height: Int?) {
+        assert(Thread.isMainThread)
+        guard let source = source else {
+            leadImageHeightConstraint.constant = 0
+            return
+        }
         guard let leadImageURLToRequest = WMFArticle.imageURL(forTargetImageWidth: traitCollection.wmf_leadImageWidth, fromImageSource: source, withOriginalWidth: width ?? 0) else {
             return
         }

--- a/Wikipedia/Code/ArticleViewController+ArticleWebMessageHandling.swift
+++ b/Wikipedia/Code/ArticleViewController+ArticleWebMessageHandling.swift
@@ -74,9 +74,6 @@ extension ArticleViewController: ArticleWebMessageHandling {
     }
     
     func handleLeadImage(source: String, width: Int?, height: Int?) {
-        guard leadImageView.image == nil && leadImageView.wmf_imageURLToFetch == nil else {
-            return
-        }
         guard let leadImageURLToRequest = WMFArticle.imageURL(forTargetImageWidth: traitCollection.wmf_leadImageWidth, fromImageSource: source, withOriginalWidth: width ?? 0) else {
             return
         }

--- a/Wikipedia/Code/ArticleViewController+References.swift
+++ b/Wikipedia/Code/ArticleViewController+References.swift
@@ -37,6 +37,7 @@ extension ArticleViewController {
         vc.modalTransitionStyle = .crossDissolve
         vc.lastClickedReferencesIndex = selectedIndex
         vc.lastClickedReferencesGroup = references
+        vc.articleURL = articleURL
         present(vc, animated: false) { // should be false even if animated is true
             self.adjustScrollForReferencePageViewController(referencesBoundingClientRect, referenceRectInScrollCoordinates: referenceRectInScrollCoordinates, viewController: vc, animated: animated)
         }

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -266,9 +266,7 @@ class ArticleViewController: ViewController {
         defer {
             callLoadCompletionIfNecessary()
         }
-        if let leadImageURL = article.imageURL(forWidth: traitCollection.wmf_leadImageWidth) {
-            loadLeadImage(with: leadImageURL)
-        }
+
         guard let request = try? fetcher.mobileHTMLRequest(articleURL: articleURL) else {
             showGenericError()
             state = .error
@@ -713,6 +711,7 @@ extension ArticleViewController: ImageScaleTransitionProviding {
             return
         }
         
+        leadImageHeightConstraint.constant = leadImageHeight
         leadImageView.image = image
         leadImageView.layer.contentsRect = imageView.layer.contentsRect
         

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -396,6 +396,14 @@ class ArticleViewController: ViewController {
         shareArticle()
     }
     
+    // MARK: Navigation
+    
+    @objc(showAnchor:)
+    func show(anchor: String) {
+        dismiss(animated: false)
+        scroll(to: anchor, animated: true)
+    }
+    
     // MARK: Refresh
     
     @objc public func refresh() {

--- a/Wikipedia/Code/ArticleWebMessagingController.swift
+++ b/Wikipedia/Code/ArticleWebMessagingController.swift
@@ -136,7 +136,7 @@ extension ArticleWebMessagingController: WKScriptMessageHandler {
         case readMoreTitlesRetrieved
         case viewLicense
         case viewInBrowser
-        case leadImage(source: String, width: Int?, height: Int?)
+        case leadImage(source: String?, width: Int?, height: Int?)
         case tableOfContents(items: [TableOfContentsItem])
         case unknown(href: String)
     }
@@ -198,13 +198,11 @@ extension ArticleWebMessagingController: WKScriptMessageHandler {
             }
         }
         func getLeadImageAction(with data: [String: Any]?) -> Action? {
-            guard
-               let leadImage = data?["leadImage"] as? [String: Any],
-               let source = leadImage["source"] as? String else {
-                return nil
-            }
-            let width = leadImage["width"] as? Int
-            let height = leadImage["height"] as? Int
+            // Send back a lead image event even if it's empty - we need to handle this case
+            let leadImage = data?["leadImage"] as? [String: Any]
+            let source = leadImage?["source"] as? String
+            let width = leadImage?["width"] as? Int
+            let height = leadImage?["height"] as? Int
             return Action.leadImage(source: source, width: width, height: height)
         }
         

--- a/Wikipedia/Code/Properties.js
+++ b/Wikipedia/Code/Properties.js
@@ -1,7 +1,5 @@
 const leadImage = pcs.c1.Page.getLeadImage();
-if (leadImage) {
-    window.webkit.messageHandlers.{{messageHandlerName}}.postMessage({action: 'leadImage', data: {leadImage}});
-}
+window.webkit.messageHandlers.{{messageHandlerName}}.postMessage({action: 'leadImage', data: {leadImage}});
 const tableOfContents = pcs.c1.Page.getTableOfContents();
 if (tableOfContents) {
     window.webkit.messageHandlers.{{messageHandlerName}}.postMessage({action: 'tableOfContents', data: {tableOfContents}});

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -232,6 +232,8 @@ static const NSString *kvo_SavedArticlesFetcher_progress = @"kvo_SavedArticlesFe
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(talkPageReplyWasPublished:) name:WMFTalkPageContainerViewController.WMFReplyPublishedNotificationName object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(talkPageTopicWasPublished:) name:WMFTalkPageContainerViewController.WMFTopicPublishedNotificationName object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(referenceLinkTapped:) name:WMFReferenceLinkTappedNotification object:nil];
 
     [self setupReadingListsHelpers];
     self.editHintController = [[WMFEditHintController alloc] init];
@@ -544,6 +546,14 @@ static const NSString *kvo_SavedArticlesFetcher_progress = @"kvo_SavedArticlesFe
 
 - (void)talkPageTopicWasPublished:(NSNotification *)note {
     [self toggleHint:self.talkPageTopicHintController context:nil];
+}
+
+- (void)referenceLinkTapped:(NSNotification *)note {
+    id maybeURL = [note object];
+    if (![maybeURL isKindOfClass:[NSURL class]]) {
+        return;
+    }
+    [self wmf_navigateToURL:maybeURL];
 }
 
 - (void)toggleHint:(HintController *)hintController context:(nullable NSDictionary<NSString *, id> *)context {
@@ -1215,6 +1225,9 @@ static const NSString *kvo_SavedArticlesFetcher_progress = @"kvo_SavedArticlesFe
     NSString *visibleKey = visibleArticleViewController.articleURL.wmf_databaseKey;
     NSString *articleKey = articleURL.wmf_databaseKey;
     if (visibleKey && articleKey && [visibleKey isEqualToString:articleKey]) {
+        if (articleURL.fragment) {
+            [visibleArticleViewController showAnchor:articleURL.fragment];
+        }
         completion();
         return visibleArticleViewController;
     }

--- a/Wikipedia/Code/WMFReferencePageViewController.swift
+++ b/Wikipedia/Code/WMFReferencePageViewController.swift
@@ -15,12 +15,13 @@ extension UIViewController {
 class WMFReferencePageViewController: UIViewController, UIPageViewControllerDataSource, Themeable {
     @objc var lastClickedReferencesIndex:Int = 0
     @objc var lastClickedReferencesGroup = [WMFLegacyReference]()
-    
     @objc weak internal var appearanceDelegate: WMFReferencePageViewAppearanceDelegate?
     
     @objc public var pageViewController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
     @IBOutlet fileprivate var containerView: UIView!
     
+    var articleURL: URL?
+
     var theme = Theme.standard
     
     func apply(theme: Theme) {
@@ -36,6 +37,7 @@ class WMFReferencePageViewController: UIViewController, UIPageViewControllerData
         
         for reference in self.lastClickedReferencesGroup {
             let panel = WMFReferencePanelViewController.wmf_viewControllerFromReferencePanelsStoryboard()
+            panel.articleURL = articleURL
             panel.apply(theme: self.theme)
             panel.reference = reference
             controllers.append(panel)

--- a/Wikipedia/Code/WMFReferencePanelViewController.swift
+++ b/Wikipedia/Code/WMFReferencePanelViewController.swift
@@ -2,6 +2,7 @@ import WMF
 
 class WMFReferencePanelViewController: UIViewController, Themeable {
     var theme = Theme.standard
+    var articleURL: URL?
     
     @objc(applyTheme:)
     func apply(theme: Theme) {
@@ -47,6 +48,7 @@ class WMFReferencePanelViewController: UIViewController, Themeable {
     
     fileprivate lazy var containerController: WMFReferencePopoverMessageViewController = {
         let referenceVC = WMFReferencePopoverMessageViewController.wmf_initialViewControllerFromClassStoryboard()
+        referenceVC?.articleURL = articleURL
         if let trc = referenceVC as Themeable? {
             trc.apply(theme: self.theme)
         }

--- a/Wikipedia/Code/WMFReferencePopoverMessageViewController.h
+++ b/Wikipedia/Code/WMFReferencePopoverMessageViewController.h
@@ -1,6 +1,8 @@
 @import UIKit;
 @import WMF.Swift;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class WMFLegacyReference;
 
 extern NSString *const WMFReferenceLinkTappedNotification;
@@ -10,9 +12,11 @@ extern NSString *const WMFReferenceLinkTappedNotification;
 @property (nonatomic) CGFloat width;
 @property (nonatomic) BOOL scrollEnabled;
 
-@property (strong, nonatomic) WMFLegacyReference *reference;
-@property (strong, nonatomic) NSURL *articleURL;
+@property (strong, nonatomic, nullable) WMFLegacyReference *reference;
+@property (strong, nonatomic, nullable) NSURL *articleURL;
 
 - (void)scrollToTop;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
- Fixes an issue where links in reference popovers wouldn't work when tapped
- Fixes an issue where the page content would extend under the lead image view because mobile-html thought the page had no lead image but the app loaded a lead image