### PR TITLE
Cache policy fixes

### DIFF
--- a/WMF Framework/CacheFetching.swift
+++ b/WMF Framework/CacheFetching.swift
@@ -132,8 +132,8 @@ extension CacheFetching where Self:Fetcher {
         return session.variantForURL(url, type: type)
     }
     
-    public func urlRequestFromPersistence(with url: URL, persistType: Header.PersistItemType, cachePolicyRawValue: UInt? = nil, headers: [String: String] = [:]) -> URLRequest? {
-        return session.urlRequestFromPersistence(with: url, persistType: persistType, cachePolicyRawValue: cachePolicyRawValue, headers: headers)
+    public func urlRequestFromPersistence(with url: URL, persistType: Header.PersistItemType, cachePolicy: WMFCachePolicy? = nil, headers: [String: String] = [:]) -> URLRequest? {
+        return session.urlRequestFromPersistence(with: url, persistType: persistType, cachePolicy: cachePolicy, headers: headers)
     }
     
     public func uniqueHeaderFileNameForItemKey(_ itemKey: CacheController.ItemKey, variant: String?) -> String? {

--- a/WMF Framework/CacheFetching.swift
+++ b/WMF Framework/CacheFetching.swift
@@ -132,8 +132,8 @@ extension CacheFetching where Self:Fetcher {
         return session.variantForURL(url, type: type)
     }
     
-    public func urlRequestFromPersistence(with url: URL, persistType: Header.PersistItemType, cachePolicy: URLRequest.CachePolicy? = nil, headers: [String: String] = [:]) -> URLRequest? {
-        return session.urlRequestFromPersistence(with: url, persistType: persistType, cachePolicy: cachePolicy, headers: headers)
+    public func urlRequestFromPersistence(with url: URL, persistType: Header.PersistItemType, cachePolicyRawValue: UInt? = nil, headers: [String: String] = [:]) -> URLRequest? {
+        return session.urlRequestFromPersistence(with: url, persistType: persistType, cachePolicyRawValue: cachePolicyRawValue, headers: headers)
     }
     
     public func uniqueHeaderFileNameForItemKey(_ itemKey: CacheController.ItemKey, variant: String?) -> String? {

--- a/WMF Framework/CacheFileWriter.swift
+++ b/WMF Framework/CacheFileWriter.swift
@@ -77,8 +77,8 @@ final class CacheFileWriter: CacheTaskTracking {
                 }
                 
                 self.fetcher.cacheResponse(httpUrlResponse: httpUrlResponse, content: .data(result.data), mimeType: result.response.mimeType, urlRequest: urlRequest, success: {
-                    let varyHeaderValue = httpUrlResponse.allHeaderFields["vary"] as? String ?? nil
-                    let variesOnLanguage = varyHeaderValue?.contains("Accept-Language") ?? false
+                    let varyHeaderValue = httpUrlResponse.allHeaderFields[HTTPURLResponse.varyHeaderKey] as? String ?? nil
+                    let variesOnLanguage = varyHeaderValue?.contains(HTTPURLResponse.acceptLanguageHeaderValue) ?? false
                     completion(.success(data: result.data, mimeType: result.response.mimeType, variesOnLanguage: variesOnLanguage))
                 }) { (error) in
                     completion(.failure(error))

--- a/WMF Framework/PermanentlyPersistableURLCache.swift
+++ b/WMF Framework/PermanentlyPersistableURLCache.swift
@@ -654,6 +654,8 @@ private extension PermanentlyPersistableURLCache {
 public extension HTTPURLResponse {
     static let etagHeaderKey = "Etag"
     static let ifNoneMatchHeaderKey = "If-None-Match"
+    static let varyHeaderKey = "Vary"
+    static let acceptLanguageHeaderValue = "Accept-Language"
 }
 
 public extension Array where Element == CacheController.ItemKeyAndVariant {

--- a/WMF Framework/PermanentlyPersistableURLCache.swift
+++ b/WMF Framework/PermanentlyPersistableURLCache.swift
@@ -85,12 +85,10 @@ extension PermanentlyPersistableURLCache {
         }
         
         if let cachePolicyRawValue = cachePolicyRawValue {
-            if let cachePolicy = URLRequest.CachePolicy(rawValue: cachePolicyRawValue) {
+            if cachePolicyRawValue == URLRequest.CachePolicy.noPersistentCacheOnError {
+                request.setValue(String(URLRequest.CachePolicy.noPersistentCacheOnError), forHTTPHeaderField: URLRequest.customCachePolicyHeaderKey)
+            } else if let cachePolicy = URLRequest.CachePolicy(rawValue: cachePolicyRawValue) {
                 request.cachePolicy = cachePolicy
-            } else {
-                if cachePolicyRawValue == URLRequest.CachePolicy.noReallyForceRemoteOnly {
-                    request.setValue(String(URLRequest.CachePolicy.noReallyForceRemoteOnly), forHTTPHeaderField: HTTPURLResponse.customCachePolicy)
-                }
             }
         }
         
@@ -111,7 +109,7 @@ extension PermanentlyPersistableURLCache {
             guard let cachedHeaders = permanentlyCachedHeaders(for: urlRequest) else {
                 break
             }
-            headers[HTTPURLResponse.ifNoneMatchHeaderKey] = cachedHeaders[HTTPURLResponse.etagHeaderKey]
+            headers[URLRequest.ifNoneMatchHeaderKey] = cachedHeaders[HTTPURLResponse.etagHeaderKey]
         case .image:
             break
         }
@@ -143,7 +141,7 @@ private extension PermanentlyPersistableURLCache {
                 if let keyString = key as? String,
                     let valueString = value as? String,
                     keyString == HTTPURLResponse.etagHeaderKey {
-                    urlRequest.setValue(valueString, forHTTPHeaderField: HTTPURLResponse.ifNoneMatchHeaderKey)
+                    urlRequest.setValue(valueString, forHTTPHeaderField: URLRequest.ifNoneMatchHeaderKey)
                 }
             }
         }
@@ -588,7 +586,7 @@ private extension PermanentlyPersistableURLCache {
                 return nil
         }
         
-        assert(!Thread.isMainThread)
+        //assert(!Thread.isMainThread)
         
         guard let responseData = FileManager.default.contents(atPath: CacheFileWriterHelper.fileURL(for: responseFileName).path) else {
             return nil
@@ -659,10 +657,13 @@ private extension PermanentlyPersistableURLCache {
 
 public extension HTTPURLResponse {
     static let etagHeaderKey = "Etag"
-    static let ifNoneMatchHeaderKey = "If-None-Match"
     static let varyHeaderKey = "Vary"
     static let acceptLanguageHeaderValue = "Accept-Language"
-    static let customCachePolicy = "Custom-Cache-Policy"
+}
+
+public extension URLRequest {
+    static let ifNoneMatchHeaderKey = "If-None-Match"
+    static let customCachePolicyHeaderKey = "Custom-Cache-Policy"
 }
 
 public extension Array where Element == CacheController.ItemKeyAndVariant {

--- a/WMF Framework/PermanentlyPersistableURLCache.swift
+++ b/WMF Framework/PermanentlyPersistableURLCache.swift
@@ -68,7 +68,7 @@ class PermanentlyPersistableURLCache: URLCache {
 //MARK: Public - URLRequest Creation
 
 extension PermanentlyPersistableURLCache {
-    func urlRequestFromURL(_ url: URL, type: Header.PersistItemType, cachePolicy: URLRequest.CachePolicy? = nil) -> URLRequest {
+    func urlRequestFromURL(_ url: URL, type: Header.PersistItemType, cachePolicyRawValue: UInt? = nil) -> URLRequest {
         
         var request = URLRequest(url: url)
         
@@ -84,8 +84,14 @@ extension PermanentlyPersistableURLCache {
             request.setValue(value, forHTTPHeaderField: key)
         }
         
-        if let cachePolicy = cachePolicy {
-            request.cachePolicy = cachePolicy
+        if let cachePolicyRawValue = cachePolicyRawValue {
+            if let cachePolicy = URLRequest.CachePolicy(rawValue: cachePolicyRawValue) {
+                request.cachePolicy = cachePolicy
+            } else {
+                if cachePolicyRawValue == URLRequest.CachePolicy.noReallyForceRemoteOnly {
+                    request.setValue(String(URLRequest.CachePolicy.noReallyForceRemoteOnly), forHTTPHeaderField: HTTPURLResponse.customCachePolicy)
+                }
+            }
         }
         
         return request
@@ -656,6 +662,7 @@ public extension HTTPURLResponse {
     static let ifNoneMatchHeaderKey = "If-None-Match"
     static let varyHeaderKey = "Vary"
     static let acceptLanguageHeaderValue = "Accept-Language"
+    static let customCachePolicy = "Custom-Cache-Policy"
 }
 
 public extension Array where Element == CacheController.ItemKeyAndVariant {

--- a/Wikipedia/Code/ArticleFetcher.swift
+++ b/Wikipedia/Code/ArticleFetcher.swift
@@ -170,18 +170,18 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
         return url
     }
     
-    public func mobileHTMLMediaListRequest(articleURL: URL, cachePolicy: URLRequest.CachePolicy? = nil) throws -> URLRequest {
+    public func mobileHTMLMediaListRequest(articleURL: URL, cachePolicyRawValue: UInt? = nil) throws -> URLRequest {
         
         let url = try mediaListURL(articleURL: articleURL)
         
-        if let urlRequest = urlRequest(from: url, cachePolicy: cachePolicy) {
+        if let urlRequest = urlRequest(from: url, cachePolicyRawValue: cachePolicyRawValue) {
             return urlRequest
         } else {
             throw ArticleFetcherError.unableToGenerateURLRequest
         }
     }
     
-    public func mobileHTMLOfflineResourcesRequest(articleURL: URL, cachePolicy: URLRequest.CachePolicy? = nil) throws -> URLRequest {
+    public func mobileHTMLOfflineResourcesRequest(articleURL: URL, cachePolicyRawValue: UInt? = nil) throws -> URLRequest {
         guard
             let articleTitle = articleURL.wmf_title,
             let percentEncodedTitle = articleTitle.percentEncodedPageTitleForPathComponents,
@@ -190,21 +190,21 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
             throw RequestError.invalidParameters
         }
         
-        if let urlRequest = urlRequest(from: url, cachePolicy: cachePolicy) {
+        if let urlRequest = urlRequest(from: url, cachePolicyRawValue: cachePolicyRawValue) {
             return urlRequest
         } else {
             throw ArticleFetcherError.unableToGenerateURLRequest
         }
     }
     
-    public func urlRequest(from url: URL, cachePolicy: URLRequest.CachePolicy? = nil) -> URLRequest? {
+    public func urlRequest(from url: URL, cachePolicyRawValue: UInt? = nil) -> URLRequest? {
         
-        let request = urlRequestFromPersistence(with: url, persistType: .article, cachePolicy: cachePolicy)
+        let request = urlRequestFromPersistence(with: url, persistType: .article, cachePolicyRawValue: cachePolicyRawValue)
         
         return request
     }
     
-    public func mobileHTMLRequest(articleURL: URL, scheme: String? = nil, cachePolicy: URLRequest.CachePolicy? = nil) throws -> URLRequest {
+    public func mobileHTMLRequest(articleURL: URL, scheme: String? = nil, cachePolicyRawValue: UInt? = nil) throws -> URLRequest {
         
         var url = try mobileHTMLURL(articleURL: articleURL)
         
@@ -214,7 +214,7 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
             url = urlComponents?.url ?? url
         }
         
-        if let urlRequest = urlRequest(from: url, cachePolicy: cachePolicy) {
+        if let urlRequest = urlRequest(from: url, cachePolicyRawValue: cachePolicyRawValue) {
             return urlRequest
         } else {
             throw ArticleFetcherError.unableToGenerateURLRequest

--- a/Wikipedia/Code/ArticleFetcher.swift
+++ b/Wikipedia/Code/ArticleFetcher.swift
@@ -170,18 +170,18 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
         return url
     }
     
-    public func mobileHTMLMediaListRequest(articleURL: URL, cachePolicyRawValue: UInt? = nil) throws -> URLRequest {
+    public func mobileHTMLMediaListRequest(articleURL: URL, cachePolicy: WMFCachePolicy? = nil) throws -> URLRequest {
         
         let url = try mediaListURL(articleURL: articleURL)
         
-        if let urlRequest = urlRequest(from: url, cachePolicyRawValue: cachePolicyRawValue) {
+        if let urlRequest = urlRequest(from: url, cachePolicy: cachePolicy) {
             return urlRequest
         } else {
             throw ArticleFetcherError.unableToGenerateURLRequest
         }
     }
     
-    public func mobileHTMLOfflineResourcesRequest(articleURL: URL, cachePolicyRawValue: UInt? = nil) throws -> URLRequest {
+    public func mobileHTMLOfflineResourcesRequest(articleURL: URL, cachePolicy: WMFCachePolicy? = nil) throws -> URLRequest {
         guard
             let articleTitle = articleURL.wmf_title,
             let percentEncodedTitle = articleTitle.percentEncodedPageTitleForPathComponents,
@@ -190,21 +190,21 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
             throw RequestError.invalidParameters
         }
         
-        if let urlRequest = urlRequest(from: url, cachePolicyRawValue: cachePolicyRawValue) {
+        if let urlRequest = urlRequest(from: url, cachePolicy: cachePolicy) {
             return urlRequest
         } else {
             throw ArticleFetcherError.unableToGenerateURLRequest
         }
     }
     
-    public func urlRequest(from url: URL, cachePolicyRawValue: UInt? = nil) -> URLRequest? {
+    public func urlRequest(from url: URL, cachePolicy: WMFCachePolicy? = nil) -> URLRequest? {
         
-        let request = urlRequestFromPersistence(with: url, persistType: .article, cachePolicyRawValue: cachePolicyRawValue)
+        let request = urlRequestFromPersistence(with: url, persistType: .article, cachePolicy: cachePolicy)
         
         return request
     }
     
-    public func mobileHTMLRequest(articleURL: URL, scheme: String? = nil, cachePolicyRawValue: UInt? = nil) throws -> URLRequest {
+    public func mobileHTMLRequest(articleURL: URL, scheme: String? = nil, cachePolicy: WMFCachePolicy? = nil) throws -> URLRequest {
         
         var url = try mobileHTMLURL(articleURL: articleURL)
         
@@ -214,7 +214,7 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
             url = urlComponents?.url ?? url
         }
         
-        if let urlRequest = urlRequest(from: url, cachePolicyRawValue: cachePolicyRawValue) {
+        if let urlRequest = urlRequest(from: url, cachePolicy: cachePolicy) {
             return urlRequest
         } else {
             throw ArticleFetcherError.unableToGenerateURLRequest

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -291,17 +291,17 @@ class ArticleViewController: ViewController {
         state = .loading
         
         setupPageContentServiceJavaScriptInterface {
-            let cachePolicy: URLRequest.CachePolicy? = self.fromNavStateRestoration ? .returnCacheDataElseLoad : nil
-            self.loadPage(cachePolicyRawValue: cachePolicy?.rawValue)
+            let cachePolicy: WMFCachePolicy? = self.fromNavStateRestoration ? .foundation(.returnCacheDataElseLoad) : nil
+            self.loadPage(cachePolicy: cachePolicy)
         }
     }
     
-    func loadPage(cachePolicyRawValue: UInt? = nil) {
+    func loadPage(cachePolicy: WMFCachePolicy? = nil) {
         defer {
             callLoadCompletionIfNecessary()
         }
         
-        guard var request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, scheme: schemeHandler.scheme, cachePolicyRawValue: cachePolicyRawValue) else {
+        guard var request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, scheme: schemeHandler.scheme, cachePolicy: cachePolicy) else {
 
             showGenericError()
             state = .error
@@ -496,7 +496,7 @@ class ArticleViewController: ViewController {
     // MARK: Refresh
     
     @objc public func refresh() {
-        loadPage(cachePolicyRawValue: URLRequest.CachePolicy.noPersistentCacheOnError)
+        loadPage(cachePolicy: .noPersistentCacheOnError)
     }
     
     // MARK: Overrideable functionality

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -496,7 +496,7 @@ class ArticleViewController: ViewController {
     // MARK: Refresh
     
     @objc public func refresh() {
-        loadPage(cachePolicyRawValue: URLRequest.CachePolicy.noReallyForceRemoteOnly)
+        loadPage(cachePolicyRawValue: URLRequest.CachePolicy.noPersistentCacheOnError)
     }
     
     // MARK: Overrideable functionality
@@ -840,16 +840,19 @@ extension ArticleViewController: ImageScaleTransitionProviding {
 // MARK: - Article Load Errors
 
 extension ArticleViewController {
-    func handleArticleLoadFailure(with error: Error) {
+    func handleArticleLoadFailure(with error: Error, showEmptyView: Bool) {
         fakeProgressController.finish()
-        wmf_showEmptyView(of: .articleDidNotLoad, theme: theme, frame: view.bounds)
+        if showEmptyView {
+            wmf_showEmptyView(of: .articleDidNotLoad, theme: theme, frame: view.bounds)
+        }
         showError(error)
+        refreshControl.endRefreshing()
     }
     
     func articleLoadDidFail(with error: Error) {
         // Convert from mobileview if necessary
         guard article.isConversionFromMobileViewNeeded else {
-            handleArticleLoadFailure(with: error)
+            handleArticleLoadFailure(with: error, showEmptyView: !article.isSaved)
             return
         }
         dataStore.migrateMobileviewToMobileHTMLIfNecessary(article: article) { [weak self] (migrationError) in
@@ -861,11 +864,11 @@ extension ArticleViewController {
     
     func oneOffArticleMigrationDidFinish(with migrationError: Error?) {
         if let error = migrationError {
-            handleArticleLoadFailure(with: error)
+            handleArticleLoadFailure(with: error, showEmptyView: true)
             return
         }
         guard !article.isConversionFromMobileViewNeeded else {
-            handleArticleLoadFailure(with: RequestError.unexpectedResponse)
+            handleArticleLoadFailure(with: RequestError.unexpectedResponse, showEmptyView: true)
             return
         }
         loadPage()

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -292,16 +292,16 @@ class ArticleViewController: ViewController {
         
         setupPageContentServiceJavaScriptInterface {
             let cachePolicy: URLRequest.CachePolicy? = self.fromNavStateRestoration ? .returnCacheDataElseLoad : nil
-            self.loadPage(cachePolicy: cachePolicy)
+            self.loadPage(cachePolicyRawValue: cachePolicy?.rawValue)
         }
     }
     
-    func loadPage(cachePolicy: URLRequest.CachePolicy? = nil) {
+    func loadPage(cachePolicyRawValue: UInt? = nil) {
         defer {
             callLoadCompletionIfNecessary()
         }
         
-        guard var request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, scheme: schemeHandler.scheme, cachePolicy: cachePolicy) else {
+        guard var request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, scheme: schemeHandler.scheme, cachePolicyRawValue: cachePolicyRawValue) else {
 
             showGenericError()
             state = .error
@@ -496,7 +496,7 @@ class ArticleViewController: ViewController {
     // MARK: Refresh
     
     @objc public func refresh() {
-        loadPage(cachePolicy: .reloadIgnoringLocalCacheData)
+        loadPage(cachePolicyRawValue: URLRequest.CachePolicy.noReallyForceRemoteOnly)
     }
     
     // MARK: Overrideable functionality

--- a/Wikipedia/Code/SchemeHandler/SchemeHandler.swift
+++ b/Wikipedia/Code/SchemeHandler/SchemeHandler.swift
@@ -114,7 +114,7 @@ private extension SchemeHandler {
         //set If-None-Match in header if it doesn't already exist
         
         let containsType = mutableRequest.allHTTPHeaderFields?[Header.persistentCacheItemType] != nil
-        let containsIfNoneMatch = mutableRequest.allHTTPHeaderFields?[HTTPURLResponse.ifNoneMatchHeaderKey] != nil
+        let containsIfNoneMatch = mutableRequest.allHTTPHeaderFields?[URLRequest.ifNoneMatchHeaderKey] != nil
 
         if var request = maybeRequest {
 

--- a/Wikipedia/Code/Session.swift
+++ b/Wikipedia/Code/Session.swift
@@ -1,7 +1,18 @@
 import Foundation
 
-public extension URLRequest.CachePolicy {
-    static let noPersistentCacheOnError: UInt = 99
+public enum WMFCachePolicy {
+    case foundation(URLRequest.CachePolicy)
+    case noPersistentCacheOnError
+    
+    var rawValue: UInt {
+        
+        switch self {
+        case .foundation(let cachePolicy):
+            return cachePolicy.rawValue
+        case .noPersistentCacheOnError:
+            return 99
+        }
+    }
 }
 
 @objc(WMFSession) public class Session: NSObject {
@@ -537,9 +548,9 @@ extension Session {
         return urlRequestFromPersistence(with: url, persistType: .imageInfo)
     }
     
-    func urlRequestFromPersistence(with url: URL, persistType: Header.PersistItemType, cachePolicyRawValue: UInt? = nil, headers: [String: String] = [:]) -> URLRequest? {
+    func urlRequestFromPersistence(with url: URL, persistType: Header.PersistItemType, cachePolicy: WMFCachePolicy? = nil, headers: [String: String] = [:]) -> URLRequest? {
         
-        var permanentCacheRequest = defaultPermanentCache.urlRequestFromURL(url, type: persistType, cachePolicyRawValue: cachePolicyRawValue)
+        var permanentCacheRequest = defaultPermanentCache.urlRequestFromURL(url, type: persistType, cachePolicy: cachePolicy)
         
         let sessionRequest = request(with: url, method: .get, bodyParameters: nil, bodyEncoding: .json, headers: headers)
         
@@ -697,17 +708,5 @@ class SessionDelegate: NSObject, URLSessionDelegate, URLSessionDataDelegate {
         }
         
         callback.success()
-    }
-}
-
-fileprivate extension URLRequest {
-    var prefersPersistentCacheOverError: Bool {
-        if let customCachePolicyValue = allHTTPHeaderFields?[URLRequest.customCachePolicyHeaderKey],
-            let intCustomCachePolicyValue = UInt(customCachePolicyValue),
-            intCustomCachePolicyValue == URLRequest.CachePolicy.noPersistentCacheOnError {
-            return false
-        }
-        
-        return true
     }
 }

--- a/Wikipedia/Code/Session.swift
+++ b/Wikipedia/Code/Session.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+public extension URLRequest.CachePolicy {
+    static let noReallyForceRemoteOnly: UInt = 99
+}
+
 @objc(WMFSession) public class Session: NSObject {
     
     public struct Request {
@@ -532,9 +536,9 @@ extension Session {
         return urlRequestFromPersistence(with: url, persistType: .imageInfo)
     }
     
-    func urlRequestFromPersistence(with url: URL, persistType: Header.PersistItemType, cachePolicy: URLRequest.CachePolicy? = nil, headers: [String: String] = [:]) -> URLRequest? {
+    func urlRequestFromPersistence(with url: URL, persistType: Header.PersistItemType, cachePolicyRawValue: UInt? = nil, headers: [String: String] = [:]) -> URLRequest? {
         
-        var permanentCacheRequest = defaultPermanentCache.urlRequestFromURL(url, type: persistType, cachePolicy: cachePolicy)
+        var permanentCacheRequest = defaultPermanentCache.urlRequestFromURL(url, type: persistType, cachePolicyRawValue: cachePolicyRawValue)
         
         let sessionRequest = request(with: url, method: .get, bodyParameters: nil, bodyEncoding: .json, headers: headers)
         

--- a/Wikipedia/Code/Session.swift
+++ b/Wikipedia/Code/Session.swift
@@ -238,8 +238,7 @@ import Foundation
                 }
             }
             
-            if let _ = error,
-            request.cachePolicy != .reloadIgnoringLocalCacheData {
+            if let _ = error {
                 
                 if let cachedResponse = self.defaultPermanentCache.cachedResponse(for: request) {
                     completionHandler(cachedResponse.data, cachedResponse.response, nil)
@@ -678,8 +677,7 @@ class SessionDelegate: NSObject, URLSessionDelegate, URLSessionDataDelegate {
         if let error = error as NSError? {
             if error.domain != NSURLErrorDomain || error.code != NSURLErrorCancelled {
                 
-                if let request = task.currentRequest,
-                request.cachePolicy != .reloadIgnoringLocalCacheData,
+                if let request = task.originalRequest,
                 let cachedResponse = (session.configuration.urlCache as? PermanentlyPersistableURLCache)?.cachedResponse(for: request) {
                     callback.response?(cachedResponse.response)
                     callback.data?(cachedResponse.data)


### PR DESCRIPTION
Review https://github.com/wikimedia/wikipedia-ios/pull/3478 first.

PR for discussion - added a custom cache policy in  `a9a1365` &  `6b0b008` that is tacked onto the URLRequest header. This gives us the pull to refresh error banner for the user in airplane mode without the previous regression issue of all saved articles showing a failed state.