### PR TITLE
Move Picture of the day's localized strings and update sample description key

### DIFF
--- a/Widgets/Widgets/PictureOfTheDayWidget+LocalizedStrings.swift
+++ b/Widgets/Widgets/PictureOfTheDayWidget+LocalizedStrings.swift
@@ -6,7 +6,7 @@ extension PictureOfTheDayWidget {
 	enum LocalizedStrings {
 		static let widgetTitle = WMFLocalizedString("potd-widget-title", value:"Picture of the day", comment: "Text for title of Picture of the day widget.")
 		static let widgetDescription = WMFLocalizedString("potd-widget-description", value:"Enjoy a beautiful daily photo selected by our community.", comment: "Text for description of Picture of the day widget displayed when adding to home screen.")
-		static let sampleEntryDescription = WMFLocalizedString("potd-sample-entry-description", value:"Two bulls running while the jockey holds on to them in pacu jawi (from Minangkabau, \"bull race\"), a traditional bull race in Tanah Datar, West Sumatra, Indonesia. 2015, Final-45.", comment: "Text for sample entry image caption. It is displayed when we we are unable to fetch Picture of the day data.")
+		static let sampleEntryDescription = WMFLocalizedString("potd-sample-entry-description", value:"Two bulls running while the jockey holds on to them in pacu jawi (from Minangkabau, \"bull race\"), a traditional bull race in Tanah Datar, West Sumatra, Indonesia. 2015, Final-45.", comment: "Text for sample entry image caption. It is displayed when app is unable to fetch Picture of the day data.")
 	}
 
 }

--- a/Widgets/Widgets/PictureOfTheDayWidget+LocalizedStrings.swift
+++ b/Widgets/Widgets/PictureOfTheDayWidget+LocalizedStrings.swift
@@ -6,7 +6,7 @@ extension PictureOfTheDayWidget {
 	enum LocalizedStrings {
 		static let widgetTitle = WMFLocalizedString("potd-widget-title", value:"Picture of the day", comment: "Text for title of Picture of the day widget.")
 		static let widgetDescription = WMFLocalizedString("potd-widget-description", value:"Enjoy a beautiful daily photo selected by our community.", comment: "Text for description of Picture of the day widget displayed when adding to home screen.")
-		static let sampleEntryDescription = WMFLocalizedString("potd-widget-description", value:"Two bulls running while the jockey holds on to them in pacu jawi (from Minangkabau, \"bull race\"), a traditional bull race in Tanah Datar, West Sumatra, Indonesia. 2015, Final-45.", comment: "Text for sample entry image caption. It is displayed when we we are unable to fetch Picture of the Day data.")
+		static let sampleEntryDescription = WMFLocalizedString("potd-sample-entry-description", value:"Two bulls running while the jockey holds on to them in pacu jawi (from Minangkabau, \"bull race\"), a traditional bull race in Tanah Datar, West Sumatra, Indonesia. 2015, Final-45.", comment: "Text for sample entry image caption. It is displayed when we we are unable to fetch Picture of the day data.")
 	}
 
 }

--- a/Widgets/Widgets/PictureOfTheDayWidget+LocalizedStrings.swift
+++ b/Widgets/Widgets/PictureOfTheDayWidget+LocalizedStrings.swift
@@ -1,0 +1,12 @@
+import Foundation
+import WMF
+
+extension PictureOfTheDayWidget {
+
+	enum LocalizedStrings {
+		static let widgetTitle = WMFLocalizedString("potd-widget-title", value:"Picture of the day", comment: "Text for title of Picture of the day widget.")
+		static let widgetDescription = WMFLocalizedString("potd-widget-description", value:"Enjoy a beautiful daily photo selected by our community.", comment: "Text for description of Picture of the day widget displayed when adding to home screen.")
+		static let sampleEntryDescription = WMFLocalizedString("potd-widget-description", value:"Two bulls running while the jockey holds on to them in pacu jawi (from Minangkabau, \"bull race\"), a traditional bull race in Tanah Datar, West Sumatra, Indonesia. 2015, Final-45.", comment: "Text for sample entry image caption. It is displayed when we we are unable to fetch Picture of the Day data.")
+	}
+
+}

--- a/Widgets/Widgets/PictureOfTheDayWidget.swift
+++ b/Widgets/Widgets/PictureOfTheDayWidget.swift
@@ -3,17 +3,6 @@ import SwiftUI
 import WMF
 import UIKit
 
-// TODO: Move into `PictureOfTheDay+LocalizedStrings.swift`
-extension PictureOfTheDayWidget {
-
-    enum LocalizedStrings {
-        static let pictureOfTheDayWidgetTitle = WMFLocalizedString("potd-widget-title", value:"Picture of the day", comment: "Text for title of Picture of the day widget.")
-        static let pictureOfTheDayWidgetDescription = WMFLocalizedString("potd-widget-description", value:"Enjoy a beautiful daily photo selected by our community.", comment: "Text for description of Picture of the day widget displayed when adding to home screen.")
-    }
-
-}
-
-
 // MARK: - Widget
 
 struct PictureOfTheDayWidget: Widget {
@@ -23,8 +12,8 @@ struct PictureOfTheDayWidget: Widget {
 		StaticConfiguration(kind: kind, provider: PictureOfTheDayProvider(), content: { entry in
 			PictureOfTheDayView(entry: entry)
 		})
-        .configurationDisplayName(PictureOfTheDayWidget.LocalizedStrings.pictureOfTheDayWidgetTitle)
-        .description(PictureOfTheDayWidget.LocalizedStrings.pictureOfTheDayWidgetDescription)
+        .configurationDisplayName(PictureOfTheDayWidget.LocalizedStrings.widgetTitle)
+        .description(PictureOfTheDayWidget.LocalizedStrings.widgetDescription)
 		.supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
 	}
 }
