### PR TITLE
Fix resolution of relative hrefs for titles with forward slashes

### DIFF
--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -529,15 +529,7 @@ class ArticleViewController: ViewController {
     // MARK: Overrideable functionality
     
     internal func handleLink(with href: String) {
-        let urlComponentsString: String
-        if href.hasPrefix(".") || href.hasPrefix("/") {
-            urlComponentsString = href.addingPercentEncoding(withAllowedCharacters: .relativePathAndFragmentAllowed) ?? href
-        } else {
-            urlComponentsString = href
-        }
-        let components = URLComponents(string: urlComponentsString)
-        // Resolve relative URLs
-        guard let resolvedURL = components?.url(relativeTo: articleURL)?.absoluteURL else {
+        guard let resolvedURL = articleURL.resolvingRelativeWikiHref(href) else {
             showGenericError()
             return
         }

--- a/Wikipedia/Code/ArticleWebMessagingController.swift
+++ b/Wikipedia/Code/ArticleWebMessagingController.swift
@@ -40,7 +40,7 @@ class ArticleWebMessagingController: NSObject {
     }
     
     func addFooter(articleURL: URL, restAPIBaseURL: URL, menuItems: [PageContentService.Footer.Menu.Item], lastModified: Date?) {
-        guard let title = articleURL.wmf_title else {
+        guard let title = articleURL.percentEncodedPageTitleForPathComponents else {
             return
         }
         var editedDaysAgo: Int?

--- a/WikipediaUnitTests/Code/URLParsingAndRoutingTests.swift
+++ b/WikipediaUnitTests/Code/URLParsingAndRoutingTests.swift
@@ -87,4 +87,11 @@ class URLParsingAndRoutingTests: XCTestCase {
         }
     }
     
+    func testTitlesWithForwardSlashes() {
+        var url = URL(string: "https://en.wikipedia.org/wiki/G/O_Media")!
+        XCTAssertEqual(url.resolvingRelativeWikiHref("./Gizmodo")?.absoluteString, "https://en.wikipedia.org/wiki/Gizmodo")
+        url = URL(string: "https://en.wikipedia.org/wiki//dev/random")!
+        XCTAssertEqual(url.resolvingRelativeWikiHref(".//dev/null")?.absoluteString, "https://en.wikipedia.org/wiki//dev/null")
+    }
+    
 }

--- a/WikipediaUnitTests/Code/XCTestCase+SwiftDefaults.swift
+++ b/WikipediaUnitTests/Code/XCTestCase+SwiftDefaults.swift
@@ -1,11 +1,11 @@
 import Foundation
 import XCTest
 
-let defaultHandler: XCWaitCompletionHandler = { (err: NSError?) -> Void in
+let defaultHandler: XCWaitCompletionHandler = { (err: Error?) -> Void in
     if let e = err {
         print("Timeout expired with error \(e)")
     }
-} as! XCWaitCompletionHandler
+}
 
 extension XCTestCase {
     public func wmf_waitForExpectations(_ timeout: TimeInterval = WMFDefaultExpectationTimeout,


### PR DESCRIPTION
Fixes [T249117](https://phabricator.wikimedia.org/T249117)

When attempting to resolve a relative URL on a page that has a title with forward slashes, `URLComponents` would treat the forward slash like it should, which is as a path component. Since we know that `articleURL` is an `articleURL`, we can percent encode everything after `/wiki/` and utilize that to resolve the relative href.