### PR TITLE
Fix inconsistent `UISwitch` state when Explore feed preferences are updated

### DIFF
--- a/Wikipedia/Code/BaseExploreFeedSettingsViewController.swift
+++ b/Wikipedia/Code/BaseExploreFeedSettingsViewController.swift
@@ -229,9 +229,6 @@ class BaseExploreFeedSettingsViewController: SubSettingsViewController {
 
     @objc private func exploreFeedPreferencesDidSave(_ notification: Notification) {
         updateFeedBeforeViewDisappears = true
-        guard displayType != .singleLanguage else {
-            return
-        }
         DispatchQueue.main.async {
             self.reload()
         }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T249522

Investigating a low touch solution for this issue led me down a spiral that revealed other more insidious issues, including a possible regression, in this "Explore feed" settings page. Will file tickets.