### PR TITLE
Reload the page when the web content process terminates

### DIFF
--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -945,6 +945,8 @@ extension ArticleViewController: WKNavigationDelegate {
     }
     
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        // On process did terminate, the WKWebView goes blank
+        // Re-load the content in this case to show it again
         webView.reload()
     }
 }

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -943,6 +943,10 @@ extension ArticleViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         articleLoadDidFail(with: error)
     }
+    
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        webView.reload()
+    }
 }
 
 extension ViewController {


### PR DESCRIPTION
When the web content process terminates, we end up with a blank article view. I've seen it intermittently on beta when returning to the app. In the old ArticleVC/WebVC this was fixed by [reloading the content](https://github.com/wikimedia/wikipedia-ios/blob/6.5.1/Wikipedia/Code/WebViewController.m#L1142). Here, we can just reload the web view because mobile-html is an actual webpage, instead of the previous setup that required more orchestration to reload the content.