### PR TITLE
Widget 0xdead10cc fixes part II

### DIFF
--- a/WMF Framework/WMFExploreFeedContentController.m
+++ b/WMF Framework/WMFExploreFeedContentController.m
@@ -110,6 +110,10 @@ NSString *const WMFNewExploreFeedPreferencesWereRejectedNotification = @"WMFNewE
 - (NSArray<id<WMFContentSource>> *)contentSources {
     NSParameterAssert(self.dataStore);
     NSParameterAssert(self.siteURLs);
+    WMFSession *session = self.dataStore.session;
+    WMFConfiguration *configuration = self.dataStore.configuration;
+    NSParameterAssert(session);
+    NSParameterAssert(configuration);
     if (!_contentSources) {
         NSMutableArray *mutableContentSources = [NSMutableArray arrayWithCapacity:2 + self.siteURLs.count * 7];
         [mutableContentSources addObject:[[WMFRelatedPagesContentSource alloc] init]];
@@ -120,9 +124,9 @@ NSString *const WMFNewExploreFeedPreferencesWereRejectedNotification = @"WMFNewE
             feedContentSource.notificationSchedulingEnabled = YES;
             [mutableContentSources addObjectsFromArray: @[[[WMFNearbyContentSource alloc] initWithSiteURL:siteURL  dataStore:self.dataStore],
                                 feedContentSource,
-                                [[WMFRandomContentSource alloc] initWithSiteURL:siteURL],
-                                [[WMFAnnouncementsContentSource alloc] initWithSiteURL:siteURL],
-                                [[WMFOnThisDayContentSource alloc] initWithSiteURL:siteURL]]];
+                                [[WMFRandomContentSource alloc] initWithSiteURL:siteURL session:session configuration:configuration],
+                                [[WMFAnnouncementsContentSource alloc] initWithSiteURL:siteURL session:session configuration:configuration],
+                                [[WMFOnThisDayContentSource alloc] initWithSiteURL:siteURL session:session configuration:configuration]]];
         }
         _contentSources = [mutableContentSources copy];
     }

