### PR TITLE
Check survey announcement end time before presenting survey

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -3206,7 +3206,7 @@
 /* Begin PBXFileReference section */
 		00A7946A245CA4E60063BA18 /* ArticleSurveyTimerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleSurveyTimerController.swift; sourceTree = "<group>"; usesTabs = 0; };
 		00D280F6247EFFFE006BEE23 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; usesTabs = 0; };
-		00D280FB247F019C006BEE23 /* Date+ExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+ExtensionTests.swift"; sourceTree = "<group>"; };
+		00D280FB247F019C006BEE23 /* Date+ExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+ExtensionTests.swift"; sourceTree = "<group>"; usesTabs = 0; };
 		040E5C4E184566F4007AFE6F /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		041EFC361996A1F800B2CB28 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		0E10C4FD1C81046300CEB5C2 /* Wikipedia.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Wikipedia.entitlements; sourceTree = "<group>"; };

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -13,6 +13,11 @@
 		00A7946C245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A7946A245CA4E60063BA18 /* ArticleSurveyTimerController.swift */; };
 		00A7946D245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A7946A245CA4E60063BA18 /* ArticleSurveyTimerController.swift */; };
 		00A7946E245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A7946A245CA4E60063BA18 /* ArticleSurveyTimerController.swift */; };
+		00D280F7247EFFFE006BEE23 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D280F6247EFFFE006BEE23 /* Date+Extensions.swift */; };
+		00D280F8247EFFFE006BEE23 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D280F6247EFFFE006BEE23 /* Date+Extensions.swift */; };
+		00D280F9247EFFFE006BEE23 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D280F6247EFFFE006BEE23 /* Date+Extensions.swift */; };
+		00D280FA247EFFFE006BEE23 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D280F6247EFFFE006BEE23 /* Date+Extensions.swift */; };
+		00D280FC247F019C006BEE23 /* Date+ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D280FB247F019C006BEE23 /* Date+ExtensionTests.swift */; };
 		041EFC371996A1F800B2CB28 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 041EFC361996A1F800B2CB28 /* MapKit.framework */; };
 		0E281A331DC263DE00FA1AB1 /* WMFLegacyReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E281A321DC263DE00FA1AB1 /* WMFLegacyReference.swift */; };
 		0E36C2271AE0B59D00C58CFF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D4991453181D51DE00E6073C /* Images.xcassets */; };
@@ -3200,6 +3205,8 @@
 
 /* Begin PBXFileReference section */
 		00A7946A245CA4E60063BA18 /* ArticleSurveyTimerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleSurveyTimerController.swift; sourceTree = "<group>"; usesTabs = 0; };
+		00D280F6247EFFFE006BEE23 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; usesTabs = 0; };
+		00D280FB247F019C006BEE23 /* Date+ExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+ExtensionTests.swift"; sourceTree = "<group>"; };
 		040E5C4E184566F4007AFE6F /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		041EFC361996A1F800B2CB28 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		0E10C4FD1C81046300CEB5C2 /* Wikipedia.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Wikipedia.entitlements; sourceTree = "<group>"; };
@@ -5077,6 +5084,7 @@
 				BC45D5831C32F79A007C72F3 /* UIScrollView */,
 				BC45D5821C32F745007C72F3 /* UIView */,
 				BC45D5811C32F6BC007C72F3 /* UIViewController */,
+				00D280F6247EFFFE006BEE23 /* Date+Extensions.swift */,
 				0EE489021D4ADCA00088505C /* UIViewController+WMFScrollToTop.swift */,
 				D81E5F871E5F2C8400E1A80C /* UIApplication+SystemSettings.swift */,
 				6707C037237F0A6E0017E7B6 /* UIFont+Extensions.swift */,
@@ -7373,6 +7381,7 @@
 				D8B9DB022271E4A300B51F14 /* SecurityTests.swift */,
 				D8396D1A22CF7052005625D8 /* WMFArticleTests.swift */,
 				8386BDE623857F87007EE89D /* URLParsingAndRoutingTests.swift */,
+				00D280FB247F019C006BEE23 /* Date+ExtensionTests.swift */,
 			);
 			name = Tests;
 			path = WikipediaUnitTests/Code;
@@ -9815,6 +9824,7 @@
 				B01662B31D1B8CAB006F4544 /* NSURL+WMFQueryParametersTests.m in Sources */,
 				D8D550811DF0D2BD00B90177 /* NSArray+WMFMatching.m in Sources */,
 				8330533323F0388E00123141 /* DataStoreTests.swift in Sources */,
