### PR TITLE
Restore ability to edit title descriptions

### DIFF
--- a/WMF Framework/ArticleSummaryFetcher.swift
+++ b/WMF Framework/ArticleSummaryFetcher.swift
@@ -44,6 +44,7 @@ public class ArticleSummary: NSObject, Codable {
         }
     }
     let id: Int64?
+    let wikidataID: String?
     let revision: String?
     let timestamp: String?
     let index: Int?
@@ -72,6 +73,7 @@ public class ArticleSummary: NSObject, Codable {
         case original = "originalimage"
         case coordinates
         case contentURLs = "content_urls"
+        case wikidataID = "wikibase_item"
     }
     
     let contentURLs: ArticleSummaryContentURLs

--- a/WMF Framework/SummaryExtensions.swift
+++ b/WMF Framework/SummaryExtensions.swift
@@ -63,9 +63,10 @@ extension WMFArticle {
         }
        
         wikidataDescription = summary.articleDescription
+        wikidataID = summary.wikidataID
         displayTitleHTML = summary.displayTitle ?? summary.title ?? ""
         snippet = summary.extract?.wmf_summaryFromText()
-
+        
         if let summaryCoordinate = summary.coordinates {
             coordinate = CLLocationCoordinate2D(latitude: summaryCoordinate.lat, longitude: summaryCoordinate.lon)
         } else {

--- a/Wikipedia/Code/ArticleViewController+Editing.swift
+++ b/Wikipedia/Code/ArticleViewController+Editing.swift
@@ -40,8 +40,12 @@ extension ArticleViewController {
     }
     
     func showTitleDescriptionEditor(with descriptionSource: ArticleDescriptionSource, funnelSource: EditFunnelSource) {
+        guard let wikidataID = article.wikidataID else {
+            showGenericError()
+            return
+        }
         editFunnel.logTitleDescriptionEditingStart(from: funnelSource, language: articleLanguage)
-        let editVC = DescriptionEditViewController.with(articleURL: articleURL, article: article, descriptionSource: descriptionSource, dataStore: dataStore, theme: theme)
+        let editVC = DescriptionEditViewController.with(articleURL: articleURL, wikidataID: wikidataID, article: article, descriptionSource: descriptionSource, dataStore: dataStore, theme: theme)
         editVC.delegate = self
         editVC.editFunnel = editFunnel
         editVC.editFunnelSource = funnelSource

--- a/Wikipedia/Code/DescriptionEditViewController.swift
+++ b/Wikipedia/Code/DescriptionEditViewController.swift
@@ -32,14 +32,16 @@ import WMF
     // These would be better as let's and a required initializer but it's not an opportune time to ditch the storyboard
     // Convert these to non-force unwrapped if there's some way to ditch the storyboard or provide an initializer with the storyboard
     var article: WMFArticle!
+    var wikidataID: String!
     var articleURL: URL!
     var descriptionSource: ArticleDescriptionSource!
     var isAddingNewTitleDescription: Bool!
     var dataStore: MWKDataStore!
-    static func with(articleURL: URL, article: WMFArticle, descriptionSource: ArticleDescriptionSource, dataStore: MWKDataStore, theme: Theme) -> DescriptionEditViewController {
+    static func with(articleURL: URL, wikidataID: String, article: WMFArticle, descriptionSource: ArticleDescriptionSource, dataStore: MWKDataStore, theme: Theme) -> DescriptionEditViewController {
         let vc = wmf_initialViewControllerFromClassStoryboard()!
         vc.articleURL = articleURL
         vc.article = article
+        vc.wikidataID = wikidataID
         vc.descriptionSource = descriptionSource
         vc.isAddingNewTitleDescription = descriptionSource == .none
         vc.dataStore = dataStore
@@ -209,10 +211,7 @@ import WMF
         enableProgressiveButton(false)
         wmf_hideKeyboard()
         
-        guard
-            let wikidataID = article.wikidataID,
-            let language = articleURL.wmf_language
-        else {
+        guard let language = articleURL.wmf_language else {
             enableProgressiveButton(true)
             assertionFailure("Expected article, datastore or article url not found")
             return


### PR DESCRIPTION
- Ensure the article's associated Wikidata ID is updated when the article summary is fetched. This occurs when the article content is loaded.
- Only show title description editor if there's an associated Wikidata ID - otherwise we have no place to put the description

https://phabricator.wikimedia.org/T250269