### PR TITLE
Hide splash view with animation after onboarding

### DIFF
--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -845,7 +845,7 @@ static const NSString *kvo_SavedArticlesFetcher_progress = @"kvo_SavedArticlesFe
             [self showExplore];
             done();
         } else {
-            [self hideSplashViewAnimated:!didShowOnboarding];
+            [self hideSplashViewAnimated:true];
             done();
         }
     }];


### PR DESCRIPTION
Something I noticed while reviewing https://github.com/wikimedia/wikipedia-ios/pull/3569: when first installing/launching the app and dismissing the onboarding, the "Wikipedia" splash view doesn't animate out with a fade out but instead just instantaneously hides. This is a jarring and unexpected experience compared to normal, when it gracefully fades out. Unless someone notices something I'm missing, any reason to not just always animate away the splash screen in this fallback else case?