### PR TITLE
Remove obsolete references in Xcode project

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -5351,13 +5351,6 @@
 			name = "Table of Contents";
 			sourceTree = "<group>";
 		};
-		0E52FD631DA4008A00587426 /* Content Display */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = "Content Display";
-			sourceTree = "<group>";
-		};
 		0E52FD651DA40EA200587426 /* Nearby */ = {
 			isa = PBXGroup;
 			children = (
@@ -5575,7 +5568,6 @@
 				83CA612920D1675800EF0C4A /* ExploreCardViewController.swift */,
 				D8B3D7651EC34F5B00930C21 /* SaveButtonsController.swift */,
 				0E03E2861B83948B00C1FBD7 /* Views */,
-				0E52FD631DA4008A00587426 /* Content Display */,
 				B0B4235F1EF9D65F00D3DC4C /* On This Day */,
 			);
 			name = Feed;

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -6751,13 +6751,6 @@
 			name = "RTL Utilities";
 			sourceTree = "<group>";
 		};
-		BC45D5551C31ED70007C72F3 /* Operations */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Operations;
-			sourceTree = "<group>";
-		};
 		BC45D5561C31EEBE007C72F3 /* Error Handling */ = {
 			isa = PBXGroup;
 			children = (
@@ -6956,7 +6949,6 @@
 			children = (
 				67DB110822613EF700F789B0 /* SchemeHandler */,
 				04C43AB7183442FC006C643B /* Categories */,
-				BC45D5551C31ED70007C72F3 /* Operations */,
 				B08423DC2384E260005E93A0 /* URLTranslations */,
 				7616D4941C5A67D20077ADF7 /* WMFUtilityMacros.h */,
 				D84BF62E1DBE616D00E0C85E /* UIViewController+WMFAlerts.swift */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -7530,7 +7530,6 @@
 				D84DAA081EEEF527008E4B18 /* SWStepSlider */,
 				D8E27B9C1F82AFE600F9D2B3 /* RMessage */,
 				D8C4D3CF1FD5D9250089CEC2 /* TUSafariActivity */,
-				D82014811E68693600BA8579 /* HexColors */,
 			);
 			name = "Third Party";
 			sourceTree = "<group>";
@@ -7585,13 +7584,6 @@
 				D8940CEA1DB56C0500E17F9E /* In The News */,
 			);
 			name = "View Controllers";
-			sourceTree = "<group>";
-		};
-		D82014811E68693600BA8579 /* HexColors */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = HexColors;
 			sourceTree = "<group>";
 		};
 		D82E951A1F101D7D007BD960 /* Extensions */ = {

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -6998,14 +6998,6 @@
 			name = Features;
 			sourceTree = "<group>";
 		};
