### PR TITLE
mobile-html: Migrate article if load fails and migration is required

### DIFF
--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -294,16 +294,20 @@ class ArticleViewController: ViewController {
         }
     }
     
-    func loadPage() {
+    func loadPage(allowCache: Bool = true) {
         defer {
             callLoadCompletionIfNecessary()
         }
         
-        guard let request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, forceCache: forceCache, scheme: schemeHandler.scheme) else {
+        guard var request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, forceCache: allowCache && forceCache, scheme: schemeHandler.scheme) else {
 
             showGenericError()
             state = .error
             return
+        }
+        
+        if !allowCache {
+            request.cachePolicy = .reloadIgnoringLocalCacheData
         }
         
         footerLoadGroup = DispatchGroup()
@@ -471,7 +475,7 @@ class ArticleViewController: ViewController {
     // MARK: Refresh
     
     @objc public func refresh() {
-        webView.reload()
+        loadPage(allowCache: false)
     }
     
     // MARK: Overrideable functionality

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -817,7 +817,8 @@ extension ArticleViewController: ImageScaleTransitionProviding {
 }
 
 extension ArticleViewController: WKNavigationDelegate {
-    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+    
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         guard article.isConversionFromMobileViewNeeded else {
             showError(error)
             return
@@ -828,7 +829,7 @@ extension ArticleViewController: WKNavigationDelegate {
                     self.showError(error)
                     return
                 }
-                guard self.article.isConversionFromMobileViewNeeded else {
+                guard !self.article.isConversionFromMobileViewNeeded else {
                     self.showGenericError()
                     return
                 }


### PR DESCRIPTION
- Migrate article if load fails and migration is required https://phabricator.wikimedia.org/T244621
- Ensure reload from pull to refresh doesn't use cached data https://phabricator.wikimedia.org/T242062