### PR TITLE
Ignore announcement endpoint and always show AaaLD experiment

### DIFF
--- a/Wikipedia/Code/Article as a Living Document/ArticleAsLivingDocController.swift
+++ b/Wikipedia/Code/Article as a Living Document/ArticleAsLivingDocController.swift
@@ -85,8 +85,10 @@ class ArticleAsLivingDocController: NSObject {
         let isENWikipediaArticle = delegate.articleURL.host == Configuration.Domain.englishWikipedia
         
         let shouldAttemptToShowArticleAsLivingDoc = articleTitleAndSiteURL() != nil && !isDeviceRTL && isENWikipediaArticle && isInValidSurveyCampaignAndArticleList && isInExperimentBucket
-        
-        return shouldAttemptToShowArticleAsLivingDoc
+
+		return true
+		// TODO: Put back in place when announcement patch is merged
+        // return shouldAttemptToShowArticleAsLivingDoc
     }
     
     var shouldShowArticleAsLivingDoc: Bool {

--- a/Wikipedia/Code/Article as a Living Document/ArticleAsLivingDocController.swift
+++ b/Wikipedia/Code/Article as a Living Document/ArticleAsLivingDocController.swift
@@ -86,8 +86,8 @@ class ArticleAsLivingDocController: NSObject {
         
         let shouldAttemptToShowArticleAsLivingDoc = articleTitleAndSiteURL() != nil && !isDeviceRTL && isENWikipediaArticle && isInValidSurveyCampaignAndArticleList && isInExperimentBucket
 
-		return true
-		// TODO: Put back in place when announcement patch is merged
+        return true
+        // TODO: Put back in place when announcement patch is merged
         // return shouldAttemptToShowArticleAsLivingDoc
     }
     


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
Just in case we need it if the announcement patch doesn't get merged.
