### PR TITLE
add missing completion handler check to prevent double calls

### DIFF
--- a/Wikipedia/Code/ArticleViewController+LinkPreviewing.swift
+++ b/Wikipedia/Code/ArticleViewController+LinkPreviewing.swift
@@ -188,7 +188,10 @@ extension ArticleViewController: WKUIDelegate {
                     }
                 }
             } else {
-                completionHandler(config)
+                if (!didCallCompletion) {
+                    completionHandler(config)
+                    didCallCompletion = true;
+                }
             }
         }
         


### PR DESCRIPTION
Fixes crash at these steps:

1. Load article
2. Force press an image later in the article
3. App crashes