### PR TITLE
underbar should respect safe area by default, with option to override

### DIFF
--- a/WMF Framework/NavigationBar.swift
+++ b/WMF Framework/NavigationBar.swift
@@ -191,6 +191,16 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
 
     private var shadowHeightConstraint: NSLayoutConstraint!
     private var extendedViewHeightConstraint: NSLayoutConstraint!
+
+    private lazy var safeAreaUnderBarConstraints = [
+        safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: underBarView.leadingAnchor),
+        safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: underBarView.trailingAnchor)
+    ]
+
+    private lazy var fullWidthUnderBarConstraints = [
+        leadingAnchor.constraint(equalTo: underBarView.leadingAnchor),
+        trailingAnchor.constraint(equalTo: underBarView.trailingAnchor)
+    ]
     
     private var titleBarTopConstraint: NSLayoutConstraint!
     private var barTopConstraint: NSLayoutConstraint!
@@ -267,9 +277,6 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
         underBarViewTopBarBottomConstraint = bar.bottomAnchor.constraint(equalTo: underBarView.topAnchor)
         underBarViewTopTitleBarBottomConstraint = titleBar.bottomAnchor.constraint(equalTo: underBarView.topAnchor)
         underBarViewTopBottomConstraint = topAnchor.constraint(equalTo: underBarView.topAnchor)
-        
-        let underBarViewLeadingConstraint = safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: underBarView.leadingAnchor)
-        let underBarViewTrailingConstraint = safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: underBarView.trailingAnchor)
 
         extendedViewHeightConstraint = extendedView.heightAnchor.constraint(equalToConstant: 0)
         extendedView.addConstraint(extendedViewHeightConstraint)
@@ -294,7 +301,8 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
         shadowTopExtendedViewBottomConstraint = extendedView.bottomAnchor.constraint(equalTo: shadow.topAnchor)
         shadowTopUnderBarViewBottomConstraint = underBarView.bottomAnchor.constraint(equalTo: shadow.topAnchor)
 
-        updatedConstraints.append(contentsOf: [titleBarTopConstraint, titleBarLeadingConstraint, titleBarTrailingConstraint, underBarViewTopTitleBarBottomConstraint, barTopConstraint, barLeadingConstraint, barTrailingConstraint, underBarViewTopBarBottomConstraint, underBarViewTopBottomConstraint, underBarViewLeadingConstraint, underBarViewTrailingConstraint, extendedViewTopConstraint, extendedViewLeadingConstraint, extendedViewTrailingConstraint, extendedViewBottomConstraint, backgroundViewTopConstraint, backgroundViewLeadingConstraint, backgroundViewTrailingConstraint, backgroundViewBottomConstraint, progressViewBottomConstraint, progressViewLeadingConstraint, progressViewTrailingConstraint, shadowTopUnderBarViewBottomConstraint, shadowTopExtendedViewBottomConstraint, shadowLeadingConstraint, shadowTrailingConstraint])
+        updatedConstraints.append(contentsOf: [titleBarTopConstraint, titleBarLeadingConstraint, titleBarTrailingConstraint, underBarViewTopTitleBarBottomConstraint, barTopConstraint, barLeadingConstraint, barTrailingConstraint, underBarViewTopBarBottomConstraint, underBarViewTopBottomConstraint, extendedViewTopConstraint, extendedViewLeadingConstraint, extendedViewTrailingConstraint, extendedViewBottomConstraint, backgroundViewTopConstraint, backgroundViewLeadingConstraint, backgroundViewTrailingConstraint, backgroundViewBottomConstraint, progressViewBottomConstraint, progressViewLeadingConstraint, progressViewTrailingConstraint, shadowTopUnderBarViewBottomConstraint, shadowTopExtendedViewBottomConstraint, shadowLeadingConstraint, shadowTrailingConstraint])
+        updatedConstraints.append(contentsOf: safeAreaUnderBarConstraints)
         addConstraints(updatedConstraints)
         
         updateTitleBarConstraints()
@@ -368,11 +376,8 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
                 return
             }
 
