### PR TITLE
Allow pronunciation audio playback when ring/silent switch is engaged

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -3571,7 +3571,7 @@
 		8330531D23EF051900123141 /* NSArray+WMFMapping.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+WMFMapping.m"; sourceTree = "<group>"; };
 		8330531E23EF051900123141 /* NSArray+WMFMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+WMFMapping.h"; sourceTree = "<group>"; };
 		8330532123EF05D000123141 /* WMFBlocksKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WMFBlocksKit.swift; sourceTree = "<group>"; };
-		8330532823EF0B4200123141 /* ArticleViewController+Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleViewController+Media.swift"; sourceTree = "<group>"; };
+		8330532823EF0B4200123141 /* ArticleViewController+Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleViewController+Media.swift"; sourceTree = "<group>"; usesTabs = 0; };
 		8330532D23EF107D00123141 /* MediaListGalleryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaListGalleryViewController.swift; sourceTree = "<group>"; };
 		8330533223F0388E00123141 /* DataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreTests.swift; sourceTree = "<group>"; };
 		8336F1422119BD6E000CDE02 /* MediaWikiAcceptLanguageMapping.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = MediaWikiAcceptLanguageMapping.json; sourceTree = "<group>"; };

--- a/Wikipedia/Code/ArticleViewController+Media.swift
+++ b/Wikipedia/Code/ArticleViewController+Media.swift
@@ -42,6 +42,7 @@ extension ArticleViewController {
     }
     
     func showAudio(with url: URL) {
+        try? AVAudioSession.sharedInstance().setCategory(.playback)
         let vc = AVPlayerViewController()
         let player = AVPlayer(url: url)
         vc.player = player


### PR DESCRIPTION
https://phabricator.wikimedia.org/T250534

Allows audio playback from articles regardless of ring/silent switch position. While there's also a way to immediately start playback of the audio clip on the user's initial tap, it feels more user conscious to force them to explicitly tap on the play button in the `AVPlayerViewController` before playing any audio. Main reason being if a user has the silent switch engaged, it's likely they don't want any unexpected sound from their device. But if they've then reached this far into the media player and explicitly tap the play button, we have a higher level of confidence they are aware their muted device may sound.  