@@ -43,7 +32,7 @@ final class PictureOfTheDayData {
 		MWKDataStore.shared()
 	}
 
-	let sampleEntry = PictureOfTheDayEntry(date: Date(), image: #imageLiteral(resourceName: "PictureOfTheYear_2019"), imageDescription:  WMFLocalizedString("potd-widget-description", value:"Two bulls running while the jockey holds on to them in pacu jawi (from Minangkabau, \"bull race\"), a traditional bull race in Tanah Datar, West Sumatra, Indonesia. 2015, Final-45.", comment: "Text for sample entry image caption. It is displayed when we we are unable to fetch Picture of the Day data."))
+    let sampleEntry = PictureOfTheDayEntry(date: Date(), image: #imageLiteral(resourceName: "PictureOfTheYear_2019"), imageDescription:  PictureOfTheDayWidget.LocalizedStrings.sampleEntryDescription)
 	let placeholderEntry = PictureOfTheDayEntry(date: Date(), contentDate: nil, contentURL: nil, imageURL: nil, image: nil, imageDescription: nil)
 
 	// MARK: Public

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		00021DEA24D48EFE00476F97 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 00021DE924D48EFE00476F97 /* Assets.xcassets */; };
 		00021DEE24D48EFE00476F97 /* WidgetsExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 00021DE124D48EFD00476F97 /* WidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		00021E0424D4A42A00476F97 /* PictureOfTheDayWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00021E0324D4A42A00476F97 /* PictureOfTheDayWidget.swift */; };
+		002AB870250BEFBE00ADAC87 /* PictureOfTheDayWidget+LocalizedStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002AB86F250BEFBE00ADAC87 /* PictureOfTheDayWidget+LocalizedStrings.swift */; };
 		0033D79924F818EC00CAB5B3 /* TopReadWidget+LocalizedStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0033D79724F818EB00CAB5B3 /* TopReadWidget+LocalizedStrings.swift */; };
 		0033D79A24F818EC00CAB5B3 /* TopReadWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0033D79824F818EC00CAB5B3 /* TopReadWidget.swift */; };
 		0033D79D24F8193900CAB5B3 /* UIColor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0033D79B24F8193900CAB5B3 /* UIColor+Extensions.swift */; };
@@ -1234,14 +1235,14 @@
 		83AE1C861F34BB64004B62E0 /* ImageDimmingExampleViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA7683C11F30C56300A487AA /* ImageDimmingExampleViewController.xib */; };
 		83AE1C871F34BB65004B62E0 /* ImageDimmingExampleViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA7683C11F30C56300A487AA /* ImageDimmingExampleViewController.xib */; };
 		83AE1C881F34BB65004B62E0 /* ImageDimmingExampleViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA7683C11F30C56300A487AA /* ImageDimmingExampleViewController.xib */; };
-		83B019D024F6ACAA0014B5EF /* WikipediaLanguageCommandLineUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B019CD24F6ACAA0014B5EF /* WikipediaLanguageCommandLineUtility.swift */; };
-		83B019D124F6ACAA0014B5EF /* WikipediaLanguageCommandLineUtilityAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B019CE24F6ACAA0014B5EF /* WikipediaLanguageCommandLineUtilityAPI.swift */; };
-		83B019D224F6ACAA0014B5EF /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B019CF24F6ACAA0014B5EF /* main.swift */; };
-		83B019D624F6C31B0014B5EF /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83B019D524F6C31B0014B5EF /* WidgetKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		83AF34F724D3341E000046D6 /* BackgroundTasks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83AF34F624D3341D000046D6 /* BackgroundTasks.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		83AF34F824D33428000046D6 /* BackgroundTasks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83AF34F624D3341D000046D6 /* BackgroundTasks.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		83AF34F924D33432000046D6 /* BackgroundTasks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83AF34F624D3341D000046D6 /* BackgroundTasks.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		83AF34FA24D3343B000046D6 /* BackgroundTasks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83AF34F624D3341D000046D6 /* BackgroundTasks.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		83B019D024F6ACAA0014B5EF /* WikipediaLanguageCommandLineUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B019CD24F6ACAA0014B5EF /* WikipediaLanguageCommandLineUtility.swift */; };
+		83B019D124F6ACAA0014B5EF /* WikipediaLanguageCommandLineUtilityAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B019CE24F6ACAA0014B5EF /* WikipediaLanguageCommandLineUtilityAPI.swift */; };
+		83B019D224F6ACAA0014B5EF /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B019CF24F6ACAA0014B5EF /* main.swift */; };
+		83B019D624F6C31B0014B5EF /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83B019D524F6C31B0014B5EF /* WidgetKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		83B01F7223DA5327001185F4 /* ArticleViewController+ArticleWebMessageHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B01F7123DA5327001185F4 /* ArticleViewController+ArticleWebMessageHandling.swift */; };
 		83B01F7323DA5327001185F4 /* ArticleViewController+ArticleWebMessageHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B01F7123DA5327001185F4 /* ArticleViewController+ArticleWebMessageHandling.swift */; };
 		83B01F7423DA5327001185F4 /* ArticleViewController+ArticleWebMessageHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B01F7123DA5327001185F4 /* ArticleViewController+ArticleWebMessageHandling.swift */; };
