### PR TITLE
Ensure the article fetched is marked as downloaded by utilizing NSManagedObjectIDs

### DIFF
--- a/Wikipedia/Code/SavedArticlesFetcher.swift
+++ b/Wikipedia/Code/SavedArticlesFetcher.swift
@@ -175,7 +175,8 @@ private extension SavedArticlesFetcher {
         }
         
         if let articleURL = article?.url,
-            let articleKey = articleURL.wmf_databaseKey {
+            let articleKey = article?.key,
+            let articleObjectID = article?.objectID {
             
             articleCacheController.add(url: articleURL, groupKey: articleKey, individualCompletion: { (itemResult) in
                 switch itemResult {
@@ -189,13 +190,13 @@ private extension SavedArticlesFetcher {
                     switch groupResult {
                     case .success(let itemKeys):
                         DDLogDebug("🥶group completion: \(articleKey), itemKeyCount: \(itemKeys.count)")
-                        self.didFetchArticle(with: articleKey)
+                        self.didFetchArticle(with: articleObjectID)
                         self.spotlightManager.addToIndex(url: articleURL as NSURL)
                         self.updateCountOfFetchesInProcess()
                     case .failure(let error):
                         DDLogDebug("🥶failure in groupCompletion of \(articleKey): \(error)")
                         self.updateCountOfFetchesInProcess()
-                        self.didFailToFetchArticle(with: articleKey, error: error)
+                        self.didFailToFetchArticle(with: articleObjectID, error: error)
                     }
                     updateAgain()
                 }
@@ -221,7 +222,7 @@ private extension SavedArticlesFetcher {
             
             if let articleToDelete = articleToDelete {
                 
-                guard let articleKey = articleToDelete.url?.wmf_databaseKey else {
+                guard let articleKey = articleToDelete.key, let articleObjectID = article?.objectID else {
                     noArticleToDeleteCompletion()
                     return
                 }
@@ -245,7 +246,7 @@ private extension SavedArticlesFetcher {
                         // Ignoring failures to ensure the DB doesn't get stuck trying
                         // to remove a cache group that doesn't exist.
                         // TODO: Clean up these DB inconsistencies in the DatabaseHousekeeper
-                        self.didRemoveArticle(with: articleKey)
+                        self.didRemoveArticle(with: articleObjectID)
                         self.updateCountOfFetchesInProcess()
                         updateAgain()
                     }
@@ -256,14 +257,14 @@ private extension SavedArticlesFetcher {
         }
     }
     
-    func didFetchArticle(with key: String) {
-        operateOnArticles(with: key) { (article) in
+    func didFetchArticle(with managedObjectID: NSManagedObjectID) {
+        operateOnArticle(with: managedObjectID) { (article) in
             article.isDownloaded = true
         }
     }
     
-    func didFailToFetchArticle(with key: String, error: Error) {
-        operateOnArticles(with: key) { (article) in
+    func didFailToFetchArticle(with managedObjectID: NSManagedObjectID, error: Error) {
+        operateOnArticle(with: managedObjectID) { (article) in
             handleFailure(with: article, error: error)
         }
     }
@@ -340,22 +341,17 @@ private extension SavedArticlesFetcher {
         article.downloadRetryDate = Date(timeIntervalSinceNow: TimeInterval(integerLiteral: secondsFromNowToAttempt))
     }
 
-    func didRemoveArticle(with key: String) {
-        operateOnArticles(with: key) { (article) in
+    func didRemoveArticle(with managedObjectID: NSManagedObjectID) {
+        operateOnArticle(with: managedObjectID) { (article) in
             article.isDownloaded = false
         }
     }
     
-    func operateOnArticles(with key: String, articleBlock: (WMFArticle) -> Void) {
-        do {
-            let articles = try dataStore.viewContext.fetchArticles(withKey: key)
-            for article in articles {
-                articleBlock(article)
-            }
-        } catch (let error) {
-            DDLogError("Error fetching WMFArticles after caching: \(error)");
+    func operateOnArticle(with managedObjectID: NSManagedObjectID, articleBlock: (WMFArticle) -> Void) {
+        guard let article = dataStore.viewContext.object(with: managedObjectID) as? WMFArticle else {
+            return
         }
-        
+        articleBlock(article)
         do {
             try dataStore.save()
         } catch (let error) {


### PR DESCRIPTION
**Fixes Phabricator ticket:** 
https://phabricator.wikimedia.org/T257461

### Notes
If there's any discrepancy between the underlying article key string and the roundtrip through NSURL to wmf_databaseKey, it's possible the app would get stuck retrying the same article because it would not appropriately mark it as downloaded.

This approach is less invasive than the approach attempted on #3622 and it feels safer to treat article keys as a black box from `SavedArticlesFetcher`'s perspective