### PR TITLE
Mitigates 0xdead10cc crashes in the widgets

### DIFF
--- a/WMF Framework/WidgetController.swift
+++ b/WMF Framework/WidgetController.swift
@@ -30,5 +30,18 @@ public final class WidgetController: NSObject {
 			WidgetCenter.shared.reloadAllTimelines()
 		}
 	}
+    
+    /// For requesting background time from widgets
+    /// - Parameter reason: the reason for requesting background time
+    /// - Parameter userCompletion: completion to be called from within the background task completion
+    /// - Returns a completion block to be called when the background task is completed
+    public func startBackgroundTask<T>(reason: String, userCompletion: @escaping (T) ->  Void) -> (T) -> Void  {
+        let processInfo = ProcessInfo.processInfo
+        let start = processInfo.beginActivity(options: .background, reason: reason)
+        return { entry in
+            userCompletion(entry)
+            processInfo.endActivity(start)
+        }
+    }
 
 }

--- a/Widgets/Widgets/OnThisDayWidget.swift
+++ b/Widgets/Widgets/OnThisDayWidget.swift
@@ -82,8 +82,6 @@ final class OnThisDayData {
 
     static let shared = OnThisDayData()
 
-    private var imageInfoFetcher = MWKImageInfoFetcher()
-
     // From https://en.wikipedia.org/api/rest_v1/feed/onthisday/events/01/15, taken on 03 Sept 2020.
     let placeholderEntry = OnThisDayEntry(isRTLLanguage: false,
                                           error: nil,

--- a/Widgets/Widgets/OnThisDayWidget.swift
+++ b/Widgets/Widgets/OnThisDayWidget.swift
@@ -40,6 +40,7 @@ struct OnThisDayProvider: TimelineProvider {
             let currentDate = Date()
             let timeline = Timeline(entries: [entry], policy: .after(currentDate.dateAtMidnight() ?? currentDate))
             completion(timeline)
+            
         }
     }
 
@@ -109,7 +110,8 @@ final class OnThisDayData {
         return dataStore.languageLinkController.appLanguage?.siteURL()
     }
     
-    func fetchLatestAvailableOnThisDayEntry(usingCache: Bool = false, _ completion: @escaping (OnThisDayEntry) -> Void) {
+    func fetchLatestAvailableOnThisDayEntry(usingCache: Bool = false, _ userCompletion: @escaping (OnThisDayEntry) -> Void) {
+        let completion =  WidgetController.shared.startBackgroundTask(reason: "Update On This Day Widget", userCompletion: userCompletion)
         guard let appLanguage = MWKDataStore.shared().languageLinkController.appLanguage, WMFOnThisDayEventsFetcher.isOnThisDaySupported(by: appLanguage.languageCode) else {
             let errorEntry = OnThisDayEntry.errorEntry(for: .featureNotSupportedInLanguage)
             completion(errorEntry)

--- a/Widgets/Widgets/TopReadWidget.swift
+++ b/Widgets/Widgets/TopReadWidget.swift
@@ -37,7 +37,8 @@ final class TopReadData {
 		MWKDataStore.shared()
 	}
 
-    func fetchLatestAvailableTopRead(usingCache: Bool = false, completion: @escaping (TopReadEntry) -> Void) {
+    func fetchLatestAvailableTopRead(usingCache: Bool = false, completion userCompletion: @escaping (TopReadEntry) -> Void) {
+        let completion =  WidgetController.shared.startBackgroundTask(reason: "Update Top Read Widget", userCompletion: userCompletion)
         let moc = dataStore.viewContext
         moc.perform {
             guard let latest = moc.newestVisibleGroup(of: .topRead), latest.isForToday else {

--- a/Wikipedia/Code/WMFContinueReadingContentSource.h
+++ b/Wikipedia/Code/WMFContinueReadingContentSource.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface WMFContinueReadingContentSource : NSObject <WMFContentSource, WMFAutoUpdatingContentSource>
 
-@property (readonly, nonatomic, strong) MWKDataStore *userDataStore;
+@property (readonly, nonatomic, weak) MWKDataStore *userDataStore;
 
 - (instancetype)initWithUserDataStore:(MWKDataStore *)userDataStore;
 

--- a/Wikipedia/Code/WMFContinueReadingContentSource.m
+++ b/Wikipedia/Code/WMFContinueReadingContentSource.m
@@ -8,7 +8,7 @@ static NSTimeInterval const WMFTimeBeforeDisplayingLastReadArticle = 60 * 60 * 2
 
 @interface WMFContinueReadingContentSource ()
 
-@property (readwrite, nonatomic, strong) MWKDataStore *userDataStore;
+@property (readwrite, nonatomic, weak) MWKDataStore *userDataStore;
 
 @end
 

--- a/Wikipedia/Code/WMFFeedContentSource.m
+++ b/Wikipedia/Code/WMFFeedContentSource.m
@@ -25,7 +25,7 @@ NSInteger const WMFFeedInTheNewsNotificationViewCountDays = 5;
 
 @property (readwrite, nonatomic, strong) NSURL *siteURL;
 
-@property (readwrite, nonatomic, strong) MWKDataStore *userDataStore;
+@property (readwrite, nonatomic, weak) MWKDataStore *userDataStore;
 @property (readwrite, nonatomic, strong) WMFNotificationsController *notificationsController;
 
 @property (readwrite, nonatomic, strong) WMFFeedContentFetcher *fetcher;

--- a/Wikipedia/Code/WMFNearbyContentSource.m
+++ b/Wikipedia/Code/WMFNearbyContentSource.m
@@ -11,7 +11,7 @@ static const CLLocationDistance WMFNearbyUpdateDistanceThresholdInMeters = 25000
 @interface WMFNearbyContentSource () <LocationManagerDelegate>
 
 @property (readwrite, nonatomic, strong) NSURL *siteURL;
-@property (readwrite, nonatomic, strong) MWKDataStore *dataStore;
+@property (readwrite, nonatomic, weak) MWKDataStore *dataStore;
 @property (nonatomic, strong, readwrite) id<LocationManagerProtocol> locationManager;
 @property (nonatomic, strong) WMFLocationSearchFetcher *locationSearchFetcher;
 


### PR DESCRIPTION
The widgets need to utilize a `MWKDataStore` to update. To prevent the widgets from causing the 0xdead10cc crash, the data store needs to be released when the widgets are done updating. To avoid creating a data store for each widget, `WidgetController` now manages a shared `MWKDataStore`. Open to suggestions on how to improve this shared data store management. This PR also fixes the retain cycles that prevented `MWKDataStore` from being deallocated since the store needs to be deallocated to fix the 0xdead10cc.