### PR TITLE
Switch to prod for beta builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -224,7 +224,7 @@ platform :ios do
   desc "updates version, builds, and pushes to TestFlight"
   lane :push_beta do |options|
     push(
-      product_name: "Wikipedia (apps.wmflabs.org mobile-html)",
+      product_name: "Wikipedia",
       app_identifier: "org.wikimedia.wikipedia",
       tag_prefix: "betas",
       build: options[:build]


### PR DESCRIPTION
The Page Content Service is live on prod. There's one known issue, the localization for the footer isn't working due to a Content Security Policy issue. It's been [fixed in the mobileapps service](https://gerrit.wikimedia.org/r/c/mediawiki/services/mobileapps/+/580445) but will need another cache clear on RESTBase to roll out everywhere. We're going to hold off on doing that second cache clear to do some testing on the service as is in prod to make sure there isn't anything else that we want to roll into that next release.