### PR TITLE
Stop background task when no more articles exist

### DIFF
--- a/Wikipedia/Code/SavedArticlesFetcher.swift
+++ b/Wikipedia/Code/SavedArticlesFetcher.swift
@@ -424,6 +424,7 @@ class MobileViewToMobileHTMLMigrationController: NSObject {
         }
 
         guard let nonNilArticle = article else {
+            stop()
             // No more articles to convert, ensure the legacy folder is deleted
             //TODO: uncomment after 6.6 Beta releases once we no longer need backup of old data
 //            DispatchQueue.global(qos: .background).async {


### PR DESCRIPTION
Fixes warning being printed to console:
```[BackgroundTask] Background Task 10 ("MobileviewToMobileHTMLConverter"), was created over 30 seconds ago. In applications running in the background, this creates a risk of termination. Remember to call UIApplication.endBackgroundTask(_:) for your task in a timely manner to avoid this.```

It seems like we were terminating the task if anything went wrong, but not in the happy path. This line stops the task, and the message is no longer shown.