### PR TITLE
On This Day Widget: Make top dot match corner radii

### DIFF
--- a/Widgets/Widgets/OnThisDayView.swift
+++ b/Widgets/Widgets/OnThisDayView.swift
@@ -54,13 +54,13 @@ struct OnThisDayView: View {
                     MainOnThisDayElement(monthDay: entry.monthDay, eventYear: entry.eventYear, eventYearsAgo: entry.eventYearsAgo, fullDate: entry.fullDate, snippet: entry.eventSnippet)
                     OnThisDayAdditionalEventsElement(otherEventsText: entry.otherEventsText)
                 }
-                .padding(EdgeInsets(top: 0, leading: 11, bottom: 0, trailing: 16))
+                .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
             case .systemSmall:
                 MainOnThisDayElement(monthDay: entry.monthDay, eventYear: entry.eventYear, eventYearsAgo: entry.eventYearsAgo, fullDate: entry.fullDate, snippet: entry.eventSnippet)
-                .padding(EdgeInsets(top: 0, leading: 11, bottom: 0, trailing: 16))
+                .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
             @unknown default:
                 MainOnThisDayElement(monthDay: entry.monthDay, eventYear: entry.eventYear, eventYearsAgo: entry.eventYearsAgo, fullDate: entry.fullDate, snippet: entry.eventSnippet)
-                .padding(EdgeInsets(top: 0, leading: 11, bottom: 0, trailing: 16))
+                .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
             }
         }
         .overlay(errorBox)


### PR DESCRIPTION
**Fixes Phabricator ticket:** N/A (feedback from Apple Design Evangelist)

### Notes
* Request to have the circle "fit into" the top leading corner.
* The large widget's timeline is now closer to the leading edge than small/medium, but since people will likely only install one widget that is probably ok.

### Test Steps
1. Install all 3 sizes off On This Day widget. Check the look.

### Screenshots/Videos
<img width="250" alt="Screenshot 2" src="https://user-images.githubusercontent.com/9295855/93507371-7223f080-f8d2-11ea-920d-499983122535.png"> <img width="250" alt="Screenshot 1" src="https://user-images.githubusercontent.com/9295855/93507387-75b77780-f8d2-11ea-982a-7b5165243577.png">