-            safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: underBarView.leadingAnchor).isActive = !shouldUnderBarIgnoreSafeArea
-            safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: underBarView.trailingAnchor).isActive = !shouldUnderBarIgnoreSafeArea
-
-            leadingAnchor.constraint(equalTo: underBarView.leadingAnchor).isActive = shouldUnderBarIgnoreSafeArea
-            trailingAnchor.constraint(equalTo: underBarView.trailingAnchor).isActive = shouldUnderBarIgnoreSafeArea
+            NSLayoutConstraint.deactivate(shouldUnderBarIgnoreSafeArea ? safeAreaUnderBarConstraints : fullWidthUnderBarConstraints)
+            NSLayoutConstraint.activate(shouldUnderBarIgnoreSafeArea ? fullWidthUnderBarConstraints : safeAreaUnderBarConstraints)
         }
     }
     

--- a/WMF Framework/NavigationBar.swift
+++ b/WMF Framework/NavigationBar.swift
@@ -268,9 +268,9 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
         underBarViewTopTitleBarBottomConstraint = titleBar.bottomAnchor.constraint(equalTo: underBarView.topAnchor)
         underBarViewTopBottomConstraint = topAnchor.constraint(equalTo: underBarView.topAnchor)
         
-        let underBarViewLeadingConstraint = leadingAnchor.constraint(equalTo: underBarView.leadingAnchor)
-        let underBarViewTrailingConstraint = trailingAnchor.constraint(equalTo: underBarView.trailingAnchor)
-        
+        let underBarViewLeadingConstraint = safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: underBarView.leadingAnchor)
+        let underBarViewTrailingConstraint = safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: underBarView.trailingAnchor)
+
         extendedViewHeightConstraint = extendedView.heightAnchor.constraint(equalToConstant: 0)
         extendedView.addConstraint(extendedViewHeightConstraint)
         
@@ -359,6 +359,20 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
         }
         set {
             setNavigationBarPercentHidden(_navigationBarPercentHidden, underBarViewPercentHidden: _underBarViewPercentHidden, extendedViewPercentHidden: newValue, topSpacingPercentHidden: _topSpacingPercentHidden, animated: false)
+        }
+    }
+
+    private var shouldUnderBarIgnoreSafeArea: Bool = false {
+        didSet {
+            guard shouldUnderBarIgnoreSafeArea != oldValue else {
+                return
+            }
+
+            safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: underBarView.leadingAnchor).isActive = !shouldUnderBarIgnoreSafeArea
+            safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: underBarView.trailingAnchor).isActive = !shouldUnderBarIgnoreSafeArea
+
+            leadingAnchor.constraint(equalTo: underBarView.leadingAnchor).isActive = shouldUnderBarIgnoreSafeArea
+            trailingAnchor.constraint(equalTo: underBarView.trailingAnchor).isActive = shouldUnderBarIgnoreSafeArea
         }
     }
     
@@ -596,11 +610,12 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
         extendedViewHeightConstraint.isActive = true
     }
     
-    @objc public func addUnderNavigationBarView(_ view: UIView) {
+    @objc public func addUnderNavigationBarView(_ view: UIView, shouldIgnoreSafeArea: Bool = false) {
         guard underBarView.subviews.first == nil else {
             return
         }
         underBarViewHeightConstraint.isActive = false
+        shouldUnderBarIgnoreSafeArea = shouldIgnoreSafeArea
         underBarView.wmf_addSubviewWithConstraintsToEdges(view)
     }
     

--- a/Wikipedia/Code/InsertMediaViewController.swift
+++ b/Wikipedia/Code/InsertMediaViewController.swift
@@ -51,7 +51,7 @@ final class InsertMediaViewController: ViewController {
         navigationBar.isTopSpacingHidingEnabled = false
 
         addChild(selectedImageViewController)
-        navigationBar.addUnderNavigationBarView(selectedImageViewController.view)
+        navigationBar.addUnderNavigationBarView(selectedImageViewController.view, shouldIgnoreSafeArea: true)
         selectedImageViewController.didMove(toParent: self)
 
         addChild(searchViewController)


### PR DESCRIPTION
**Fixes Phabricator ticket:** part of already-completed https://phabricator.wikimedia.org/T261979

### Notes
* This is being pushed to 6.7.1 to have some more testing time.

### Test Steps
1. Run app on a phone/simulator with a notch.
1. Open On This Day VC (from Explore feed or deep link).
1. Rotate phone so notch is on leading edge. Ensure the On This Day header respects the safe area. 
1. Open a reading list (on saved tab). Rotate phone so notch is on leading edge. Ensure the title header (`x articles`/`[title of list]`) respects the safe area.
1. Edit a section of any article, tap the insert image icon.
1. Rotate phone so notch is on leading edge. Ensure the header goes edge-to-edge (does NOT respect the safe area).