### PR TITLE
Use primary app language for On this day and Top read widget content

### DIFF
--- a/WMF Framework/WMFContentGroup+Extensions.h
+++ b/WMF Framework/WMFContentGroup+Extensions.h
@@ -118,6 +118,8 @@ typedef NS_ENUM(int16_t, WMFContentGroupUndoType) {
 
 - (nullable WMFContentGroup *)newestGroupOfKind:(WMFContentGroupKind)kind;
 
+- (nullable WMFContentGroup *)newestGroupOfKind:(WMFContentGroupKind)kind forSiteURL:(nullable NSURL *)siteURL;
+
 - (nullable WMFContentGroup *)groupOfKind:(WMFContentGroupKind)kind forDate:(NSDate *)date;
 
 - (nullable WMFContentGroup *)groupOfKind:(WMFContentGroupKind)kind forDate:(NSDate *)date siteURL:(NSURL *)url;

--- a/WMF Framework/WMFContentGroup+Extensions.m
+++ b/WMF Framework/WMFContentGroup+Extensions.m
@@ -704,6 +704,14 @@
     return [self newestGroupOfKind:kind requireIsVisible:NO];
 }
 
+- (nullable WMFContentGroup *)newestGroupOfKind:(WMFContentGroupKind)kind forSiteURL:(nullable NSURL *)siteURL {
+    if (!siteURL) {
+        return [self newestGroupOfKind:kind requireIsVisible:NO];
+    }    
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"siteURLString == %@", siteURL.wmf_databaseKey];
+    return [self newestGroupOfKind:kind withPredicate:predicate requireIsVisible:NO];
+}
+
 - (nullable WMFContentGroup *)groupOfKind:(WMFContentGroupKind)kind forDate:(NSDate *)date {
     NSFetchRequest *fetchRequest = [WMFContentGroup fetchRequest];
     fetchRequest.predicate = [NSPredicate predicateWithFormat:@"contentGroupKindInteger == %@ && midnightUTCDate == %@", @(kind), date.wmf_midnightUTCDateFromLocalDate];

--- a/Widgets/Widgets/OnThisDayWidget.swift
+++ b/Widgets/Widgets/OnThisDayWidget.swift
@@ -132,8 +132,10 @@ final class OnThisDayData {
             self.assembleOnThisDayFromContentGroup(latest, completion: completion)
         }
     }