+				00D280FC247F019C006BEE23 /* Date+ExtensionTests.swift in Sources */,
 				B0E8088F1C0D16140065EBC0 /* WMFAsyncTestCase.m in Sources */,
 				B0E8087D1C0D15760065EBC0 /* WMFRandomFileUtilities.m in Sources */,
 				BC90DE791C57C5AD007E0E81 /* WMFWelcomeLanguageViewControllerVisualTests.m in Sources */,
@@ -10083,6 +10093,7 @@
 				B066F0D51E513DAA00A199F8 /* UIViewController+WMFHideKeyboard.swift in Sources */,
 				832289DB1F7291BA0081A5FB /* SizeThatFitsReusableView.swift in Sources */,
 				8368BB8424129F3D00BC88BA /* ViewController+ArticleErrorHandling.swift in Sources */,
+				00D280F7247EFFFE006BEE23 /* Date+Extensions.swift in Sources */,
 				67F73E712267B8020079DEEF /* TalkPageTopicListViewController.swift in Sources */,
 				7A19C64820DD3440000EF7F7 /* BaseExploreFeedSettingsViewController.swift in Sources */,
 				6782DBD32343FE03003FA21B /* DiffListGroupViewModel.swift in Sources */,
@@ -10878,6 +10889,7 @@
 				67EA9E16228F035E008D9EFD /* TalkPageReplyFooterView.swift in Sources */,
 				D8E27BA41F82B38200F9D2B3 /* RMessageView.m in Sources */,
 				83FBE9721F6172ED0026C7EB /* ShareAFactActivityTextItemProvider.swift in Sources */,
+				00D280FA247EFFFE006BEE23 /* Date+Extensions.swift in Sources */,
 				7ABAD6B720338CFB006A364C /* ReadingListDetailUnderBarViewController.swift in Sources */,
 				7A19C64B20DD3440000EF7F7 /* BaseExploreFeedSettingsViewController.swift in Sources */,
 				832289DE1F7291BA0081A5FB /* SizeThatFitsReusableView.swift in Sources */,
@@ -11362,6 +11374,7 @@
 				B0432345210680A900A9A6B6 /* WMFContentGroupKind+FeedCustomization.swift in Sources */,
 				83987AD120E4FB2C00C92C60 /* UISearchBar+Theme.swift in Sources */,
 				D8CE25951E698E2400DAE2E0 /* UIScrollView+ScrollSubviewToLocation.m in Sources */,
+				00D280F9247EFFFE006BEE23 /* Date+Extensions.swift in Sources */,
 				832289DC1F7291BA0081A5FB /* SizeThatFitsReusableView.swift in Sources */,
 				7AB209FA22FC67B4006FECB4 /* PageHistoryViewController.swift in Sources */,
 				6782DBBC2343B861003FA21B /* DiffListViewController.swift in Sources */,
@@ -11815,6 +11828,7 @@
 				83AE1C821F34BB5A004B62E0 /* ImageDimmingExampleViewController.swift in Sources */,
 				D8EC3E8E1E9BDA35006712EB /* WMFSettingsMenuItem.m in Sources */,
 				D8EC3E901E9BDA35006712EB /* UIScrollView+ScrollSubviewToLocation.m in Sources */,
+				00D280F8247EFFFE006BEE23 /* Date+Extensions.swift in Sources */,
 				D8EC3E911E9BDA35006712EB /* MTLValueTransformer+WMFNumericValueTransformer.m in Sources */,
 				7AB209FB22FC67B4006FECB4 /* PageHistoryViewController.swift in Sources */,
 				6782DBBD2343B861003FA21B /* DiffListViewController.swift in Sources */,

