### PR TITLE
Allow user to tap article to dismiss references

### DIFF
--- a/Wikipedia/Code/ArticleViewController+References.swift
+++ b/Wikipedia/Code/ArticleViewController+References.swift
@@ -206,6 +206,10 @@ extension ArticleViewController: ReferenceBackLinksViewControllerDelegate {
 
 extension ArticleViewController: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return true
+        if gestureRecognizer === referenceWebViewBackgroundTapGestureRecognizer {
+            return true
+        }
+        
+        return false //default
     }
 }

--- a/Wikipedia/Code/ArticleViewController+References.swift
+++ b/Wikipedia/Code/ArticleViewController+References.swift
@@ -81,6 +81,10 @@ extension ArticleViewController {
         dismiss(animated: true)
     }
     
+    @objc func tappedWebViewBackground() {
+        dismissReferenceBackLinksViewController()
+    }
+    
     func showReferenceBackLinks(_ backLinks: [ReferenceBackLink], referenceId: String, referenceText: String) {
         guard let vc = ReferenceBackLinksViewController(referenceId: referenceId, referenceText: referenceText, backLinks: backLinks, delegate: self, theme: theme) else {
             showGenericError()
@@ -89,14 +93,16 @@ extension ArticleViewController {
         addChild(vc)
         view.wmf_addSubviewWithConstraintsToEdges(vc.view)
         vc.didMove(toParent: self)
+        referenceWebViewBackgroundTapGestureRecognizer.isEnabled = true
     }
     
     func dismissReferenceBackLinksViewController() {
         let vc = children.first { $0 is ReferenceBackLinksViewController }
-       vc?.willMove(toParent: nil)
-       vc?.view.removeFromSuperview()
-       vc?.removeFromParent()
-       messagingController.removeElementHighlights()
+        vc?.willMove(toParent: nil)
+        vc?.view.removeFromSuperview()
+        vc?.removeFromParent()
+        messagingController.removeElementHighlights()
+        referenceWebViewBackgroundTapGestureRecognizer.isEnabled = false
     }
 }
 
@@ -195,5 +201,11 @@ extension ArticleViewController: ReferenceBackLinksViewControllerDelegate {
                 self?.messagingController.removeElementHighlights()
             }
         }
+    }
+}
+
+extension ArticleViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
     }
 }

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -57,6 +57,14 @@ class ArticleViewController: ViewController, HintPresenting {
         return rc
     }()
     
+    lazy var referenceWebViewBackgroundTapGestureRecognizer: UITapGestureRecognizer = {
+        let tapGR = UITapGestureRecognizer(target: self, action: #selector(tappedWebViewBackground))
+        tapGR.delegate = self
+        webView.scrollView.addGestureRecognizer(tapGR)
+        tapGR.isEnabled = false
+        return tapGR
+    }()
+    
     @objc init?(articleURL: URL, dataStore: MWKDataStore, theme: Theme, schemeHandler: SchemeHandler = SchemeHandler.shared) {
         guard
             let article = dataStore.fetchOrCreateArticle(with: articleURL),


### PR DESCRIPTION
https://phabricator.wikimedia.org/T244627#6117483

Attempt to allow the user to both scroll the article underneath and tap to dismiss while the `ReferenceBackLinksViewController` overlay is presenting.