### PR TITLE
Remove extraneous HTML from AAaLD article insert event descriptions.

### DIFF
--- a/WMF Framework/Significant Events Endpoint/ArticleAsLivingDocViewModels.swift
+++ b/WMF Framework/Significant Events Endpoint/ArticleAsLivingDocViewModels.swift
@@ -601,7 +601,7 @@ public extension ArticleAsLivingDocViewModel {
                     userGroups = newTalkPageTopic.userGroups
                     
                     if let talkPageSection = newTalkPageTopic.section {
-                        self.buttonsToDisplay = .viewDiscussion(sectionName: Self.sectionTitleWithWikitextStripped(originalTitle: talkPageSection))
+                        self.buttonsToDisplay = .viewDiscussion(sectionName: Self.sectionTitleWithWikitextAndHtmlStripped(originalTitle: talkPageSection))
                     } else {
                         self.buttonsToDisplay = .viewDiscussion(sectionName: nil)
                     }
@@ -910,14 +910,15 @@ public extension ArticleAsLivingDocViewModel.Event.Large {
         }
         
         //strip == signs from all section titles
-        let finalSet = set.map { Self.sectionTitleWithWikitextStripped(originalTitle: $0) }
+        let finalSet = set.map { Self.sectionTitleWithWikitextAndHtmlStripped(originalTitle: $0) }
 
         return Set(finalSet)
     }
     
     //remove one or more equal signs and zero or more spaces on either side of the title text
-    private static func sectionTitleWithWikitextStripped(originalTitle: String) -> String {
-        var loopTitle = originalTitle
+    //also removing html for display and potential javascript injection issues - https://phabricator.wikimedia.org/T268201
+    private static func sectionTitleWithWikitextAndHtmlStripped(originalTitle: String) -> String {
+        var loopTitle = originalTitle.removingHTML
         
         let regex = "^=+\\s*|\\s*=+$"
         var maybeMatch = loopTitle.range(of: regex, options: .regularExpression)
@@ -945,7 +946,7 @@ public extension ArticleAsLivingDocViewModel.Event.Large {
             localizedString = String.localizedStringWithFormat(CommonStrings.manySectionsDescription, sections.count)
         }
 
-        return " " + localizedString.removingHTML
+        return " " + localizedString
     }
     
     private func localizedSectionHtmlSnippet(sectionsSet: Set<String>) -> String? {

--- a/WMF Framework/Significant Events Endpoint/ArticleAsLivingDocViewModels.swift
+++ b/WMF Framework/Significant Events Endpoint/ArticleAsLivingDocViewModels.swift
@@ -660,7 +660,7 @@ public extension ArticleAsLivingDocViewModel.Event.Large {
     
     func articleInsertHtmlSnippet(isFirst: Bool = false, isLast: Bool = false, indexPath: IndexPath) -> String? {
         guard let timestampForDisplay = self.fullyRelativeTimestampForDisplay(),
-              let eventDescription = eventDescriptionHtmlSnippet(indexPath: indexPath)?.removingHTML,
+              let eventDescription = eventDescriptionHtmlSnippet(indexPath: indexPath),
               let userInfo = userInfoHtmlSnippet() else {
             return nil
         }
@@ -911,7 +911,7 @@ public extension ArticleAsLivingDocViewModel.Event.Large {
         
         //strip == signs from all section titles
         let finalSet = set.map { Self.sectionTitleWithWikitextStripped(originalTitle: $0) }
-        
+
         return Set(finalSet)
     }
     
@@ -945,9 +945,7 @@ public extension ArticleAsLivingDocViewModel.Event.Large {
             localizedString = String.localizedStringWithFormat(CommonStrings.manySectionsDescription, sections.count)
         }
 
-        // Uncomment to remove extraneous HTML in the modal
-        // return " " + localizedString.removingHTML
-        return " " + localizedString
+        return " " + localizedString.removingHTML
     }
     
     private func localizedSectionHtmlSnippet(sectionsSet: Set<String>) -> String? {

--- a/WMF Framework/Significant Events Endpoint/ArticleAsLivingDocViewModels.swift
+++ b/WMF Framework/Significant Events Endpoint/ArticleAsLivingDocViewModels.swift
@@ -660,7 +660,7 @@ public extension ArticleAsLivingDocViewModel.Event.Large {
     
     func articleInsertHtmlSnippet(isFirst: Bool = false, isLast: Bool = false, indexPath: IndexPath) -> String? {
         guard let timestampForDisplay = self.fullyRelativeTimestampForDisplay(),
-              let eventDescription = eventDescriptionHtmlSnippet(indexPath: indexPath),
+              let eventDescription = eventDescriptionHtmlSnippet(indexPath: indexPath)?.removingHTML,
               let userInfo = userInfoHtmlSnippet() else {
             return nil
         }
@@ -944,7 +944,9 @@ public extension ArticleAsLivingDocViewModel.Event.Large {
         default:
             localizedString = String.localizedStringWithFormat(CommonStrings.manySectionsDescription, sections.count)
         }
-        
+
+        // Uncomment to remove extraneous HTML in the modal
+        // return " " + localizedString.removingHTML
         return " " + localizedString
     }
     


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T268201

### Notes
To guard against a JavaScript injection error, use our existing `removingHTML` helper before injecting interstitial article snippet. We may not necessarily need this depending on where your endpoint changes land, but honestly it might be a nice extra line of defense in case the endpoint returns something unexpected that causes the experiment to fail. So far, I haven't knowingly witnessed any regressions using this with other articles in the experiment, but I've only been testing for a couple hours so far so I could very well be missing something.

The part I keep going back and forth on is the element I commented out - whether to apply it to both the article insert description and the modal content descriptions, or just the insert itself. I left it commented out in `localizedStringFromSections`. I guess I slightly lean towards it being ok to use this in the modal as well (see screenshot below), since at worst case so far it removes some formatting but at best it removes a bunch of useless cruft. But again, I could be missing something.

What do you think?

### Test Steps
1. Open `Joe Biden` article
2. Confirm AAaLD experiment loads and that the article insert segment renders
3. Open known to be currently working on 6.7.3 TestFlight build articles in experiment
4. Confirm same elements as Step 2

### Screenshots

Here's a screenshot of before and after removing the HTML in the modal - we lose the italic formatting, but in the article insert itself that's more desirable than the experiment failing to load at all.

<img width="703" alt="section" src="https://user-images.githubusercontent.com/5652327/99736043-8e7f0d80-2a7a-11eb-9429-9c08e7924027.png">


