### PR TITLE
Fix missing footer on pages with apostrophes in the title

### DIFF
--- a/Wikipedia/Code/ActionHandlerScript.swift
+++ b/Wikipedia/Code/ActionHandlerScript.swift
@@ -66,7 +66,7 @@ final class PageContentService   {
         guard let string = String(data: data, encoding: .utf8) else {
             throw RequestError.invalidParameters
         }
-        return "JSON.parse('\(string)')"
+        return "JSON.parse(`\(string.sanitizedForJavaScriptTemplateLiterals)`)"
     }
     
     final class SetupScript: WKUserScript {


### PR DESCRIPTION
Repro steps:
1. Open enwiki > Armstrong's Acid
2. Scroll to the footer

Expected:
There's a footer

Actual:
There's no footer

https://phabricator.wikimedia.org/T249142