### PR TITLE
Do not strip out minus entities

### DIFF
--- a/Wikipedia/Code/NSString+WMFHTMLParsing.m
+++ b/Wikipedia/Code/NSString+WMFHTMLParsing.m
@@ -242,7 +242,7 @@
     static NSDictionary *entityReplacements;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        entityReplacements = @{@"amp": @"&", @"nbsp": @" ", @"gt": @">", @"lt": @"<", @"apos": @"'", @"quot": @"\"", @"ndash": @"\u2013", @"mdash": @"\u2014"};
+        entityReplacements = @{@"amp": @"&", @"nbsp": @" ", @"gt": @">", @"lt": @"<", @"apos": @"'", @"quot": @"\"", @"ndash": @"\u2013", @"mdash": @"\u2014", @"#8722": @"\u2212"};
     });
     NSMutableString *mutableSelf = [self mutableCopy];
     __block NSInteger offset = 0;

--- a/WikipediaUnitTests/Code/NSString+WMFHTMLParsingTests.m
+++ b/WikipediaUnitTests/Code/NSString+WMFHTMLParsingTests.m
@@ -87,4 +87,22 @@
     XCTAssertEqualObjects(newsPlainText, plaintext);
 }
 
+- (void)testRemovingHTMLRetainsMinusEntity {
+    //https://phabricator.wikimedia.org/T252047
+    NSString *displayTitle = @"<i>B</i> &#8722; <i>L</i>";
+    NSString *displayTitlePlainText = [displayTitle wmf_stringByRemovingHTML];
+    XCTAssertEqualObjects(@"B − L", displayTitlePlainText);
+    
+    UIFont *standard = [UIFont systemFontOfSize:12];
+    UIFont *italic = [UIFont italicSystemFontOfSize:12];
+    NSMutableAttributedString *displayTitleAttributedString = [displayTitle wmf_attributedStringFromHTMLWithFont:standard boldFont:nil italicFont:italic boldItalicFont:nil color:nil linkColor:nil handlingLinks:NO handlingLists:NO handlingSuperSubscripts:NO tagMapping:nil additionalTagAttributes:nil];
+    NSMutableAttributedString *attributedStringToCompare = [[NSMutableAttributedString alloc] initWithString:@"B − L"];
+    [attributedStringToCompare addAttributes:@{NSFontAttributeName: italic} range:NSMakeRange(0, 1)];
+    [attributedStringToCompare addAttributes:@{NSFontAttributeName: standard} range:NSMakeRange(1, 3)];
+    [attributedStringToCompare addAttributes:@{NSFontAttributeName: italic} range:NSMakeRange(4, 1)];
+    
+    XCTAssertEqualObjects(displayTitleAttributedString, attributedStringToCompare);
+    
+}
+
 @end


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T252047

### Notes
* This seems to be called from display-type methods, so I believe it's fairly low-impact. Also wmf_databaseURL and wmf_databaseKey retains the entity and I can read the article in offline mode (minus an unrelated [issue](https://phabricator.wikimedia.org/T254290#6219131) with math formulas) so I think we're good on the spike Josh wanted as a part of this.

### Test Steps
1. Fresh install. Search for article B - L.
2. Confirm you see minus sign in search result. Visit article. Confirm you see minus sign in article content. Save article.
3. Go to Explore and pull to refresh. You may see a continue reading or related reading card. Confirm you see the minus sign there.
4. Go to history tab. Confirm you see the minus sign there.
5. Edit article title description. Confirm you see minus sign on title description edit screen. 
