### PR TITLE
Migrate MWKLanguageLinkController to Core Data

### DIFF
--- a/TopReadWidget/WMFTodayTopReadWidgetViewController.swift
+++ b/TopReadWidget/WMFTodayTopReadWidgetViewController.swift
@@ -63,12 +63,13 @@ class WMFTodayTopReadWidgetViewController: ExtensionViewController, NCWidgetProv
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        guard let appLanguage = MWKLanguageLinkController.sharedInstance().appLanguage else {
+        userStore = MWKDataStore.shared()
+
+        guard let appLanguage = userStore.languageLinkController.appLanguage else {
             return
         }
     
         siteURL = appLanguage.siteURL()
-        userStore = MWKDataStore.shared()
         contentSource = WMFFeedContentSource(siteURL: siteURL, userDataStore: userStore, notificationsController: nil)
 
         let tapGR = UITapGestureRecognizer(target: self, action: #selector(self.handleTapGestureRecognizer(_:)))

--- a/WMF Framework/NSManagedObjectContext+WMFKeyValue.h
+++ b/WMF Framework/NSManagedObjectContext+WMFKeyValue.h
@@ -9,6 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable WMFKeyValue *)wmf_keyValueForKey:(NSString *)key;
 - (nullable NSNumber *)wmf_numberValueForKey:(NSString *)key;
 - (nullable NSString *)wmf_stringValueForKey:(NSString *)key;
+- (nullable NSArray *)wmf_arrayValueForKey:(NSString *)key;
 
 - (WMFKeyValue *)wmf_setValue:(nullable id<NSCoding>)value forKey:(NSString *)key;
 

--- a/WMF Framework/NSManagedObjectContext+WMFKeyValue.m
+++ b/WMF Framework/NSManagedObjectContext+WMFKeyValue.m
@@ -40,6 +40,10 @@
     return [self wmf_valueOfClass:[NSString class] forKey:key];
 }
 
