### PR TITLE
Fix User-Agent being sent by WKWebView, add X-Analytics header to explicitly declare pageviews

### DIFF
--- a/Wikipedia/Code/ArticleFetcher.swift
+++ b/Wikipedia/Code/ArticleFetcher.swift
@@ -295,7 +295,7 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
         return request
     }
     
-    public func mobileHTMLRequest(articleURL: URL, revisionID: UInt64? = nil, scheme: String? = nil, cachePolicy: WMFCachePolicy? = nil) throws -> URLRequest {
+    public func mobileHTMLRequest(articleURL: URL, revisionID: UInt64? = nil, scheme: String? = nil, cachePolicy: WMFCachePolicy? = nil, isPageView: Bool = false) throws -> URLRequest {
         
         var url = try mobileHTMLURL(articleURL: articleURL, revisionID: revisionID)
         
@@ -309,6 +309,10 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
             if revisionID != nil {
                 // Enables the caching system to update the revisionless url cache when this call goes through
                 urlRequest.customCacheUpdatingURL = try mobileHTMLURL(articleURL: articleURL)
+            }
+            if isPageView {
+                // https://phabricator.wikimedia.org/T256507
+                urlRequest.setValue("pageview=1", forHTTPHeaderField: "X-Analytics")
             }
             return urlRequest
         } else {

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -410,7 +410,7 @@ class ArticleViewController: ViewController, HintPresenting {
             callLoadCompletionIfNecessary()
         }
         
-        guard var request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, revisionID: revisionID, scheme: schemeHandler.scheme, cachePolicy: cachePolicy, isPageView: true) else {
+        guard let request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, revisionID: revisionID, scheme: schemeHandler.scheme, cachePolicy: cachePolicy, isPageView: true) else {
             showGenericError()
             state = .error
             return

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -410,12 +410,16 @@ class ArticleViewController: ViewController, HintPresenting {
             callLoadCompletionIfNecessary()
         }
         
-        guard let request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, revisionID: revisionID, scheme: schemeHandler.scheme, cachePolicy: cachePolicy) else {
+        guard var request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, revisionID: revisionID, scheme: schemeHandler.scheme, cachePolicy: cachePolicy) else {
             showGenericError()
             state = .error
             return
         }
-                
+        
+        // Declare that this request is a pageview
+        // https://phabricator.wikimedia.org/T256507
+        request.setValue("pageview=1", forHTTPHeaderField: "X-Analytics")
+
         webView.load(request)
     }
     

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -920,6 +920,9 @@ private extension ArticleViewController {
         // Delegates
         webView.uiDelegate = self
         webView.navigationDelegate = self
+        
+        // User Agent
+        webView.customUserAgent = WikipediaAppUtils.versionedUserAgent()
     }
     
     /// Adds the lead image view to the web view's scroll view and configures the associated constraints

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -410,15 +410,11 @@ class ArticleViewController: ViewController, HintPresenting {
             callLoadCompletionIfNecessary()
         }
         
-        guard var request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, revisionID: revisionID, scheme: schemeHandler.scheme, cachePolicy: cachePolicy) else {
+        guard var request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, revisionID: revisionID, scheme: schemeHandler.scheme, cachePolicy: cachePolicy, isPageView: true) else {
             showGenericError()
             state = .error
             return
         }
-        
-        // Declare that this request is a pageview
-        // https://phabricator.wikimedia.org/T256507
-        request.setValue("pageview=1", forHTTPHeaderField: "X-Analytics")
 
         webView.load(request)
     }


### PR DESCRIPTION
**Fixes Phabricator ticket:** 
https://phabricator.wikimedia.org/T256507
https://phabricator.wikimedia.org/T257389

### Test Steps
1. Inspect network requests while opening an uncached page in the article view
2. Verify the User-Agent starts with `WikipediaApp/6.6.2.0`
3. Verify the X-Analytics header is set to `pageview=1`

