### PR TITLE
Remove unused code using "blocklist"

### DIFF
--- a/Wikipedia/Code/WMFContentGroup+WMFFeedContentDisplaying.m
+++ b/Wikipedia/Code/WMFContentGroup+WMFFeedContentDisplaying.m
@@ -135,18 +135,6 @@ NS_ASSUME_NONNULL_BEGIN
     return WMFFeedHeaderActionTypeOpenFirstItem;
 }
 
-- (WMFFeedBlocklistOption)blockListOptions {
-    switch (self.contentGroupKind) {
-        case WMFContentGroupKindRelatedPages:
-            return WMFFeedBlocklistOptionContent;
-        case WMFContentGroupKindLocationPlaceholder:
-            return WMFFeedBlocklistOptionSection;
-        default:
-            break;
-    }
-    return WMFFeedBlocklistOptionNone;
-}
-
 - (WMFFeedDisplayType)displayTypeForItemAtIndex:(NSInteger)index {
     switch (self.contentGroupKind) {
         case WMFContentGroupKindContinueReading:

--- a/Wikipedia/Code/WMFFeedContentDisplaying.h
+++ b/Wikipedia/Code/WMFFeedContentDisplaying.h
@@ -55,13 +55,6 @@ typedef NS_ENUM(NSUInteger, WMFFeedMoreType) {
     WMFFeedMoreTypeOnThisDay
 };
 
-typedef NS_OPTIONS(NSInteger, WMFFeedBlocklistOption) {
-    WMFFeedBlocklistOptionNone = 0,
-    WMFFeedBlocklistOptionContent = 1 << 0,    //blocklist specific section content
-    WMFFeedBlocklistOptionSection = 1 << 1,    //blocklist this section
-    WMFFeedBlocklistOptionAllSections = 1 << 2 // blocklist all sections of this type
-};
-
 @protocol WMFFeedContentDisplaying
 
 /**
@@ -97,11 +90,6 @@ typedef NS_OPTIONS(NSInteger, WMFFeedBlocklistOption) {
  * The action that shoud be performed when a user taps on the header.
  */
 @property (nonatomic, readonly) WMFFeedHeaderActionType headerActionType;
-
-/*
- * Options for the blocklist menu
- */
-@property (nonatomic, readonly) WMFFeedBlocklistOption blockListOptions;
 
 /**
  *  How to display the content of the section.


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T257238

### Notes
* Thanks to @izno's [comment](https://phabricator.wikimedia.org/T257238#6298265), I looked at whether we could improve the naming of "blocklist"... and realized we don't use that bit of code. (I believe this is dead code - couldn't find any code that uses it, and it still compiles fine.) Better than renaming outdated terms? Removing them.

### Test Steps
1. Run app.
1. Using the three dots next to explore feed cards, hide an explore feed card.
1. Using the three dots next to explore feed cards, hide an explore feed category
