### PR TITLE
add 2nd missing completion handler check

### DIFF
--- a/Wikipedia/Code/ArticleViewController+LinkPreviewing.swift
+++ b/Wikipedia/Code/ArticleViewController+LinkPreviewing.swift
@@ -143,8 +143,12 @@ extension ArticleViewController: WKUIDelegate {
             return nil
         }
         
+        var didCallCompletion = false
         let bail = {
-            completionHandler(nullConfig)
+            if (!didCallCompletion) {
+                completionHandler(nullConfig)
+                didCallCompletion = true;
+            }
         }
         
         guard let linkURL = elementInfo.linkURL else {
@@ -155,7 +159,6 @@ extension ArticleViewController: WKUIDelegate {
         // It's helpful if we can fetch the article before calling the completion
         // However, we need to timeout if it takes too long
         var config = nullConfig
-        var didCallCompletion = false
         dispatchAfterDelayInSeconds(1.0, DispatchQueue.main) {
             if (!didCallCompletion) {
                 completionHandler(config)


### PR DESCRIPTION
Missed this one last time. Fixes crash at these steps:

1. Load article
2. Force press an external link
3. App crashes

Feels a little weird that this does nothing now but this is how it acts in 6.5.1. Might be worth bringing up to the others for better handling.