### PR TITLE
Remove mimeType logic

### DIFF
--- a/WMF Framework/ArticleCacheController.swift
+++ b/WMF Framework/ArticleCacheController.swift
@@ -134,7 +134,7 @@ public final class ArticleCacheController: CacheController {
         }
     }
     
-    public func cacheFromMigration(desktopArticleURL: URL, content: String, mimeType: String, completionHandler: @escaping ((Error?) -> Void)) { //articleURL should be desktopURL
+    public func cacheFromMigration(desktopArticleURL: URL, content: String, completionHandler: @escaping ((Error?) -> Void)) { //articleURL should be desktopURL
         
         guard let articleDBWriter = dbWriter as? ArticleCacheDBWriter else {
             completionHandler(ArticleCacheControllerError.invalidDBWriterType)
@@ -145,7 +145,7 @@ public final class ArticleCacheController: CacheController {
             
             articleDBWriter.addMobileHtmlURLForMigration(desktopArticleURL: desktopArticleURL, success: { urlRequest in
                 
-                self.fileWriter.addMobileHtmlContentForMigration(content: content, urlRequest: urlRequest, mimeType: mimeType, success: {
+                self.fileWriter.addMobileHtmlContentForMigration(content: content, urlRequest: urlRequest, success: {
 
                     articleDBWriter.markDownloaded(urlRequest: urlRequest, response: nil) { (result) in
                         switch result {

--- a/WMF Framework/CacheFetching.swift
+++ b/WMF Framework/CacheFetching.swift
@@ -28,7 +28,7 @@ public protocol CacheFetching {
     func cachedResponseForURL(_ url: URL, type: Header.PersistItemType) -> CachedURLResponse?
     func cachedResponseForURLRequest(_ urlRequest: URLRequest) -> CachedURLResponse? //assumes urlRequest is already populated with the proper cache headers
     func uniqueKeyForURL(_ url: URL, type: Header.PersistItemType) -> String?
-    func cacheResponse(httpUrlResponse: HTTPURLResponse, content: CacheResponseContentType, mimeType: String?, urlRequest: URLRequest, success: @escaping () -> Void, failure: @escaping (Error) -> Void)
+    func cacheResponse(httpUrlResponse: HTTPURLResponse, content: CacheResponseContentType, urlRequest: URLRequest, success: @escaping () -> Void, failure: @escaping (Error) -> Void)
     func uniqueFileNameForItemKey(_ itemKey: CacheController.ItemKey, variant: String?) -> String?
     func uniqueHeaderFileNameForItemKey(_ itemKey: CacheController.ItemKey, variant: String?) -> String?
     func uniqueFileNameForURLRequest(_ urlRequest: URLRequest) -> String?
@@ -103,9 +103,9 @@ extension CacheFetching where Self:Fetcher {
         return session.uniqueKeyForURL(url, type: type)
     }
     
-    public func cacheResponse(httpUrlResponse: HTTPURLResponse, content: CacheResponseContentType, mimeType: String?, urlRequest: URLRequest, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+    public func cacheResponse(httpUrlResponse: HTTPURLResponse, content: CacheResponseContentType, urlRequest: URLRequest, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         
-        session.cacheResponse(httpUrlResponse: httpUrlResponse, content: content, mimeType: mimeType, urlRequest: urlRequest, success: success, failure: failure)
+        session.cacheResponse(httpUrlResponse: httpUrlResponse, content: content, urlRequest: urlRequest, success: success, failure: failure)
     }
     
     public func writeBundledFiles(mimeType: String, bundledFileURL: URL, urlRequest: URLRequest, completion: @escaping (Result<Void, Error>) -> Void) {

--- a/WMF Framework/CacheFileWriter.swift
+++ b/WMF Framework/CacheFileWriter.swift
@@ -76,7 +76,7 @@ final class CacheFileWriter: CacheTaskTracking {
                     return
                 }
                 
-                self.fetcher.cacheResponse(httpUrlResponse: httpUrlResponse, content: .data(result.data), mimeType: result.response.mimeType, urlRequest: urlRequest, success: {
+                self.fetcher.cacheResponse(httpUrlResponse: httpUrlResponse, content: .data(result.data), urlRequest: urlRequest, success: {
                     completion(.success(response: httpUrlResponse, data: result.data))
                 }) { (error) in
                     completion(.failure(error))
@@ -153,7 +153,7 @@ final class CacheFileWriter: CacheTaskTracking {
 extension CacheFileWriter {
     
     //assumes urlRequest is already populated with the right type header
-    func addMobileHtmlContentForMigration(content: String, urlRequest: URLRequest, mimeType: String, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+    func addMobileHtmlContentForMigration(content: String, urlRequest: URLRequest, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         
         guard let url =  urlRequest.url else {
                 failure(CacheFileWriterError.missingURLInRequest)
@@ -166,7 +166,7 @@ extension CacheFileWriter {
             return
         }
         
-        fetcher.cacheResponse(httpUrlResponse: response, content: .string(content), mimeType: mimeType, urlRequest: urlRequest, success: {
+        fetcher.cacheResponse(httpUrlResponse: response, content: .string(content), urlRequest: urlRequest, success: {
             success()
         }) { (error) in
             failure(error)

--- a/WMF Framework/CacheFileWriterHelper.swift
+++ b/WMF Framework/CacheFileWriterHelper.swift
@@ -10,7 +10,7 @@ final class CacheFileWriterHelper {
         return CacheController.cacheURL.appendingPathComponent(key, isDirectory: false)
     }
     
-    static func saveData(data: Data, toNewFileWithKey key: String, mimeType: String?, completion: @escaping (FileSaveResult) -> Void) {
+    static func saveData(data: Data, toNewFileWithKey key: String, completion: @escaping (FileSaveResult) -> Void) {
         do {
             let newFileURL = self.fileURL(for: key)
             try data.write(to: newFileURL)
@@ -26,7 +26,7 @@ final class CacheFileWriterHelper {
         }
     }
     
-    static func copyFile(from fileURL: URL, toNewFileWithKey key: String, mimeType: String?, completion: @escaping (FileSaveResult) -> Void) {
+    static func copyFile(from fileURL: URL, toNewFileWithKey key: String, completion: @escaping (FileSaveResult) -> Void) {
         do {
             let newFileURL = self.fileURL(for: key)
             try FileManager.default.copyItem(at: fileURL, to: newFileURL)
@@ -115,7 +115,7 @@ final class CacheFileWriterHelper {
     }
 
     
-    static func saveContent(_ content: String, toNewFileName fileName: String, mimeType: String?, completion: @escaping (FileSaveResult) -> Void) {
+    static func saveContent(_ content: String, toNewFileName fileName: String, completion: @escaping (FileSaveResult) -> Void) {
         
         do {
             let newFileURL = self.fileURL(for: fileName)

--- a/WMF Framework/CacheFileWriterHelper.swift
+++ b/WMF Framework/CacheFileWriterHelper.swift
@@ -14,9 +14,6 @@ final class CacheFileWriterHelper {
         do {
             let newFileURL = self.fileURL(for: key)
             try data.write(to: newFileURL)
-            if let mimeType = mimeType {
-                FileManager.default.setValue(mimeType, forExtendedFileAttributeNamed: WMFExtendedFileAttributeNameMIMEType, forFileAtPath: newFileURL.path)
-            }
             completion(.success)
         } catch let error as NSError {
             if error.domain == NSCocoaErrorDomain, error.code == NSFileWriteFileExistsError {
@@ -33,9 +30,6 @@ final class CacheFileWriterHelper {
         do {
             let newFileURL = self.fileURL(for: key)
             try FileManager.default.copyItem(at: fileURL, to: newFileURL)
-            if let mimeType = mimeType {
-                FileManager.default.setValue(mimeType, forExtendedFileAttributeNamed: WMFExtendedFileAttributeNameMIMEType, forFileAtPath: newFileURL.path)
-            }
             completion(.success)
         } catch let error as NSError {
             if error.domain == NSCocoaErrorDomain, error.code == NSFileWriteFileExistsError {
@@ -126,9 +120,6 @@ final class CacheFileWriterHelper {
         do {
             let newFileURL = self.fileURL(for: fileName)
             try content.write(to: newFileURL, atomically: true, encoding: .utf8)
-            if let mimeType = mimeType {
-                FileManager.default.setValue(mimeType, forExtendedFileAttributeNamed: WMFExtendedFileAttributeNameMIMEType, forFileAtPath: newFileURL.path)
-            }
             completion(.success)
         } catch let error as NSError {
             if error.domain == NSCocoaErrorDomain, error.code == NSFileWriteFileExistsError {

--- a/WMF Framework/FileManager+CacheExtensions.swift
+++ b/WMF Framework/FileManager+CacheExtensions.swift
@@ -16,17 +16,3 @@ extension FileManager {
         return String(bytesNoCopy: buffer, length: readLen, encoding: .utf8, freeWhenDone: true)
     }
 }
-
-extension FileManager {
-    func setValue(_ value: String, forExtendedFileAttributeNamed attributeName: String, forFileAtPath path: String) {
-        let attributeNamePointer = (attributeName as NSString).utf8String
-        let pathPointer = (path as NSString).fileSystemRepresentation
-        guard let valuePointer = (value as NSString).utf8String else {
-            assert(false, "unable to get value pointer from \(value)")
-            return
-        }
-
-        let result = setxattr(pathPointer, attributeNamePointer, valuePointer, strlen(valuePointer), 0, 0)
-        assert(result != -1)
-    }
-}

--- a/WMF Framework/FileManager+CacheExtensions.swift
+++ b/WMF Framework/FileManager+CacheExtensions.swift
@@ -2,6 +2,10 @@
 import Foundation
 
 extension FileManager {
+    /// DEPRECATED: This should only be used for migrating legacy data to the new cache format. The app should no longer need to store information in extended file attributes. Previously, this was used to store the MIME type of a cached file so the approrpriate Content-Type could be set when serving it as a cached response. Now, the response headers are cached in a separate file, removing the need to attach MIME type (or any other info) to the file itself. This function can be removed when the corresponding migration is removed.
+    /// - Parameter attributeName: Extended file attribute name
+    /// - Parameter path: Path of the file
+    /// - Returns: the attribute value for the given attributeName or nil if no such attribute exists on the file
     func getValueForExtendedFileAttributeNamed(_ attributeName: String, forFileAtPath path: String) -> String? {
         let name = (attributeName as NSString).utf8String
         let path = (path as NSString).fileSystemRepresentation

--- a/WMF Framework/PermanentlyPersistableURLCache.swift
+++ b/WMF Framework/PermanentlyPersistableURLCache.swift
@@ -330,7 +330,7 @@ public enum CacheResponseContentType {
 
 extension PermanentlyPersistableURLCache {
     
-    func cacheResponse(httpUrlResponse: HTTPURLResponse, content: CacheResponseContentType, mimeType: String?, urlRequest: URLRequest, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+    func cacheResponse(httpUrlResponse: HTTPURLResponse, content: CacheResponseContentType, urlRequest: URLRequest, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         
         guard let url = urlRequest.url else {
             failure(PermanentlyPersistableURLCacheError.unableToDetermineURLFromRequest)
@@ -371,7 +371,7 @@ extension PermanentlyPersistableURLCache {
         switch content {
         case .data((let data)):
             dispatchGroup.enter()
-            CacheFileWriterHelper.saveData(data: data, toNewFileWithKey: contentFileName, mimeType: mimeType) { (result) in
+            CacheFileWriterHelper.saveData(data: data, toNewFileWithKey: contentFileName) { (result) in
                 
                 defer {
                     dispatchGroup.leave()
@@ -386,7 +386,7 @@ extension PermanentlyPersistableURLCache {
             }
         case .string(let string):
             dispatchGroup.enter()
-            CacheFileWriterHelper.saveContent(string, toNewFileName: contentFileName, mimeType: mimeType) { (result) in
+            CacheFileWriterHelper.saveContent(string, toNewFileName: contentFileName) { (result) in
                 defer {
                     dispatchGroup.leave()
                 }
@@ -439,7 +439,7 @@ extension PermanentlyPersistableURLCache {
             return
         }
         
-        CacheFileWriterHelper.copyFile(from: bundledFileURL, toNewFileWithKey: contentFileName, mimeType: mimeType) { (result) in
+        CacheFileWriterHelper.copyFile(from: bundledFileURL, toNewFileWithKey: contentFileName) { (result) in
             switch result {
             case .success, .exists:
                  CacheFileWriterHelper.saveResponseHeader(headerFields: ["Content-Type": mimeType], toNewFileName: headerFileName) { (result) in

--- a/Wikipedia/Code/MWKDataStore+LegacyMobileview.swift
+++ b/Wikipedia/Code/MWKDataStore+LegacyMobileview.swift
@@ -72,7 +72,7 @@ extension MWKDataStore {
                 return
             }
 
-            articleCacheController.cacheFromMigration(desktopArticleURL: articleURL, content: mobileHTML, mimeType: "text/html"){ error in
+            articleCacheController.cacheFromMigration(desktopArticleURL: articleURL, content: mobileHTML){ error in
                 // Conversion succeeded so can safely blast old mobileview folder.
                 //TODO: uncomment after 6.6 Beta releases if we decide to delete old data incrementally
                 //removeArticleMobileviewSavedDataFolder()

--- a/Wikipedia/Code/Session.swift
+++ b/Wikipedia/Code/Session.swift
@@ -591,9 +591,9 @@ extension Session {
         return defaultPermanentCache.cachedResponse(for: urlRequest)
     }
     
-    func cacheResponse(httpUrlResponse: HTTPURLResponse, content: CacheResponseContentType, mimeType: String?, urlRequest: URLRequest, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+    func cacheResponse(httpUrlResponse: HTTPURLResponse, content: CacheResponseContentType, urlRequest: URLRequest, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         
-        defaultPermanentCache.cacheResponse(httpUrlResponse: httpUrlResponse, content: content, mimeType: mimeType, urlRequest: urlRequest, success: success, failure: failure)
+        defaultPermanentCache.cacheResponse(httpUrlResponse: httpUrlResponse, content: content, urlRequest: urlRequest, success: success, failure: failure)
     }
     
     func uniqueFileNameForItemKey(_ itemKey: CacheController.ItemKey, variant: String?) -> String? {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T247856

Since we are saving the entire response header, we no longer need to save mimeType separately. This will also get around these assertion failures we were seeing during large syncs.