### PR TITLE
Fix On This Day collection view inset for RTL languages

### DIFF
--- a/WMF Framework/NavigationBar.swift
+++ b/WMF Framework/NavigationBar.swift
@@ -268,9 +268,9 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
         underBarViewTopTitleBarBottomConstraint = titleBar.bottomAnchor.constraint(equalTo: underBarView.topAnchor)
         underBarViewTopBottomConstraint = topAnchor.constraint(equalTo: underBarView.topAnchor)
         
-        let underBarViewLeadingConstraint = leadingAnchor.constraint(equalTo: underBarView.leadingAnchor)
-        let underBarViewTrailingConstraint = trailingAnchor.constraint(equalTo: underBarView.trailingAnchor)
-        
+        let underBarViewLeadingConstraint = safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: underBarView.leadingAnchor)
+        let underBarViewTrailingConstraint = safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: underBarView.trailingAnchor)
+
         extendedViewHeightConstraint = extendedView.heightAnchor.constraint(equalToConstant: 0)
         extendedView.addConstraint(extendedViewHeightConstraint)
         
@@ -359,6 +359,20 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
         }
         set {
             setNavigationBarPercentHidden(_navigationBarPercentHidden, underBarViewPercentHidden: _underBarViewPercentHidden, extendedViewPercentHidden: newValue, topSpacingPercentHidden: _topSpacingPercentHidden, animated: false)
+        }
+    }
+
+    private var shouldUnderBarIgnoreSafeArea: Bool = false {
+        didSet {
+            guard shouldUnderBarIgnoreSafeArea != oldValue else {
+                return
+            }
+
+            safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: underBarView.leadingAnchor).isActive = !shouldUnderBarIgnoreSafeArea
+            safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: underBarView.trailingAnchor).isActive = !shouldUnderBarIgnoreSafeArea
+
+            leadingAnchor.constraint(equalTo: underBarView.leadingAnchor).isActive = shouldUnderBarIgnoreSafeArea
+            trailingAnchor.constraint(equalTo: underBarView.trailingAnchor).isActive = shouldUnderBarIgnoreSafeArea
         }
     }
     
@@ -596,11 +610,12 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
         extendedViewHeightConstraint.isActive = true
     }
     
-    @objc public func addUnderNavigationBarView(_ view: UIView) {
+    @objc public func addUnderNavigationBarView(_ view: UIView, shouldIgnoreSafeArea: Bool = false) {
         guard underBarView.subviews.first == nil else {
             return
         }
         underBarViewHeightConstraint.isActive = false
+        shouldUnderBarIgnoreSafeArea = shouldIgnoreSafeArea
         underBarView.wmf_addSubviewWithConstraintsToEdges(view)
     }
     

--- a/Wikipedia/Code/InsertMediaViewController.swift
+++ b/Wikipedia/Code/InsertMediaViewController.swift
@@ -51,7 +51,7 @@ final class InsertMediaViewController: ViewController {
         navigationBar.isTopSpacingHidingEnabled = false
 
         addChild(selectedImageViewController)
-        navigationBar.addUnderNavigationBarView(selectedImageViewController.view)
+        navigationBar.addUnderNavigationBarView(selectedImageViewController.view, shouldIgnoreSafeArea: true)
         selectedImageViewController.didMove(toParent: self)
 
         addChild(searchViewController)

--- a/Wikipedia/Code/SideScrollingCollectionViewCell.swift
+++ b/Wikipedia/Code/SideScrollingCollectionViewCell.swift
@@ -153,6 +153,8 @@ public class SideScrollingCollectionViewCell: CollectionViewCell, SubCellProtoco
     }
 
     public func resetContentOffset() {
+        /// Without a layout pass, RTL languages on LTR chrome have an incorrect initial inset.
+        layoutIfNeeded()
         let x: CGFloat = semanticContentAttributeOverride == .forceRightToLeft ? collectionView.contentSize.width - collectionView.bounds.size.width + collectionView.contentInset.right : -collectionView.contentInset.left
         collectionView.contentOffset = CGPoint(x: x, y: 0)
     }


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T262497

### Notes
* Turns out it was only on initial load - if you scrolled down and then up (reloading a cell), all worked as expected.
* In the end, we only needed a layout pass.

### Test Steps
1. Open On This Day in RTL and LTR languages, in both RTL and LTR chrome languages. Make sure it looks as expected.

### Screenshots/Videos
<img width="200" alt="Screenshot" src="https://user-images.githubusercontent.com/9295855/93386398-7ee60d00-f81c-11ea-8bf3-a3c93e6eedaf.png">