--- a/WMF Framework/WidgetController.swift
+++ b/WMF Framework/WidgetController.swift
@@ -33,14 +33,13 @@ public final class WidgetController: NSObject {
     /// - Parameter userCompletion: the completion block to call with the result
     /// - Parameter task: block that takes the `MWKDataStore` to use for updates and the completion block to call when done as parameters
     public func startWidgetUpdateTask<T>(_ userCompletion: @escaping (T) -> Void, _ task: @escaping (MWKDataStore, @escaping (T) -> Void) -> Void)  {
-        let processInfo = ProcessInfo.processInfo
-        let start = processInfo.beginActivity(options: [.background, .suddenTerminationDisabled, .automaticTerminationDisabled], reason: "Updating Wikipedia Widgets - " + UUID().uuidString)
         getRetainedSharedDataStore { dataStore in
             task(dataStore, { result in
                 DispatchQueue.main.async {
-                    userCompletion(result)
                     self.releaseSharedDataStore()
-                    processInfo.endActivity(start)
+                    DispatchQueue.main.async {
+                        userCompletion(result)
+                    }
                 }
             })
         }

--- a/Wikipedia/Code/WMFAnnouncementsContentSource.h
+++ b/Wikipedia/Code/WMFAnnouncementsContentSource.h
@@ -1,9 +1,12 @@
 #import <WMF/WMFContentSource.h>
 
+@class WMFSession;
+@class WMFConfiguration;
+
 @interface WMFAnnouncementsContentSource : NSObject <WMFContentSource, WMFOptionalNewContentSource>
 
 @property (readonly, nonatomic, strong) NSURL *siteURL;
 
-- (instancetype)initWithSiteURL:(NSURL *)siteURL;
+- (instancetype)initWithSiteURL:(NSURL *)siteURL session:(WMFSession *)session configuration:(WMFConfiguration *)configuration;
 
 @end

--- a/Wikipedia/Code/WMFAnnouncementsContentSource.m
+++ b/Wikipedia/Code/WMFAnnouncementsContentSource.m
@@ -12,23 +12,17 @@
 
 @implementation WMFAnnouncementsContentSource
 
-- (instancetype)initWithSiteURL:(NSURL *)siteURL {
+- (instancetype)initWithSiteURL:(NSURL *)siteURL session:(WMFSession *)session configuration:(WMFConfiguration *)configuration {
     NSParameterAssert(siteURL);
     self = [super init];
     if (self) {
         self.siteURL = siteURL;
+        self.fetcher = [[WMFAnnouncementsFetcher alloc] initWithSession:session configuration:configuration];
     }
     return self;
 }
 
 #pragma mark - Accessors
-
-- (WMFAnnouncementsFetcher *)fetcher {
-    if (_fetcher == nil) {
-        _fetcher = [[WMFAnnouncementsFetcher alloc] init];
-    }
-    return _fetcher;
-}
 
 - (void)removeAllContentInManagedObjectContext:(NSManagedObjectContext *)moc {
 }

--- a/Wikipedia/Code/WMFFeedContentFetcher.m
+++ b/Wikipedia/Code/WMFFeedContentFetcher.m
@@ -18,13 +18,25 @@ static const NSInteger WMFFeedContentFetcherMinimumMaxAge = 18000; // 5 minutes
 
 @implementation WMFFeedContentFetcher
 
+- (instancetype)initWithSession:(WMFSession *)session configuration:(WMFConfiguration *)configuration {
+    self = [super initWithSession:session configuration:configuration];
+    if (self) {
+        [self setup];
+    }
+    return self;
+}
+
 - (instancetype)init {
     self = [super init];
     if (self) {
-        NSString *queueID = [NSString stringWithFormat:@"org.wikipedia.feedcontentfetcher.accessQueue.%@", [[NSUUID UUID] UUIDString]];
-        self.serialQueue = dispatch_queue_create([queueID cStringUsingEncoding:NSUTF8StringEncoding], DISPATCH_QUEUE_SERIAL);
+        [self setup];
     }
     return self;
+}
+
+- (void)setup {
+    NSString *queueID = [NSString stringWithFormat:@"org.wikipedia.feedcontentfetcher.accessQueue.%@", [[NSUUID UUID] UUIDString]];
+    self.serialQueue = dispatch_queue_create([queueID cStringUsingEncoding:NSUTF8StringEncoding], DISPATCH_QUEUE_SERIAL);
 }
 
 + (NSURL *)feedContentURLForSiteURL:(NSURL *)siteURL onDate:(NSDate *)date configuration:(WMFConfiguration *)configuration {

--- a/Wikipedia/Code/WMFFeedContentSource.m
+++ b/Wikipedia/Code/WMFFeedContentSource.m
@@ -51,7 +51,7 @@ NSInteger const WMFFeedInTheNewsNotificationViewCountDays = 5;
 
 - (WMFFeedContentFetcher *)fetcher {
     if (_fetcher == nil) {
-        _fetcher = [[WMFFeedContentFetcher alloc] init];
+        _fetcher = [[WMFFeedContentFetcher alloc] initWithSession:self.userDataStore.session configuration:self.userDataStore.configuration];
     }
     return _fetcher;
 }

--- a/Wikipedia/Code/WMFNearbyContentSource.m
+++ b/Wikipedia/Code/WMFNearbyContentSource.m
@@ -47,7 +47,7 @@ static const CLLocationDistance WMFNearbyUpdateDistanceThresholdInMeters = 25000
 
 - (WMFLocationSearchFetcher *)locationSearchFetcher {
     if (_locationSearchFetcher == nil) {
-        _locationSearchFetcher = [[WMFLocationSearchFetcher alloc] init];
+        _locationSearchFetcher = [[WMFLocationSearchFetcher alloc] initWithSession:self.dataStore.session configuration:self.dataStore.configuration];
     }
     return _locationSearchFetcher;
 }

--- a/Wikipedia/Code/WMFOnThisDayContentSource.h
+++ b/Wikipedia/Code/WMFOnThisDayContentSource.h
@@ -1,12 +1,15 @@
 #import <WMF/WMFContentSource.h>
 
+@class WMFSession;
+@class WMFConfiguration;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WMFOnThisDayContentSource : NSObject <WMFContentSource, WMFDateBasedContentSource>
 
 @property (readonly, nonatomic, strong) NSURL *siteURL;
 
-- (instancetype)initWithSiteURL:(NSURL *)siteURL;
+- (instancetype)initWithSiteURL:(NSURL *)siteURL session:(WMFSession *)session configuration:(WMFConfiguration *)configuration;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Wikipedia/Code/WMFOnThisDayContentSource.m
+++ b/Wikipedia/Code/WMFOnThisDayContentSource.m
@@ -21,20 +21,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation WMFOnThisDayContentSource
 
-- (instancetype)initWithSiteURL:(NSURL *)siteURL {
+- (instancetype)initWithSiteURL:(NSURL *)siteURL session:(WMFSession *)session configuration:(WMFConfiguration *)configuration {
     NSParameterAssert(siteURL);
     self = [super init];
     if (self) {
         self.siteURL = siteURL;
+        self.fetcher = [[WMFOnThisDayEventsFetcher alloc] initWithSession:session configuration:configuration];
     }
     return self;
-}
-
-- (WMFOnThisDayEventsFetcher *)fetcher {
-    if (_fetcher == nil) {
-        _fetcher = [[WMFOnThisDayEventsFetcher alloc] init];
-    }
-    return _fetcher;
 }
 
 #pragma mark - WMFContentSource

--- a/Wikipedia/Code/WMFRandomContentSource.h
+++ b/Wikipedia/Code/WMFRandomContentSource.h
@@ -1,12 +1,15 @@
 #import <WMF/WMFContentSource.h>
 
+@class WMFSession;
+@class WMFConfiguration;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WMFRandomContentSource : NSObject <WMFContentSource, WMFDateBasedContentSource>
 
 @property (readonly, nonatomic, strong) NSURL *siteURL;
 
-- (instancetype)initWithSiteURL:(NSURL *)siteURL;
+- (instancetype)initWithSiteURL:(NSURL *)siteURL session:(WMFSession *)session configuration:(WMFConfiguration *)configuration;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Wikipedia/Code/WMFRandomContentSource.m
+++ b/Wikipedia/Code/WMFRandomContentSource.m
@@ -19,20 +19,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation WMFRandomContentSource
 
-- (instancetype)initWithSiteURL:(NSURL *)siteURL {
+- (instancetype)initWithSiteURL:(NSURL *)siteURL session:(WMFSession *)session configuration:(WMFConfiguration *)configuration {
     NSParameterAssert(siteURL);
     self = [super init];
     if (self) {
         self.siteURL = siteURL;
+        self.fetcher = [[WMFRandomArticleFetcher alloc] initWithSession:session configuration:configuration];
     }
     return self;
-}
-
-- (WMFRandomArticleFetcher *)fetcher {
-    if (_fetcher == nil) {
-        _fetcher = [[WMFRandomArticleFetcher alloc] init];
-    }
-    return _fetcher;
 }
 
 #pragma mark - WMFContentSource


### PR DESCRIPTION
**Fixes Phabricator ticket:** 
https://phabricator.wikimedia.org/T263247

### Notes
* Fixes an instance I missed where `[MWKDataStore shared]` was still being called from the widgets when instantiating feed content fetchers
* Fixes the order of operations between releasing the data store and calling the widget's completion block. This should ensure the data store is released before we send the snapshot or timeline completion back to iOS.
* Add a debug assertion that explicitly checks for locked files. Based on [this thread with a response from Apple Developer Technical Support](https://developer.apple.com/forums/thread/655225).
* It's unclear if `NSProcessInfo` is necessary, so remove it for now

### Test Steps
1. Simulator > Erase all content and settings
2. Restart Xcode
3. Set a breakpoint on `[MWKDataStore shared]`
4. Run the widget target
5. Ensure the breakpoint isn't hit
6. Inspect the memory graph
7. Ensure there are no data stores remaining 
