### PR TITLE
Add `ArticleSurveyTimerController` for survey timer management

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		00841DE524477805003CF74A /* AppTabBarDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE891452445150B0058B642 /* AppTabBarDelegate.swift */; };
 		00841DE724477806003CF74A /* AppTabBarDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE891452445150B0058B642 /* AppTabBarDelegate.swift */; };
+		00A7946B245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A7946A245CA4E60063BA18 /* ArticleSurveyTimerController.swift */; };
+		00A7946C245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A7946A245CA4E60063BA18 /* ArticleSurveyTimerController.swift */; };
+		00A7946D245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A7946A245CA4E60063BA18 /* ArticleSurveyTimerController.swift */; };
+		00A7946E245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A7946A245CA4E60063BA18 /* ArticleSurveyTimerController.swift */; };
 		041EFC371996A1F800B2CB28 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 041EFC361996A1F800B2CB28 /* MapKit.framework */; };
 		0E281A331DC263DE00FA1AB1 /* WMFLegacyReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E281A321DC263DE00FA1AB1 /* WMFLegacyReference.swift */; };
 		0E36C2271AE0B59D00C58CFF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D4991453181D51DE00E6073C /* Images.xcassets */; };
@@ -3194,6 +3198,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		00A7946A245CA4E60063BA18 /* ArticleSurveyTimerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleSurveyTimerController.swift; sourceTree = "<group>"; usesTabs = 0; };
 		040E5C4E184566F4007AFE6F /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		041EFC361996A1F800B2CB28 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		0E10C4FD1C81046300CEB5C2 /* Wikipedia.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Wikipedia.entitlements; sourceTree = "<group>"; };
@@ -3282,9 +3287,9 @@
 		6707C031237DBCEA0017E7B6 /* DiffRevisionTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffRevisionTransition.swift; sourceTree = "<group>"; };
 		6707C037237F0A6E0017E7B6 /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
 		670F765E22B0C10600D87545 /* FakeProgressLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeProgressLoading.swift; sourceTree = "<group>"; };
-		67146031243B885E008CE885 /* SurveyAnnouncementsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyAnnouncementsController.swift; sourceTree = "<group>"; };
+		67146031243B885E008CE885 /* SurveyAnnouncementsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyAnnouncementsController.swift; sourceTree = "<group>"; usesTabs = 0; };
 		67146033243B8B4F008CE885 /* AnnouncementType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementType.swift; sourceTree = "<group>"; };
-		67146035243BCE51008CE885 /* ArticleViewController+SurveyAnnouncements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleViewController+SurveyAnnouncements.swift"; sourceTree = "<group>"; };
+		67146035243BCE51008CE885 /* ArticleViewController+SurveyAnnouncements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleViewController+SurveyAnnouncements.swift"; sourceTree = "<group>"; usesTabs = 0; };
 		6714D6CA245A2B9700CE5A4A /* ArticleCacheReadingManualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCacheReadingManualTests.swift; sourceTree = "<group>"; };
 		6714D6CC245A2C1D00CE5A4A /* ArticleTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleTestHelpers.swift; sourceTree = "<group>"; };
 		671AC2552226FB9B005B37F8 /* ReadingThemesControlsProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingThemesControlsProtocols.swift; sourceTree = "<group>"; };
@@ -3632,7 +3637,7 @@
 		83A642742226CCF1004A1796 /* SwiftKVOCrashWorkaround.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftKVOCrashWorkaround.swift; sourceTree = "<group>"; };
 		83A8E33F21A431F100B3FF82 /* WMFLegacySerializer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WMFLegacySerializer.h; path = "WMF Framework/WMFLegacySerializer.h"; sourceTree = SOURCE_ROOT; };
 		83A8E34021A431F100B3FF82 /* WMFLegacySerializer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = WMFLegacySerializer.m; path = "WMF Framework/WMFLegacySerializer.m"; sourceTree = SOURCE_ROOT; };
-		83B01F7123DA5327001185F4 /* ArticleViewController+ArticleWebMessageHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleViewController+ArticleWebMessageHandling.swift"; sourceTree = "<group>"; };
+		83B01F7123DA5327001185F4 /* ArticleViewController+ArticleWebMessageHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleViewController+ArticleWebMessageHandling.swift"; sourceTree = "<group>"; usesTabs = 0; };
 		83B01F7623DA5348001185F4 /* ArticleViewController+ArticleToolbarHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleViewController+ArticleToolbarHandling.swift"; sourceTree = "<group>"; };
 		83B01F7B23DB0BA2001185F4 /* ArticleViewController+Editing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleViewController+Editing.swift"; sourceTree = "<group>"; };
 		83B01F8023DB1235001185F4 /* SectionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionFetcher.swift; sourceTree = "<group>"; };
@@ -5930,6 +5935,7 @@
 			isa = PBXGroup;
 			children = (
 				67DC5BEE23A1427C00B03A84 /* ActionHandlerScript.swift */,
