### PR TITLE
Persist article settings on refresh

### DIFF
--- a/Wikipedia/Code/ActionHandlerScript.swift
+++ b/Wikipedia/Code/ActionHandlerScript.swift
@@ -9,8 +9,8 @@ final class PageContentService   {
             let platform = "ios"
             let version = 1
             
-            let theme: String
-            let dimImages: Bool
+            var theme: String
+            var dimImages: Bool
 
             struct Margins: Codable {
                 // these values are strings to allow for units to be included
@@ -19,13 +19,13 @@ final class PageContentService   {
                 let bottom: String
                 let left: String
             }
-            let margins: Margins
-            let leadImageHeight: String // units are included
+            var margins: Margins
+            var leadImageHeight: String // units are included
 
-            let areTablesInitiallyExpanded: Bool
-            let textSizeAdjustmentPercentage: String // string like '125%'
+            var areTablesInitiallyExpanded: Bool
+            var textSizeAdjustmentPercentage: String // string like '125%'
             
-            let userGroups: [String]
+            var userGroups: [String]
         }
     }
     


### PR DESCRIPTION
Fixes https://phabricator.wikimedia.org/T249505

On reload, `WKWebView` re-runs any `userScripts`. The `PageContentService.SetupScript` needs to be re-created with the new settings, otherwise the old settings will be applied on page load.