### PR TITLE
Request picture of the day image closer to display size

### DIFF
--- a/Widgets/Widgets/PictureOfTheDayWidget.swift
+++ b/Widgets/Widgets/PictureOfTheDayWidget.swift
@@ -32,7 +32,7 @@ final class PictureOfTheDayData {
 
     // MARK: Public
 
-    func fetchLatestAvailablePictureEntry(usingCache: Bool = false, completion userCompletion: @escaping (PictureOfTheDayEntry) -> Void) {
+    func fetchLatestAvailablePictureEntry(for imageSize: CGSize, usingCache: Bool = false, completion userCompletion: @escaping (PictureOfTheDayEntry) -> Void) {
         WidgetController.shared.startWidgetUpdateTask(userCompletion) { (dataStore, completion) in
             let moc = dataStore.viewContext
             moc.perform {
@@ -41,17 +41,17 @@ final class PictureOfTheDayData {
                         completion(self.sampleEntry)
                         return
                     }
-                    self.fetchLatestAvailablePictureEntryFromNetwork(with: dataStore, completion: completion)
+                    self.fetchLatestAvailablePictureEntryFromNetwork(with: dataStore, imageSize: imageSize, completion: completion)
                     return
                 }
-                self.assemblePictureEntryFromContentGroup(latest, dataStore: dataStore, usingImageCache: usingCache, completion: completion)
+                self.assemblePictureEntryFromContentGroup(latest, dataStore: dataStore, imageSize: imageSize, usingImageCache: usingCache, completion: completion)
             }
         }
     }
 
     // MARK: Private
 
-    private func fetchLatestAvailablePictureEntryFromNetwork(with dataStore: MWKDataStore, completion: @escaping (PictureOfTheDayEntry) -> Void) {
+    private func fetchLatestAvailablePictureEntryFromNetwork(with dataStore: MWKDataStore, imageSize: CGSize, completion: @escaping (PictureOfTheDayEntry) -> Void) {
         dataStore.feedContentController.updateFeedSourcesUserInitiated(false) {
             let moc = dataStore.viewContext
             moc.perform {
@@ -59,13 +59,13 @@ final class PictureOfTheDayData {
                     completion(self.sampleEntry)
                     return
                 }
-                self.assemblePictureEntryFromContentGroup(latest, dataStore: dataStore, completion: completion)
+                self.assemblePictureEntryFromContentGroup(latest, dataStore: dataStore, imageSize: imageSize, completion: completion)
             }
         }
 
     }
 
-    private func assemblePictureEntryFromContentGroup(_ contentGroup: WMFContentGroup, dataStore: MWKDataStore, usingImageCache: Bool = false, completion: @escaping (PictureOfTheDayEntry) -> Void) {
+    private func assemblePictureEntryFromContentGroup(_ contentGroup: WMFContentGroup, dataStore: MWKDataStore, imageSize: CGSize, usingImageCache: Bool = false, completion: @escaping (PictureOfTheDayEntry) -> Void) {
         guard let imageContent = contentGroup.contentPreview as? WMFFeedImage else {
             completion(self.sampleEntry)
             return
@@ -75,7 +75,7 @@ final class PictureOfTheDayData {
         let contentDate = contentGroup.date
         let contentURL = contentGroup.url
         let canonicalPageTitle = imageContent.canonicalPageTitle
-        let imageThumbnailURL = imageContent.imageThumbURL
+        let imageThumbnailURL: URL = imageContent.getImageURL(forWidth: Double(imageSize.width), height: Double(imageSize.height)) ?? imageContent.imageThumbURL
         let imageDescription = imageContent.imageDescription
 
         guard !usingImageCache else {
@@ -186,7 +186,7 @@ struct PictureOfTheDayProvider: TimelineProvider {
     }
     
     func getTimeline(in context: Context, completion: @escaping (Timeline<PictureOfTheDayEntry>) -> Void) {
-        dataStore.fetchLatestAvailablePictureEntry { entry in
+        dataStore.fetchLatestAvailablePictureEntry(for: context.imageSize) { entry in
             let currentDate = Date()
             let nextUpdate: Date
             let isError = (entry.image == nil || entry.image == dataStore.sampleEntry.image)
@@ -202,7 +202,7 @@ struct PictureOfTheDayProvider: TimelineProvider {
     }
 
     func getSnapshot(in context: Context, completion: @escaping (PictureOfTheDayEntry) -> Void) {
-        dataStore.fetchLatestAvailablePictureEntry(usingCache: context.isPreview) { entry in
+        dataStore.fetchLatestAvailablePictureEntry(for: context.imageSize, usingCache: context.isPreview) { entry in
             completion(entry)
         }
     }
@@ -320,5 +320,12 @@ struct PictureOfTheDayWidget_Previews: PreviewProvider {
     static var previews: some View {
         PictureOfTheDayView(entry: PictureOfTheDayData.shared.placeholderEntry)
             .previewContext(WidgetPreviewContext(family: .systemLarge))
+    }
+}
+
+extension TimelineProviderContext {
+    var imageSize: CGSize {
+        let maxDisplayScale = environmentVariants.displayScale?.max() ?? 2
+        return CGSize(width: displaySize.width * maxDisplayScale, height: displaySize.height * maxDisplayScale)
     }
 }

--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/WidgetsExtension.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/WidgetsExtension.xcscheme
@@ -80,7 +80,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "_XCWidgetKind"
-            value = "org.wikimedia.wikipedia.widgets.onThisDay"
+            value = "org.wikimedia.wikipedia.widgets.potd"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/Wikipedia/Code/UIScreen+WMFImageWidth.h
+++ b/Wikipedia/Code/UIScreen+WMFImageWidth.h
@@ -23,7 +23,11 @@ typedef NS_ENUM(NSInteger, WMFImageWidth) {
     /**
      *  A slightly larger width, e.g. modal gallery.
      */
-    WMFImageWidthLarge = 640
+    WMFImageWidthLarge = 640,
+
+    WMFImageWidthExtraLarge = 1280,
+    
+    WMFImageWidthExtraExtraLarge = 1920
 };
 
 @interface UIScreen (WMFImageWidth)

--- a/Wikipedia/Code/WMFFeedImage.h
+++ b/Wikipedia/Code/WMFFeedImage.h
@@ -14,6 +14,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, copy) NSURL *imageURL;
 
+@property (nonatomic, readonly, copy, nullable) NSNumber *imageWidth;
+
+@property (nonatomic, readonly, copy, nullable) NSNumber *imageHeight;
+
+- (nullable NSURL *)getImageURLForWidth:(double)width height:(double)height;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFFeedImage.m
+++ b/Wikipedia/Code/WMFFeedImage.m
@@ -3,13 +3,14 @@
 #import <WMF/WMFImageURLParsing.h>
 #import <WMF/NSURL+WMFExtras.h>
 #import <WMF/MWLanguageInfo.h>
+#import <WMF/UIScreen+WMFImageWidth.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation WMFFeedImage
 
 + (NSUInteger)modelVersion {
-    return 2;
+    return 3;
 }
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
@@ -17,6 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
              WMF_SAFE_KEYPATH(WMFFeedImage.new, imageDescription): @"description.text",
              WMF_SAFE_KEYPATH(WMFFeedImage.new, imageDescriptionIsRTL): @"description.lang",
              WMF_SAFE_KEYPATH(WMFFeedImage.new, imageURL): @"image.source",
+             WMF_SAFE_KEYPATH(WMFFeedImage.new, imageWidth): @"image.width",
+             WMF_SAFE_KEYPATH(WMFFeedImage.new, imageHeight): @"image.height",
              WMF_SAFE_KEYPATH(WMFFeedImage.new, imageThumbURL): @"thumbnail.source"};
 }
 
@@ -26,8 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
                                               BOOL *success,
                                               NSError *__autoreleasing *error) {
             NSInteger sizePrefix = WMFParseSizePrefixFromSourceURL(urlString);
-            if (sizePrefix < 640) {
-                urlString = WMFChangeImageSourceURLSizePrefix(urlString, 640);
+            if (sizePrefix < WMFImageWidthExtraLarge) {
+                urlString = WMFChangeImageSourceURLSizePrefix(urlString, WMFImageWidthExtraLarge);
             }
             return [NSURL wmf_optionalURLWithString:urlString];
         }
@@ -56,6 +59,36 @@ NS_ASSUME_NONNULL_BEGIN
     return [MTLValueTransformer transformerUsingForwardBlock:^(NSString *lang, BOOL *success, NSError *__autoreleasing *error) {
         return @(lang && [[MWLanguageInfo rtlLanguages] containsObject:lang]);
     }];
+}
+
+- (nullable NSURL *)getImageURLForWidth:(double)width height:(double)height {
+    if (!self.imageWidth || !self.imageHeight) {
+        return self.imageThumbURL ?: self.imageURL;
+    }
+    double imageWidth = self.imageWidth.doubleValue;
+    double imageHeight = self.imageHeight.doubleValue;
+    double widthScale = width / imageWidth;
+    double heightScale = height / imageHeight;
+    NSInteger targetWidth;
+    if (widthScale > heightScale) {
+        targetWidth = imageWidth * widthScale;
+    } else {
+        targetWidth = imageWidth * heightScale;
+    }
+    if (targetWidth > imageWidth) {
+        return self.imageURL;
+    }
+    NSInteger thumbnailBucketSize;
+    if (targetWidth <= WMFImageWidthLarge) {
+        thumbnailBucketSize = WMFImageWidthLarge;
+    } else if (targetWidth <= WMFImageWidthExtraLarge) {
+        thumbnailBucketSize = WMFImageWidthExtraLarge;
+    } else {
+        thumbnailBucketSize = WMFImageWidthExtraExtraLarge;
+    }
+    NSString *adjustedString = WMFChangeImageSourceURLSizePrefix(self.imageThumbURL.absoluteString, thumbnailBucketSize);
+    NSURL *adujstedURL = [NSURL URLWithString:adjustedString];
+    return adujstedURL ?: self.imageThumbURL ?: self.imageURL;
 }
 
 @end

--- a/Wikipedia/Code/WMFFeedImage.m
+++ b/Wikipedia/Code/WMFFeedImage.m
@@ -89,8 +89,8 @@ NS_ASSUME_NONNULL_BEGIN
         thumbnailBucketSize = WMFImageWidthExtraExtraLarge;
     }
     NSString *adjustedString = WMFChangeImageSourceURLSizePrefix(self.imageThumbURL.absoluteString, thumbnailBucketSize);
-    NSURL *adujstedURL = [NSURL URLWithString:adjustedString];
-    return adujstedURL ?: self.imageThumbURL ?: self.imageURL;
+    NSURL *adjustedURL = [NSURL URLWithString:adjustedString];
+    return adjustedURL ?: self.imageThumbURL ?: self.imageURL;
 }
 
 @end

--- a/Wikipedia/Code/WMFFeedImage.m
+++ b/Wikipedia/Code/WMFFeedImage.m
@@ -69,13 +69,15 @@ NS_ASSUME_NONNULL_BEGIN
     double imageHeight = self.imageHeight.doubleValue;
     double widthScale = width / imageWidth;
     double heightScale = height / imageHeight;
-    NSInteger targetWidth;
-    if (widthScale > heightScale) {
-        targetWidth = imageWidth * widthScale;
-    } else {
-        targetWidth = imageWidth * heightScale;
+    double maxScale = MAX(widthScale, heightScale);
+    NSInteger targetWidth = imageWidth * maxScale;
+    NSInteger targetHeight = imageHeight * maxScale;
+    if (targetHeight > WMFImageWidthExtraExtraLarge) {
+        double scaleDownForTooTallImage = (double)WMFImageWidthExtraLarge / targetHeight;
+        targetWidth = targetWidth * scaleDownForTooTallImage;
     }
     if (targetWidth > imageWidth) {
+        // We can't request a width larger than the original width, so return the original image URL
         return self.imageURL;
     }
     NSInteger thumbnailBucketSize;


### PR DESCRIPTION
**Fixes Phabricator ticket:** 
https://phabricator.wikimedia.org/T263278

### Notes
* Update branch after #3714 is merged

### Test Steps
1. Open POTD on a day there's a panoramic image
2. Verify the image requested is the closest thumbnail size (one of the WMFImageWidth buckets) we can get to a 1:1 image pixel:display pixel

### Screenshots
Before:
![IMG_1865](https://user-images.githubusercontent.com/741327/94204954-42578880-fe90-11ea-85af-a8607509fe04.PNG)


After:
![IMG_1866](https://user-images.githubusercontent.com/741327/94204949-3f5c9800-fe90-11ea-8fc1-c077e6f12793.PNG)