+				00A7946A245CA4E60063BA18 /* ArticleSurveyTimerController.swift */,
 				67DC5BE223A017CA00B03A84 /* ArticleViewController.swift */,
 				D8A47C8E23D7338C002AA823 /* ArticleViewController+TableOfContents.swift */,
 				83B01F7123DA5327001185F4 /* ArticleViewController+ArticleWebMessageHandling.swift */,
@@ -9859,6 +9865,7 @@
 				D8A6BAED1E4C9BF400A981C8 /* UserLocationAnnotationView.swift in Sources */,
 				6798331A22C174ED0073CE6F /* LinkOnlyTextView.swift in Sources */,
 				B0E8059A1C0CE2E40065EBC0 /* WMFSearchFunnel.m in Sources */,
+				00A7946B245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */,
 				41FCAA3621C844CB001D8411 /* ReadingListEntryCollectionViewController.swift in Sources */,
 				672C35EB22D8E7CA007B8D46 /* EmptyViewController.swift in Sources */,
 				7AB6F0FF22AEF4DF00F552B4 /* UIActivity.ActivityType+CustomTypes.swift in Sources */,
@@ -10652,6 +10659,7 @@
 				6798331D22C174F00073CE6F /* LinkOnlyTextView.swift in Sources */,
 				D8A42A581E815A9C00D8E281 /* WMFSearchFunnel.m in Sources */,
 				8368BB8724129F3D00BC88BA /* ViewController+ArticleErrorHandling.swift in Sources */,
+				00A7946E245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */,
 				41FCAA3921C844CB001D8411 /* ReadingListEntryCollectionViewController.swift in Sources */,
 				672C35EE22D8E7D2007B8D46 /* EmptyViewController.swift in Sources */,
 				7AB6F10222AEF4DF00F552B4 /* UIActivity.ActivityType+CustomTypes.swift in Sources */,
@@ -11477,6 +11485,7 @@
 				7AB7DEC9227203A600DD61A2 /* InsertMediaViewController.swift in Sources */,
 				B0CD9DDD1F70997400051843 /* WMFWelcomeAnimationView.swift in Sources */,
 				B0F929A01F84789D002A0788 /* WMFWelcomeInitialViewController.swift in Sources */,
+				00A7946D245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */,
 				B09705B5236B29D7006FDB5C /* DiffThanker.swift in Sources */,
 				D8CE25F01E698E2400DAE2E0 /* WMFAccountCreationViewController.swift in Sources */,
 				D8CE25F11E698E2400DAE2E0 /* UIImage+WMFFocalImageDrawing.m in Sources */,
@@ -11929,6 +11938,7 @@
 				7AB7DECA227203A600DD61A2 /* InsertMediaViewController.swift in Sources */,
 				D8EC3EE91E9BDA35006712EB /* WMFForgotPasswordViewController.swift in Sources */,
 				D8EC3EEB1E9BDA35006712EB /* WMFImageGalleryViewController.m in Sources */,
+				00A7946C245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */,
 				B09705B6236B29D7006FDB5C /* DiffThanker.swift in Sources */,
 				D8EC3EEF1E9BDA35006712EB /* WMFAccountCreationViewController.swift in Sources */,
 				D8EC3EF01E9BDA35006712EB /* UIImage+WMFFocalImageDrawing.m in Sources */,

