### PR TITLE
Update Top read snapshot to use `context.isPreview` when constructing data

### DIFF
--- a/Widgets/Widgets/TopReadWidget.swift
+++ b/Widgets/Widgets/TopReadWidget.swift
@@ -31,11 +31,11 @@ final class TopReadData {
 		return TopReadEntry(date: Date())
 	}
 
-	// MARK: Public
+    private var dataStore: MWKDataStore {
+        MWKDataStore.shared()
+    }
 
-	private var dataStore: MWKDataStore {
-		MWKDataStore.shared()
-	}
+	// MARK: Public
 
     func fetchLatestAvailableTopRead(usingCache: Bool = false, completion: @escaping (TopReadEntry) -> Void) {
         let moc = dataStore.viewContext
@@ -51,8 +51,10 @@ final class TopReadData {
             self.assembleTopReadFromContentGroup(latest, usingImageCache: usingCache, completion: completion)
         }
     }
+
+    // MARK: Private
     
-    func fetchLatestAvailableTopReadFromNetwork(completion: @escaping (TopReadEntry) -> Void) {
+    private func fetchLatestAvailableTopReadFromNetwork(completion: @escaping (TopReadEntry) -> Void) {
         dataStore.feedContentController.updateFeedSourcesUserInitiated(false) {
             let moc = self.dataStore.viewContext
             moc.perform {
@@ -65,7 +67,7 @@ final class TopReadData {
         }
     }
     
-    func assembleTopReadFromContentGroup(_ topRead: WMFContentGroup, usingImageCache: Bool = false, completion: @escaping (TopReadEntry) -> Void) {
+    private func assembleTopReadFromContentGroup(_ topRead: WMFContentGroup, usingImageCache: Bool = false, completion: @escaping (TopReadEntry) -> Void) {
         guard let results = topRead.contentPreview as? [WMFFeedTopReadArticlePreview] else {
             completion(placeholder)
             return
@@ -113,6 +115,7 @@ final class TopReadData {
             completion(TopReadEntry(date: Date(), rankedElements: rankedElements, groupURL: topRead.url, contentLayoutDirection: layoutDirection))
         }
     }
+
 }
 
 // MARK: - Model
@@ -161,7 +164,7 @@ struct TopReadProvider: TimelineProvider {
 	}
 
 	func getSnapshot(in context: Context, completion: @escaping (TopReadEntry) -> Void) {
-        dataStore.fetchLatestAvailableTopRead(usingCache: true) { (entry) in
+        dataStore.fetchLatestAvailableTopRead(usingCache: context.isPreview) { (entry) in
             completion(entry)
         }
     }


### PR DESCRIPTION
### Notes
Follow-up from https://github.com/wikimedia/wikipedia-ios/pull/3692#discussion_r489059113.

### Test Steps
I don't feel I can provide meaning test steps because all of Apple's use of `getSnapshot` aren't documented (as far as I'm aware). They state that when `context.isPreview` is true, the widget is being displayed in the gallery, but other than that only that this method is called in "transient" situations. I suppose at minimum we should try and confirm the behavioral characteristics of this change seem similar to without it, especially when exploring our widgets in the gallery, adding the widget and observing the change in content as it's added, and scrolling into a home screen page containing the widget after some meaningful amount of time has passed.