### PR TITLE
Fix issue introduced by #3624

### DIFF
--- a/Wikipedia/Code/SavedArticlesFetcher.swift
+++ b/Wikipedia/Code/SavedArticlesFetcher.swift
@@ -222,10 +222,12 @@ private extension SavedArticlesFetcher {
             
             if let articleToDelete = articleToDelete {
                 
-                guard let articleKey = articleToDelete.key, let articleObjectID = article?.objectID else {
+                guard let articleKey = articleToDelete.key else {
                     noArticleToDeleteCompletion()
                     return
                 }
+                
+                let articleObjectID = articleToDelete.objectID
                 
                 articleCacheController.remove(groupKey: articleKey, individualCompletion: { (itemResult) in
                     switch itemResult {


### PR DESCRIPTION
**Fixes Phabricator ticket:** 
Follow on fix for https://phabricator.wikimedia.org/T257461

### Notes
Use articleToDelete's objectID instead of article's obejctID - article doesn't exist when deleting, articleToDelete does.

### Test Steps
1. Try to remove an article from saved pages
2. Observe if it's removed from the cache
