### PR TITLE
Update url scheme docs

### DIFF
--- a/docs/url_schemes.md
+++ b/docs/url_schemes.md
@@ -2,10 +2,13 @@
 
 The URL scheme is `wikipedia://`. The following URLs are currently handled:
 
-| Feature      | Format                                   | Example                                  |
-| ------------ | ---------------------------------------- | ---------------------------------------- |
-| Open article | wikipedia://[site]/wiki/[page_id]        | wikipedia://en.wikipedia.org/wiki/Red    |
-| Explore      | wikipedia://explore                      |                                          |
-| History      | wikipedia://history                      |                                          |
-| Saved pages  | wikipedia://saved                        |                                          |
-| Search       | wikipedia://[site]/w/index.php?search=[query] | wikipedia://en.wikipedia.org/w/index.php?search=dog |
+| Feature            | Format                                   | Example                                  |
+| ------------------ | ---------------------------------------- | ---------------------------------------- |
+| Article            | wikipedia://[site]/wiki/[page_id]        | wikipedia://en.wikipedia.org/wiki/Red    |
+|                    | https://[[site]/wiki/[page_id]           | https://en.wikipedia.org/wiki/Red        |
+| Content            | wikipedia://content                      |                                          |
+| Explore            | wikipedia://explore                      |                                          |
+| History            | wikipedia://history                      |                                          |
+| Places             | wikipedia://places[?WMFArticleURL=]      |                                          |
+| Saved pages        | wikipedia://saved                        |                                          |
+| Search             | wikipedia://[site]/w/index.php?search=[query] | wikipedia://en.wikipedia.org/w/index.php?search=dog |


### PR DESCRIPTION
Updates the schemes, reconstructed from the source code.

I'm unsure about the Content urls, I couldn't figure out what they are supposed to do. 

Also, the search scheme doesn't work currently: the expected activity type is `WMFUserActivityTypeSearchResults`, but `NSUserActivity.wmf_type` doesn't return this. It constructs a search url in the form of `https://en.wikipedia.org/w/index.php?search=dog&title=Special:Search&fulltext=1`, passes it to the router which does not know what to do with it.

