### PR TITLE
Fix initial flash of content when restoring state

### DIFF
--- a/Wikipedia/Code/ArticleViewController+ArticleWebMessageHandling.swift
+++ b/Wikipedia/Code/ArticleViewController+ArticleWebMessageHandling.swift
@@ -59,7 +59,6 @@ extension ArticleViewController: ArticleWebMessageHandling {
         articleLoadWaitGroup?.leave()
         restoreStateIfNecessary()
         addToHistory()
-        fromNavStateRestoration = false
         syncCachedResourcesIfNeeded()
     }
     

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -24,7 +24,7 @@ class ArticleViewController: ViewController {
     
     /// Set by the state restoration system
     /// Scroll to the last viewed scroll position in this case
-    /// Also pull from cache so the user sees the article as quickly as possible
+    /// Also prioritize pulling data from cache (without revision/etag validation) so the user sees the article as quickly as possible
     var isRestoringState: Bool = false
     /// Set internally to wait for content size changes to chill before restoring the scroll offset
     var isRestoringStateOnNextContentSizeChange: Bool = false

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -24,6 +24,7 @@ class ArticleViewController: ViewController {
     
     /// Set by the state restoration system
     /// Scroll to the last viewed scroll position in this case
+    /// Also pull from cache so the user sees the article as quickly as possible
     var isRestoringState: Bool = false
     /// Set internally to wait for content size changes to chill before restoring the scroll offset
     var isRestoringStateOnNextContentSizeChange: Bool = false
@@ -45,9 +46,6 @@ class ArticleViewController: ViewController {
 
     private var leadImageHeight: CGFloat = 210
 
-    //tells calls to try pulling from cache first so the user sees the article as quickly as possible
-    internal var fromNavStateRestoration: Bool = false
-
     private var contentSizeObservation: NSKeyValueObservation? = nil
     lazy var refreshControl: UIRefreshControl = {
         let rc = UIRefreshControl()
@@ -55,7 +53,7 @@ class ArticleViewController: ViewController {
         return rc
     }()
     
-    @objc init?(articleURL: URL, dataStore: MWKDataStore, theme: Theme, fromNavStateRestoration: Bool = false) {
+    @objc init?(articleURL: URL, dataStore: MWKDataStore, theme: Theme) {
         guard
             let article = dataStore.fetchOrCreateArticle(with: articleURL),
             let cacheController = ArticleCacheController.shared
@@ -70,8 +68,6 @@ class ArticleViewController: ViewController {
         self.dataStore = dataStore
 
         self.schemeHandler = SchemeHandler.shared
-        
-        self.fromNavStateRestoration = fromNavStateRestoration
 
         self.cacheController = cacheController
         
@@ -298,7 +294,7 @@ class ArticleViewController: ViewController {
         state = .loading
         
         setupPageContentServiceJavaScriptInterface {
-            let cachePolicy: WMFCachePolicy? = self.fromNavStateRestoration ? .foundation(.returnCacheDataElseLoad) : nil
+            let cachePolicy: WMFCachePolicy? = self.isRestoringState ? .foundation(.returnCacheDataElseLoad) : nil
             self.loadPage(cachePolicy: cachePolicy)
         }
     }

--- a/Wikipedia/Code/NavigationStateController.swift
+++ b/Wikipedia/Code/NavigationStateController.swift
@@ -105,7 +105,7 @@ final class NavigationStateController: NSObject {
                 guard let articleURL = articleURL(from: info) else {
                     return
                 }
-                guard let articleVC = ArticleViewController(articleURL: articleURL, dataStore: dataStore, theme: theme, fromNavStateRestoration: true) else {
+                guard let articleVC = ArticleViewController(articleURL: articleURL, dataStore: dataStore, theme: theme) else {
                     return
                 }
                 articleVC.isRestoringState = true

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1242,7 +1242,7 @@ static const NSString *kvo_SavedArticlesFetcher_progress = @"kvo_SavedArticlesFe
         [nc dismissViewControllerAnimated:NO completion:NULL];
     }
 
-    WMFArticleViewController *articleVC = [[WMFArticleViewController alloc] initWithArticleURL:articleURL dataStore:self.dataStore theme:self.theme fromNavStateRestoration: NO];
+    WMFArticleViewController *articleVC = [[WMFArticleViewController alloc] initWithArticleURL:articleURL dataStore:self.dataStore theme:self.theme];
     articleVC.loadCompletion = completion;
     [nc pushViewController:articleVC animated:YES];
     return articleVC;

--- a/Wikipedia/Code/WMFFirstRandomViewController.m
+++ b/Wikipedia/Code/WMFFirstRandomViewController.m
@@ -43,7 +43,7 @@
                                             [[WMFAlertManager sharedInstance] showErrorAlert:error ?: [WMFFetcher unexpectedResponseError] sticky:NO dismissPreviousAlerts:NO tapCallBack:NULL];
                                             return;
                                         }
-                                        WMFRandomArticleViewController *randomArticleVC = [[WMFRandomArticleViewController alloc] initWithArticleURL:articleURL dataStore:self.dataStore theme:self.theme fromNavStateRestoration:NO];
+                                        WMFRandomArticleViewController *randomArticleVC = [[WMFRandomArticleViewController alloc] initWithArticleURL:articleURL dataStore:self.dataStore theme:self.theme];
                                         NSMutableArray *viewControllers = [self.navigationController.viewControllers mutableCopy];
                                         [viewControllers replaceObjectAtIndex:viewControllers.count - 1 withObject:randomArticleVC];
                                         [self.navigationController setViewControllers:viewControllers];


### PR DESCRIPTION
Follow-on fix for [T248094](https://phabricator.wikimedia.org/T248094)

The web view would still show briefly before restoring state, occasionally with content, so the transition could still be jarring.

**Before:**
Hard to capture in a GIF, but here's one of the offending frames, the web view isn't hidden as you can see the divider between the lead image view and the article content:
<img width="600" alt="Screen Shot 2020-04-02 at 7 02 09 AM" src="https://user-images.githubusercontent.com/741327/78242803-ac2e4100-74b0-11ea-91d2-7d21e7c67700.png">

**After:**
![a mov](https://user-images.githubusercontent.com/741327/78242735-8f920900-74b0-11ea-8ab1-74b8f2d78d83.gif)

