### PR TITLE
add loading indicator to bottom of AaaLD

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -2955,6 +2955,10 @@
 		D8FEECCD1DE3729400B883F0 /* WMFChange.m in Sources */ = {isa = PBXBuildFile; fileRef = D8FEECCC1DE3729400B883F0 /* WMFChange.m */; };
 		E1CFD6E6210C103900D8E37C /* ExploreCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CA612920D1675800EF0C4A /* ExploreCardViewController.swift */; };
 		FF2090F02500247100849774 /* ThreeLineHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2090EE2500247100849774 /* ThreeLineHeaderView.swift */; };
+		FF2B2110254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2B210F254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift */; };
+		FF2B2111254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2B210F254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift */; };
+		FF2B2112254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2B210F254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift */; };
+		FF2B2113254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2B210F254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift */; };
 		FF921857252E8F4F00C39A8F /* ThanksGiving.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF921856252E8F4F00C39A8F /* ThanksGiving.swift */; };
 		FF92187C252F7EA300C39A8F /* ThanksGiving.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF921856252E8F4F00C39A8F /* ThanksGiving.swift */; };
 		FF921887252F7EA500C39A8F /* ThanksGiving.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF921856252E8F4F00C39A8F /* ThanksGiving.swift */; };
@@ -4828,6 +4832,7 @@
 		D8FFF6932031CB3E00A028E0 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = cy; path = cy.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		D8FFF6942031CB4000A028E0 /* tcy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = tcy; path = tcy.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		FF2090EE2500247100849774 /* ThreeLineHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeLineHeaderView.swift; sourceTree = "<group>"; };
+		FF2B210F254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorCollectionViewFooter.swift; sourceTree = "<group>"; };
 		FF921856252E8F4F00C39A8F /* ThanksGiving.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThanksGiving.swift; sourceTree = "<group>"; };
 		FF9416D724E203030070FEE7 /* OnThisDayWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayWidget.swift; sourceTree = "<group>"; usesTabs = 0; };
 		FF9416DD24E2098C0070FEE7 /* OnThisDayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayView.swift; sourceTree = "<group>"; };
@@ -6036,6 +6041,7 @@
 				6771C9532509FE6B00A7254B /* ArticleAsLivingDocHeaderView.xib */,
 				6798036024F94CEE00D765AA /* ArticleAsLivingDocController.swift */,
 				67985A852524E05F00EBF353 /* ArticleAsLivingDocHintViewController.swift */,
+				FF2B210F254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift */,
 			);
 			path = "Article as a Living Document";
 			sourceTree = "<group>";
@@ -10370,6 +10376,7 @@
 				83FBE9751F6181E00026C7EB /* ShareAFactActivityImageItemProvider.swift in Sources */,
 				D8A47C8A23D728A4002AA823 /* ArticleTableOfContentsDisplayController.swift in Sources */,
 				D84F2C031D30162700963D42 /* WMFFirstRandomViewController.m in Sources */,
+				FF2B2110254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift in Sources */,
 				7A28126320D3F84A009B42B5 /* FeedCardSettingsViewController.swift in Sources */,
 				67E466FA241BED770014149B /* EditHistoryCompareFunnel.swift in Sources */,
 				8386BDF62386D735007EE89D /* ViewController+URLHandling.swift in Sources */,
@@ -11182,6 +11189,7 @@
 				D8A42B541E815A9C00D8E281 /* WMFRandomDiceButton.m in Sources */,
 				7A1C4998227265CD00230ED2 /* InsertMediaSelectedImageViewController.swift in Sources */,
 				D8A47C8D23D728A4002AA823 /* ArticleTableOfContentsDisplayController.swift in Sources */,
+				FF2B2113254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift in Sources */,
 				7A71567122697AAF0066FEC4 /* InsertMediaCustomImageSizeSettingTableViewCell.swift in Sources */,
 				D8A42B5B1E815A9C00D8E281 /* WMFFirstRandomViewController.m in Sources */,
 				D8A42B5D1E815A9C00D8E281 /* ArticlePopoverViewController.swift in Sources */,
@@ -11369,6 +11377,7 @@
 				6782DBB02343B812003FA21B /* DiffHeaderCompareView.swift in Sources */,
 				83DAA9B123FEB611002D5716 /* ReferenceBackLinksViewController.swift in Sources */,
 				7A9524D822669A8B00C55CDC /* InsertMediaSettingsButtonView.swift in Sources */,
