### PR TITLE
make git hooks directory if needed in install script

### DIFF
--- a/scripts/setup_git_hooks
+++ b/scripts/setup_git_hooks
@@ -2,5 +2,6 @@
 # sets up pre commit hooks
 
 rm -rf .git/hooks/pre-commit
+mkdir -p .git/hooks
 cp -f scripts/clang_format_git_diff .git/hooks/pre-commit
 cat scripts/strip_header >> .git/hooks/pre-commit


### PR DESCRIPTION
### Notes
* This hopefully fixes installation troubles of IRC user. I was able to repro by removing the .git/hooks directory entirely, then trying to run .scripts/setup_git_hooks from the main directory.

### Repro Steps
1. Clone new repo.
2. Go to .git folder in main directory, delete subdirectory 'hooks' if it's there.
3. Run `./scripts/setup` in Terminal from the main directory.
4. You will see ".git/hooks/pre-commit: No such file or directory" error.

### Test Steps
1. Clone new repo, switch to this PR branch and follow other steps from Repro steps. Confirm you don't see an error.