### PR TITLE
Only recognize iOS announcements version 3

### DIFF
--- a/WMF Framework/WMFAnnouncementsFetcher.m
+++ b/WMF Framework/WMFAnnouncementsFetcher.m
@@ -79,7 +79,7 @@
         if (![obj isKindOfClass:[WMFAnnouncement class]]) {
             return NO;
         }
-        if ([obj.platforms containsObject:@"iOSAppV2"]) {
+        if ([obj.platforms containsObject:@"iOSAppV3"]) {
             return YES;
         } else {
             return NO;


### PR DESCRIPTION
Wikifeeds [patch](https://gerrit.wikimedia.org/r/#/c/mediawiki/services/wikifeeds/+/586472/) now outputs iOSV3 for survey announcement (we'll need to remember to make it iOSV3 for the 2020 fundraising announcement). Without these fixes 6.5.1 would have displayed the survey announcement on article load as if it were a fundraising announcement.