+				FF2B2112254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift in Sources */,
 				8351CE7920D4424100E32FC1 /* CollectionViewHeader.swift in Sources */,
 				7A20AE092057F39C005FB5DF /* UIView+Identifier.swift in Sources */,
 				D8E27BA21F82B38100F9D2B3 /* RMessageView.m in Sources */,
@@ -11840,6 +11849,7 @@
 				6782DBB12343B812003FA21B /* DiffHeaderCompareView.swift in Sources */,
 				83DAA9B223FEB611002D5716 /* ReferenceBackLinksViewController.swift in Sources */,
 				7A9524D922669A8B00C55CDC /* InsertMediaSettingsButtonView.swift in Sources */,
+				FF2B2111254B7D6A0009E61A /* ActivityIndicatorCollectionViewFooter.swift in Sources */,
 				83023C2120E6584F00EC7592 /* SearchTransition.swift in Sources */,
 				D8EC3DF61E9BDA35006712EB /* NSDate+WMFPOTDTitle.m in Sources */,
 				D8EC3DF71E9BDA35006712EB /* WMFTableHeaderFooterLabelView.m in Sources */,

--- a/Wikipedia/Code/Article as a Living Document/ActivityIndicatorCollectionViewFooter.swift
+++ b/Wikipedia/Code/Article as a Living Document/ActivityIndicatorCollectionViewFooter.swift
@@ -15,19 +15,20 @@ class ActivityIndicatorCollectionViewFooter: UICollectionReusableView {
         loadingLabel.font = UIFont.wmf_font(.footnote, compatibleWithTraitCollection: traitCollection)
         loadingLabel.text = WMFLocalizedString("loading-indicator-text", value: "Loading", comment: "Text shown underneath loading indicator.").uppercased()
 
-        let stackView = UIStackView(arrangedSubviews: [loadingIndicator, loadingLabel])
-        stackView.axis = .vertical
-        stackView.spacing = 4.0
-        stackView.alignment = .center
+        addSubview(loadingLabel)
+        addSubview(loadingIndicator)
+        loadingLabel.translatesAutoresizingMaskIntoConstraints = false
+        loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
 
-        addSubview(stackView)
-        stackView.translatesAutoresizingMaskIntoConstraints = false
+        // Need to give this a non-1000 priority to avoid constraint issues in the logs.
+        let separationConstraint = loadingLabel.topAnchor.constraint(equalTo: loadingIndicator.bottomAnchor, constant: 4)
+        separationConstraint.priority = UILayoutPriority(999)
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 30),
-            stackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -30),
-            stackView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 30),
-            stackView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -30),
-            stackView.centerXAnchor.constraint(equalTo: centerXAnchor)
+            loadingIndicator.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 30),
+            separationConstraint,
+            loadingLabel.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -30),
+            loadingIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            loadingLabel.centerXAnchor.constraint(equalTo: centerXAnchor)
         ])
         loadingIndicator.startAnimating()
     }

--- a/Wikipedia/Code/Article as a Living Document/ActivityIndicatorCollectionViewFooter.swift
+++ b/Wikipedia/Code/Article as a Living Document/ActivityIndicatorCollectionViewFooter.swift
@@ -18,8 +18,17 @@ class ActivityIndicatorCollectionViewFooter: UICollectionReusableView {
         let stackView = UIStackView(arrangedSubviews: [loadingIndicator, loadingLabel])
         stackView.axis = .vertical
         stackView.spacing = 4.0
+        stackView.alignment = .center
 
-        wmf_addSubview(stackView, withConstraintsToEdgesWithInsets: UIEdgeInsets(top: 30, left: 30, bottom: 30, right: 30))
+        addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 30),
+            stackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -30),
+            stackView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 30),
+            stackView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -30),
+            stackView.centerXAnchor.constraint(equalTo: centerXAnchor)
+        ])
         loadingIndicator.startAnimating()
     }
 }

