### PR TITLE
Various crash fixes

### DIFF
--- a/WMF Framework/Significant Events Endpoint/SignificantEventsFetcher.swift
+++ b/WMF Framework/Significant Events Endpoint/SignificantEventsFetcher.swift
@@ -41,11 +41,12 @@ public class SignificantEventsFetcher: Fetcher {
     
     private func significantEventsURL(rvStartId: UInt? = nil, title: String, siteURL: URL) -> URL? {
         let labsHost = "mobileapps-ios-experiments.wmflabs.org"
-        guard let siteHost = siteURL.host else {
+        guard let siteHost = siteURL.host,
+              let percentEncodedTitle = title.percentEncodedPageTitleForPathComponents else {
             return nil
         }
 
-        let pathComponents = [siteHost, "v1", "page", "significant-events", title]
+        let pathComponents = [siteHost, "v1", "page", "significant-events", percentEncodedTitle]
         var components = URLComponents()
         components.host = labsHost
         components.scheme = "https"

--- a/Wikipedia/Code/URL+LinkParsing.swift
+++ b/Wikipedia/Code/URL+LinkParsing.swift
@@ -179,7 +179,8 @@ extension URL {
         mutableComponents.append(mp3Filename)
 
         var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: true)
-        urlComponents?.percentEncodedPath = "/" + mutableComponents.joined(separator: "/")
+        let path = "/" + mutableComponents.joined(separator: "/")
+        urlComponents?.percentEncodedPath = path.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlPathAllowed) ?? path
         return urlComponents?.url ?? self
     }
 }


### PR DESCRIPTION
**Fixes Phabricator ticket:** 
https://phabricator.wikimedia.org/T265171#6533497

### First Crash

This crash is straightforward, it looks to me like we just needed to percent encode article titles before fetching from the significant events endpoint.

#### Test Steps
1. Look up regular character article on EN Wikipedia, like "Cat", and confirm significant events fetches and shows fine in the article.
2. Look up "History of the Wales national football team (1876–1976)", confirm you can load the article view with significant events (it crashed before).
3. Look up "Laocoön and His Sons", confirm you can load the article view with significant events (it crashed before).

### Second Crash

This second crash occurs through the `byMakingAudioFileCompatibilityAdjustments` method, so I think it happened with an audio file link from an article that had special characters. Here's the [crash log](https://phabricator.wikimedia.org/T265171#6533497) from the ticket. I couldn't find a real linked file in the wild so for test steps we're making an arbitrary one:

#### Test Steps

1. Update the method call in [this file](https://github.com/wikimedia/wikipedia-ios/blob/da88cc25522bbbe78ea69d069d57515a747bf443/Wikipedia/Code/ArticleViewController%2BArticleWebMessageHandling.swift#L13) with this code:

```
if (href.contains("Dean")) {
   let fakeHref = "//upload.wikimedia.org/wikipedia/en/3/3f/Laocoön.ogg"
    handleLink(with: fakeHref)
} else {
    handleLink(with: href)
}
```

2. Build and run. Go to article "Howard Dean" on EN Wikipedia.
3. Scroll to "Iowa Caucus setback and the Dean Scream media gaffe"
4. Select "Yeah!" link
5. Before app would crash. Now it doesn't (it doesn't play audio either but that's because we created an arbitrary audio file link with special characters above).

I'm happy to back out this crash fix or do some more digging to find a crashing audio file in the wild if there's pushback on these weird test steps.

