### PR TITLE
Verify the etag changed before updating the cache

### DIFF
--- a/WMF Framework/PermanentlyPersistableURLCache.swift
+++ b/WMF Framework/PermanentlyPersistableURLCache.swift
@@ -479,6 +479,14 @@ extension PermanentlyPersistableURLCache {
             guard isCached else {
                 return
             }
+
+            let cachedHeaders = self.permanentlyCachedHeaders(for: request)
+            let cachedETag = cachedHeaders?[HTTPURLResponse.etagHeaderKey]
+            let responseETag = httpResponse.allHeaderFields[HTTPURLResponse.etagHeaderKey] as? String
+            guard cachedETag == nil || cachedETag != responseETag else {
+                return
+            }
+            
             let headerFileName = self.uniqueHeaderFileNameForItemKey(itemKey, variant: variant)
             let contentFileName = self.uniqueFileNameForItemKey(itemKey, variant: variant)
             


### PR DESCRIPTION
Ensure that even if we get a 200 status code from the server that if the ETag didn't change, the cache files won't be rewritten