@@ -3232,6 +3233,7 @@
 		00021DE924D48EFE00476F97 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		00021DEB24D48EFE00476F97 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00021E0324D4A42A00476F97 /* PictureOfTheDayWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PictureOfTheDayWidget.swift; sourceTree = "<group>"; usesTabs = 0; };
+		002AB86F250BEFBE00ADAC87 /* PictureOfTheDayWidget+LocalizedStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PictureOfTheDayWidget+LocalizedStrings.swift"; sourceTree = "<group>"; };
 		0033D79724F818EB00CAB5B3 /* TopReadWidget+LocalizedStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TopReadWidget+LocalizedStrings.swift"; sourceTree = "<group>"; };
 		0033D79824F818EC00CAB5B3 /* TopReadWidget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopReadWidget.swift; sourceTree = "<group>"; };
 		0033D79B24F8193900CAB5B3 /* UIColor+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Extensions.swift"; sourceTree = "<group>"; };
@@ -3700,12 +3702,11 @@
 		83ACAAA624E6E655003B3035 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = main.swift; path = "Command Line Tools/Update Localizations/main.swift"; sourceTree = SOURCE_ROOT; };
 		83ACAAAA24E6E745003B3035 /* WikipediaLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikipediaLookup.swift; sourceTree = "<group>"; };
 		83ACAAAC24E6EED9003B3035 /* WikipediaSiteInfoLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikipediaSiteInfoLookup.swift; sourceTree = "<group>"; };
+		83AF34F624D3341D000046D6 /* BackgroundTasks.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BackgroundTasks.framework; path = System/Library/Frameworks/BackgroundTasks.framework; sourceTree = SDKROOT; };
 		83B019CD24F6ACAA0014B5EF /* WikipediaLanguageCommandLineUtility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WikipediaLanguageCommandLineUtility.swift; sourceTree = "<group>"; };
 		83B019CE24F6ACAA0014B5EF /* WikipediaLanguageCommandLineUtilityAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WikipediaLanguageCommandLineUtilityAPI.swift; sourceTree = "<group>"; };
 		83B019CF24F6ACAA0014B5EF /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		83B019D524F6C31B0014B5EF /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/System/iOSSupport/System/Library/Frameworks/WidgetKit.framework; sourceTree = DEVELOPER_DIR; };
-		83ACAAAF24E6F8FF003B3035 /* WikipediaLanguageCommandLineUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikipediaLanguageCommandLineUtility.swift; sourceTree = "<group>"; };
-		83AF34F624D3341D000046D6 /* BackgroundTasks.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BackgroundTasks.framework; path = System/Library/Frameworks/BackgroundTasks.framework; sourceTree = SDKROOT; };
 		83B01F7123DA5327001185F4 /* ArticleViewController+ArticleWebMessageHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleViewController+ArticleWebMessageHandling.swift"; sourceTree = "<group>"; usesTabs = 0; };
 		83B01F7623DA5348001185F4 /* ArticleViewController+ArticleToolbarHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleViewController+ArticleToolbarHandling.swift"; sourceTree = "<group>"; };
 		83B01F7B23DB0BA2001185F4 /* ArticleViewController+Editing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleViewController+Editing.swift"; sourceTree = "<group>"; };
@@ -4991,6 +4992,7 @@
 			isa = PBXGroup;
 			children = (
 				00021E0324D4A42A00476F97 /* PictureOfTheDayWidget.swift */,
+				002AB86F250BEFBE00ADAC87 /* PictureOfTheDayWidget+LocalizedStrings.swift */,
 				0033D79824F818EC00CAB5B3 /* TopReadWidget.swift */,
 				0033D79724F818EB00CAB5B3 /* TopReadWidget+LocalizedStrings.swift */,
 			);
@@ -9840,6 +9842,7 @@
 				006D273524D8BAFB00947551 /* View+Extensions.swift in Sources */,
 				0033D7A124F8199300CAB5B3 /* Sparkline.swift in Sources */,
 				00021E0424D4A42A00476F97 /* PictureOfTheDayWidget.swift in Sources */,
+				002AB870250BEFBE00ADAC87 /* PictureOfTheDayWidget+LocalizedStrings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This moves Picture of the day's localized strings into a separate file to match the Top read widget and also fixes the duplicate `potd-widget-description` key.