+- (nullable NSArray *)wmf_arrayValueForKey:(NSString *)key {
+    return [self wmf_valueOfClass:[NSArray class] forKey:key];
+}
+
 - (WMFKeyValue *)wmf_setValue:(nullable id<NSCoding>)value forKey:(NSString *)key {
     NSArray<WMFKeyValue *> *results = [self wmf_keyValuesForKey:key fetchLimit:0];
     if (results.count > 1) {

--- a/WMF Framework/ReadingListsSyncOperation.swift
+++ b/WMF Framework/ReadingListsSyncOperation.swift
@@ -388,7 +388,7 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
                 for i in 1...countOfEntriesToCreate {
                     
                     if !englishOnly {
-                        if let randomLanguage = MWKLanguageLinkController.sharedInstance().allLanguages.randomElement() {
+                        if let randomLanguage = dataStore.languageLinkController.allLanguages.randomElement() {
                             maybeSiteURL = randomLanguage.siteURL()
                         }
                     }

--- a/WMF Framework/Remote Notifications/Operations/RemoteNotificationsFetchOperation.swift
+++ b/WMF Framework/Remote Notifications/Operations/RemoteNotificationsFetchOperation.swift
@@ -1,9 +1,12 @@
 class RemoteNotificationsFetchOperation: RemoteNotificationsOperation {
+    let targetWikis: [String]
+    init(with apiController: RemoteNotificationsAPIController, modelController: RemoteNotificationsModelController, targetWikis: [String]) {
+        self.targetWikis = targetWikis
+        super.init(with: apiController, modelController: modelController)
+    }
     override func execute() {
         self.managedObjectContext.perform {
-            var targetWikis = MWKLanguageLinkController.sharedInstance().readPreferredLanguageCodes()
-            targetWikis.append("wikidata")
-            self.apiController.getAllUnreadNotifications(from: targetWikis) { fetchedNotifications, error in
+            self.apiController.getAllUnreadNotifications(from: self.targetWikis) { fetchedNotifications, error in
                 if let error = error {
                     self.finish(with: error)
                 } else {

--- a/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
@@ -1,8 +1,8 @@
 @objc public final class RemoteNotificationsController: NSObject {
     private let operationsController: RemoteNotificationsOperationsController
-
-    @objc public required init(session: Session, configuration: Configuration) {
-        operationsController = RemoteNotificationsOperationsController(session: session, configuration: configuration)
+    
+    @objc public required init(session: Session, configuration: Configuration, preferredLanguageCodesProvider: WMFPreferredLanguageCodesProviding) {
+        operationsController = RemoteNotificationsOperationsController(session: session, configuration: configuration, preferredLanguageCodesProvider: preferredLanguageCodesProvider)
         super.init()
     }
 }

--- a/WMF Framework/WMFExploreFeedContentController.m
+++ b/WMF Framework/WMFExploreFeedContentController.m
@@ -401,7 +401,7 @@ NSString *const WMFNewExploreFeedPreferencesWereRejectedNotification = @"WMFNewE
 }
 
 - (NSSet <NSURL *> *)preferredSiteURLs {
-    return [NSSet setWithArray:[MWKLanguageLinkController sharedInstance].preferredSiteURLs];
+    return [NSSet setWithArray:self.dataStore.languageLinkController.preferredSiteURLs];
 }
 
 - (NSDictionary *)exploreFeedPreferencesInManagedObjectContext:(NSManagedObjectContext *)moc {

--- a/WMF Framework/WMFPrefferedLanguageCodesProviding.h
+++ b/WMF Framework/WMFPrefferedLanguageCodesProviding.h
@@ -1,0 +1,10 @@
+#ifndef WMFPreferredLanguageCodesProviding_h
+#define WMFPreferredLanguageCodesProviding_h
+NS_ASSUME_NONNULL_BEGIN
+@protocol WMFPreferredLanguageCodesProviding
+
+- (void)getPreferredLanguageCodes:(void (^)(NSArray<NSString *> *))completion;
+
+@end
+NS_ASSUME_NONNULL_END
+#endif /* WMFPreferredLanguageCodesProviding_h */

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -1290,6 +1290,7 @@
 		83DE45BA2449C09B00671878 /* SplashScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83DE45B72449C09B00671878 /* SplashScreenViewController.swift */; };
 		83DE45BB2449C09B00671878 /* SplashScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83DE45B72449C09B00671878 /* SplashScreenViewController.swift */; };
 		83DE45BC2449C09B00671878 /* SplashScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83DE45B72449C09B00671878 /* SplashScreenViewController.swift */; };
+		83DF1D1424F53878007E08D8 /* WMFPrefferedLanguageCodesProviding.h in Headers */ = {isa = PBXBuildFile; fileRef = 83DF1D1324F53878007E08D8 /* WMFPrefferedLanguageCodesProviding.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		83E3E7252440F1FE00AA2E9A /* LoadingAnimationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E3E7242440F1FE00AA2E9A /* LoadingAnimationViewController.swift */; };
 		83E3E7262440F1FE00AA2E9A /* LoadingAnimationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E3E7242440F1FE00AA2E9A /* LoadingAnimationViewController.swift */; };
 		83E3E7272440F1FE00AA2E9A /* LoadingAnimationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E3E7242440F1FE00AA2E9A /* LoadingAnimationViewController.swift */; };
@@ -3687,6 +3688,7 @@
 		83DB0A5D23EEDE4400DA5F58 /* LegacyArticle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyArticle.swift; sourceTree = "<group>"; };
 		83DB440F244A57590046FABE /* RootNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationController.swift; sourceTree = "<group>"; };
 		83DE45B72449C09B00671878 /* SplashScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreenViewController.swift; sourceTree = "<group>"; };
+		83DF1D1324F53878007E08D8 /* WMFPrefferedLanguageCodesProviding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WMFPrefferedLanguageCodesProviding.h; sourceTree = "<group>"; };
 		83E3E7242440F1FE00AA2E9A /* LoadingAnimationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingAnimationViewController.swift; sourceTree = "<group>"; };
 		83E3E7292440F24300AA2E9A /* LoadingAnimationViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LoadingAnimationViewController.xib; sourceTree = "<group>"; };
 		83E52BB21F681F940045E776 /* ShareAFactViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAFactViewController.swift; sourceTree = "<group>"; };
@@ -5333,6 +5335,7 @@
 				B0E807B41C0CF0180065EBC0 /* MWKSavedPageList.h */,
 				B0E807B51C0CF0180065EBC0 /* MWKSavedPageList.m */,
 				D8C41DDA23FC09EE00353DCE /* NSManagedObjectContext+History.swift */,
+				83DF1D1324F53878007E08D8 /* WMFPrefferedLanguageCodesProviding.h */,
 			);
 			name = "User DataStore";
 			sourceTree = "<group>";
@@ -6134,7 +6137,6 @@
 				7A52C01A2150389D00A3A4A1 /* RemoteNotificationsController.swift */,
 				7A0312F82153DEB30095C953 /* RemoteNotificationsAPIController.swift */,
 				7A03130221542F5C0095C953 /* RemoteNotificationsOperationsController.swift */,
-				7A60E9D0215D41FA00F2D325 /* Views */,
 				7A03130121542F250095C953 /* Model */,
 				7A03130021542F120095C953 /* Operations */,
 			);
@@ -6165,13 +6167,6 @@
 				7A5A0542225FBE0500BBEAC1 /* InsertMediaSearchResultCollectionViewCell.swift */,
 			);
 			name = Search;
-			sourceTree = "<group>";
-		};
-		7A60E9D0215D41FA00F2D325 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Views;
 			sourceTree = "<group>";
 		};
 		7A60E9D5215D4FD900F2D325 /* Remote Notifications */ = {
@@ -8355,6 +8350,7 @@
 				D8FA18BD1E1BD891009675C3 /* NSFileManager+WMFExtendedFileAttributes.h in Headers */,
 				D8FA18B01E1BD891009675C3 /* NSBundle+WMFInfoUtils.h in Headers */,
 				D8FA18AD1E1BD891009675C3 /* NSDictionary+WMFPageViewsSortedByDate.h in Headers */,
+				83DF1D1424F53878007E08D8 /* WMFPrefferedLanguageCodesProviding.h in Headers */,
 				D8FA18EA1E1BD8B9009675C3 /* WMFHashing.h in Headers */,
 				D8FA18B21E1BD891009675C3 /* WMFNumberOfExtractCharacters.h in Headers */,
 			);

--- a/Wikipedia/Code/AccountViewController.swift
+++ b/Wikipedia/Code/AccountViewController.swift
@@ -113,7 +113,7 @@ class AccountViewController: SubSettingsViewController {
             showLogoutAlert()
         case .talkPage:
             if let username = WMFAuthenticationManager.sharedInstance.loggedInUsername,
-                let language = MWKLanguageLinkController.sharedInstance().appLanguage {
+                let language = MWKDataStore.shared().languageLinkController.appLanguage {
                 let siteURL = language.siteURL()
                 let title = TalkPageType.user.titleWithCanonicalNamespacePrefix(title: username, siteURL: siteURL)
                 

--- a/Wikipedia/Code/BaseExploreFeedSettingsViewController.swift
+++ b/Wikipedia/Code/BaseExploreFeedSettingsViewController.swift
@@ -167,7 +167,7 @@ class BaseExploreFeedSettingsViewController: SubSettingsViewController {
     }
 
     var preferredLanguages: [MWKLanguageLink] {
-        return MWKLanguageLinkController.sharedInstance().preferredLanguages
+        return MWKDataStore.shared().languageLinkController.preferredLanguages
     }
 
     lazy var languages: [ExploreFeedSettingsLanguage] = {

--- a/Wikipedia/Code/EditLinkViewController.swift
+++ b/Wikipedia/Code/EditLinkViewController.swift
@@ -42,7 +42,7 @@ class EditLinkViewController: ViewController {
 
     init?(link: Link, siteURL: URL?, dataStore: MWKDataStore) {
         guard
-            let siteURL = siteURL ?? MWKLanguageLinkController.sharedInstance().appLanguage?.siteURL() ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale(),
+            let siteURL = siteURL ?? MWKDataStore.shared().languageLinkController.appLanguage?.siteURL() ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale(),
             let articleURL = link.articleURL(for: siteURL)
         else {
             return nil

--- a/Wikipedia/Code/EventLoggingFunnel.m
+++ b/Wikipedia/Code/EventLoggingFunnel.m
@@ -86,7 +86,7 @@ EventLoggingLabel const EventLoggingLabelPictureOfTheDay = @"picture_of_the_day"
 
 - (NSString *)primaryLanguage {
     NSString *primaryLanguage = @"en";
-    MWKLanguageLink *appLanguage = [MWKLanguageLinkController sharedInstance].appLanguage;
+    MWKLanguageLink *appLanguage = [MWKDataStore shared].languageLinkController.appLanguage;
     if (appLanguage) {
         primaryLanguage = appLanguage.languageCode;
     }

--- a/Wikipedia/Code/ExploreFeedSettingsViewController.swift
+++ b/Wikipedia/Code/ExploreFeedSettingsViewController.swift
@@ -96,7 +96,7 @@ private class FeedCard: ExploreFeedSettingsItem {
 
     private func multipleLanguagesDisclosureText(for contentGroupKind: WMFContentGroupKind) -> String {
         guard contentGroupKind.isGlobal else {
-            let preferredLanguages = MWKLanguageLinkController.sharedInstance().preferredLanguages
+            let preferredLanguages = MWKDataStore.shared().languageLinkController.preferredLanguages
             let languageCodes = contentGroupKind.languageCodes
             switch languageCodes.count {
             case preferredLanguages.count:

--- a/Wikipedia/Code/MWKDataStore.h
+++ b/Wikipedia/Code/MWKDataStore.h
@@ -10,6 +10,7 @@
 @class RemoteNotificationsController;
 @class WMFArticleSummaryController;
 @class MobileviewToMobileHTMLConverter;
+@class MWKLanguageLinkController;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -64,6 +65,7 @@ typedef NS_OPTIONS(NSUInteger, RemoteConfigOption) {
 @property (readonly, strong, nonatomic) WikidataDescriptionEditingController *wikidataDescriptionEditingController;
 @property (readonly, strong, nonatomic) RemoteNotificationsController *remoteNotificationsController;
 @property (readonly, strong, nonatomic) WMFArticleSummaryController *articleSummaryController;
+@property (readonly, strong, nonatomic) MWKLanguageLinkController *languageLinkController;
 
 @property (nonatomic, strong, readonly) NSManagedObjectContext *viewContext;
 @property (nonatomic, strong, readonly) NSManagedObjectContext *feedImportContext;

--- a/Wikipedia/Code/MWKImageInfoFetcher.m
+++ b/Wikipedia/Code/MWKImageInfoFetcher.m
@@ -84,7 +84,7 @@ static CGSize MWKImageInfoSizeFromJSON(NSDictionary *json, NSString *widthKey, N
     
     NSMutableArray *itemListBuilder = [NSMutableArray arrayWithCapacity:[[indexedImages allKeys] count]];
 
-    NSArray<NSString *> *preferredLangCodes = [[[MWKLanguageLinkController sharedInstance] preferredLanguages] wmf_map:^NSString *(MWKLanguageLink *language) {
+    NSArray<NSString *> *preferredLangCodes = [MWKDataStore.shared.languageLinkController.preferredLanguages wmf_map:^NSString *(MWKLanguageLink *language) {
         return [language languageCode];
     }];
 

--- a/Wikipedia/Code/MWKLanguageLinkController.h
+++ b/Wikipedia/Code/MWKLanguageLinkController.h
@@ -1,6 +1,8 @@
 #import <WMF/MWKLanguageFilter.h>
-
+#import <WMF/WMFPrefferedLanguageCodesProviding.h>
+@class NSManagedObjectContext;
 @class MWKLanguageLink;
+@class MWKDataStore;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -8,9 +10,10 @@ extern NSString *const WMFPreferredLanguagesDidChangeNotification;
 
 extern NSString *const WMFAppLanguageDidChangeNotification;
 
-@interface MWKLanguageLinkController : NSObject <MWKLanguageFilterDataSource>
+@interface MWKLanguageLinkController : NSObject <MWKLanguageFilterDataSource, WMFPreferredLanguageCodesProviding>
 
-+ (instancetype)sharedInstance;
+/// Initializes `MWKLanguageLinkController` with the `NSManagedObjectContext` used for storage
+- (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)moc;
 
 /**
  * Returns all languages of the receiver, sorted by name, minus unsupported languages.
@@ -83,6 +86,8 @@ extern NSString *const WMFAppLanguageDidChangeNotification;
 - (nullable MWKLanguageLink *)languageForSiteURL:(NSURL *)siteURL;
 
 - (nullable MWKLanguageLink *)languageForLanguageCode:(NSString *)languageCode;
+
++ (void)migratePreferredLanguagesToManagedObjectContext:(NSManagedObjectContext *)moc;
 
 @end
 

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -199,7 +199,7 @@ static id _sharedInstance;
     }];
 }
 
-// This method can only be safely called from the main app target, as extension's standard `NSUserDefaults` are independent from the main app's.
+// This method can only be safely called from the main app target, as an extension's standard `NSUserDefaults` are independent from the main app and other targets.
 + (void)migratePreferredLanguagesToManagedObjectContext:(NSManagedObjectContext *)moc {
     NSArray *preferredLanguages = [[NSUserDefaults standardUserDefaults] arrayForKey:WMFPreviousLanguagesKey];
     [moc wmf_setValue:preferredLanguages forKey:WMFPreviousLanguagesKey];

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -199,6 +199,7 @@ static id _sharedInstance;
     }];
 }
 
+// This method can only be safely called from the main app target, as extension's standard `NSUserDefaults` are independent from the main app's.
 + (void)migratePreferredLanguagesToManagedObjectContext:(NSManagedObjectContext *)moc {
     NSArray *preferredLanguages = [[NSUserDefaults standardUserDefaults] arrayForKey:WMFPreviousLanguagesKey];
     [moc wmf_setValue:preferredLanguages forKey:WMFPreviousLanguagesKey];

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -1,5 +1,6 @@
 #import <WMF/MWKLanguageLinkController_Private.h>
 #import <WMF/WMF-Swift.h>
+#import <WMF/MWKDataStore.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,11 +12,7 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
 
 @interface MWKLanguageLinkController ()
 
-@property (copy, nonatomic) NSArray *preferredLanguages;
-
-@property (copy, nonatomic) NSArray *otherLanguages;
-
-@property (copy, nonatomic) NSArray<MWKLanguageLink *> *allLanguages;
+@property (weak, nonatomic) NSManagedObjectContext *moc;
 
 @end
 
@@ -23,30 +20,28 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
 
 static id _sharedInstance;
 
-+ (instancetype)sharedInstance {
-    static dispatch_once_t once;
-    dispatch_once(&once, ^{
-        _sharedInstance = [[[self class] alloc] init];
-    });
-    return _sharedInstance;
-}
-
-- (instancetype)init {
-    assert(_sharedInstance == nil);
-    self = [super init];
-    if (self) {
-        [self loadLanguagesFromFile];
+- (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)moc {
+    if (self = [super init]) {
+        self.moc = moc;
     }
     return self;
 }
 
-#pragma mark - Loading
+#pragma mark - Getters & Setters
 
-- (void)loadLanguagesFromFile {
-    self.allLanguages = [WikipediaLookup allLanguageLinks];
++ (NSArray<MWKLanguageLink *> *)allLanguages {
+    /// Separate static array here so the array is only bridged once
+    static dispatch_once_t onceToken;
+    static NSArray<MWKLanguageLink *> *allLanguages;
+    dispatch_once(&onceToken, ^{
+        allLanguages =  WikipediaLookup.allLanguageLinks;
+    });
+    return allLanguages;
 }
 
-#pragma mark - Getters & Setters
+- (NSArray<MWKLanguageLink *> *)allLanguages {
+    return [MWKLanguageLinkController allLanguages];
+}
 
 - (nullable MWKLanguageLink *)languageForSiteURL:(NSURL *)siteURL {
     return [self.allLanguages wmf_match:^BOOL(MWKLanguageLink *obj) {
@@ -129,10 +124,14 @@ static id _sharedInstance;
     [self savePreferredLanguageCodes:langCodes];
 }
 
-#pragma mark - Reading/Saving Preferred Language Codes to NSUserDefaults
+#pragma mark - Reading/Saving Preferred Language Codes
 
-- (NSArray<NSString *> *)readPreferredLanguageCodesWithoutOSPreferredLanguages {
-    NSArray<NSString *> *preferredLanguages = [[NSUserDefaults standardUserDefaults] arrayForKey:WMFPreviousLanguagesKey] ?: @[];
+- (NSArray<NSString *>
+   *)readPreferredLanguageCodesWithoutOSPreferredLanguages {
+    __block NSArray<NSString *> *preferredLanguages = nil;
+    [self.moc performBlockAndWait:^{
+        preferredLanguages = [self.moc wmf_arrayValueForKey:WMFPreviousLanguagesKey] ?: @[];
+    }];
     return preferredLanguages;
 }
 
@@ -166,7 +165,9 @@ static id _sharedInstance;
     self.previousPreferredLanguages = self.preferredLanguages;
     NSString *previousAppLanguageCode = self.appLanguage.languageCode;
     [self willChangeValueForKey:WMF_SAFE_KEYPATH(self, allLanguages)];
-    [[NSUserDefaults standardUserDefaults] setObject:languageCodes forKey:WMFPreviousLanguagesKey];
+    [self.moc performBlockAndWait:^{
+        [self.moc wmf_setValue:languageCodes forKey:WMFPreviousLanguagesKey];
+    }];
     [self didChangeValueForKey:WMF_SAFE_KEYPATH(self, allLanguages)];
     [[NSNotificationCenter defaultCenter] postNotificationName:WMFPreferredLanguagesDidChangeNotification object:self];
     if (self.appLanguage.languageCode && ![self.appLanguage.languageCode isEqualToString:previousAppLanguageCode]) {
@@ -177,7 +178,9 @@ static id _sharedInstance;
 // Reminder: "resetPreferredLanguages" is for testing only!
 - (void)resetPreferredLanguages {
     [self willChangeValueForKey:WMF_SAFE_KEYPATH(self, allLanguages)];
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:WMFPreviousLanguagesKey];
+    [self.moc performBlockAndWait:^{
+        [self.moc wmf_setValue:nil forKey:WMFPreviousLanguagesKey];
+    }];
     [self didChangeValueForKey:WMF_SAFE_KEYPATH(self, allLanguages)];
     [[NSNotificationCenter defaultCenter] postNotificationName:WMFPreferredLanguagesDidChangeNotification object:self];
 }
@@ -188,6 +191,17 @@ static id _sharedInstance;
                BOOL answer = [obj isEqualToString:language.languageCode];
                return answer;
            }] != nil;
+}
+
+- (void)getPreferredLanguageCodes:(void (^)(NSArray<NSString *> *))completion {
+    [self.moc performBlock:^{
+        completion([self readPreferredLanguageCodes]);
+    }];
+}
+
++ (void)migratePreferredLanguagesToManagedObjectContext:(NSManagedObjectContext *)moc {
+    NSArray *preferredLanguages = [[NSUserDefaults standardUserDefaults] arrayForKey:WMFPreviousLanguagesKey];
+    [moc wmf_setValue:preferredLanguages forKey:WMFPreviousLanguagesKey];
 }
 
 @end

--- a/Wikipedia/Code/PlacesViewController.swift
+++ b/Wikipedia/Code/PlacesViewController.swift
@@ -40,7 +40,7 @@ class PlacesViewController: ViewController, UISearchBarDelegate, ArticlePopoverV
     fileprivate var searchSuggestionController: PlaceSearchSuggestionController!
 
     fileprivate var siteURL: URL {
-        return MWKLanguageLinkController.sharedInstance().appLanguage?.siteURL() ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale()!
+        return MWKDataStore.shared().languageLinkController.appLanguage?.siteURL() ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale()!
     }
     
     fileprivate var currentGroupingPrecision: QuadKeyPrecision = 1

--- a/Wikipedia/Code/SearchLanguagesBarViewController.swift
+++ b/Wikipedia/Code/SearchLanguagesBarViewController.swift
@@ -33,11 +33,11 @@ class SearchLanguagesBarViewController: UIViewController, WMFPreferredLanguagesV
     
     @objc fileprivate(set) var currentlySelectedSearchLanguage: MWKLanguageLink? {
         get {
-            if let siteURL = UserDefaults.standard.wmf_currentSearchLanguageDomain(), let selectedLanguage = MWKLanguageLinkController.sharedInstance().language(forSiteURL: siteURL) {
+            if let siteURL = UserDefaults.standard.wmf_currentSearchLanguageDomain(), let selectedLanguage = MWKDataStore.shared().languageLinkController.language(forSiteURL: siteURL) {
                 return selectedLanguage
             } else {
                 
-                if let appLang = MWKLanguageLinkController.sharedInstance().appLanguage {
+                if let appLang = MWKDataStore.shared().languageLinkController.appLanguage {
                     self.currentlySelectedSearchLanguage = appLang
                     return appLang
                 } else {
@@ -106,7 +106,7 @@ class SearchLanguagesBarViewController: UIViewController, WMFPreferredLanguagesV
     }
     
     fileprivate func languageBarLanguages() -> [MWKLanguageLink] {
-        return Array(MWKLanguageLinkController.sharedInstance().preferredLanguages.prefix(3))
+        return Array(MWKDataStore.shared().languageLinkController.preferredLanguages.prefix(3))
     }
     
     fileprivate func updateLanguageBarLanguageButtons(){
@@ -169,7 +169,7 @@ class SearchLanguagesBarViewController: UIViewController, WMFPreferredLanguagesV
     func languagesController(_ controller: WMFLanguagesViewController, didSelectLanguage language: MWKLanguageLink) {
         // If the selected language will not be displayed because we only display max 3 languages, move it to index 2
         if(languageBarLanguages().firstIndex(of: language) == nil && languageBarLanguages().count > 2){
-            MWKLanguageLinkController.sharedInstance().reorderPreferredLanguage(language, to: 2)
+            MWKDataStore.shared().languageLinkController.reorderPreferredLanguage(language, to: 2)
         }
         
         currentlySelectedSearchLanguage = language

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -103,7 +103,7 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
 
     var siteURL: URL? {
         get {
-            return _siteURL ?? searchLanguageBarViewController?.currentlySelectedSearchLanguage?.siteURL() ?? MWKLanguageLinkController.sharedInstance().appLanguage?.siteURL() ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale()
+            return _siteURL ?? searchLanguageBarViewController?.currentlySelectedSearchLanguage?.siteURL() ?? MWKDataStore.shared().languageLinkController.appLanguage?.siteURL() ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale()
         }
         set {
             _siteURL = newValue

--- a/Wikipedia/Code/UserHistoryFunnel.swift
+++ b/Wikipedia/Code/UserHistoryFunnel.swift
@@ -131,7 +131,7 @@ private typealias ContentGroupKindAndLoggingCode = (kind: WMFContentGroupKind, l
 
 private extension WMFContentGroupKind {
     var offLanguageCodes: Set<String> {
-        let preferredLangCodes = MWKLanguageLinkController.sharedInstance().preferredLanguages.map{$0.languageCode}
+        let preferredLangCodes = MWKDataStore.shared().languageLinkController.preferredLanguages.map{$0.languageCode}
         return Set(preferredLangCodes).subtracting(languageCodes)
     }
     

--- a/Wikipedia/Code/WMFAccountCreationViewController.swift
+++ b/Wikipedia/Code/WMFAccountCreationViewController.swift
@@ -111,7 +111,7 @@ class WMFAccountCreationViewController: WMFScrollViewController, WMFCaptchaViewC
     
     fileprivate func getCaptcha() {
         let failure: WMFErrorHandler = {error in }
-        let siteURL = MWKLanguageLinkController.sharedInstance().appLanguage?.siteURL()
+        let siteURL = MWKDataStore.shared().languageLinkController.appLanguage?.siteURL()
         accountCreationInfoFetcher.fetchAccountCreationInfoForSiteURL(siteURL!, success: { info in
             DispatchQueue.main.async {
                 self.captchaViewController?.captcha = info.captcha
@@ -204,7 +204,7 @@ class WMFAccountCreationViewController: WMFScrollViewController, WMFCaptchaViewC
     }
     
     public func captchaSiteURL() -> URL {
-        return (MWKLanguageLinkController.sharedInstance().appLanguage?.siteURL())!
+        return (MWKDataStore.shared().languageLinkController.appLanguage?.siteURL())!
     }
     
     public func captchaHideSubtitle() -> Bool {
@@ -322,7 +322,7 @@ class WMFAccountCreationViewController: WMFScrollViewController, WMFCaptchaViewC
         }
         
         self.setViewControllerUserInteraction(enabled: false)
-        let siteURL = MWKLanguageLinkController.sharedInstance().appLanguage?.siteURL()
+        let siteURL = MWKDataStore.shared().languageLinkController.appLanguage?.siteURL()
         accountCreator.createAccount(username: usernameField.text!, password: passwordField.text!, retypePassword: passwordRepeatField.text!, email: emailField.text!, captchaID: captchaViewController?.captcha?.captchaID, captchaWord: captchaViewController?.solution, siteURL: siteURL!, success: {_ in
             DispatchQueue.main.async {
                 self.login()

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -264,7 +264,7 @@ static const NSString *kvo_SavedArticlesFetcher_progress = @"kvo_SavedArticlesFe
 }
 
 - (NSURL *)siteURL {
-    return [[[MWKLanguageLinkController sharedInstance] appLanguage] siteURL];
+    return [[self.dataStore.languageLinkController appLanguage] siteURL];
 }
 
 #pragma mark - Setup
@@ -412,14 +412,14 @@ static const NSString *kvo_SavedArticlesFetcher_progress = @"kvo_SavedArticlesFe
 
 - (void)preferredLanguagesDidChange:(NSNotification *)note {
     [self updateExploreFeedPreferencesIfNecessary];
-    self.dataStore.feedContentController.siteURLs = [[MWKLanguageLinkController sharedInstance] preferredSiteURLs];
+    self.dataStore.feedContentController.siteURLs = [self.dataStore.languageLinkController preferredSiteURLs];
 }
 
 /**
  Updates explore feed preferences if new preferred language was appeneded or removed.
  */
 - (void)updateExploreFeedPreferencesIfNecessary {
-    MWKLanguageLinkController *languageLinkController = [MWKLanguageLinkController sharedInstance];
+    MWKLanguageLinkController *languageLinkController = self.dataStore.languageLinkController;
     NSArray<MWKLanguageLink *> *preferredLanguages = languageLinkController.preferredLanguages;
     NSArray<MWKLanguageLink *> *previousPreferredLanguages = languageLinkController.previousPreferredLanguages;
     if (preferredLanguages.count == previousPreferredLanguages.count) { // reordered

--- a/Wikipedia/Code/WMFAuthenticationManager.swift
+++ b/Wikipedia/Code/WMFAuthenticationManager.swift
@@ -107,7 +107,7 @@ public class WMFAuthenticationManager: Fetcher {
     @objc public static let sharedInstance = WMFAuthenticationManager()
     
     var loginSiteURL: URL? {
-        return MWKLanguageLinkController.sharedInstance().appLanguage?.siteURL() ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale()
+        return dataStore.languageLinkController.appLanguage?.siteURL() ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale()
     }
     
     public func attemptLogin(reattemptOn401Response: Bool = false, completion: @escaping AuthenticationResultHandler) {

--- a/Wikipedia/Code/WMFForgotPasswordViewController.swift
+++ b/Wikipedia/Code/WMFForgotPasswordViewController.swift
@@ -89,7 +89,7 @@ class WMFForgotPasswordViewController: WMFScrollViewController, Themeable {
     }
     
     func sendPasswordResetEmail(userName: String?, email: String?) {
-        guard let siteURL = MWKLanguageLinkController.sharedInstance().appLanguage?.siteURL() else {
+        guard let siteURL = MWKDataStore.shared().languageLinkController.appLanguage?.siteURL() else {
             WMFAlertManager.sharedInstance.showAlert("No site url", sticky: true, dismissPreviousAlerts: true, tapCallBack: nil)
             return
         }

--- a/Wikipedia/Code/WMFLanguagesViewController.m
+++ b/Wikipedia/Code/WMFLanguagesViewController.m
@@ -199,7 +199,7 @@ static CGFloat const WMFLanguageHeaderHeight = 57.f;
 
 - (MWKLanguageFilter *)languageFilter {
     if (!_languageFilter) {
-        _languageFilter = [[MWKLanguageFilter alloc] initWithLanguageDataSource:[MWKLanguageLinkController sharedInstance]];
+        _languageFilter = [[MWKLanguageFilter alloc] initWithLanguageDataSource:MWKDataStore.shared.languageLinkController];
     }
     return _languageFilter;
 }
@@ -274,7 +274,7 @@ static CGFloat const WMFLanguageHeaderHeight = 57.f;
 }
 
 - (CGFloat)alphaForDeleteButton {
-    return !self.tableView.editing || ([MWKLanguageLinkController sharedInstance].preferredLanguages.count == 1) ? 0.f : 1.f;
+    return !self.tableView.editing || (MWKDataStore.shared.languageLinkController.preferredLanguages.count == 1) ? 0.f : 1.f;
 }
 
 - (MWKLanguageLink *)languageAtIndexPath:(NSIndexPath *)indexPath {
@@ -358,11 +358,11 @@ static CGFloat const WMFLanguageHeaderHeight = 57.f;
     switch (editingStyle) {
         case UITableViewCellEditingStyleInsert: {
             MWKLanguageLink *langLink = self.languageFilter.filteredOtherLanguages[indexPath.row];
-            [[MWKLanguageLinkController sharedInstance] appendPreferredLanguage:langLink];
+            [MWKDataStore.shared.languageLinkController appendPreferredLanguage:langLink];
         } break;
         case UITableViewCellEditingStyleDelete: {
             MWKLanguageLink *langLink = self.languageFilter.filteredPreferredLanguages[indexPath.row];
-            [[MWKLanguageLinkController sharedInstance] removePreferredLanguage:langLink];
+            [MWKDataStore.shared.languageLinkController removePreferredLanguage:langLink];
         } break;
         case UITableViewCellEditingStyleNone:
             break;
@@ -438,7 +438,7 @@ static CGFloat const WMFLanguageHeaderHeight = 57.f;
 
 - (void)reloadDataSections {
     [super reloadDataSections];
-    self.navigationItem.rightBarButtonItem = [MWKLanguageLinkController sharedInstance].preferredLanguages.count > 1 ? self.editButtonItem : nil;
+    self.navigationItem.rightBarButtonItem = MWKDataStore.shared.languageLinkController.preferredLanguages.count > 1 ? self.editButtonItem : nil;
 }
 
 - (void)viewDidLoad {
@@ -478,7 +478,7 @@ static CGFloat const WMFLanguageHeaderHeight = 57.f;
 }
 
 - (void)languagesController:(WMFLanguagesViewController *)controller didSelectLanguage:(MWKLanguageLink *)language {
-    [[MWKLanguageLinkController sharedInstance] appendPreferredLanguage:language];
+    [MWKDataStore.shared.languageLinkController appendPreferredLanguage:language];
     [self reloadDataSections];
     [controller dismissViewControllerAnimated:YES completion:NULL];
     [self notifyDelegateThatPreferredLanguagesDidUpdate];
@@ -486,7 +486,7 @@ static CGFloat const WMFLanguageHeaderHeight = 57.f;
 
 - (void)notifyDelegateThatPreferredLanguagesDidUpdate {
     if ([self.delegate respondsToSelector:@selector(languagesController:didUpdatePreferredLanguages:)]) {
-        [self.delegate languagesController:self didUpdatePreferredLanguages:[MWKLanguageLinkController sharedInstance].preferredLanguages];
+        [self.delegate languagesController:self didUpdatePreferredLanguages:MWKDataStore.shared.languageLinkController.preferredLanguages];
     }
 }
 
@@ -524,12 +524,12 @@ static CGFloat const WMFLanguageHeaderHeight = 57.f;
 }
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
-    return [MWKLanguageLinkController sharedInstance].preferredLanguages.count > 1;
+    return MWKDataStore.shared.languageLinkController.preferredLanguages.count > 1;
 }
 
 - (void)tableView:(UITableView *)tableView moveRowAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath {
-    MWKLanguageLink *langLink = [MWKLanguageLinkController sharedInstance].preferredLanguages[sourceIndexPath.row];
-    [[MWKLanguageLinkController sharedInstance] reorderPreferredLanguage:langLink toIndex:destinationIndexPath.row];
+    MWKLanguageLink *langLink = MWKDataStore.shared.languageLinkController.preferredLanguages[sourceIndexPath.row];
+    [MWKDataStore.shared.languageLinkController reorderPreferredLanguage:langLink toIndex:destinationIndexPath.row];
 
     // TODO: reloadData is a bit brute force, but had issues with the "PRIMARY" indicator
     // showing on more than one cell after re-ordering first cell.
@@ -541,7 +541,7 @@ static CGFloat const WMFLanguageHeaderHeight = 57.f;
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
     [super tableView:tableView commitEditingStyle:editingStyle forRowAtIndexPath:indexPath];
     [self notifyDelegateThatPreferredLanguagesDidUpdate];
-    if ([MWKLanguageLinkController sharedInstance].preferredLanguages.count == 1) {
+    if (MWKDataStore.shared.languageLinkController.preferredLanguages.count == 1) {
         [self setEditing:NO animated:YES];
         self.navigationItem.rightBarButtonItem = nil;
     }
@@ -588,7 +588,7 @@ static CGFloat const WMFLanguageHeaderHeight = 57.f;
 - (MWKTitleLanguageController *)titleLanguageController {
     NSAssert(self.articleURL != nil, @"Article Title must be set before accessing titleLanguageController");
     if (!_titleLanguageController) {
-        _titleLanguageController = [[MWKTitleLanguageController alloc] initWithArticleURL:self.articleURL languageController:[MWKLanguageLinkController sharedInstance]];
+        _titleLanguageController = [[MWKTitleLanguageController alloc] initWithArticleURL:self.articleURL languageController:MWKDataStore.shared.languageLinkController];
     }
     return _titleLanguageController;
 }

--- a/Wikipedia/Code/WMFLoginViewController.swift
+++ b/Wikipedia/Code/WMFLoginViewController.swift
@@ -289,7 +289,7 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
                 self.funnel?.logError(error.localizedDescription)
             }
         }
-        let siteURL = MWKLanguageLinkController.sharedInstance().appLanguage?.siteURL()
+        let siteURL = MWKDataStore.shared().languageLinkController.appLanguage?.siteURL()
         loginInfoFetcher.fetchLoginInfoForSiteURL(siteURL!, success: { info in
             DispatchQueue.main.async {
                 self.captchaViewController?.captcha = info.captcha
@@ -308,7 +308,7 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
     }
     
     public func captchaSiteURL() -> URL {
-        return (MWKLanguageLinkController.sharedInstance().appLanguage?.siteURL())!
+        return (MWKDataStore.shared().languageLinkController.appLanguage?.siteURL())!
     }
     
     func captchaKeyboardReturnKeyTapped() {

--- a/Wikipedia/Code/WMFNearbyContentSource.m
+++ b/Wikipedia/Code/WMFNearbyContentSource.m
@@ -133,7 +133,7 @@ static const CLLocationDistance WMFNearbyUpdateDistanceThresholdInMeters = 25000
 }
 
 - (void)showAuthorizationPlaceholderInManagedObjectContext:(NSManagedObjectContext *)moc completion:(nonnull dispatch_block_t)completion {
-    NSString *preferredSiteURLString = [[MWKLanguageLinkController.sharedInstance.preferredSiteURLs firstObject] wmf_databaseKey];
+    NSString *preferredSiteURLString = [[self.dataStore.languageLinkController.preferredSiteURLs firstObject] wmf_databaseKey];
     NSString *mySiteURLString = self.siteURL.wmf_databaseKey;
     if (preferredSiteURLString && mySiteURLString && ![mySiteURLString isEqualToString:preferredSiteURLString]) {
         if (completion) {

--- a/Wikipedia/Code/WMFSettingsMenuItem.m
+++ b/Wikipedia/Code/WMFSettingsMenuItem.m
@@ -53,7 +53,7 @@
                                                  iconName:@"settings-language"
                                                 iconColor:[UIColor wmf_colorWithHex:0x1F95DE]
                                            disclosureType:WMFSettingsMenuItemDisclosureType_ViewControllerWithDisclosureText
-                                           disclosureText:[[[MWKLanguageLinkController sharedInstance] appLanguage].languageCode uppercaseString]
+                                           disclosureText:[MWKDataStore.shared.languageLinkController.appLanguage.languageCode uppercaseString]
                                                isSwitchOn:NO];
         }
         case WMFSettingsMenuItemType_Search: {

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -284,7 +284,7 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
 - (NSURL *)donationURL {
     NSString *url = WMFSettingsURLDonation;
 
-    NSString *languageCode = [[MWKLanguageLinkController sharedInstance] appLanguage].languageCode;
+    NSString *languageCode = MWKDataStore.shared.languageLinkController.appLanguage.languageCode;
     languageCode = [languageCode stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
 
     NSString *appVersion = [[NSBundle mainBundle] wmf_debugVersion];

--- a/Wikipedia/Code/WMFWelcomeLanguageTableViewController.swift
+++ b/Wikipedia/Code/WMFWelcomeLanguageTableViewController.swift
@@ -43,17 +43,17 @@ class WMFWelcomeLanguageTableViewController: ThemeableViewController, WMFPreferr
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        UserDefaults.standard.wmf_setShowSearchLanguageBar(MWKLanguageLinkController.sharedInstance().preferredLanguages.count > 1)
+        UserDefaults.standard.wmf_setShowSearchLanguageBar(MWKDataStore.shared().languageLinkController.preferredLanguages.count > 1)
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return MWKLanguageLinkController.sharedInstance().preferredLanguages.count
+        return MWKDataStore.shared().languageLinkController.preferredLanguages.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: WMFLanguageCell.wmf_nibName(), for: indexPath) as! WMFLanguageCell
         cell.collapseSideSpacing()
-        let langLink = MWKLanguageLinkController.sharedInstance().preferredLanguages[indexPath.row]
+        let langLink = MWKDataStore.shared().languageLinkController.preferredLanguages[indexPath.row]
         cell.languageName = langLink.name
         cell.isPrimary = indexPath.row == 0
         (cell as Themeable).apply(theme: theme)

--- a/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
+++ b/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
@@ -1,6 +1,7 @@
 #import <XCTest/XCTest.h>
 #import "MWKLanguageLinkController_Private.h"
 #import "MWKLanguageLink.h"
+#import "MWKDataStore+TemporaryDataStore.h"
 #import "NSString+WMFExtras.h"
 #import "NSUserDefaults+WMFReset.h"
 
@@ -24,7 +25,7 @@
              [NSLocale preferredLanguages]);
 
     // all tests must start w/ a clean slate
-    self.controller = [MWKLanguageLinkController sharedInstance];
+    self.controller = MWKDataStore.temporaryDataStore.languageLinkController;
     self.filter = [[MWKLanguageFilter alloc] initWithLanguageDataSource:self.controller];
     [self.controller resetPreferredLanguages];
 }
@@ -67,7 +68,7 @@
 }
 
 - (void)testLanguagesPropertiesAreNonnull {
-    self.controller = [MWKLanguageLinkController sharedInstance];
+    self.controller = MWKDataStore.temporaryDataStore.languageLinkController;
     XCTAssertTrue(self.controller.allLanguages.count > 0);
     XCTAssertTrue(self.controller.otherLanguages.count > 0);
     XCTAssertTrue(self.controller.preferredLanguages.count > 0);


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T257250 

### Notes

When `UserDefaults` were [migrated off the named suite](https://github.com/wikimedia/wikipedia-ios/pull/3439) into using the standard suite, the today widgets stopped accurately polling the currently selected app language. This was because the today widgets were referencing the standard `UserDefaults` suite, which isn't shared between the main app and the extensions. Joe migrated the app language component here from `UserDefaults` into Core Data, which should mitigate the issue.

I'll review this one myself because it relates to some widget stuff I'm working on. (It won't let me self-assign for review, so I'll self-assign as an assignee).

### Test Steps
1. Open app, change primary language
2. Open today widgets (e.g. Top read), confirm the widget's language matches the primary language selected in app