-    
-    func fetchLatestOnThisDayEntryFromNetwork(_ completion: @escaping (OnThisDayEntry) -> Void) {
+
+    // MARK: Private
+
+    private func fetchLatestOnThisDayEntryFromNetwork(_ completion: @escaping (OnThisDayEntry) -> Void) {
         dataStore.feedContentController.updateFeedSourcesUserInitiated(false) {
             let moc = self.dataStore.viewContext
             moc.perform {
@@ -147,7 +149,7 @@ final class OnThisDayData {
         }
     }
     
-    func assembleOnThisDayFromContentGroup(_ contentGroup: WMFContentGroup, completion: @escaping (OnThisDayEntry) -> Void) {
+    private func assembleOnThisDayFromContentGroup(_ contentGroup: WMFContentGroup, completion: @escaping (OnThisDayEntry) -> Void) {
         guard let previewEvents = contentGroup.contentPreview as? [WMFFeedOnThisDayEvent],
               let previewEvent = previewEvents.first
         else {
@@ -172,7 +174,7 @@ final class OnThisDayData {
         }
     }
     
-    func handleNoInternetError(_ completion: @escaping (OnThisDayEntry) -> Void) {
+    private func handleNoInternetError(_ completion: @escaping (OnThisDayEntry) -> Void) {
         let errorEntry = OnThisDayEntry.errorEntry(for: .noInternet)
         completion(errorEntry)
     }

--- a/Widgets/Widgets/OnThisDayWidget.swift
+++ b/Widgets/Widgets/OnThisDayWidget.swift
@@ -118,7 +118,7 @@ final class OnThisDayData {
 
         let moc = dataStore.viewContext
         moc.perform {
-            guard let latest = moc.newestVisibleGroup(of: .onThisDay, forSiteURL: self.siteURL),
+            guard let latest = moc.newestGroup(of: .onThisDay, forSiteURL: self.siteURL),
                   latest.isForToday
             else {
                 guard !usingCache else {
@@ -136,7 +136,7 @@ final class OnThisDayData {
         dataStore.feedContentController.updateFeedSourcesUserInitiated(false) {
             let moc = self.dataStore.viewContext
             moc.perform {
-                guard let latest = moc.newestVisibleGroup(of: .onThisDay, forSiteURL: self.siteURL) else {
+                guard let latest = moc.newestGroup(of: .onThisDay, forSiteURL: self.siteURL) else {
                     // If there's no content even after a network fetch, it's likely an error
                     self.handleNoInternetError(completion)
                     return

--- a/Widgets/Widgets/OnThisDayWidget.swift
+++ b/Widgets/Widgets/OnThisDayWidget.swift
@@ -82,9 +82,14 @@ final class OnThisDayData {
     static let shared = OnThisDayData()
 
     private var imageInfoFetcher = MWKImageInfoFetcher()
+
     private var dataStore: MWKDataStore {
         MWKDataStore.shared()
     }
+
+	private var primaryAppLanguageSiteURL: URL? {
+		return dataStore.languageLinkController.appLanguage?.siteURL()
+	}
 
     // From https://en.wikipedia.org/api/rest_v1/feed/onthisday/events/01/15, taken on 03 Sept 2020.
     let placeholderEntry = OnThisDayEntry(isRTLLanguage: false,
@@ -104,10 +109,6 @@ final class OnThisDayData {
                                           yearRange: CommonStrings.onThisDayHeaderDateRangeMessage(with: "en", locale: Locale(identifier: "en"), lastEvent: "69", firstEvent: "2019"))
 
     // MARK: Public
-
-    private var siteURL: URL? {
-        return dataStore.languageLinkController.appLanguage?.siteURL()
-    }
     
     func fetchLatestAvailableOnThisDayEntry(usingCache: Bool = false, _ completion: @escaping (OnThisDayEntry) -> Void) {
         guard let appLanguage = MWKDataStore.shared().languageLinkController.appLanguage, WMFOnThisDayEventsFetcher.isOnThisDaySupported(by: appLanguage.languageCode) else {
@@ -118,7 +119,7 @@ final class OnThisDayData {
 
         let moc = dataStore.viewContext
         moc.perform {
-            guard let latest = moc.newestGroup(of: .onThisDay, forSiteURL: self.siteURL),
+			guard let latest = moc.newestGroup(of: .onThisDay, forSiteURL: self.primaryAppLanguageSiteURL),
                   latest.isForToday
             else {
                 guard !usingCache else {
@@ -136,7 +137,7 @@ final class OnThisDayData {
         dataStore.feedContentController.updateFeedSourcesUserInitiated(false) {
             let moc = self.dataStore.viewContext
             moc.perform {
-                guard let latest = moc.newestGroup(of: .onThisDay, forSiteURL: self.siteURL) else {
+				guard let latest = moc.newestGroup(of: .onThisDay, forSiteURL: self.primaryAppLanguageSiteURL) else {
                     // If there's no content even after a network fetch, it's likely an error
                     self.handleNoInternetError(completion)
                     return

--- a/Widgets/Widgets/PictureOfTheDayWidget.swift
+++ b/Widgets/Widgets/PictureOfTheDayWidget.swift
@@ -40,7 +40,7 @@ final class PictureOfTheDayData {
     func fetchLatestAvailablePictureEntry(usingCache: Bool = false, completion: @escaping (PictureOfTheDayEntry) -> Void) {
         let moc = dataStore.viewContext
         moc.perform {
-            guard let latest = moc.newestVisibleGroup(of: .pictureOfTheDay), latest.isForToday else {
+            guard let latest = moc.newestGroup(of: .pictureOfTheDay), latest.isForToday else {
                 guard !usingCache else {
                     completion(self.sampleEntry)
                     return
@@ -58,7 +58,7 @@ final class PictureOfTheDayData {
         dataStore.feedContentController.updateFeedSourcesUserInitiated(false) {
             let moc = self.dataStore.viewContext
             moc.perform {
-                guard let latest = moc.newestVisibleGroup(of: .pictureOfTheDay) else {
+                guard let latest = moc.newestGroup(of: .pictureOfTheDay) else {
                     completion(self.sampleEntry)
                     return
                 }

--- a/Widgets/Widgets/TopReadWidget.swift
+++ b/Widgets/Widgets/TopReadWidget.swift
@@ -35,12 +35,16 @@ final class TopReadData {
         MWKDataStore.shared()
     }
 
+    private var primaryAppLanguageSiteURL: URL? {
+        return dataStore.languageLinkController.appLanguage?.siteURL()
+    }
+
 	// MARK: Public
 
     func fetchLatestAvailableTopRead(usingCache: Bool = false, completion: @escaping (TopReadEntry) -> Void) {
         let moc = dataStore.viewContext
         moc.perform {
-            guard let latest = moc.newestGroup(of: .topRead), latest.isForToday else {
+            guard let latest = moc.newestGroup(of: .topRead, forSiteURL: self.primaryAppLanguageSiteURL), latest.isForToday else {
                 guard !usingCache else {
                     completion(self.placeholder)
                     return
@@ -58,7 +62,7 @@ final class TopReadData {
         dataStore.feedContentController.updateFeedSourcesUserInitiated(false) {
             let moc = self.dataStore.viewContext
             moc.perform {
-                guard let latest = moc.newestGroup(of: .topRead) else {
+                guard let latest = moc.newestGroup(of: .topRead, forSiteURL: self.primaryAppLanguageSiteURL) else {
                     completion(self.placeholder)
                     return
                 }

--- a/Widgets/Widgets/TopReadWidget.swift
+++ b/Widgets/Widgets/TopReadWidget.swift
@@ -40,7 +40,7 @@ final class TopReadData {
     func fetchLatestAvailableTopRead(usingCache: Bool = false, completion: @escaping (TopReadEntry) -> Void) {
         let moc = dataStore.viewContext
         moc.perform {
-            guard let latest = moc.newestVisibleGroup(of: .topRead), latest.isForToday else {
+            guard let latest = moc.newestGroup(of: .topRead), latest.isForToday else {
                 guard !usingCache else {
                     completion(self.placeholder)
                     return
@@ -58,7 +58,7 @@ final class TopReadData {
         dataStore.feedContentController.updateFeedSourcesUserInitiated(false) {
             let moc = self.dataStore.viewContext
             moc.perform {
-                guard let latest = moc.newestVisibleGroup(of: .topRead) else {
+                guard let latest = moc.newestGroup(of: .topRead) else {
                     completion(self.placeholder)
                     return
                 }

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -4492,7 +4492,7 @@
 		D84448561DDCE49D00425630 /* WMFContentGroup+CoreDataProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WMFContentGroup+CoreDataProperties.h"; sourceTree = "<group>"; };
 		D84448571DDCE49D00425630 /* WMFContentGroup+CoreDataProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WMFContentGroup+CoreDataProperties.m"; sourceTree = "<group>"; };
 		D844485C1DDCE4E500425630 /* WMFContentGroup+Extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WMFContentGroup+Extensions.h"; sourceTree = "<group>"; };
-		D844485D1DDCE4E500425630 /* WMFContentGroup+Extensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WMFContentGroup+Extensions.m"; sourceTree = "<group>"; };
+		D844485D1DDCE4E500425630 /* WMFContentGroup+Extensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WMFContentGroup+Extensions.m"; sourceTree = "<group>"; usesTabs = 0; };
 		D844D96C1D6CB2600042D692 /* WMF.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WMF.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D844D96E1D6CB2600042D692 /* WMF.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = WMF.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		D844D96F1D6CB2600042D692 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -4782,7 +4782,7 @@
 		D8FFF6932031CB3E00A028E0 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = cy; path = cy.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		D8FFF6942031CB4000A028E0 /* tcy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = tcy; path = tcy.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		FF2090EE2500247100849774 /* ThreeLineHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeLineHeaderView.swift; sourceTree = "<group>"; };
-		FF9416D724E203030070FEE7 /* OnThisDayWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayWidget.swift; sourceTree = "<group>"; };
+		FF9416D724E203030070FEE7 /* OnThisDayWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayWidget.swift; sourceTree = "<group>"; usesTabs = 0; };
 		FF9416DD24E2098C0070FEE7 /* OnThisDayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayView.swift; sourceTree = "<group>"; };
 		FFD7B84524AEAB3F005C2471 /* ArticleScrolling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleScrolling.swift; sourceTree = "<group>"; };
 		FFD7B85524B3B384005C2471 /* ReferenceBackLinksViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferenceBackLinksViewControllerDelegate.swift; sourceTree = "<group>"; };


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T263187

### Notes
Decouples widget content from explore feed settings. Updates On this day and Top read widgets to use the app's primary language for content display purposes.

### Test Steps
1. Add an On this day or Top read widget.
2. Change your primary Wikipedia language in app.
3. Observe that the widget's language matches that primary language (may need to jiggle the sort order toggle from step 2 like Matt mentioned, or scroll away/re-add the widget from the gallery).
4. Add an additional non-primary Wikipedia language and turn off your primary language in the explore feed settings.
5. Observe that the widget's language matches that primary language.
6. Turn off the explore feed altogether.
7. Observe that the widget's language matches that primary language.
