### PR TITLE
Add Amharic, Aramaic, Gothic, and Tigrinya language support

### DIFF
--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -13,6 +13,7 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
  * List of unsupported language codes.
  *
  * As of iOS 8, the system font doesn't support these languages, e.g. "arc" (Aramaic, Syriac font). [0]
+ * As of iOS 9, it appears that Syriac languages are now natively supported in iOS.
  *
  * 0: http://syriaca.org/documentation/view-syriac.html
  */

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -20,7 +20,7 @@ static NSArray *WMFUnsupportedLanguages() {
     static NSArray *unsupportedLanguageCodes;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        unsupportedLanguageCodes = @[@"am", @"lez", @"arc", @"got", @"ti"];
+        unsupportedLanguageCodes = @[@"lez"];
     });
     return unsupportedLanguageCodes;
 }


### PR DESCRIPTION
**Phabricator Ticket:** https://phabricator.wikimedia.org/T256067

### Notes
Removes Amharic, Aramaic, Gothic, and Tigrinya from the list of unsupported languages (thanks Toni for pointing to `MWKLanguageLinkController` in the ticket). It appears that both iOS 12 and iOS 13 support Syriac text and are able to render these languages correctly*. Lezghian remains in the unsupported list because its native language name rendering in app didn't appear to match the rendering [here](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes).

### Test Steps
1. In Settings > My Languages, add these: Amharic, Aramaic, Gothic, and Tigrinya
2. Search for articles in these languages.
3. Observe that they render correctly*. Of the list, Aramaic should show as RTL in the article view and the rest appear to be LTR languages.

`* I do not speak/read any of these languages myself, so I'm basing correctness on if they seem to render similar to the Desktop Wikipedia`

Amharic:
![amharic](https://user-images.githubusercontent.com/5652327/87090441-dd738700-c1ec-11ea-87a6-26cd7041cc08.png)