### PR TITLE
Fix inconsistent `UISwitch` state when Search settings table cells are configured

### DIFF
--- a/Wikipedia/Code/SearchSettingsViewController.swift
+++ b/Wikipedia/Code/SearchSettingsViewController.swift
@@ -18,15 +18,18 @@ final class SearchSettingsViewController: SubSettingsViewController {
         super.viewDidLoad()
         tableView.register(WMFSettingsTableViewCell.wmf_classNib(), forCellReuseIdentifier: WMFSettingsTableViewCell.identifier)
         title = CommonStrings.searchTitle
+        reloadSectionData()
     }
 
-    private lazy var sections: [Section] = {
+    private lazy var sections: [Section] = []
+
+    private func reloadSectionData() {
         let showLanguagesOnSearch = Item(title: WMFLocalizedString("settings-language-bar", value: "Show languages on search", comment: "Title in Settings for toggling the display the language bar in the search view"), isOn: UserDefaults.standard.wmf_showSearchLanguageBar(), controlTag: 1)
         let openAppOnSearchTab = Item(title: WMFLocalizedString("settings-search-open-app-on-search", value: "Open app on Search tab", comment: "Title for setting that allows users to open app on Search tab"), isOn: UserDefaults.standard.wmf_openAppOnSearchTab, controlTag: 2)
         let items = [showLanguagesOnSearch, openAppOnSearchTab]
         let sections = [Section(items: items, footerTitle: WMFLocalizedString("settings-search-footer-text", value: "Set the app to open to the Search tab instead of the Explore tab", comment: "Footer text for section that allows users to customize certain Search settings"))]
-        return sections
-    }()
+        self.sections = sections
+    }
 
     private func getSection(at index: Int) -> Section {
         assert(sections.indices.contains(index), "Section at index \(index) doesn't exist")
@@ -95,5 +98,6 @@ extension SearchSettingsViewController: WMFSettingsTableViewCellDelegate {
         default:
             break
         }
+        reloadSectionData()
     }
 }


### PR DESCRIPTION
For certain Settings subpages, it's possible that table cells can get configured with stale data. One of the places I noticed this is in the "Search" Settings subpage. When toggling a switch in this view, then scrolling away and returning to the toggled row, the switch's value resets to its initial value instead of the new toggled value.

When this Search subpage is presented, its table's data is constructed on initialization and never directly mutated. So while a user's toggling of a switch does change the underlying data store (`UserDefaults`), it doesn't change the intermediary data store (`sections`) used to configure the actual table.

This leads to stale data being presented. The immutable value type section data (`sections`) is reused as if it had reference semantics (specifically `UserDefaults.wmf.wmf_showSearchLanguageBar()`), so when the table cell is reconfigured for display it's incorrect. `sections` doesn't represent the underlying data store's state again until the user returns to Settings and taps into Search again. This PR addresses the issue in the Search settings subpage.

**REPRO STEPS**

Here are Simulator repro steps on a fresh install (easier to replicate on devices with constrained vertical sizes like the iPhone SE):

1. Load Settings > Search
2. Observe the current state of the "Show languages on search" switch
3. Toggle the "Show languages on search" switch
4. Scroll the table such that the "Show languages on search" switch goes off screen
5. Scroll back to the reconfigured "Show languages on search" row and observe its state is the same as in step 2 instead of step 3

![settings_state](https://user-images.githubusercontent.com/5652327/74869681-41181900-530d-11ea-9740-083c580a17c3.gif)

**NOTES**

The solution presented here is a low-touch tradeoff based the size of the data set. It would be an unfavorably expensive call if the data set's characteristics were such that it could be unusually large or grew dynamically.

Another option would be to mutate the `sections` data to update appropriately when the user taps a switch. Ideally it might make sense for the private `Section` and `Item` structs to have reference semantics instead, so the `isOn` property is always representative of the data store's "truth", avoiding this intermediate stale data situation altogether.