### PR TITLE
Update midnight widget refresh extension to use random time after midnight

### DIFF
--- a/Widgets/Utilities/Date+Extensions.swift
+++ b/Widgets/Utilities/Date+Extensions.swift
@@ -2,11 +2,12 @@ import Foundation
 
 extension Date {
 
-	// TODO: Document nil Date
-    func dateAtMidnight(calendar: Calendar = .current) -> Date? {
-		let components = DateComponents(day: 1)
-		let startOfDay = calendar.startOfDay(for: Date())
+    /// Return a randomized `Date` in the next midnight hour. Will return nil if a `Date` can't be constructed given the calendar
+    /// and component constraints, though in practice will likely always return some value.
+    func randomDateShortlyAfterMidnight(calendar: Calendar = .current) -> Date? {
+        let components = DateComponents(day: 1, minute: .random(in: 0..<60), second: .random(in: 0..<60))
+        let startOfDay = calendar.startOfDay(for: self)
         return calendar.date(byAdding: components, to: startOfDay)
-	}
+    }
 
 }

--- a/Widgets/Utilities/Date+Extensions.swift
+++ b/Widgets/Utilities/Date+Extensions.swift
@@ -5,7 +5,7 @@ extension Date {
     /// Return a randomized `Date` in the next midnight hour. Will return nil if a `Date` can't be constructed given the calendar
     /// and component constraints, though in practice will likely always return some value.
     func randomDateShortlyAfterMidnight(calendar: Calendar = .current) -> Date? {
-        let components = DateComponents(day: 1, minute: .random(in: 0..<60), second: .random(in: 0..<60))
+        let components = DateComponents(day: 1, minute: .random(in: 0..<30), second: .random(in: 0..<60))
         let startOfDay = calendar.startOfDay(for: self)
         return calendar.date(byAdding: components, to: startOfDay)
     }

--- a/Widgets/Widgets/OnThisDayWidget.swift
+++ b/Widgets/Widgets/OnThisDayWidget.swift
@@ -40,7 +40,7 @@ struct OnThisDayProvider: TimelineProvider {
             let currentDate = Date()
             let nextUpdate: Date
             if entry.error == nil {
-                nextUpdate = currentDate.dateAtMidnight() ?? currentDate
+                nextUpdate = currentDate.randomDateShortlyAfterMidnight() ?? currentDate
             } else {
                 let components = DateComponents(hour: 2)
                 nextUpdate = Calendar.current.date(byAdding: components, to: currentDate) ?? currentDate

--- a/Widgets/Widgets/PictureOfTheDayWidget.swift
+++ b/Widgets/Widgets/PictureOfTheDayWidget.swift
@@ -174,7 +174,7 @@ struct PictureOfTheDayProvider: TimelineProvider {
             let nextUpdate: Date
             let isError = (entry.image == nil || entry.image == dataStore.sampleEntry.image)
             if !isError {
-                nextUpdate = currentDate.dateAtMidnight() ?? currentDate
+                nextUpdate = currentDate.randomDateShortlyAfterMidnight() ?? currentDate
             } else {
                 let components = DateComponents(hour: 2)
                 nextUpdate = Calendar.current.date(byAdding: components, to: currentDate) ?? currentDate


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T264881

### Notes
To possibly help mitigate spikes of traffic on the hour, randomize the requested refresh time of Picture of the day and On this day from midnight local time to some random minute and second within an hour after midnight local time.