### PR TITLE
Fix bugs found with AaaLD event logging

### DIFF
--- a/Wikipedia/Code/Article as a Living Document/ArticleAsLivingDocViewController.swift
+++ b/Wikipedia/Code/Article as a Living Document/ArticleAsLivingDocViewController.swift
@@ -156,7 +156,7 @@ class ArticleAsLivingDocViewController: ColumnarCollectionViewController {
     }
     
     private func updateLoggingPositionsForItemsInSections(_ sections: [ArticleAsLivingDocViewModel.SectionHeader]) {
-        var currentPosition: Int = 1
+        var currentPosition: Int = 0
         for section in sections {
             for item in section.typedEvents {
                 switch item {

--- a/Wikipedia/Code/ArticleAsLivingDocFunnel.swift
+++ b/Wikipedia/Code/ArticleAsLivingDocFunnel.swift
@@ -11,7 +11,7 @@ fileprivate extension Dictionary where Key == String, Value == Any {
     
     func appendingPosition(position: Int) -> [String: Any] {
         var mutableDict = self
-        mutableDict["position"] = "\(position)"
+        mutableDict["position"] = position
         return mutableDict
     }
     

--- a/Wikipedia/Code/ArticleAsLivingDocFunnel.swift
+++ b/Wikipedia/Code/ArticleAsLivingDocFunnel.swift
@@ -17,7 +17,7 @@ fileprivate extension Dictionary where Key == String, Value == Any {
     
     func appendingTypes(types: [ArticleAsLivingDocFunnel.EventType]) -> [String: Any] {
         var mutableDict = self
-        let type = types.map { $0.rawValue }.joined(separator: ",")
+        let type = types.map { "'\($0.rawValue)'" }.joined(separator: ",")
         mutableDict["type"] = type
         return mutableDict
     }

--- a/Wikipedia/Code/ArticleAsLivingDocFunnel.swift
+++ b/Wikipedia/Code/ArticleAsLivingDocFunnel.swift
@@ -28,7 +28,7 @@ public final class ArticleAsLivingDocFunnel: EventLoggingFunnel, EventLoggingSta
     public static let shared = ArticleAsLivingDocFunnel()
     
     private override init() {
-        super.init(schema: "MobileWikiAppiOSLivingDoc", version: 20636844)
+        super.init(schema: "MobileWikiAppiOSLivingDoc", version: 20692447)
     }
     
     public enum ArticleContentInsertEventDescriptionType: Int {


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T262616

### Notes
* Position was failing because we were sending it as a string
* Also starting position counting at 0 to match how we log tapping on search results.
* Also added single quotes around the `type` value to help Shay parse on the back end.

WIP to fix issues with the `type` field. We need more info from Analytics side on the proper way to send this value.

### Test Steps
#### (copied from the original PR)
1. Fresh install app. In onboarding toggle on the sending of analytics data on the last page.
2. Perform various actions in the schema deck. You should see something like EventLoggingService: 0x60000337dd20 <x-coredata:///WMFEventRecord/t2B6FC470-29D4-46F2-B143-AE3D8F2D0B4A7> recorded! in the console with each event you trigger.
3. Watch the network via a proxy. You will see dumps every so often of events that start with https://meta.wikimedia.org/beacon/event....
4. Take that event url and decode it through a url decoder. You should see events with the schema value of MobileWikiAppiOSLivingDoc.
#### (new things to look for)
5. Thank someone, tap a View Changes button, View Discussion button, or Small Changes link, and inspect the post that goes out.
6. Confirm `position` is now sent as a 0-based integer (before it started at 1 and was wrapped in quotes).
7. Confirm `type` value has single quotes around each type, e.g. `"type":"'char_added','char_deleted'"`