### PR TITLE
Article as a Living Doc: Nav bar on iPhone shouldn't disappear when scrolling on a discussion

### DIFF
--- a/Wikipedia/Code/ViewControllerRouter.swift
+++ b/Wikipedia/Code/ViewControllerRouter.swift
@@ -30,9 +30,7 @@ class ViewControllerRouter: NSObject {
         if #available(iOS 13.0, *), navigationController.children.contains(where: { $0 is ArticleAsLivingDocViewController }) {
             if let vc = viewController as? SinglePageWebViewController, navigationController.modalPresentationStyle == .pageSheet {
                 vc.doesUseSimpleNavigationBar = true
-                if UIDevice.current.userInterfaceIdiom == .pad {
-                    vc.navigationBar.isBarHidingEnabled = false
-                }
+                vc.navigationBar.isBarHidingEnabled = false
             }
         }
 


### PR DESCRIPTION
**Fixes Phabricator ticket:** No ticket - direct feedback from @carolynlimadeo 

### Notes
* We fixed the [nav bar on iPad](https://github.com/wikimedia/wikipedia-ios/pull/3756/), but it then caused the nav bar on iPhone to scroll away - not what we wanted.

### Test Steps
1. Run app on an iPhone (or iPhone simulator).
1. Open an article in the AAALD experiment.
1. Open AAALD modal.
1. Find a "View discussion" button, tap it.
1. Scroll down on the discussion page.
1. Ensure the nav bar doesn't disappear as you scroll.

