### PR TITLE
Handle underbar header when programatically scrolling

### DIFF
--- a/Wikipedia/Code/NavigationBarHider.swift
+++ b/Wikipedia/Code/NavigationBarHider.swift
@@ -45,6 +45,10 @@ public class NavigationBarHider: NSObject {
     }
 
     public func setIsProgramaticallyScrolling(_ isProgramaticallyScrolling: Bool, yOffset: CGFloat, topContentInset: CGFloat) {
+        guard navigationBar?.isInteractiveHidingEnabled == true else {
+            return
+        }
+        
         self.isProgramaticallyScrolling = isProgramaticallyScrolling
 
         if isProgramaticallyScrolling {
@@ -65,9 +69,11 @@ public class NavigationBarHider: NSObject {
             return
         }
 
-        /// When programatically scrolling on a just-created scroll view, we need a layout pass to get accurate heights.
-        scrollView.layoutIfNeeded()
-        navigationBar.layoutIfNeeded()
+        if isProgramaticallyScrolling {
+            /// When programatically scrolling on a just-created scroll view, we need a layout pass to get accurate heights.
+            scrollView.layoutIfNeeded()
+            navigationBar.layoutIfNeeded()
+        }
 
         guard scrollView.contentSize.height > 0 else {
             if navigationBar.isAdjustingHidingFromContentInsetChangesEnabled  {

--- a/Wikipedia/Code/OnThisDayViewController.swift
+++ b/Wikipedia/Code/OnThisDayViewController.swift
@@ -96,7 +96,9 @@ class OnThisDayViewController: ColumnarCollectionViewController, DetailPresentin
             return
         }
         let sectionIndex = eventIndex + 1 // index + 1 because section 0 is the header
+        isProgramaticallyScrolling = true
         collectionView.scrollToItem(at: IndexPath(item: 0, section: sectionIndex), at: sectionIndex < 1 ? .top : .centeredVertically, animated: false)
+        isProgramaticallyScrolling = false
     }
     
     override func scrollViewInsetsDidChange() {
@@ -147,6 +149,12 @@ class OnThisDayViewController: ColumnarCollectionViewController, DetailPresentin
     // MARK: - ColumnarCollectionViewLayoutDelegate
     
     override func collectionView(_ collectionView: UICollectionView, estimatedHeightForHeaderInSection section: Int, forColumnWidth columnWidth: CGFloat) -> ColumnarCollectionViewLayoutHeightEstimate {
+
+        /// When presenting with navigation bar, first two section headers do not exist.
+        guard !shouldShowNavigationBar || section >= 2 else {
+            return ColumnarCollectionViewLayoutHeightEstimate(precalculated: false, height: 0)
+        }
+
         guard section > 0 else {
             return super.collectionView(collectionView, estimatedHeightForHeaderInSection: section, forColumnWidth: columnWidth)
         }

--- a/Wikipedia/Code/ViewController.swift
+++ b/Wikipedia/Code/ViewController.swift
@@ -29,6 +29,15 @@ class ViewController: PreviewingViewController, NavigationBarHiderDelegate {
         return NavigationBarHider()
     }()
 
+    var isProgramaticallyScrolling: Bool = false {
+        didSet {
+            guard let yOffset = scrollView?.contentOffset.y, let topInset = scrollView?.contentInset.top else {
+                return
+            }
+            navigationBarHider.setIsProgramaticallyScrolling(isProgramaticallyScrolling, yOffset: yOffset, topContentInset: topInset)
+        }
+    }
+
     private var keyboardFrame: CGRect? {
         didSet {
             keyboardDidChangeFrame(from: oldValue, newKeyboardFrame: keyboardFrame)


### PR DESCRIPTION
**Fixes Phabricator ticket:** none, bug came from PR https://github.com/wikimedia/wikipedia-ios/pull/3677

### Notes
* A programatic scroll doesn't call the relevant delegate functions that allow `NavigationBarHider` to work. This adds `isProgramaticallyScrolling` to allow it to work in these case.

### Test Steps
1. Run app.
1. In a terminal window, run `xcrun simctl openurl booted 'https://en.wikipedia.org/wiki/Wikipedia:On_this_day/Today'`. Ensure `On This Day` VC opens appropriately, with header looking good. Scroll up and down, nothing should jump.
1. In a terminal window, run `xcrun simctl openurl booted 'https://en.wikipedia.org/wiki/Wikipedia:On_this_day/Today?0'`. Ensure `On This Day` VC opens appropriately, with header looking good. Scroll up and down, nothing should jump.
1. In a terminal window, run `xcrun simctl openurl booted 'https://en.wikipedia.org/wiki/Wikipedia:On_this_day/Today?1'`. Ensure `On This Day` VC opens appropriately, with header looking good. Scroll up and down, nothing should jump.
1. In a terminal window, run `xcrun simctl openurl booted 'https://en.wikipedia.org/wiki/Wikipedia:On_this_day/Today?6'`. Ensure `On This Day` VC opens appropriately, with header looking good. Scroll up and down, nothing should jump.