### PR TITLE
Stop the SavedArticlesFetcher when offline

### DIFF
--- a/WMF Framework/CacheController.swift
+++ b/WMF Framework/CacheController.swift
@@ -1,10 +1,10 @@
 
 import Foundation
 
-enum CacheControllerError: Error {
-    case atLeastOneItemFailedInFileWriter
+public enum CacheControllerError: Error {
+    case atLeastOneItemFailedInFileWriter(Error)
     case failureToGenerateItemResult
-    case atLeastOneItemFailedInSync
+    case atLeastOneItemFailedInSync(Error)
 }
 
 public class CacheController {
@@ -161,7 +161,7 @@ public class CacheController {
             case .success(let urlRequests):
                 
                 var successfulKeys: [CacheController.UniqueKey] = []
-                var failedKeys: [CacheController.UniqueKey] = []
+                var failedKeys: [(CacheController.UniqueKey, Error)] = []
                 
                 let group = DispatchGroup()
                 for urlRequest in urlRequests {
@@ -211,7 +211,7 @@ public class CacheController {
                                     individualResult = FinalIndividualResult.success(uniqueKey: uniqueKey)
                                     
                                 case .failure(let error):
-                                    failedKeys.append(uniqueKey)
+                                    failedKeys.append((uniqueKey, error))
                                     individualResult = FinalIndividualResult.failure(error: error)
                                 }
                                 
@@ -226,16 +226,19 @@ public class CacheController {
                                 group.leave()
                             }
                             
-                            failedKeys.append(uniqueKey)
+                            failedKeys.append((uniqueKey, error))
                             let individualResult = FinalIndividualResult.failure(error: error)
                             self.gatekeeper.runAndRemoveIndividualCompletions(uniqueKey: uniqueKey, individualResult: individualResult)
                         }
                     }
                     
                     group.notify(queue: DispatchQueue.global(qos: .userInitiated)) {
-                        
-                        let groupResult = failedKeys.count > 0 ? FinalGroupResult.failure(error: CacheControllerError.atLeastOneItemFailedInFileWriter) : FinalGroupResult.success(uniqueKeys: successfulKeys)
-                        
+                        let groupResult: FinalGroupResult
+                        if let error = failedKeys.first?.1 {
+                            groupResult = FinalGroupResult.failure(error: CacheControllerError.atLeastOneItemFailedInFileWriter(error))
+                        } else {
+                            groupResult = FinalGroupResult.success(uniqueKeys: successfulKeys)
+                        }
                         groupCompleteBlock(groupResult)
                     }
                 }
@@ -286,7 +289,7 @@ public class CacheController {
             case .success(let keys):
                 
                 var successfulKeys: [CacheController.UniqueKey] = []
-                var failedKeys: [CacheController.UniqueKey] = []
+                var failedKeys: [(CacheController.UniqueKey, Error)] = []
                 
                 let group = DispatchGroup()
                 for key in keys {
@@ -323,7 +326,7 @@ public class CacheController {
                                     successfulKeys.append(uniqueKey)
                                     individualResult = FinalIndividualResult.success(uniqueKey: uniqueKey)
                                 case .failure(let error):
-                                    failedKeys.append(uniqueKey)
+                                    failedKeys.append((uniqueKey, error))
                                     individualResult = FinalIndividualResult.failure(error: error)
                                 }
                                 
@@ -331,7 +334,7 @@ public class CacheController {
                             }
                             
                         case .failure(let error):
-                            failedKeys.append(uniqueKey)
+                            failedKeys.append((uniqueKey, error))
                             let individualResult = FinalIndividualResult.failure(error: error)
                             self.gatekeeper.runAndRemoveIndividualCompletions(uniqueKey: uniqueKey, individualResult: individualResult)
                             group.leave()
@@ -340,26 +343,23 @@ public class CacheController {
                 }
                 
                 group.notify(queue: DispatchQueue.global(qos: .userInitiated)) {
-                    
-                    if failedKeys.count == 0 {
-                        
-                        self.dbWriter.remove(groupKey: groupKey, completion: { (result) in
-                            
-                            var groupResult: FinalGroupResult
-                            switch result {
-                            case .success:
-                                groupResult = FinalGroupResult.success(uniqueKeys: successfulKeys)
-                                
-                            case .failure(let error):
-                                groupResult = FinalGroupResult.failure(error: error)
-                            }
-                            
-                           groupCompleteBlock(groupResult)
-                        })
-                    } else {
-                        let groupResult = FinalGroupResult.failure(error: CacheControllerError.atLeastOneItemFailedInFileWriter)
+                    if let error = failedKeys.first?.1 {
+                        let groupResult = FinalGroupResult.failure(error: CacheControllerError.atLeastOneItemFailedInFileWriter(error))
                         groupCompleteBlock(groupResult)
+                        return
                     }
+                    self.dbWriter.remove(groupKey: groupKey, completion: { (result) in
+                        var groupResult: FinalGroupResult
+                        switch result {
+                        case .success:
+                            groupResult = FinalGroupResult.success(uniqueKeys: successfulKeys)
+                            
+                        case .failure(let error):
+                            groupResult = FinalGroupResult.failure(error: error)
+                        }
+                        
+                        groupCompleteBlock(groupResult)
+                    })
                 }
                 
             case .failure(let error):


### PR DESCRIPTION
- Ensure all errors are bubbled up from the caching layer
- Stop the `SavedArticlesFetcher` when the failure is due to network connectivity
- The `SavedArticlesFetcher` is automatically resumed by the `WMFAppViewController` when connectivity resumes (not in this patch, it's still there from before)