### PR TITLE
Fix for non-functional "next" button in References

### DIFF
--- a/Wikipedia/Code/ReferenceBackLinksViewController.swift
+++ b/Wikipedia/Code/ReferenceBackLinksViewController.swift
@@ -35,7 +35,17 @@ class ReferenceBackLinksViewController: ReferenceViewController {
 
     func setupToolbar() {
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        toolbar.items = [countItem, flexibleSpace, previousButton, nextButton]
+        if #available(iOS 14.0, *) {
+            toolbar.items = [countItem, flexibleSpace, previousButton, nextButton]
+        } else if #available(iOS 13.5, *) {
+            /// `fakeButton`'s existance allows `nextButton` to work. Analysis - with a diagnosis of "likely iOS 13.5 bug" - here: https://phabricator.wikimedia.org/T255283
+            /// As of early betas of iOS 14, this bug has been fixed, and thus higher versions of iOS can use the typical code path.
+            let fakeButton = UIBarButtonItem(image: UIImage(named: "transparent-pixel"), landscapeImagePhone: nil, style: .plain, target: nil, action: nil)
+            toolbar.items = [countItem, flexibleSpace, previousButton, nextButton, fakeButton]
+        } else {
+            toolbar.items = [countItem, flexibleSpace, previousButton, nextButton]
+        }
+
         if backLinks.count <= 1 {
             previousButton.isEnabled = false
             nextButton.isEnabled = false


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T255283

### Notes
This is a hacky fix. I believe - though am not confident - that this bad behavior was [caused by Apple in 13.5](https://stackoverflow.com/questions/61787614/toolbar-button-unresponsive-after-ios-13-4-1-update) and is currently on track to be fixed in 14.0 (as of current beta). More details on the Phab ticket, and I'm open to other suggestions.

Tradeoff for the hack is a bit more padding on the trailing side of the toolbar, because of that "fake" button. 
 
I don't think there is a way to have alternate code paths for a specific range of iOS versions. (This could be because Apple expects this to be used when checking for if a *new* API is available, not if you're in the range where a bug active.)

### Test Steps
1. In "references" section, tap a backlink (`[1]`, etc.) for a reference that is cited multiple times in the article.
1. Tap the next button in the bottom right corner, ensure it works.
1. Tap the previous button in the bottom right corner, ensure it works.

### Screenshot of interface inspector
![Screenshot 2](https://user-images.githubusercontent.com/9295855/86858921-73d16c80-c076-11ea-8181-563a13c1d550.png)
