### PR TITLE
Sync with campaign id prefix tweak for iOS announcement

### DIFF
--- a/Wikipedia/Code/WMFAnnouncementsContentSource.m
+++ b/Wikipedia/Code/WMFAnnouncementsContentSource.m
@@ -62,7 +62,6 @@
             }];
         }
         success:^(NSArray<WMFAnnouncement *> *announcements) {
-            
             [self saveAnnouncements:announcements
                 inManagedObjectContext:moc
                             completion:^{
@@ -129,10 +128,10 @@
 
     // Workaround for the great fundraising mystery of 2019: https://phabricator.wikimedia.org/T247554
     // TODO: Further investigate the root cause before adding the 2020 fundraising banner: https://phabricator.wikimedia.org/T247976
-    //also deleting SURVEY20 because we want to bypass persistence and only consider in online mode
+    //also deleting IOSSURVEY20 because we want to bypass persistence and only consider in online mode
     NSArray *announcements = [moc contentGroupsOfKind:WMFContentGroupKindAnnouncement];
     for (WMFContentGroup *announcement in announcements) {
-        if (![announcement.key containsString:@"FUNDRAISING19"] && ![announcement.key containsString:@"SURVEY20"]) {
+        if (![announcement.key containsString:@"FUNDRAISING19"] && ![announcement.key containsString:@"IOSSURVEY20"]) {
             continue;
         }
         [moc deleteObject:announcement];


### PR DESCRIPTION
This shouldn't affect anything since we use `containsString` to find this identifier, but since the backend identifier prefix [changed](https://gerrit.wikimedia.org/r/#/c/mediawiki/services/wikifeeds/+/595954/) I feel better syncing it up client side as well to be closer to how it was when we ran the tests.

After changing the iOS campaign end date locally and running, I attached what the output looks like before vs. after the server-side change. Notice only the `id` changes for our announcement from `SURVEY20IOSV3EN` to `IOSSURVEY20IOSV3EN`.

[before.txt](https://github.com/wikimedia/wikipedia-ios/files/4624001/before.txt)
[after.txt](https://github.com/wikimedia/wikipedia-ios/files/4624000/after.txt)
