### PR TITLE
Language fixes

### DIFF
--- a/WMF Framework/ArticleCacheController.swift
+++ b/WMF Framework/ArticleCacheController.swift
@@ -56,9 +56,9 @@ public final class ArticleCacheController: CacheController {
                     
                     self.fileWriter.add(groupKey: groupKey, urlRequest: urlRequest) { (fileWriterResult) in
                         switch fileWriterResult {
-                        case .success(let data, let mimeType, let variesOnLanguage):
+                        case .success(let response, let data):
                             
-                            self.dbWriter.markDownloaded(urlRequest: urlRequest, shouldSetVariant: variesOnLanguage) { (dbWriterResult) in
+                            self.dbWriter.markDownloaded(urlRequest: urlRequest, response: response) { (dbWriterResult) in
                             
                                 defer {
                                     group.leave()
@@ -149,7 +149,7 @@ public final class ArticleCacheController: CacheController {
                 
                 self.fileWriter.addMobileHtmlContentForMigration(content: content, urlRequest: urlRequest, mimeType: mimeType, success: {
 
-                    articleDBWriter.markDownloaded(urlRequest: urlRequest, shouldSetVariant: false) { (result) in
+                    articleDBWriter.markDownloaded(urlRequest: urlRequest, response: nil) { (result) in
                         switch result {
                         case .success:
                             
@@ -195,7 +195,7 @@ public final class ArticleCacheController: CacheController {
                     
                     self.fileWriter.addBundledResourcesForMigration(urlRequests: requests, success: { (_) in
                         
-                        let bulkRequests = requests.map { ArticleCacheDBWriter.BulkMarkDownloadRequest(urlRequest: $0, shouldSetVariant: false) }
+                        let bulkRequests = requests.map { ArticleCacheDBWriter.BulkMarkDownloadRequest(urlRequest: $0, response: nil) }
                         articleDBWriter.markDownloaded(requests: bulkRequests) { (result) in
                             switch result {
                             case .success:

--- a/WMF Framework/ArticleCacheController.swift
+++ b/WMF Framework/ArticleCacheController.swift
@@ -56,9 +56,9 @@ public final class ArticleCacheController: CacheController {
                     
                     self.fileWriter.add(groupKey: groupKey, urlRequest: urlRequest) { (fileWriterResult) in
                         switch fileWriterResult {
-                        case .success(let data, let mimeType):
+                        case .success(let data, let mimeType, let variesOnLanguage):
                             
-                            self.dbWriter.markDownloaded(urlRequest: urlRequest) { (dbWriterResult) in
+                            self.dbWriter.markDownloaded(urlRequest: urlRequest, shouldSetVariant: variesOnLanguage) { (dbWriterResult) in
                             
                                 defer {
                                     group.leave()
@@ -149,7 +149,7 @@ public final class ArticleCacheController: CacheController {
                 
                 self.fileWriter.addMobileHtmlContentForMigration(content: content, urlRequest: urlRequest, mimeType: mimeType, success: {
 
-                    articleDBWriter.markDownloaded(urlRequest: urlRequest) { (result) in
+                    articleDBWriter.markDownloaded(urlRequest: urlRequest, shouldSetVariant: false) { (result) in
                         switch result {
                         case .success:
                             
@@ -195,7 +195,8 @@ public final class ArticleCacheController: CacheController {
                     
                     self.fileWriter.addBundledResourcesForMigration(urlRequests: requests, success: { (_) in
                         
-                        articleDBWriter.markDownloaded(urlRequests: requests) { (result) in
+                        let bulkRequests = requests.map { ArticleCacheDBWriter.BulkMarkDownloadRequest(urlRequest: $0, shouldSetVariant: false) }
+                        articleDBWriter.markDownloaded(requests: bulkRequests) { (result) in
                             switch result {
                             case .success:
                                 completionHandler(nil)

--- a/WMF Framework/ArticleCacheDBWriter+SyncResources.swift
+++ b/WMF Framework/ArticleCacheDBWriter+SyncResources.swift
@@ -81,7 +81,7 @@ extension ArticleCacheDBWriter {
                     let variant = self.articleFetcher.variantForURL(url, type: .article)
                     
                     guard let itemKeyAndVariant = CacheController.ItemKeyAndVariant(itemKey: itemKey, variant: variant),
-                        let urlRequest = self.articleFetcher.urlRequestFromURL(url, type: .article) else {
+                        let urlRequest = self.articleFetcher.urlRequestFromPersistence(with: url, persistType: .article) else {
                         return nil
                     }
                     
@@ -97,7 +97,7 @@ extension ArticleCacheDBWriter {
                     let variant = self.articleFetcher.variantForURL(url, type: .image)
                     
                     guard let itemKeyAndVariant = CacheController.ItemKeyAndVariant(itemKey: itemKey, variant: variant),
-                        let urlRequest = self.articleFetcher.urlRequestFromURL(url, type: .image) else {
+                        let urlRequest = self.articleFetcher.urlRequestFromPersistence(with: url, persistType: .image) else {
                         return nil
                     }
                     
@@ -137,7 +137,7 @@ extension ArticleCacheDBWriter {
                     
                     let variant = self.articleFetcher.variantForURL(url, type: .imageInfo)
                     guard let itemKeyAndVariant = CacheController.ItemKeyAndVariant(itemKey: itemKey, variant: variant),
-                        let urlRequest = self.articleFetcher.urlRequestFromURL(url, type: .imageInfo) else {
+                        let urlRequest = self.articleFetcher.urlRequestFromPersistence(with: url, persistType: .imageInfo) else {
                         return nil
                     }
                     

--- a/WMF Framework/ArticleCacheResourceDBWriting.swift
+++ b/WMF Framework/ArticleCacheResourceDBWriting.swift
@@ -97,9 +97,8 @@ extension ArticleCacheResourceDBWriting {
                         return
                 }
                 
-                let variant = self.fetcher.variantForURLRequest(urlRequest)
-                
-                guard let item = CacheDBWriterHelper.fetchOrCreateCacheItem(with: url, itemKey: itemKey, variant: variant, in: context) else {
+                //note, we purposefully do not set variant here. We need to wait until CacheFileWriter determines if the response varies on language, then set it when we call markDownloaded
+                guard let item = CacheDBWriterHelper.fetchOrCreateCacheItem(with: url, itemKey: itemKey, variant: nil, in: context) else {
                     completion(.failure(ArticleCacheDBWriterError.failureFetchOrCreateMustHaveCacheItem))
                     return
                 }
@@ -115,13 +114,10 @@ extension ArticleCacheResourceDBWriting {
                         continue
                 }
                 
-                let variant = self.fetcher.variantForURLRequest(urlRequest)
-                
-                guard let item = CacheDBWriterHelper.fetchOrCreateCacheItem(with: url, itemKey: itemKey, variant: variant, in: context) else {
+                guard let item = CacheDBWriterHelper.fetchOrCreateCacheItem(with: url, itemKey: itemKey, variant: nil, in: context) else {
                     continue
                 }
                 
-                item.variant = variant
                 group.addToCacheItems(item)
             }
             

--- a/WMF Framework/CacheController.swift
+++ b/WMF Framework/CacheController.swift
@@ -195,9 +195,9 @@ public class CacheController {
                         }
                         
                         switch result {
-                        case .success(let data, let mimeType, let variesOnLanguage):
+                        case .success(let response, let data):
                             
-                            self.dbWriter.markDownloaded(urlRequest: urlRequest, shouldSetVariant: variesOnLanguage) { (result) in
+                            self.dbWriter.markDownloaded(urlRequest: urlRequest, response: response) { (result) in
                                 
                                 defer {
                                     group.leave()
@@ -218,7 +218,7 @@ public class CacheController {
                                 self.gatekeeper.runAndRemoveIndividualCompletions(uniqueKey: uniqueKey, individualResult: individualResult)
                             }
                             
-                            self.finishFileSave(data: data, mimeType: mimeType, uniqueKey: uniqueKey, url: url)
+                            self.finishFileSave(data: data, mimeType: response.mimeType, uniqueKey: uniqueKey, url: url)
                             
                         case .failure(let error):
                             

--- a/WMF Framework/CacheController.swift
+++ b/WMF Framework/CacheController.swift
@@ -195,9 +195,9 @@ public class CacheController {
                         }
                         
                         switch result {
-                        case .success(let data, let mimeType):
+                        case .success(let data, let mimeType, let variesOnLanguage):
                             
-                            self.dbWriter.markDownloaded(urlRequest: urlRequest) { (result) in
+                            self.dbWriter.markDownloaded(urlRequest: urlRequest, shouldSetVariant: variesOnLanguage) { (result) in
                                 
                                 defer {
                                     group.leave()

--- a/WMF Framework/CacheDBWriting.swift
+++ b/WMF Framework/CacheDBWriting.swift
@@ -50,42 +50,11 @@ protocol CacheDBWriting: CacheTaskTracking {
     func remove(itemAndVariantKey: CacheController.ItemKeyAndVariant, completion: @escaping (CacheDBWritingResult) -> Void)
     func remove(groupKey: String, completion: @escaping (CacheDBWritingResult) -> Void)
     func fetchKeysToRemove(for groupKey: CacheController.GroupKey, completion: @escaping CacheDBWritingCompletionWithItemAndVariantKeys)
-    func markDownloaded(urlRequest: URLRequest, completion: @escaping (CacheDBWritingResult) -> Void)
+    func markDownloaded(urlRequest: URLRequest, shouldSetVariant: Bool, completion: @escaping (CacheDBWritingResult) -> Void)
 }
 
 extension CacheDBWriting {
-    
-    func markDownloaded(urlRequest: URLRequest, completion: @escaping (CacheDBWritingResult) -> Void) {
-        
-        guard let context = CacheController.backgroundCacheContext else {
-            completion(.failure(CacheDBWritingMarkDownloadedError.missingMOC))
-            return
-        }
-        
-        guard let itemKey = fetcher.itemKeyForURLRequest(urlRequest) else {
-            completion(.failure(CacheDBWritingMarkDownloadedError.unableToDetermineItemKey))
-            return
-        }
-        
-        let variant = fetcher.variantForURLRequest(urlRequest)
-    
-        context.perform {
-            guard let cacheItem = CacheDBWriterHelper.cacheItem(with: itemKey, variant: variant, in: context) else {
-                completion(.failure(CacheDBWritingMarkDownloadedError.cannotFindCacheItem))
-                return
-            }
-            cacheItem.isDownloaded = true
-            CacheDBWriterHelper.save(moc: context) { (result) in
-                switch result {
-                case .success:
-                    completion(.success)
-                case .failure(let error):
-                    completion(.failure(error))
-                }
-            }
-        }
-    }
-    
+
     func fetchKeysToRemove(for groupKey: CacheController.GroupKey, completion: @escaping CacheDBWritingCompletionWithItemAndVariantKeys) {
         
         guard let context = CacheController.backgroundCacheContext else {

--- a/WMF Framework/CacheDBWriting.swift
+++ b/WMF Framework/CacheDBWriting.swift
@@ -50,7 +50,7 @@ protocol CacheDBWriting: CacheTaskTracking {
     func remove(itemAndVariantKey: CacheController.ItemKeyAndVariant, completion: @escaping (CacheDBWritingResult) -> Void)
     func remove(groupKey: String, completion: @escaping (CacheDBWritingResult) -> Void)
     func fetchKeysToRemove(for groupKey: CacheController.GroupKey, completion: @escaping CacheDBWritingCompletionWithItemAndVariantKeys)
-    func markDownloaded(urlRequest: URLRequest, shouldSetVariant: Bool, completion: @escaping (CacheDBWritingResult) -> Void)
+    func markDownloaded(urlRequest: URLRequest, response: HTTPURLResponse?, completion: @escaping (CacheDBWritingResult) -> Void)
 }
 
 extension CacheDBWriting {

--- a/WMF Framework/CacheFetching.swift
+++ b/WMF Framework/CacheFetching.swift
@@ -19,7 +19,7 @@ public protocol CacheFetching {
     typealias DataCompletion = (Result<CacheFetchingResult, Error>) -> Void
     
     //internally populates urlRequest with cache header fields
-    func dataForURL(_ url: URL, type: Header.PersistItemType, completion: @escaping DataCompletion) -> URLSessionTask?
+    func dataForURL(_ url: URL, persistType: Header.PersistItemType, completion: @escaping DataCompletion) -> URLSessionTask?
     
     //assumes urlRequest is already populated with cache header fields
     func dataForURLRequest(_ urlRequest: URLRequest, completion: @escaping DataCompletion) -> URLSessionTask?
@@ -72,9 +72,9 @@ extension CacheFetching where Self:Fetcher {
         return task
     }
     
-    @discardableResult public func dataForURL(_ url: URL, type: Header.PersistItemType, completion: @escaping DataCompletion) -> URLSessionTask? {
+    @discardableResult public func dataForURL(_ url: URL, persistType: Header.PersistItemType, completion: @escaping DataCompletion) -> URLSessionTask? {
         
-        guard let urlRequest = session.urlRequestFromURL(url, type: type) else {
+        guard let urlRequest = session.urlRequestFromPersistence(with: url, persistType: persistType) else {
             completion(.failure(CacheFetchingError.unableToDetermineURLRequest))
             return nil
         }
@@ -132,8 +132,8 @@ extension CacheFetching where Self:Fetcher {
         return session.variantForURL(url, type: type)
     }
     
-    public func urlRequestFromURL(_ url: URL, type: Header.PersistItemType, cachePolicy: URLRequest.CachePolicy? = nil) -> URLRequest? {
-        return session.urlRequestFromURL(url, type: type, cachePolicy: cachePolicy)
+    public func urlRequestFromPersistence(with url: URL, persistType: Header.PersistItemType, cachePolicy: URLRequest.CachePolicy? = nil, headers: [String: String] = [:]) -> URLRequest? {
+        return session.urlRequestFromPersistence(with: url, persistType: persistType, cachePolicy: cachePolicy, headers: headers)
     }
     
     public func uniqueHeaderFileNameForItemKey(_ itemKey: CacheController.ItemKey, variant: String?) -> String? {

--- a/WMF Framework/CacheFileWriter.swift
+++ b/WMF Framework/CacheFileWriter.swift
@@ -77,8 +77,8 @@ final class CacheFileWriter: CacheTaskTracking {
                 }
                 
                 self.fetcher.cacheResponse(httpUrlResponse: httpUrlResponse, content: .data(result.data), mimeType: result.response.mimeType, urlRequest: urlRequest, success: {
-                    let varyHeaderValue = httpUrlResponse.allHeaderFields["vary"] as? String ?? nil
-                    let variesOnLanguage = varyHeaderValue?.contains("Accept-Language") ?? false
+                    let varyHeaderValue = httpUrlResponse.allHeaderFields[HTTPURLResponse.varyHeaderKey] as? String ?? nil
+                    let variesOnLanguage = varyHeaderValue?.contains(HTTPURLResponse.acceptLanguageHeaderValue) ?? false
                     completion(.success(data: result.data, mimeType: result.response.mimeType, variesOnLanguage: variesOnLanguage))
                 }) { (error) in
                     completion(.failure(error))

--- a/WMF Framework/CacheFileWriter.swift
+++ b/WMF Framework/CacheFileWriter.swift
@@ -16,7 +16,7 @@ enum CacheFileWriterError: Error {
 }
 
 enum CacheFileWriterAddResult {
-    case success(data: Data, mimeType: String?)
+    case success(data: Data, mimeType: String?, variesOnLanguage: Bool)
     case failure(Error)
 }
 
@@ -77,7 +77,9 @@ final class CacheFileWriter: CacheTaskTracking {
                 }
                 
                 self.fetcher.cacheResponse(httpUrlResponse: httpUrlResponse, content: .data(result.data), mimeType: result.response.mimeType, urlRequest: urlRequest, success: {
-                    completion(.success(data: result.data, mimeType: result.response.mimeType))
+                    let varyHeaderValue = httpUrlResponse.allHeaderFields["vary"] as? String ?? nil
+                    let variesOnLanguage = varyHeaderValue?.contains("Accept-Language") ?? false
+                    completion(.success(data: result.data, mimeType: result.response.mimeType, variesOnLanguage: variesOnLanguage))
                 }) { (error) in
                     completion(.failure(error))
                 }

--- a/WMF Framework/CacheFileWriter.swift
+++ b/WMF Framework/CacheFileWriter.swift
@@ -16,7 +16,7 @@ enum CacheFileWriterError: Error {
 }
 
 enum CacheFileWriterAddResult {
-    case success(data: Data, mimeType: String?, variesOnLanguage: Bool)
+    case success(response: HTTPURLResponse, data: Data)
     case failure(Error)
 }
 
@@ -77,9 +77,7 @@ final class CacheFileWriter: CacheTaskTracking {
                 }
                 
                 self.fetcher.cacheResponse(httpUrlResponse: httpUrlResponse, content: .data(result.data), mimeType: result.response.mimeType, urlRequest: urlRequest, success: {
-                    let varyHeaderValue = httpUrlResponse.allHeaderFields[HTTPURLResponse.varyHeaderKey] as? String ?? nil
-                    let variesOnLanguage = varyHeaderValue?.contains(HTTPURLResponse.acceptLanguageHeaderValue) ?? false
-                    completion(.success(data: result.data, mimeType: result.response.mimeType, variesOnLanguage: variesOnLanguage))
+                    completion(.success(response: httpUrlResponse, data: result.data))
                 }) { (error) in
                     completion(.failure(error))
                 }

--- a/WMF Framework/ImageCacheController.swift
+++ b/WMF Framework/ImageCacheController.swift
@@ -97,7 +97,7 @@ public final class ImageCacheController: CacheController {
             }
             let schemedURL = (url as NSURL).wmf_urlByPrependingSchemeIfSchemeless() as URL
             
-            let task = self.imageFetcher.dataForURL(schemedURL, type: .image) { (result) in
+            let task = self.imageFetcher.dataForURL(schemedURL, persistType: .image) { (result) in
                 switch result {
                 case .failure(let error):
                     guard !self.isCancellationError(error) else {

--- a/WMF Framework/ImageCacheDBWriter.swift
+++ b/WMF Framework/ImageCacheDBWriter.swift
@@ -40,7 +40,7 @@ final class ImageCacheDBWriter: CacheDBWriting {
         cacheImages(groupKey: groupKey, urlRequests: urlRequests, completion: completion)
     }
     
-    func markDownloaded(urlRequest: URLRequest, shouldSetVariant: Bool, completion: @escaping (CacheDBWritingResult) -> Void) {
+    func markDownloaded(urlRequest: URLRequest, response: HTTPURLResponse?, completion: @escaping (CacheDBWritingResult) -> Void) {
         
         guard let context = CacheController.backgroundCacheContext else {
             completion(.failure(CacheDBWritingMarkDownloadedError.missingMOC))

--- a/WMF Framework/ImageCacheDBWriter.swift
+++ b/WMF Framework/ImageCacheDBWriter.swift
@@ -25,7 +25,7 @@ final class ImageCacheDBWriter: CacheDBWriting {
     
     func add(url: URL, groupKey: CacheController.GroupKey, completion: @escaping (CacheDBWritingResultWithURLRequests) -> Void) {
         
-        guard let urlRequest = imageFetcher.urlRequestFromURL(url, type: .image) else {
+        guard let urlRequest = imageFetcher.urlRequestFromPersistence(with: url, persistType: .image) else {
             completion(.failure(ImageCacheDBWriterError.unableToDetermineURLRequest))
             return
         }
@@ -35,7 +35,7 @@ final class ImageCacheDBWriter: CacheDBWriting {
     
     func add(urls: [URL], groupKey: CacheController.GroupKey, completion: @escaping (CacheDBWritingResultWithURLRequests) -> Void) {
         
-        let urlRequests = urls.compactMap { imageFetcher.urlRequestFromURL($0, type: .image) }
+        let urlRequests = urls.compactMap { imageFetcher.urlRequestFromPersistence(with: $0, persistType: .image) }
         
         cacheImages(groupKey: groupKey, urlRequests: urlRequests, completion: completion)
     }

--- a/WMF Framework/PermanentlyPersistableURLCache.swift
+++ b/WMF Framework/PermanentlyPersistableURLCache.swift
@@ -654,6 +654,8 @@ private extension PermanentlyPersistableURLCache {
 public extension HTTPURLResponse {
     static let etagHeaderKey = "Etag"
     static let ifNoneMatchHeaderKey = "If-None-Match"
+    static let varyHeaderKey = "Vary"
+    static let acceptLanguageHeaderValue = "Accept-Language"
 }
 
 public extension Array where Element == CacheController.ItemKeyAndVariant {

--- a/Wikipedia/Code/ArticleFetcher.swift
+++ b/Wikipedia/Code/ArticleFetcher.swift
@@ -199,7 +199,7 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
     
     public func urlRequest(from url: URL, cachePolicy: URLRequest.CachePolicy? = nil) -> URLRequest? {
         
-        let request = urlRequestFromURL(url, type: .article, cachePolicy: cachePolicy)
+        let request = urlRequestFromPersistence(with: url, persistType: .article, cachePolicy: cachePolicy)
         
         return request
     }

--- a/Wikipedia/Code/MWKImageInfoFetcher.m
+++ b/Wikipedia/Code/MWKImageInfoFetcher.m
@@ -211,7 +211,7 @@ metadataLanguage:(nullable NSString *)metadataLanguage
 
 - (nullable NSURLRequest *)urlRequestForFromURL: (NSURL *)url {
     
-    return [self.session imageInfoURLRequestFromURL:url];
+    return [self.session imageInfoURLRequestFromPersistenceWith: url];
 }
 
 - (id<MWKImageInfoRequest>)fetchInfoForTitles:(NSArray *)titles

--- a/Wikipedia/Code/Session.swift
+++ b/Wikipedia/Code/Session.swift
@@ -238,8 +238,7 @@ import Foundation
                 }
             }
             
-            if let _ = error,
-            request.cachePolicy != .reloadIgnoringLocalCacheData {
+            if let _ = error {
                 
                 if let cachedResponse = self.defaultPermanentCache.cachedResponse(for: request) {
                     completionHandler(cachedResponse.data, cachedResponse.response, nil)
@@ -678,8 +677,7 @@ class SessionDelegate: NSObject, URLSessionDelegate, URLSessionDataDelegate {
         if let error = error as NSError? {
             if error.domain != NSURLErrorDomain || error.code != NSURLErrorCancelled {
                 
-                if let request = task.currentRequest,
-                request.cachePolicy != .reloadIgnoringLocalCacheData,
+                if let request = task.originalRequest,
                 let cachedResponse = (session.configuration.urlCache as? PermanentlyPersistableURLCache)?.cachedResponse(for: request) {
                     callback.response?(cachedResponse.response)
                     callback.data?(cachedResponse.data)

--- a/Wikipedia/Code/Session.swift
+++ b/Wikipedia/Code/Session.swift
@@ -529,12 +529,23 @@ enum SessionPermanentCacheError: Error {
 
 extension Session {
     
-    @objc func imageInfoURLRequestFromURL(_ url: URL) -> URLRequest? {
-        return urlRequestFromURL(url, type: .imageInfo)
+    @objc func imageInfoURLRequestFromPersistence(with url: URL) -> URLRequest? {
+        return urlRequestFromPersistence(with: url, persistType: .imageInfo)
     }
     
-    func urlRequestFromURL(_ url: URL, type: Header.PersistItemType, cachePolicy: URLRequest.CachePolicy? = nil) -> URLRequest? {
-        return defaultPermanentCache.urlRequestFromURL(url, type: type, cachePolicy: cachePolicy)
+    func urlRequestFromPersistence(with url: URL, persistType: Header.PersistItemType, cachePolicy: URLRequest.CachePolicy? = nil, headers: [String: String] = [:]) -> URLRequest? {
+        
+        var permanentCacheRequest = defaultPermanentCache.urlRequestFromURL(url, type: persistType, cachePolicy: cachePolicy)
+        
+        let sessionRequest = request(with: url, method: .get, bodyParameters: nil, bodyEncoding: .json, headers: headers)
+        
+        if let headerFields = sessionRequest?.allHTTPHeaderFields {
+            for (key, value) in headerFields {
+                permanentCacheRequest.addValue(value, forHTTPHeaderField: key)
+            }
+        }
+        
+        return permanentCacheRequest
     }
     
     public func typeHeadersForType(_ type: Header.PersistItemType) -> [String: String] {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T240017

- Now checking `"Vary":"Accept-Language"` in response header for populating variant in the DB.
- Also funneling new URLRequest generation methods through old Session method so default `accept-language` headers are populated.
- Added fix to update any variant of an article or image info request - it doesn't have to be that particular language variant. To test this piece: 

1. Prefer Chinese Simplified language in iOS Settings
2. Save zh.wiki article.
3. Go to airplane mode, change iOS Settings to Chinese Traditional. Load article, confirm old article version shows (fallback still works).
4. Leave airplane mode, load article, confirm you see traditional variant content.
5. Re-enter airplane mode, load article, confirm you see traditional variant content. Simplified was updated with Traditional content in step 4.
