### PR TITLE
Allow external links in EditPreview

### DIFF
--- a/Wikipedia/Code/EditPreviewViewController.swift
+++ b/Wikipedia/Code/EditPreviewViewController.swift
@@ -183,7 +183,7 @@ extension EditPreviewViewController: ArticleWebMessageHandling {
         case .unknown(let href):
             showExternalLinkInAlert(link: href)
         case .link(let href, _, let title):
-            if let title = title {
+            if let title = title, !title.isEmpty {
                 guard
                     let host = articleURL?.host,
                     let encodedTitle = title.percentEncodedPageTitleForPathComponents,


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T253892

### Notes
* Don't know when/if the regression was introduced, but an empty string was the problem here - we were assuming a lack of string would be the bat signal and were thus thrown by an existing (yet empty) string.
* I did *not* fix iOS 13's context preview (aka peek & pop). We got some behavior for free on iOS 12, and on the Phab ticket I asked @carolynlimadeo about which behavior we want to create here. Depending on when feedback is provided, I'll either update this PR or create a new one for that work.

### Test Steps
1. Open any article, edit it, make a small change, get to edit preview page. (Ensure the section you're editing has at least one external link. Citations and infoboxes are good sources of external links.)
1. Try tapping a link to another wikipedia article. You should get a small preview with an "OK" button below it. Tapping that "OK" button will drop you back to the edit preview.
1. Try tapping an external link. Ensure you get the external link dialog:
<img width="378" alt="Screenshot" src="https://user-images.githubusercontent.com/9295855/86188476-9e11b000-baf3-11ea-89fb-5632db95c810.png">

{