### PR TITLE
Remove extension method on NSLocale, replace with more recent API.

### DIFF
--- a/TopReadWidget/WMFTodayTopReadWidgetViewController.swift
+++ b/TopReadWidget/WMFTodayTopReadWidgetViewController.swift
@@ -161,7 +161,7 @@ class WMFTodayTopReadWidgetViewController: ExtensionViewController, NCWidgetProv
         var language: String? = nil
         let siteURL = dataStore.languageLinkController.appLanguage?.siteURL()
         if let languageCode = siteURL?.wmf_language {
-            language = (Locale.current as NSLocale).wmf_localizedLanguageNameForCode(languageCode)
+            language = Locale.current.localizedString(forLanguageCode: languageCode)
         }
         
         var headerText = ""

--- a/Wikipedia/Code/NSLocale+WMFExtras.swift
+++ b/Wikipedia/Code/NSLocale+WMFExtras.swift
@@ -107,16 +107,11 @@ extension NSLocale {
     }
     
     @objc public static func wmf_isCurrentLocaleEnglish() -> Bool {
-        guard let langCode = (NSLocale.current as NSLocale).object(forKey: NSLocale.Key.languageCode) as? String else {
+        guard let langCode = NSLocale.current.languageCode else {
             return false
         }
         return (langCode == "en" || langCode.hasPrefix("en-")) ? true : false;
     }
-
-    @objc public func wmf_localizedLanguageNameForCode(_ code: String) -> String? {
-        return (self as NSLocale).displayName(forKey: NSLocale.Key.languageCode, value: code)
-    }
-
     
     @objc public static func wmf_uniqueLanguageCodesForLanguages(_ languages: [String]) -> [String] {
         return Locale.uniqueWikipediaLanguages(with: languages)

--- a/Wikipedia/Code/TalkPageContainerViewController.swift
+++ b/Wikipedia/Code/TalkPageContainerViewController.swift
@@ -472,7 +472,7 @@ private extension TalkPageContainerViewController {
     func stringWithLocalizedCurrentSiteLanguageReplacingPlaceholderInString(string: String, fallbackGenericString: String) -> String {
         
         if let code = siteURL.wmf_language,
-            let language = (Locale.current as NSLocale).wmf_localizedLanguageNameForCode(code) {
+            let language = Locale.current.localizedString(forLanguageCode: code) {
             return NSString.localizedStringWithFormat(string as NSString, language) as String
         } else {
             return fallbackGenericString

--- a/Wikipedia/Code/WMFContentGroup+WMFFeedContentDisplaying.m
+++ b/Wikipedia/Code/WMFContentGroup+WMFFeedContentDisplaying.m
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)stringWithLocalizedCurrentSiteLanguageReplacingPlaceholderInString:(NSString *)string fallingBackOnGenericString:(NSString *)genericString {
     // fall back to language code if it can't be localized
-    NSString *language = [[NSLocale currentLocale] wmf_localizedLanguageNameForCode:self.siteURL.wmf_language];
+    NSString *language = [[NSLocale currentLocale] localizedStringForLanguageCode:self.siteURL.wmf_language];
 
     NSString *result = nil;
 
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
         case WMFContentGroupKindNews:
             return [self stringWithLocalizedCurrentSiteLanguageReplacingPlaceholderInString:WMFLocalizedStringWithDefaultValue(@"in-the-news-sub-title-from-language-wikipedia", nil, nil, @"From %1$@ Wikipedia", @"Subtext beneath the 'In the news' header when describing which specific Wikipedia. %1$@ will be replaced with the language - for example, 'From English Wikipedia'") fallingBackOnGenericString:WMFLocalizedStringWithDefaultValue(@"in-the-news-sub-title-from-wikipedia", nil, nil, @"From Wikipedia", @"Subtext beneath the 'In the news' header when the specific language wikipedia is unknown.")];
         case WMFContentGroupKindOnThisDay: {
-            NSString *language = [[NSLocale currentLocale] wmf_localizedLanguageNameForCode:self.siteURL.wmf_language];
+            NSString *language = [[NSLocale currentLocale] localizedStringForLanguageCode:self.siteURL.wmf_language];
             if (language) {
                 return
                     [NSString localizedStringWithFormat:WMFLocalizedStringWithDefaultValue(@"on-this-day-sub-title-for-date-from-language-wikipedia", nil, nil, @"%1$@ from %2$@ Wikipedia", @"Subtext beneath the 'On this day' header when describing the date and which specific Wikipedia. %1$@ will be substituted with the date. %2$@ will be replaced with the language - for example, 'June 8th from English Wikipedia'"), [[NSDateFormatter wmf_utcMonthNameDayOfMonthNumberDateFormatter] stringFromDate:self.midnightUTCDate], language];

--- a/Wikipedia/Code/WikipediaLookup.swift
+++ b/Wikipedia/Code/WikipediaLookup.swift
@@ -22,7 +22,7 @@ import CocoaLumberjackSwift
             if !wikipedia.languageCode.contains("-") {
                 // iOS will return less descriptive name for compound codes - ie "Chinese" for zh-yue which
                 // should be "Cantonese". It looks like iOS ignores anything after the "-".
-                if let iOSLocalizedName = (Locale.current as NSLocale).wmf_localizedLanguageNameForCode(wikipedia.languageCode) {
+                if let iOSLocalizedName = Locale.current.localizedString(forLanguageCode: wikipedia.languageCode) {
                     localizedName = iOSLocalizedName
                 }
             }


### PR DESCRIPTION
This is some pre-work / code cleanup as part of the Chinese variants feature https://phabricator.wikimedia.org/T195265 
It does not have a corresponding ticket.

### Notes
When the code was originally written, this API had just been introduced and so couldn't be used immediately.
This PR removes an extension method and simplifies the call sites where the extension was used.

### Test Steps
1. There should be no changes to the behavior to the app.