-		BC45D58F1C32FEAF007C72F3 /* MediaWikiKit */ = {
-			isa = PBXGroup;
-			children = (
-				BCB58F401A890D8200465627 /* Categories */,
-			);
-			name = MediaWikiKit;
-			sourceTree = "<group>";
-		};
 		BC45D59F1C33018C007C72F3 /* User */ = {
 			isa = PBXGroup;
 			children = (
@@ -7261,13 +7253,6 @@
 			name = Utilities;
 			sourceTree = "<group>";
 		};
-		BCB58F401A890D8200465627 /* Categories */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Categories;
-			sourceTree = "<group>";
-		};
 		BCB669621A83DB8100C7B1FE /* Serializers */ = {
 			isa = PBXGroup;
 			children = (
@@ -7281,7 +7266,6 @@
 			isa = PBXGroup;
 			children = (
 				229C20D91CB08FA500BC17AD /* PageHistory */,
-				BC45D58F1C32FEAF007C72F3 /* MediaWikiKit */,
 			);
 			name = Model;
 			path = Wikipedia/Code;

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -6224,7 +6224,6 @@
 			children = (
 				7AB7DEC7227203A600DD61A2 /* InsertMediaViewController.swift */,
 				7A0D4D41225EABFC00774A5A /* Insert */,
-				7AF8CEDE2265281F000B7676 /* Upload */,
 			);
 			name = Media;
 			sourceTree = "<group>";
@@ -6308,13 +6307,6 @@
 				7A9524CA22665E6400C55CDC /* InsertMediaSettingsImageView.xib */,
 			);
 			name = Settings;
-			sourceTree = "<group>";
-		};
-		7AF8CEDE2265281F000B7676 /* Upload */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Upload;
 			sourceTree = "<group>";
 		};
 		83023C1720E6581A00EC7592 /* Transitions */ = {

--- a/Wikipedia/Resources/LibrariesUsed.plist
+++ b/Wikipedia/Resources/LibrariesUsed.plist
@@ -1,5 +1,5 @@
-bplist00Ñ]LibrariesUsed¬
- %*05:?Ó	UTitle[LicenseText[LicenseNameTMaps_DApple Maps: 
+bplist00Ñ]LibrariesUsed«
+ %+05:Ó	UTitle[LicenseText[LicenseNameTMaps_DApple Maps: 
 
 https://gspe21-ssl.ls.apple.com/html/attribution.html
 PÓ[LicenseText[LicenseName_CocoaLumberjack_BSoftware License Agreement (BSD License)
@@ -101,31 +101,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-Ó&'()[LicenseText[LicenseName\GCDWebServer_ÉCopyright (c) 2012-2014, Pierre-Olivier Latour
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * The name of Pierre-Olivier Latour may not be used to endorse
-      or promote products derived from this software without specific
-      prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-Ó+,-./[LicenseText[LicenseName^NYTPhotoViewer_FCopyright (c) 2015-2016 The New York Times Company
+Ó&'()*[LicenseText[LicenseName^NYTPhotoViewer_FCopyright (c) 2015-2016 The New York Times Company
  
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this library except in compliance with the License.
@@ -138,7 +114,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-ZApache 2.0Ó1234[LicenseText[LicenseNameXRMessage_DCopyright (c) 2016 TouchSix, Inc. Adonis Peralta <donileo@gmail.com>
+ZApache 2.0Ó,-./[LicenseText[LicenseNameXRMessage_DCopyright (c) 2016 TouchSix, Inc. Adonis Peralta <donileo@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -156,7 +132,7 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.Ó6789[LicenseText[LicenseName\SWStepSlider_CCopyright (c) 2016 Sarun Wongpatcharapakorn <artwork.th@gmail.com>
+THE SOFTWARE.Ó1234[LicenseText[LicenseName\SWStepSlider_CCopyright (c) 2016 Sarun Wongpatcharapakorn <artwork.th@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -175,7 +151,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-Ó;<=>[LicenseText[LicenseName_TUSafariActivity_;Copyright (c) 2012 ThinkUltimate (http://thinkultimate.com).
+Ó6789[LicenseText[LicenseName_TUSafariActivity_;Copyright (c) 2012 ThinkUltimate (http://thinkultimate.com).
 
 http://github.com/davbeck/TUSafariActivity
 
@@ -198,7 +174,7 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
-Ó@ABC[LicenseText[LicenseNameVTweaks_ïBSD License
+Ó;<=>[LicenseText[LicenseNameVTweaks_ïBSD License
 
 For Tweaks software
 
@@ -228,4 +204,4 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-    & - 3 ? K P — ˜ Ÿ « · É&29ÊÎÕáíóAHT`k¢©µÁÓ#/<#	###(#7%%Œ%“%Ÿ%«%´)ü****(.o.v.‚.Ž.¡3à3ç3ó3ÿ4             D              9ù
+    % , 2 > J O – — ž ª ¶ È%18ÉÍÔàìò@GS_j¡¨´ÀÒ".=‡’™¥±º$$	$$!$.(u(|(ˆ(”(§-æ-í-ù..             ?              3ÿ


### PR DESCRIPTION
• Removes several empty groups in Xcode
• Removes license for unused framework `GCDWebServer` listed in `LibrariesUsedViewController`