--- a/Wikipedia/Code/ArticleViewController+SurveyAnnouncements.swift
+++ b/Wikipedia/Code/ArticleViewController+SurveyAnnouncements.swift
@@ -3,8 +3,8 @@ import Foundation
 extension ArticleViewController {
 
     func showSurveyAnnouncementPanel(surveyAnnouncementResult: SurveyAnnouncementsController.SurveyAnnouncementResult) {
-        
-        guard state == .loaded else {
+        let currentDate = Date()
+        guard state == .loaded, let surveyEndTime = surveyAnnouncementResult.announcement.endTime, currentDate.isBefore(surveyEndTime) else {
             return
         }
         

--- a/Wikipedia/Code/Date+Extensions.swift
+++ b/Wikipedia/Code/Date+Extensions.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+extension Date {
+
+    /// Determine if `self` is before the specified `date`.
+    /// - Parameters:
+    ///   - date: The date to compare with
+    ///   - inclusive: Whether to include `self` in comparison range (i.e. <=)
+    /// - Returns: A boolean indicating if `self` is before specified `date`.
+    public func isBefore(_ date: Date, inclusive: Bool = false) -> Bool {
+        return inclusive ? self <= date : self < date
+    }
+
+    /// Determine if `self` is after the specified `date`.
+    /// - Parameters:
+    ///   - date: The date to compare with
+    ///   - inclusive: Whether to include `self` in comparison range (i.e. >=)
+    /// - Returns: A boolean indicating if `self` is after specified `date`.
+    public func isAfter(_ date: Date, inclusive: Bool = false) -> Bool {
+        return inclusive ? self >= date : self > date
+    }
+
+}

--- a/WikipediaUnitTests/Code/Date+ExtensionTests.swift
+++ b/WikipediaUnitTests/Code/Date+ExtensionTests.swift
@@ -3,30 +3,30 @@ import XCTest
 class Date_ExtensionTests: XCTestCase {
 
     func testBeforeAfter() throws {
-		let currentDate = Date()
-		let beforeDate = currentDate.addingTimeInterval(-100)
-		let afterDate = currentDate.addingTimeInterval(100)
+        let currentDate = Date()
+        let beforeDate = currentDate.addingTimeInterval(-100)
+        let afterDate = currentDate.addingTimeInterval(100)
 
-		// Date in past
-		XCTAssert(beforeDate.isBefore(afterDate))
-		XCTAssert(!beforeDate.isAfter(afterDate))
+        // Date in past
+        XCTAssert(beforeDate.isBefore(afterDate))
+        XCTAssert(!beforeDate.isAfter(afterDate))
 
-		XCTAssert(beforeDate.isBefore(afterDate, inclusive: true))
-		XCTAssert(!beforeDate.isAfter(afterDate, inclusive: true))
+        XCTAssert(beforeDate.isBefore(afterDate, inclusive: true))
+        XCTAssert(!beforeDate.isAfter(afterDate, inclusive: true))
 
-		// Date in future
-		XCTAssert(!afterDate.isBefore(beforeDate))
-		XCTAssert(afterDate.isAfter(beforeDate))
+        // Date in future
+        XCTAssert(!afterDate.isBefore(beforeDate))
+        XCTAssert(afterDate.isAfter(beforeDate))
 
-		XCTAssert(!afterDate.isBefore(beforeDate, inclusive: true))
-		XCTAssert(afterDate.isAfter(beforeDate, inclusive: true))
+        XCTAssert(!afterDate.isBefore(beforeDate, inclusive: true))
+        XCTAssert(afterDate.isAfter(beforeDate, inclusive: true))
 
-		// Inclusive cases
-		XCTAssert(currentDate.isBefore(currentDate, inclusive: true))
-		XCTAssert(currentDate.isAfter(currentDate, inclusive: true))
+        // Inclusive cases
+        XCTAssert(currentDate.isBefore(currentDate, inclusive: true))
+        XCTAssert(currentDate.isAfter(currentDate, inclusive: true))
 
-		XCTAssert(!currentDate.isAfter(currentDate))
-		XCTAssert(!currentDate.isBefore(currentDate))
-	}
+        XCTAssert(!currentDate.isAfter(currentDate))
+        XCTAssert(!currentDate.isBefore(currentDate))
+    }
 
 }

--- a/WikipediaUnitTests/Code/Date+ExtensionTests.swift
+++ b/WikipediaUnitTests/Code/Date+ExtensionTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+class Date_ExtensionTests: XCTestCase {
+
+    func testBeforeAfter() throws {
+		let currentDate = Date()
+		let beforeDate = currentDate.addingTimeInterval(-100)
+		let afterDate = currentDate.addingTimeInterval(100)
+
+		// Date in past
+		XCTAssert(beforeDate.isBefore(afterDate))
+		XCTAssert(!beforeDate.isAfter(afterDate))
+
+		XCTAssert(beforeDate.isBefore(afterDate, inclusive: true))
+		XCTAssert(!beforeDate.isAfter(afterDate, inclusive: true))
+
+		// Date in future
+		XCTAssert(!afterDate.isBefore(beforeDate))
+		XCTAssert(afterDate.isAfter(beforeDate))
+
+		XCTAssert(!afterDate.isBefore(beforeDate, inclusive: true))
+		XCTAssert(afterDate.isAfter(beforeDate, inclusive: true))
+
+		// Inclusive cases
+		XCTAssert(currentDate.isBefore(currentDate, inclusive: true))
+		XCTAssert(currentDate.isAfter(currentDate, inclusive: true))
+
+		XCTAssert(!currentDate.isAfter(currentDate))
+		XCTAssert(!currentDate.isBefore(currentDate))
+	}
+
+}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T253156

Checks announcement end time before presenting survey.

Also adds a little `Date` extension with tests to make date comparison a little easier to read and reason in my opinion (`currentDate.isBefore(endDate)` vs `currentDate < endDate`), but @tonisevener I'm totally happy to rip it out if you'd prefer we just use comparison operators.