--- a/Wikipedia/Code/ArticleSurveyTimerController.swift
+++ b/Wikipedia/Code/ArticleSurveyTimerController.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Manages the timer used to display survey announcements on articles
+final class ArticleSurveyTimerController {
+
+    // MARK: - Public Properties
+
+    var timerFireBlock: ((SurveyAnnouncementsController.SurveyAnnouncementResult) -> Void)?
+
+    // MARK: - Private Properties
+
+    private let articleURL: URL
+    private let surveyController: SurveyAnnouncementsController
+
+    private var timer: Timer?
+    private var timeIntervalRemainingWhenBackgrounded: TimeInterval?
+    private var shouldPauseOnBackground = false
+    private var shouldResumeOnForeground: Bool { return shouldPauseOnBackground }
+
+    // MARK: - Computed Properties
+
+    private var surveyAnnouncementResult: SurveyAnnouncementsController.SurveyAnnouncementResult? {
+        get {
+            guard let articleTitle = articleURL.wmf_title?.denormalizedPageTitle, let siteURL = articleURL.wmf_site else {
+                    return nil
+            }
+
+            return SurveyAnnouncementsController.shared.activeSurveyAnnouncementResultForTitle(articleTitle, siteURL: siteURL)
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    init(articleURL: URL, surveyController: SurveyAnnouncementsController) {
+        self.articleURL = articleURL
+        self.surveyController = surveyController
+    }
+
+    // MARK: - Public
+
+    func articleContentDidLoad() {
+        startTimer()
+    }
+
+    func viewWillAppear(withState state: ArticleViewController.ViewState) {
+        if state == .loaded, surveyAnnouncementResult != nil {
+            shouldPauseOnBackground = true
+            startTimer()
+        }
+    }
+
+    func viewWillDisappear(withState state: ArticleViewController.ViewState) {
+        // Do not listen for background/foreground notifications to pause and resume survey if this article is not on screen anymore
+        if state == .loaded, surveyAnnouncementResult != nil {
+            shouldPauseOnBackground = false
+            stopTimer()
+        }
+    }
+
+    func willResignActive(withState state: ArticleViewController.ViewState) {
+        if state == .loaded, shouldPauseOnBackground {
+            pauseTimer()
+        }
+    }
+
+    func didBecomeActive(withState state: ArticleViewController.ViewState) {
+        if state == .loaded, shouldResumeOnForeground {
+            resumeTimer()
+        }
+    }
+
+    // MARK: - Timer State Management
+
+    private func startTimer(withTimeInterval customTimeInterval: TimeInterval? = nil) {
+        guard let surveyAnnouncementResult = surveyAnnouncementResult else {
+            return
+        }
+
+        shouldPauseOnBackground = true
+        let timeInterval = customTimeInterval ?? surveyAnnouncementResult.displayDelay
+
+        timer = Timer.scheduledTimer(withTimeInterval: timeInterval, repeats: false, block: { [weak self] timer in
+            guard let self = self else {
+                return
+            }
+
+            self.timerFireBlock?(surveyAnnouncementResult)
+            self.stopTimer()
+            self.shouldPauseOnBackground = false
+        })
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func pauseTimer() {
+        guard timer != nil, shouldPauseOnBackground else {
+            return
+        }
+
+        timeIntervalRemainingWhenBackgrounded = calculateRemainingTimerTimeInterval()
+        stopTimer()
+    }
+
+    private func resumeTimer() {
+        guard timer == nil, shouldResumeOnForeground else {
+            return
+        }
+
+        startTimer(withTimeInterval: timeIntervalRemainingWhenBackgrounded)
+    }
+
+    /// Calculate remaining TimeInterval (if any) until survey timer fire date
+    private func calculateRemainingTimerTimeInterval() -> TimeInterval? {
+        guard let timer = timer else {
+            return nil
+        }
+
+        let remainingTime = timer.fireDate.timeIntervalSince(Date())
+        return remainingTime < 0 ? nil : remainingTime
+    }
+
+}

--- a/Wikipedia/Code/ArticleSurveyTimerController.swift
+++ b/Wikipedia/Code/ArticleSurveyTimerController.swift
@@ -22,7 +22,7 @@ final class ArticleSurveyTimerController {
     private var surveyAnnouncementResult: SurveyAnnouncementsController.SurveyAnnouncementResult? {
         get {
             guard let articleTitle = articleURL.wmf_title?.denormalizedPageTitle, let siteURL = articleURL.wmf_site else {
-                    return nil
+                return nil
             }
 
             return surveyController.activeSurveyAnnouncementResultForTitle(articleTitle, siteURL: siteURL)

--- a/Wikipedia/Code/ArticleSurveyTimerController.swift
+++ b/Wikipedia/Code/ArticleSurveyTimerController.swift
@@ -25,7 +25,7 @@ final class ArticleSurveyTimerController {
                     return nil
             }
 
-            return SurveyAnnouncementsController.shared.activeSurveyAnnouncementResultForTitle(articleTitle, siteURL: siteURL)
+            return surveyController.activeSurveyAnnouncementResultForTitle(articleTitle, siteURL: siteURL)
         }
     }
 

--- a/Wikipedia/Code/ArticleViewController+ArticleWebMessageHandling.swift
+++ b/Wikipedia/Code/ArticleViewController+ArticleWebMessageHandling.swift
@@ -51,7 +51,7 @@ extension ArticleViewController: ArticleWebMessageHandling {
         webView.becomeFirstResponder()
         showWIconPopoverIfNecessary()
         refreshControl.endRefreshing()
-        startSurveyAnnouncementTimer()
+        surveyTimerController.articleContentDidLoad()
     }
     
     @objc func handlePCSDidFinishFinalSetup() {

--- a/Wikipedia/Code/ArticleViewController+SurveyAnnouncements.swift
+++ b/Wikipedia/Code/ArticleViewController+SurveyAnnouncements.swift
@@ -1,27 +1,8 @@
-
 import Foundation
 
 extension ArticleViewController {
-    
-    func startSurveyAnnouncementTimer() {
-        
-        guard let surveyAnnouncementResult = surveyAnnouncementResult else {
-            return
-        }
-        
-        surveyAnnouncementTimer = Timer.scheduledTimer(withTimeInterval: surveyAnnouncementResult.displayDelay, repeats: false, block: { [weak self] (timer) in
-            
-            guard let self = self else {
-                return
-            }
-            
-            self.showSurveyAnnouncementPanel(surveyAnnouncementResult: surveyAnnouncementResult)
-            
-            self.stopSurveyAnnouncementTimer()
-        })
-    }
-    
-    private func showSurveyAnnouncementPanel(surveyAnnouncementResult: SurveyAnnouncementsController.SurveyAnnouncementResult) {
+
+    func showSurveyAnnouncementPanel(surveyAnnouncementResult: SurveyAnnouncementsController.SurveyAnnouncementResult) {
         
         guard state == .loaded else {
             return
@@ -47,9 +28,5 @@ extension ArticleViewController {
             }
         }, theme: self.theme)
     }
-    
-    func stopSurveyAnnouncementTimer() {
-        surveyAnnouncementTimer?.invalidate()
-        surveyAnnouncementTimer = nil
-    }
+
 }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T248510#6098622

Incomplete and not particularly happy with my approach here, but at least wanted to have something for you to look at by the morning. Feel free to unassign me and pick it up from here or I can continue on it in the morning.

1. Pause/resume survey timer when app's backgrounded/foregrounded
2. Start survey timer in `viewWillAppear` if PCS is loaded to handle case of navigating back to article

Just stubbed a `surveyAnnouncementResult` to test timer appearance stuff. Please don't merge without removing those TODOs and testing against actual survey announcement stack – there may be stale state issues depending on how/when `surveyAnnouncementResult` is mutated. There's also a separate issue with the background/foreground notifications being triggered multiple times, but didn't want to touch anything there in case there were unintended consequences.
