### PR TITLE
Pull article summaries from cache when device is offline

### DIFF
--- a/Wikipedia/Code/ArticlePeekPreviewViewController.swift
+++ b/Wikipedia/Code/ArticlePeekPreviewViewController.swift
@@ -33,7 +33,7 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
             completion?()
             return
         }
-        dataStore.articleSummaryController.updateOrCreateArticleSummaryForArticle(withKey: key) { (article, _) in
+        dataStore.articleSummaryController.updateOrCreateArticleSummaryForArticle(withKey: key, cachePolicy: .returnCacheDataElseLoad) { (article, _) in
             defer {
                 completion?()
             }


### PR DESCRIPTION
This is a fix to the "when offline, cached summaries don't show in 3d touch's peek" problem. See **Testing** (below) for important info. I'm only partially confident in this solution, as I'm testing on simulator (no 3D touch devices in the home) and can only somewhat replicate this mode.

This is my first time messing with our caching layer - I spent quite a while digging in, and my understanding is that this change is pulling the summary from the cache, and falling back to making a request if it doesn't exist. (Please let me know if this is understanding is incorrect.) This brings us to a...

**Tradeoff**
When peeking, we're not checking for a new article summary if one is cached. So each time, we show the summary that is from the last time we cached the full article. (I confirmed that the summary gets cached with the full article load.) This does give a slight performance boost for cached article summaries, but at the cost of potentially slightly out-of-date data. Is this an acceptable tradeoff? (And if not, anyone have an idea on a cache policy for "prefer getting new article summary, but fall back to cache if no internet" option? Or do we need to create that ourselves?)

**Test Steps**
1. This PR can only be tested on [a device w/ 3D touch](https://en.wikipedia.org/wiki/Force_Touch#Products), or simulator of such a device. To be extra-clear: This will not be testable on a iPhone 11 simulator, but will be on something like an iPhone 8 simulator.
1. Save an article. Wait a few seconds to ensure it caches.
1. Turn off internet for the device. (Via airplane mode if on a real device. If on simulator, see below.)
1. On the Saved tab, force touch a saved article so that the peek (small view w/ article summary) appears over part of the Saved articles list, but don't press so hard that you pop into the entire article. Ensure you can see the article summary, and don't get an everlasting spinner in the peek mini-view.

**Testing notes**
This would be much better to test on a device. I have not been able to do so, and thus it's possible I've missed some nuances of this problem/fix.

Testing on simulator: To simulate offline/airplane mode on a simulator, turn off wifi on to your laptop. (First, of course, say a temporary goodbye to your streaming music.) I'm getting inconsistent behavior when doing this. There are times that when wifi is off, requests (of articles, article summaries, etc.) just end up seemingly waiting for a long timeout. I've found best results when quitting the simulator, turning off laptop wifi, and then launching the app. At that point, I believe you can toggle the laptop wifi at will.

*Example of article summary peek*
<img src="https://user-images.githubusercontent.com/9295855/82379392-aeeee200-99db-11ea-96c5-b97a6f660308.png" width=200 />