### PR TITLE
Only show updating animation if a library migration is occurring on launch

### DIFF
--- a/Wikipedia/Code/MWKDataStore.h
+++ b/Wikipedia/Code/MWKDataStore.h
@@ -51,9 +51,8 @@ typedef NS_OPTIONS(NSUInteger, RemoteConfigOption) {
 
 @property (readonly, strong, nonatomic) NSURL *containerURL;
 
-- (void)performLibraryUpdates:(dispatch_block_t)completion;
+- (void)performLibraryUpdates:(dispatch_block_t)completion needsMigrateBlock:(dispatch_block_t)needsMigrateBlock;
 - (void)performInitialLibrarySetup;
-- (void)performUpdatesFromLibraryVersion:(NSUInteger)currentLibraryVersion inManagedObjectContext:(NSManagedObjectContext *)moc;
 
 - (void)updateLocalConfigurationFromRemoteConfigurationWithCompletion:(nullable void (^)(NSError *nullable))completion;
 @property (readwrite, nonatomic) BOOL isLocalConfigUpdateAllowed;

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -452,7 +452,7 @@ static uint64_t bundleHash() {
 
 /// Library updates are separate from Core Data migration and can be used to orchestrate migrations that are more complex than automatic Core Data migration allows.
 /// They can also be used to perform migrations when the underlying Core Data model has not changed version but the apps' logic has changed in a way that requires data migration.
-- (void)performLibraryUpdates:(dispatch_block_t)completion {
+- (void)performLibraryUpdates:(dispatch_block_t)completion needsMigrateBlock:(dispatch_block_t)needsMigrateBlock {
     dispatch_block_t combinedCompletion = ^{
         [WMFImageCacheControllerWrapper performLibraryUpdates:^(NSError * _Nullable error) {
             if (error) {
@@ -476,6 +476,8 @@ static uint64_t bundleHash() {
         combinedCompletion();
         return;
     }
+    
+    needsMigrateBlock();
     [self performBackgroundCoreDataOperationOnATemporaryContext:^(NSManagedObjectContext *moc) {
         [self performUpdatesFromLibraryVersion:currentUserLibraryVersion inManagedObjectContext:moc];
         combinedCompletion();

--- a/Wikipedia/Code/RootNavigationController.swift
+++ b/Wikipedia/Code/RootNavigationController.swift
@@ -39,4 +39,8 @@ class RootNavigationController: WMFThemeableNavigationController {
         }
         splashScreenViewController = nil
     }
+    
+    @objc func triggerMigratingAnimation() {
+        splashScreenViewController?.triggerMigratingAnimation()
+    }
 }

--- a/Wikipedia/Code/SplashScreenViewController.swift
+++ b/Wikipedia/Code/SplashScreenViewController.swift
@@ -20,8 +20,7 @@ class SplashScreenViewController: ThemeableViewController {
         setupSplashView()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    func triggerMigratingAnimation() {
         perform(#selector(showLoadingAnimation), with: nil, afterDelay: SplashScreenViewController.maximumNonInteractiveTimeInterval)
     }
     
@@ -89,7 +88,7 @@ class SplashScreenViewController: ThemeableViewController {
        return LoadingAnimationViewController(nibName: "LoadingAnimationViewController", bundle: nil)
     }()
     
-    @objc func showLoadingAnimation() {
+    @objc private func showLoadingAnimation() {
         loadingAnimationShowTime = CFAbsoluteTimeGetCurrent()
         wmf_add(childController: loadingAnimationViewController, andConstrainToEdgesOfContainerView: view, belowSubview: splashView)
         UIView.animate(withDuration: SplashScreenViewController.crossFadeAnimationDuration) {

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -775,6 +775,7 @@ static const NSString *kvo_SavedArticlesFetcher_progress = @"kvo_SavedArticlesFe
 //    };
 
     self.migrationActive = YES;
+    [(WMFRootNavigationController *)self.navigationController triggerMigratingAnimation];
 
     [self.dataStore performLibraryUpdates:^{
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -775,7 +775,6 @@ static const NSString *kvo_SavedArticlesFetcher_progress = @"kvo_SavedArticlesFe
 //    };
 
     self.migrationActive = YES;
-    [(WMFRootNavigationController *)self.navigationController triggerMigratingAnimation];
 
     [self.dataStore performLibraryUpdates:^{
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -787,6 +786,10 @@ static const NSString *kvo_SavedArticlesFetcher_progress = @"kvo_SavedArticlesFe
             if (!self.isWaitingToResumeApp) {
                 [self resumeApp:NULL];
             }
+        });
+    } needsMigrateBlock: ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [(WMFRootNavigationController *)self.navigationController triggerMigratingAnimation];
         });
     }];
 }

--- a/Wikipedia/Code/WMFThemeableNavigationController.m
+++ b/Wikipedia/Code/WMFThemeableNavigationController.m
@@ -5,7 +5,6 @@
 @interface WMFThemeableNavigationController ()
 
 @property (nonatomic, strong) WMFTheme *theme;
-@property (nonatomic, nullable) WMFSplashScreenViewController *splashScreenViewController;
 @property (nonatomic) WMFThemeableNavigationControllerStyle style;
 @end
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T252155

To do this I separated the `showLoadingAnimation` method from the `viewDidAppear` lifecycle event, leaving `AppViewController` to trigger it explicitly. In `performLibraryUpdates`, I trigger a block that shows the animation if it reaches a point where the we know their current library version is not the latest. This will fail if we do a long-running Core Data migration (either auto or custom) _without_ bumping up the WMFCurrentLibraryVersion. I wasn't sure if we ever do that or need that. Worst case in that situation they should see the old splash screen for longer instead of the animation.

Some test cases to try:

1. Fresh install and launch, you should not see animation.
2. Migrate with a small library (something that takes < 4 seconds), you should not see animation.
3. Migrate with a large library, you should see animation and animation and splash screen properly disappears once complete.
4. Launch app via deep link, you should not see the animation.