### PR TITLE
Improve VoiceOver for Table of Contents

### DIFF
--- a/Wikipedia/Code/TableOfContentsCell.swift
+++ b/Wikipedia/Code/TableOfContentsCell.swift
@@ -11,6 +11,11 @@ class TableOfContentsCell: UITableViewCell {
         didSet {
             titleLabelTopConstraint.constant = titleIndentationLevel == 0 ? 19 : 11;
             indentationConstraint.constant =  indentationWidth * CGFloat(1 + titleIndentationLevel)
+            if (titleIndentationLevel == 0) {
+                accessibilityTraits = .header
+            } else {
+                accessibilityValue = String.localizedStringWithFormat(WMFLocalizedString("table-of-contents-subheading-label", value:"Subheading %1$d", comment:"VoiceOver label to indicate level of subheading in table of contents. %1$d is replaced by the level of subheading."), titleIndentationLevel)
+            }
         }
     }
     
@@ -81,6 +86,8 @@ class TableOfContentsCell: UITableViewCell {
         indentationLevel = 1
         setSectionSelected(false, animated: false)
         isTitleLabelHighlighted = false
+        accessibilityTraits = []
+        accessibilityValue = nil
     }
     
     

--- a/Wikipedia/Code/TableOfContentsViewController.swift
+++ b/Wikipedia/Code/TableOfContentsViewController.swift
@@ -252,7 +252,13 @@ class TableOfContentsViewController: UIViewController, UITableViewDelegate, UITa
         cell.titleIndentationLevel = item.indentationLevel
         let color = item.itemType == .primary ? theme.colors.primaryText : theme.colors.secondaryText
         let selectionColor = theme.colors.link
-        cell.setTitleHTML(item.titleHTML, with: item.itemType.titleTextStyle, highlighted: index == indexOfSelectedItem, color: color, selectionColor: selectionColor)
+        let isHighlighted = index == indexOfSelectedItem
+        cell.setTitleHTML(item.titleHTML, with: item.itemType.titleTextStyle, highlighted: isHighlighted, color: color, selectionColor: selectionColor)
+
+        if (isHighlighted) {
+            // This makes no difference to sighted users; it allows VoiceOver to read highlighted cell as selected.
+            cell.accessibilityTraits = .selected
+        }
         
         cell.setNeedsLayout()
 

--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -761,6 +761,7 @@
 "table-of-contents-close-accessibility-label" = "Close Table of contents";
 "table-of-contents-heading" = "Contents";
 "table-of-contents-hide-button-label" = "Hide table of contents";
+"table-of-contents-subheading-label" = "Subheading $1";
 "talk-page-add-discussion-accessibility-label" = "Add discussion";
 "talk-page-discussion-accessibility-hint" = "Double tap to open discussion thread";
 "talk-page-discussion-read-accessibility-label" = "Read";

--- a/Wikipedia/Localizations/qqq.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/qqq.lproj/Localizable.strings
@@ -761,6 +761,7 @@
 "table-of-contents-close-accessibility-label" = "Accessibility label for closing table of contents";
 "table-of-contents-heading" = "Header text appearing above the first section in the table of contents {{Identical|Content}}";
 "table-of-contents-hide-button-label" = "Accessibility label for the hide Table of Contents button";
+"table-of-contents-subheading-label" = "VoiceOver label to indicate level of subheading in table of contents. $1 is replaced by the level of subheading.";
 "talk-page-add-discussion-accessibility-label" = "Accessibility label for a button that opens the add new discussion screen.";
 "talk-page-discussion-accessibility-hint" = "Accessibility hint when user is on a discussion title cell.";
 "talk-page-discussion-read-accessibility-label" = "Accessibility text for indicating that a discussion's contents have been read.";


### PR DESCRIPTION
This does two things for VoiceOver:
- Reads the selected section as "Selected"
- Gives depth of header information.

We get the main header level for free via Apple's built in accessibility (in English, it reads "Heading"), but need to role our own subheader translations. This is my first time adding a new translation string in the app (I've been doing PCS-side localizable elements so far), so please let me know if any of this looks wrong.

Bug: T251318