### PR TITLE
On This Day deep link improvements

### DIFF
--- a/WMF Framework/NavigationBar.swift
+++ b/WMF Framework/NavigationBar.swift
@@ -268,8 +268,8 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
         underBarViewTopTitleBarBottomConstraint = titleBar.bottomAnchor.constraint(equalTo: underBarView.topAnchor)
         underBarViewTopBottomConstraint = topAnchor.constraint(equalTo: underBarView.topAnchor)
         
-        let underBarViewLeadingConstraint = safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: underBarView.leadingAnchor)
-        let underBarViewTrailingConstraint = safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: underBarView.trailingAnchor)
+        let underBarViewLeadingConstraint = leadingAnchor.constraint(equalTo: underBarView.leadingAnchor)
+        let underBarViewTrailingConstraint = trailingAnchor.constraint(equalTo: underBarView.trailingAnchor)
         
         extendedViewHeightConstraint = extendedView.heightAnchor.constraint(equalToConstant: 0)
         extendedView.addConstraint(extendedViewHeightConstraint)

--- a/WMF Framework/NavigationBar.swift
+++ b/WMF Framework/NavigationBar.swift
@@ -268,8 +268,8 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
         underBarViewTopTitleBarBottomConstraint = titleBar.bottomAnchor.constraint(equalTo: underBarView.topAnchor)
         underBarViewTopBottomConstraint = topAnchor.constraint(equalTo: underBarView.topAnchor)
         
-        let underBarViewLeadingConstraint = leadingAnchor.constraint(equalTo: underBarView.leadingAnchor)
-        let underBarViewTrailingConstraint = trailingAnchor.constraint(equalTo: underBarView.trailingAnchor)
+        let underBarViewLeadingConstraint = safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: underBarView.leadingAnchor)
+        let underBarViewTrailingConstraint = safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: underBarView.trailingAnchor)
         
         extendedViewHeightConstraint = extendedView.heightAnchor.constraint(equalToConstant: 0)
         extendedView.addConstraint(extendedViewHeightConstraint)

--- a/WMF Framework/NavigationState.swift
+++ b/WMF Framework/NavigationState.swift
@@ -75,6 +75,8 @@ public struct NavigationState: Codable {
             public var readingListURIString: String?
             
             public var searchTerm: String?
+
+            public var shouldShowNavigationBar: Bool?
             
             public var contentGroupIDURIString: String?
 
@@ -84,7 +86,7 @@ public struct NavigationState: Codable {
             
             // TODO: Remove after moving to Swift 5.1 -
             // https://github.com/apple/swift-evolution/blob/master/proposals/0242-default-values-memberwise.md
-            public init(url: URL? = nil, selectedIndex: Int? = nil, articleKey: String? = nil, articleSectionAnchor: String? = nil, talkPageSiteURLString: String? = nil, talkPageTitle: String? = nil, talkPageTypeRawValue: Int? = nil, currentSavedViewRawValue: Int? = nil, readingListURIString: String? = nil, searchTerm: String? = nil, contentGroupIDURIString: String? = nil, presentedContentGroupKey: String? = nil) {
+            public init(url: URL? = nil, selectedIndex: Int? = nil, articleKey: String? = nil, articleSectionAnchor: String? = nil, talkPageSiteURLString: String? = nil, talkPageTitle: String? = nil, talkPageTypeRawValue: Int? = nil, currentSavedViewRawValue: Int? = nil, readingListURIString: String? = nil, searchTerm: String? = nil, shouldShowNavigationBar: Bool? = nil, contentGroupIDURIString: String? = nil, presentedContentGroupKey: String? = nil) {
                 self.url = url
                 self.selectedIndex = selectedIndex
                 self.articleKey = articleKey
@@ -95,6 +97,7 @@ public struct NavigationState: Codable {
                 self.currentSavedViewRawValue = currentSavedViewRawValue
                 self.readingListURIString = readingListURIString
                 self.searchTerm = searchTerm
+                self.shouldShowNavigationBar = shouldShowNavigationBar
                 self.contentGroupIDURIString = contentGroupIDURIString
                 self.presentedContentGroupKey = presentedContentGroupKey
             }

--- a/Wikipedia/Code/NavigationStateController.swift
+++ b/Wikipedia/Code/NavigationStateController.swift
@@ -157,6 +157,9 @@ final class NavigationStateController: NSObject {
                 else {
                     return
                 }
+                if let onThisDayVC = detailVC as? OnThisDayViewController, let shouldShowNavigationBar = viewController.info?.shouldShowNavigationBar {
+                    onThisDayVC.shouldShowNavigationBar = shouldShowNavigationBar
+                }
                 pushOrPresent(detailVC, navigationController: navigationController, presentation: viewController.presentation)
             case (.singleWebPage, let info):
                 guard let url = info?.url else {
@@ -235,7 +238,8 @@ final class NavigationStateController: NSObject {
             info = Info(readingListURIString: readingListDetailVC.readingList.objectID.uriRepresentation().absoluteString)
         case let detailPresenting as DetailPresentingFromContentGroup:
             kind = .detail
-            info = Info(contentGroupIDURIString: detailPresenting.contentGroupIDURIString)
+            let shouldShowNavigationBar = (viewController as? OnThisDayViewController)?.shouldShowNavigationBar
+            info = Info(shouldShowNavigationBar: shouldShowNavigationBar, contentGroupIDURIString: detailPresenting.contentGroupIDURIString)
         case let singlePageWebViewController as SinglePageWebViewController:
             kind = .singleWebPage
             info = Info(url: singlePageWebViewController.url)


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T261979

### Notes
* 3 of the items in the Phab ticket were already fixed by another PR, it seems.
* Safe area for header: Underbar issue was a pre-existing bug - It also shows up when viewing a reading list on a rotated X-sized device.
* On This Day restoration: Now saving what type of navigation header the VC should have.

### Test Steps
On this day restoration:
1. Open On This Day from Explore feed. Confirm: It should have an "X" to close the view.
1. Tap to an article.
1. In terminal, open On This Day via a deep link: `xcrun simctl openurl booted "https://en.wikipedia.org/wiki/Wikipedia:On_this_day/Today"` (alternatively: tap an On This Day widget) Confirm: it should have a normal nav bar
1. Tap an article.
1. Background the app, so the state is saved.
1. Re run the app. Tap the back button through the stack, and ensure the two On This Day VCs have their expecteed nav styles.

Header safe area:
1. Run app on a phone/simulator with a notch.
1. Open On This Day VC (from Explore feed or deep link).
1. Rotate phone so notch is on leading edge. Ensure the On This Day header respects the safe area.

### Screenshots/Videos
<img width="924" alt="Screenshot" src="https://user-images.githubusercontent.com/9295855/93253954-72927f00-f74c-11ea-9efc-676429b1d89c.png">
