### PR TITLE
Make sure fallback response runs on cacheBackgroundContext

### DIFF
--- a/WMF Framework/PermanentlyPersistableURLCache.swift
+++ b/WMF Framework/PermanentlyPersistableURLCache.swift
@@ -471,9 +471,7 @@ extension PermanentlyPersistableURLCache {
     }
     
     private func updateCacheWithCachedResponse(_ cachedResponse: CachedURLResponse, request: URLRequest) {
-        
-        
-        
+
         let isArticleOrImageInfoRequest: Bool
         if let typeRaw = request.allHTTPHeaderFields?[Header.persistentCacheItemType],
             let type = Header.PersistItemType(rawValue: typeRaw),
@@ -657,35 +655,38 @@ private extension PermanentlyPersistableURLCache {
         }
         
         //lookup fallback itemKey/variant in DB (language fallback logic for article item type, size fallback logic for image item type)
-        
-        var allVariantItems = CacheDBWriterHelper.allDownloadedVariantItems(itemKey: itemKey, in: moc)
-        
-        switch type {
-        case .image:
-            allVariantItems.sortAsImageCacheItems()
-        case .article, .imageInfo:
-            break
-        }
-        
-        if let fallbackItemKey = allVariantItems.first?.key {
+
+        var response: CachedURLResponse? = nil
+        moc.performAndWait {
+            var allVariantItems = CacheDBWriterHelper.allDownloadedVariantItems(itemKey: itemKey, in: moc)
             
-            let fallbackVariant = allVariantItems.first?.variant
-            
-            //migrated images do not have urls. defaulting to url passed in here.
-            let fallbackURL = allVariantItems.first?.url ?? url
-            
-            //first see if URLCache has the fallback
-            let quickCheckRequest = URLRequest(url: fallbackURL)
-            if let response = URLCache.shared.cachedResponse(for: quickCheckRequest) {
-                return response
+            switch type {
+            case .image:
+                allVariantItems.sortAsImageCacheItems()
+            case .article, .imageInfo:
+                break
             }
             
-            //then see if persistent cache has the fallback
-            let request = PersistedResponseRequest.fallbackItemKeyAndVariant(url: fallbackURL, itemKey: fallbackItemKey, variant: fallbackVariant)
-            return persistedResponseWithRequest(request)
+            if let fallbackItemKey = allVariantItems.first?.key {
+                
+                let fallbackVariant = allVariantItems.first?.variant
+                
+                //migrated images do not have urls. defaulting to url passed in here.
+                let fallbackURL = allVariantItems.first?.url ?? url
+                
+                //first see if URLCache has the fallback
+                let quickCheckRequest = URLRequest(url: fallbackURL)
+                if let systemCachedResponse = URLCache.shared.cachedResponse(for: quickCheckRequest) {
+                    response = systemCachedResponse
+                }
+                
+                //then see if persistent cache has the fallback
+                let request = PersistedResponseRequest.fallbackItemKeyAndVariant(url: fallbackURL, itemKey: fallbackItemKey, variant: fallbackVariant)
+                response = persistedResponseWithRequest(request)
+            }
         }
         
-        return nil
+        return response
     }
 }
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T249135

We are seeing an odd Core Data crash in `allDownloadedVariantItems`. The stack trace complains about the `NSPredicate` but I couldn't reproduce. We aren't checking to make sure this call site runs on the cacheBackgroundContext thread, so trying this (hopefully) lower impact fix first.