--- a/Wikipedia/Code/Article as a Living Document/ActivityIndicatorCollectionViewFooter.swift
+++ b/Wikipedia/Code/Article as a Living Document/ActivityIndicatorCollectionViewFooter.swift
@@ -1,0 +1,33 @@
+class ActivityIndicatorCollectionViewFooter: UICollectionReusableView {
+    private let loadingIndicator = UIActivityIndicatorView(style: .gray)
+    private let loadingLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        loadingLabel.font = UIFont.wmf_font(.footnote, compatibleWithTraitCollection: traitCollection)
+        loadingLabel.text = WMFLocalizedString("loading-indicator-text", value: "Loading", comment: "Text shown underneath loading indicator.").uppercased()
+
+        let stackView = UIStackView(arrangedSubviews: [loadingIndicator, loadingLabel])
+        stackView.axis = .vertical
+        stackView.spacing = 4.0
+
+        wmf_addSubview(stackView, withConstraintsToEdgesWithInsets: UIEdgeInsets(top: 30, left: 30, bottom: 30, right: 30))
+        loadingIndicator.startAnimating()
+    }
+}
+
+extension ActivityIndicatorCollectionViewFooter: Themeable {
+    func apply(theme: Theme) {
+        backgroundColor = theme.colors.paperBackground
+        loadingLabel.textColor = theme.colors.secondaryText
+        loadingIndicator.color = theme.colors.secondaryText
+    }
+}

--- a/Wikipedia/Code/Article as a Living Document/ArticleAsLivingDocViewController.swift
+++ b/Wikipedia/Code/Article as a Living Document/ArticleAsLivingDocViewController.swift
@@ -6,6 +6,7 @@ import WMF
 protocol ArticleAsLivingDocViewControllerDelegate: class {
     var articleAsLivingDocViewModel: ArticleAsLivingDocViewModel? { get }
     var articleURL: URL { get }
+    var isFetchingAdditionalPages: Bool { get }
     func fetchNextPage(nextRvStartId: UInt, theme: Theme)
     func showEditHistory(scrolledTo revisionID: Int?)
     func handleLink(with href: String)
@@ -55,6 +56,7 @@ class ArticleAsLivingDocViewController: ColumnarCollectionViewController {
         layoutManager.register(ArticleAsLivingDocLargeEventCollectionViewCell.self, forCellWithReuseIdentifier: ArticleAsLivingDocLargeEventCollectionViewCell.identifier, addPlaceholder: true)
         layoutManager.register(ArticleAsLivingDocSmallEventCollectionViewCell.self, forCellWithReuseIdentifier: ArticleAsLivingDocSmallEventCollectionViewCell.identifier, addPlaceholder: true)
         layoutManager.register(ArticleAsLivingDocSectionHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ArticleAsLivingDocSectionHeaderView.identifier, addPlaceholder: true)
+        layoutManager.register(ActivityIndicatorCollectionViewFooter.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: ActivityIndicatorCollectionViewFooter.identifier, addPlaceholder: false)
         
         self.title = headerText
         
@@ -130,6 +132,11 @@ class ArticleAsLivingDocViewController: ColumnarCollectionViewController {
                 sectionHeaderView.configure(viewModel: section, theme: theme)
                 return sectionHeaderView
             } else if kind == UICollectionView.elementKindSectionFooter {
+                if self.delegate?.isFetchingAdditionalPages == true,
+                    let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: ActivityIndicatorCollectionViewFooter.identifier, for: indexPath) as? ActivityIndicatorCollectionViewFooter {
+                    footer.apply(theme: theme)
+                    return footer
+                }
                 guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: CollectionViewFooter.identifier, for: indexPath) as? CollectionViewFooter else {
                     return UICollectionReusableView()
                 }

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -1126,6 +1126,10 @@ extension ArticleViewController: ArticleAsLivingDocViewControllerDelegate {
     func fetchNextPage(nextRvStartId: UInt, theme: Theme) {
         articleAsLivingDocController.fetchNextPage(nextRvStartId: nextRvStartId, traitCollection: traitCollection, theme: theme)
     }
+
+    var isFetchingAdditionalPages: Bool {
+        return articleAsLivingDocController.isFetchingAdditionalPages
+    }
 }
 
 extension ArticleViewController: ArticleAsLivingDocControllerDelegate {


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T265677

### Notes
* LAYOUT BUG: The footer is sized to fit around the loading indicator (w/ edge insets). Thus, it currently isn't centered, as the footer isn't full width. @tonisevener, is there a gotcha w/ how autolayout works w/ our collection views? Or am I just forgetting some gotcha on footers and collection views? Do I need to manually set the width to the collection view size?

* We talked about keeping it on screen for a minimum of 1 second. It gets replaced by the just-loaded items, and so it disappears in context. The only time it would just stop being shown is if we don't load more items (because of a network error, or otherwise). This seems rare enough that it didn't seem worth building the "1 second minimum" logic into an experiment. @carolynlimadeo, can you please let me know if you'd like it in there anyway?

### Test Steps
1. Open AaaLD modal. Scroll to bottom. See loading indicator and text saying "LOADING" beneath it. 
1. Repeat for other themes.
