### PR TITLE
On This Day widget: Allow another line of text

### DIFF
--- a/Widgets/Widgets/OnThisDayView.swift
+++ b/Widgets/Widgets/OnThisDayView.swift
@@ -291,7 +291,7 @@ struct MainOnThisDayElement: View {
                             .font(.caption)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.top, 9)
-                            .padding(.bottom, (widgetSize == .systemSmall ? 16 : 8))
+                            .padding(.bottom, (widgetSize == .systemMedium ? 4 : 8))
                 ).layoutPriority(1.0)
             }
         }.layoutPriority(1.0)
@@ -429,12 +429,12 @@ struct OnThisDayAdditionalEventsElement: View {
                 .lineLimit(1)
                 .foregroundColor(OnThisDayColors.blueColor(colorScheme))
                 .frame(maxWidth: .infinity, alignment: .topLeading)
-            .padding(.top, 8)
+            .padding(.top, 2)
             .overlay (
                 GeometryReader { geometryProxy in
                   Color.clear
-                    .preference(key: SmallYValuePreferenceKey.self, value: startYOfCircle(viewHeight: geometryProxy.size.height, circleHeight: TimelineSmallCircleElement.smallCircleHeight, topPadding: 4))
-                    /// The padding of 4 is a little arbitrary. These views aren't perfectly laid out in SwiftUI - see the "+20" comment above - and we needed an extra 4 points to make this layout properly.
+                    .preference(key: SmallYValuePreferenceKey.self, value: startYOfCircle(viewHeight: geometryProxy.size.height, circleHeight: TimelineSmallCircleElement.smallCircleHeight, topPadding: 0))
+                    /// The padding of 0 is a little arbitrary. These views aren't perfectly laid out in SwiftUI - see the "+20" comment above - and depending on spacing/padding we sometims need to tweak the padding to make this layout properly.
                 }
             )
             .padding(.bottom, 16)


### PR DESCRIPTION
**Fixes Phabricator ticket:** No ticket, but discussed this w/ Carolyn and she ok'd the new screenshots

### Notes
* More information now available for our users! The mocks had an additional line of text that padding wasn't allowing for on medium. Also, small and large were able to fit an extra line. 

### Test Steps
1. Run app, install small/medium/large versions of On This Day widget. Ensure they don't have any awkwardly large amounts of whitespace that end in `...`.

### Screenshots/Videos
**Old, broken, and bogus**
<img width="250" alt="Screenshot 2" src="https://user-images.githubusercontent.com/9295855/94491748-abdfdb80-019d-11eb-985c-403e3da74f4b.png"> <img width="250" alt="Screenshot 4" src="https://user-images.githubusercontent.com/9295855/94491751-ada99f00-019d-11eb-953d-0fb3c5abf569.png">

**New w/ a long event description**
<img width="250" alt="Screenshot 7" src="https://user-images.githubusercontent.com/9295855/94491809-cb770400-019d-11eb-8366-dd1efcc19213.png"> <img width="250" alt="Screenshot 8" src="https://user-images.githubusercontent.com/9295855/94491818-cf0a8b00-019d-11eb-8efd-d349671a90b6.png">

**New w/ a short event description (this is the same, but showing it has no regressions)**
<img width="250" alt="Screenshot 9" src="https://user-images.githubusercontent.com/9295855/94491833-d29e1200-019d-11eb-8d00-752e23d9dc87.png"> <img width="250" alt="Screenshot 10" src="https://user-images.githubusercontent.com/9295855/94491835-d3cf3f00-019d-11eb-8ec6-e2774df9ff1a.png">


