### PR TITLE
Widget stack cleanup & crash fixes

### DIFF
--- a/WMF Framework/ImageCacheController.swift
+++ b/WMF Framework/ImageCacheController.swift
@@ -279,6 +279,11 @@ public final class ImageCacheController: CacheController {
         case .rightMirrored: return .rightMirrored
         }
     }
+    
+    public override func cancelAllTasks() {
+        super.cancelAllTasks()
+        dataCompletionManager.cancelAll()
+    }
 }
 
 private extension ImageCacheController {

--- a/WMF Framework/WidgetController.swift
+++ b/WMF Framework/WidgetController.swift
@@ -63,11 +63,10 @@ public final class WidgetController: NSObject {
     }
     
     private func fetchCachedWidgetContentGroup(with kind: WMFContentGroupKind, isAnyLanguageAllowed: Bool, in dataStore: MWKDataStore, completion:  @escaping (WMFContentGroup?) -> Void) {
+        assert(Thread.isMainThread, "Cached widget content group must be fetched from the main queue")
         let moc = dataStore.viewContext
         let siteURL = isAnyLanguageAllowed ? dataStore.languageLinkController.appLanguage?.siteURL() : nil
-        moc.perform {
-            completion(moc.newestGroup(of: kind, forSiteURL: siteURL))
-        }
+        completion(moc.newestGroup(of: kind, forSiteURL: siteURL))
     }
     
     public func updateFeedContent(in dataStore: MWKDataStore, completion: @escaping () -> Void) {

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -114,8 +114,9 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
 }
 
 - (void)teardown:(nullable dispatch_block_t)completion {
+    [self stopCoreDataSynchronizers];
+    [self.session teardown];
     if (self.cacheController) {
-        [self.session teardown];
         [self.cacheController teardown:^{
             if (completion) {
                 completion();


### PR DESCRIPTION
**Fixes Phabricator ticket:** 
https://phabricator.wikimedia.org/T263247

### Notes
One of the crash reports from 1777 points to `ImageControllerCompletionManager` holding on to the `NSURLStorageURLCacheDB`. This PR ensures those completions are cleared on `teardown` of the `MWKDataStore`.
```
0   libsystem_kernel.dylib        	0x00000001bf6746a0 __fcntl + 8
1   libsystem_kernel.dylib        	0x00000001bf656974 fcntl + 84 (fcntl-base.c:82)
2   libsqlite3.dylib              	0x00000001acf7bb30 unixSync + 196 (sqlite3.c:39853)
3   libsqlite3.dylib              	0x00000001acf913dc sqlite3WalCheckpoint + 3624 (sqlite3.c:23740)
4   libsqlite3.dylib              	0x00000001acf82c68 sqlite3WalClose + 196 (sqlite3.c:68735)
5   libsqlite3.dylib              	0x00000001acf82998 sqlite3PagerClose + 332 (sqlite3.c:62833)
6   libsqlite3.dylib              	0x00000001acf823e8 sqlite3BtreeClose + 404 (sqlite3.c:73860)
7   libsqlite3.dylib              	0x00000001acfa4eb8 sqlite3LeaveMutexAndCloseZombie + 248 (sqlite3.c:169512)
8   libsqlite3.dylib              	0x00000001acfad850 sqlite3Close + 1432 (sqlite3.c:169447)
9   CFNetwork                     	0x0000000194c0738c -[NSURLStorageURLCacheDB _closeDBWriteConnections] + 36 (NSURLStorageURLCacheDB.mm:60)
10  CFNetwork                     	0x0000000194c0725c -[NSURLStorageURLCacheDB dealloc] + 92 (NSURLStorageURLCacheDB.mm:53)
11  CFNetwork                     	0x0000000194b07ae8 __CFURLCache::~__CFURLCache() + 256 (CFURLCache.mm:1822)
12  CFNetwork                     	0x0000000194aa94d4 -[NSURLCacheInternal dealloc] + 140 (memory:3445)
13  CFNetwork                     	0x0000000194aa941c -[NSURLCache dealloc] + 28 (NSURLCache.mm:856)
14  CFNetwork                     	0x0000000194ceb7e0 -[NSURLSessionConfiguration dealloc] + 172 (CFURLSessionConfiguration.mm:1141)
15  CFNetwork                     	0x0000000194c582f0 -[NSURLSession dealloc] + 256 (Session.mm:439)
16  CFNetwork                     	0x0000000194a9d1ac -[__NSURLSessionLocal dealloc] + 224 (LocalSession.mm:974)
17  CFNetwork                     	0x0000000194cd977c -[NSURLSessionTask dealloc] + 624 (SessionTask.mm:198)
18  CFNetwork                     	0x0000000194a9a51c -[__NSCFLocalSessionTask dealloc] + 332 (LocalSessionTask.mm:233)
19  WMF                           	0x00000001031389b4 specialized closure #1 in ImageControllerCompletionManager.complete(_:identifier:enumerator:) + 792 (ImageControllerCompletionManager.swift:0)
```
