### PR TITLE
Fix crash in the article view on iOS 14

### DIFF
--- a/Wikipedia/Code/ArticleViewController+ArticleWebMessageHandling.swift
+++ b/Wikipedia/Code/ArticleViewController+ArticleWebMessageHandling.swift
@@ -48,7 +48,6 @@ extension ArticleViewController: ArticleWebMessageHandling {
     
     func handlePCSDidFinishInitialSetup() {
         state = .loaded
-        webView.becomeFirstResponder()
         showWIconPopoverIfNecessary()
         refreshControl.endRefreshing()
         surveyTimerController.articleContentDidLoad()


### PR DESCRIPTION
**HOLD** pending decision on whether or not to roll a 6.6.3 release or wait to see if this is fixed in the next iOS 14 beta

**Fixes Phabricator ticket:** 
https://phabricator.wikimedia.org/T258210

### Notes
The crash occurs when calling `webView.becomeFirstResponder()` in `ArticleViewController+ArticleWebMessageHandling`. It was added in [this commit](https://github.com/wikimedia/wikipedia-ios/commit/c00ae2a3695289b88e23b376784403c1bea6b72b)~, possibly as a port over from `WMFArticleViewController`~. There was no call to `[webView becomeFirstResponder]` in `WMFArticleViewController`. Removing it doesn't affect the W icon popover display and it seems we can remove this line entirely.

### Test Steps
On iPhone X running iOS 14 Public Beta 1
1. On Explore feed, tap on featured article.
2. Immediately swipe backwards to Explore screen (from leading side of screen - don't tap back button) before the article finishes loading.
3. Repeat steps 1 and 2 a few times, get crash.

