### PR TITLE
Fix On This Day collection view inset for RTL languages

### DIFF
--- a/Wikipedia/Code/SideScrollingCollectionViewCell.swift
+++ b/Wikipedia/Code/SideScrollingCollectionViewCell.swift
@@ -153,6 +153,8 @@ public class SideScrollingCollectionViewCell: CollectionViewCell, SubCellProtoco
     }
 
     public func resetContentOffset() {
+        /// Without a layout pass, RTL languages on LTR chrome have an incorrect initial inset.
+        layoutIfNeeded()
         let x: CGFloat = semanticContentAttributeOverride == .forceRightToLeft ? collectionView.contentSize.width - collectionView.bounds.size.width + collectionView.contentInset.right : -collectionView.contentInset.left
         collectionView.contentOffset = CGPoint(x: x, y: 0)
     }


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T262497

### Notes
* Turns out it was only on initial load - if you scrolled down and then up (reloading a cell), all worked as expected.
* In the end, we only needed a layout pass.

### Test Steps
1. Open On This Day in RTL and LTR languages, in both RTL and LTR chrome languages. Make sure it looks as expected.

### Screenshots/Videos
<img width="200" alt="Screenshot" src="https://user-images.githubusercontent.com/9295855/93386398-7ee60d00-f81c-11ea-8bf3-a3c93e6eedaf.png">


