### PR TITLE
Fix animated images in the gallery view

### DIFF
--- a/Wikipedia/Code/MediaListGalleryViewController.swift
+++ b/Wikipedia/Code/MediaListGalleryViewController.swift
@@ -82,7 +82,11 @@ class MediaListGalleryViewController: WMFImageGalleryViewController {
             }
         }) { [weak self] (download) in
             DispatchQueue.main.async {
-                photo.image = download.image.staticImage
+                if let animatedImage = download.image.animatedImage {
+                    photo.imageData = animatedImage.data
+                } else {
+                    photo.image = download.image.staticImage
+                }
                 self?.updateImageForPhoto(afterUserInteractionIsFinished: photo)
             }
         }


### PR DESCRIPTION
Utilize `imageData` when there's an animated image to match the functionality in 6.5.1