### PR TITLE
Improve offline experience when refreshing articles

### DIFF
--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -557,7 +557,6 @@ class ArticleViewController: ViewController, HintPresenting {
     
     @objc public func refresh() {
         if !shouldPerformWebRefreshAfterScrollViewDeceleration {
-            toolbarController.setToolbarButtons(enabled: false)
             updateRefreshOverlay(visible: true)
         }
         shouldPerformWebRefreshAfterScrollViewDeceleration = true
@@ -577,6 +576,7 @@ class ArticleViewController: ViewController, HintPresenting {
         UIViewPropertyAnimator.runningPropertyAnimator(withDuration: duration, delay: 0, options: [.curveEaseIn], animations: {
             self.refreshOverlay.alpha = alpha
         })
+        toolbarController.setToolbarButtons(enabled: !visible)
     }
     
     // MARK: Overrideable functionality
@@ -1014,7 +1014,6 @@ extension ArticleViewController: WKNavigationDelegate {
         if shouldPerformWebRefreshAfterScrollViewDeceleration {
             updateRefreshOverlay(visible: false)
             webView.scrollView.showsVerticalScrollIndicator = true
-            toolbarController.setToolbarButtons(enabled: true)
             shouldPerformWebRefreshAfterScrollViewDeceleration = false
         }
     }

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -564,7 +564,7 @@ class ArticleViewController: ViewController, HintPresenting {
     }
 
     internal func performWebViewRefresh() {
-        #if DEBUG // on debug builds, reload everything including JS and CSS
+        #if WMF_LOCAL_PAGE_CONTENT_SERVICE // on local PCS builds, reload everything including JS and CSS
             webView.reloadFromOrigin()
         #else // on release builds, just reload the page with a different cache policy
             loadPage(cachePolicy: .noPersistentCacheOnError)

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -558,9 +558,7 @@ class ArticleViewController: ViewController, HintPresenting {
     @objc public func refresh() {
         if !shouldPerformWebRefreshAfterScrollViewDeceleration {
             toolbarController.setToolbarButtons(enabled: false)
-            UIViewPropertyAnimator.runningPropertyAnimator(withDuration: 0.15, delay: 0, options: [.curveEaseIn], animations: {
-                self.refreshOverlay.alpha = 0.30
-            })
+            updateRefreshOverlay(visible: true)
         }
         shouldPerformWebRefreshAfterScrollViewDeceleration = true
     }
@@ -571,6 +569,14 @@ class ArticleViewController: ViewController, HintPresenting {
         #else // on release builds, just reload the page with a different cache policy
             loadPage(cachePolicy: .noPersistentCacheOnError)
         #endif
+    }
+
+    internal func updateRefreshOverlay(visible: Bool, animated: Bool = true) {
+        let duration = animated ? (visible ? 0.15 : 0.1) : 0.0
+        let alpha: CGFloat = visible ? 0.3 : 0.0
+        UIViewPropertyAnimator.runningPropertyAnimator(withDuration: duration, delay: 0, options: [.curveEaseIn], animations: {
+            self.refreshOverlay.alpha = alpha
+        })
     }
     
     // MARK: Overrideable functionality
@@ -1005,9 +1011,7 @@ extension ArticleViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
         if shouldPerformWebRefreshAfterScrollViewDeceleration {
-            UIViewPropertyAnimator.runningPropertyAnimator(withDuration: 0.1, delay: 0, options: [.curveEaseIn], animations: {
-                self.refreshOverlay.alpha = 0
-            })
+            updateRefreshOverlay(visible: false)
             webView.scrollView.showsVerticalScrollIndicator = true
             toolbarController.setToolbarButtons(enabled: true)
             shouldPerformWebRefreshAfterScrollViewDeceleration = false

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -940,6 +940,7 @@ extension ArticleViewController {
         }
         showError(error)
         refreshControl.endRefreshing()
+        updateRefreshOverlay(visible: false)
     }
     
     func articleLoadDidFail(with error: Error) {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T249626

This is the second part of the article refresh work. This PR addresses some corner cases surrounding the user being interaction locked when offline in a saved article. My confidence in the user's offline experience regarding this functionality has improved, but let me know if you notice anything odd.

The last component of the work we split off from the original ticket is trying to pin down that last 10% of jitteriness, which I'll attempt to address in a separate PR.