### PR TITLE
Only display gallery images matching `showInGallery` flag.

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -3719,7 +3719,7 @@
 		8330531E23EF051900123141 /* NSArray+WMFMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+WMFMapping.h"; sourceTree = "<group>"; };
 		8330532123EF05D000123141 /* WMFBlocksKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WMFBlocksKit.swift; sourceTree = "<group>"; };
 		8330532823EF0B4200123141 /* ArticleViewController+Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleViewController+Media.swift"; sourceTree = "<group>"; usesTabs = 0; };
-		8330532D23EF107D00123141 /* MediaListGalleryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaListGalleryViewController.swift; sourceTree = "<group>"; };
+		8330532D23EF107D00123141 /* MediaListGalleryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaListGalleryViewController.swift; sourceTree = "<group>"; usesTabs = 0; };
 		8330533223F0388E00123141 /* DataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreTests.swift; sourceTree = "<group>"; };
 		8336F1422119BD6E000CDE02 /* MediaWikiAcceptLanguageMapping.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = MediaWikiAcceptLanguageMapping.json; sourceTree = "<group>"; };
 		8338AF8B21F7B33E000C4055 /* WMFLegacyFetcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WMFLegacyFetcher.h; sourceTree = "<group>"; };

--- a/Wikipedia/Code/MediaListGalleryViewController.swift
+++ b/Wikipedia/Code/MediaListGalleryViewController.swift
@@ -4,7 +4,7 @@ class MediaListGalleryViewController: WMFImageGalleryViewController {
     let articleURL: URL
     required init(articleURL: URL, mediaList: MediaList, dataStore: MWKDataStore, initialItem: MediaListItem?, theme: Theme, overlayViewTopBarHidden: Bool = false) {
         self.articleURL = articleURL
-		let photos = mediaList.items.filter { $0.showInGallery }.compactMap { MediaListItemNYTPhotoWrapper($0) }
+        let photos = mediaList.items.filter { $0.showInGallery }.compactMap { MediaListItemNYTPhotoWrapper($0) }
         let initialPhoto: WMFPhoto?
         if let initialItem = initialItem {
             initialPhoto = photos.first { $0.mediaListItem.title == initialItem.title }

--- a/Wikipedia/Code/MediaListGalleryViewController.swift
+++ b/Wikipedia/Code/MediaListGalleryViewController.swift
@@ -4,7 +4,7 @@ class MediaListGalleryViewController: WMFImageGalleryViewController {
     let articleURL: URL
     required init(articleURL: URL, mediaList: MediaList, dataStore: MWKDataStore, initialItem: MediaListItem?, theme: Theme, overlayViewTopBarHidden: Bool = false) {
         self.articleURL = articleURL
-        let photos = mediaList.items.compactMap { MediaListItemNYTPhotoWrapper($0) }
+		let photos = mediaList.items.filter { $0.showInGallery }.compactMap { MediaListItemNYTPhotoWrapper($0) }
         let initialPhoto: WMFPhoto?
         if let initialItem = initialItem {
             initialPhoto = photos.first { $0.mediaListItem.title == initialItem.title }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T269288

### Notes
Currently, the article gallery controller attempts to display all photos from the media list endpoint for an article, regardless of the value of the `showInGallery` flag from the API response. This leads to unexpected situations, like trying and failing to display media that shouldn't be displayed in the gallery.

### Test Steps

1. Open https://en.wikipedia.org/wiki/Basic_reproduction_number article
2. Tap the image in "Contact rate and infectious period" section
3. With the gallery open, swipe left or right to the next or previous images. Confirm you're not able to because there are no other images in the article.
