### PR TITLE
Fix console errors for event logging dev debug scheme

### DIFF
--- a/WMF Framework/EventLoggingService.swift
+++ b/WMF Framework/EventLoggingService.swift
@@ -26,7 +26,7 @@ public class EventLoggingService : NSObject, URLSessionDelegate {
     
 
 #if WMF_EVENT_LOGGING_DEV_DEBUG
-    private static let scheme = "http"
+    private static let scheme = "https"
     private static let host = "deployment.wikimedia.beta.wmflabs.org"
 #else
     private static let scheme = "https"


### PR DESCRIPTION
We were seeing ATS policy errors in the console. Changing to `https` fixes it & calls successfully post with 204.