### PR TITLE
Some MWKLanguageLinkController cleanup

### DIFF
--- a/WMF Framework/WMFContentGroup+Extensions.m
+++ b/WMF Framework/WMFContentGroup+Extensions.m
@@ -7,7 +7,6 @@
 #import <WMF/NSDateFormatter+WMFExtensions.h>
 #import <WMF/WMFLogging.h>
 #import <WMF/NSCharacterSet+WMFLinkParsing.h>
-#import <WMF/MWKLanguageLinkController.h>
 #import <WMF/MWLanguageInfo.h>
 
 @implementation WMFContentGroup (Extensions)

--- a/Wikipedia/Code/MWKLanguageFilter.h
+++ b/Wikipedia/Code/MWKLanguageFilter.h
@@ -1,6 +1,5 @@
 @import Foundation;
 
-@class MWKLanguageLinkController;
 @class MWKLanguageLink;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Wikipedia/Code/MWKLanguageFilter.m
+++ b/Wikipedia/Code/MWKLanguageFilter.m
@@ -1,5 +1,4 @@
 #import <WMF/MWKLanguageFilter.h>
-#import <WMF/MWKLanguageLinkController.h>
 #import <WMF/MWKLanguageLink.h>
 #import <WMF/NSString+WMFExtras.h>
 #import <WMF/WMF-Swift.h>

--- a/Wikipedia/Code/MWKLanguageLinkController.h
+++ b/Wikipedia/Code/MWKLanguageLinkController.h
@@ -53,13 +53,6 @@ extern NSString *const WMFAppLanguageDidChangeNotification;
 @property (readonly, copy, nonatomic) NSArray<MWKLanguageLink *> *otherLanguages;
 
 /**
- *  Uniquely adds a new preferred language. The new language will be the first preferred language.
- *
- *  @param language the language to add
- */
-- (void)addPreferredLanguage:(MWKLanguageLink *)language;
-
-/**
  *  Uniquely appends a new preferred language. The new language will be the last preferred language.
  *
  *  @param language the language to append
@@ -81,11 +74,7 @@ extern NSString *const WMFAppLanguageDidChangeNotification;
  */
 - (void)removePreferredLanguage:(MWKLanguageLink *)language;
 
-- (BOOL)languageIsOSLanguage:(MWKLanguageLink *)language;
-
 - (nullable MWKLanguageLink *)languageForSiteURL:(NSURL *)siteURL;
-
-- (nullable MWKLanguageLink *)languageForLanguageCode:(NSString *)languageCode;
 
 + (void)migratePreferredLanguagesToManagedObjectContext:(NSManagedObjectContext *)moc;
 

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -49,12 +49,6 @@ static id _sharedInstance;
     }];
 }
 
-- (nullable MWKLanguageLink *)languageForLanguageCode:(NSString *)languageCode {
-    return [self.allLanguages wmf_match:^BOOL(MWKLanguageLink *obj) {
-        return [obj.languageCode isEqualToString:languageCode];
-    }];
-}
-
 - (nullable MWKLanguageLink *)appLanguage {
     return [self.preferredLanguages firstObject];
 }
@@ -187,14 +181,6 @@ static id _sharedInstance;
     }];
     [self didChangeValueForKey:WMF_SAFE_KEYPATH(self, allLanguages)];
     [[NSNotificationCenter defaultCenter] postNotificationName:WMFPreferredLanguagesDidChangeNotification object:self];
-}
-
-- (BOOL)languageIsOSLanguage:(MWKLanguageLink *)language {
-    NSArray *languageCodes = [self readOSPreferredLanguageCodes];
-    return [languageCodes wmf_match:^BOOL(NSString *obj) {
-               BOOL answer = [obj isEqualToString:language.languageCode];
-               return answer;
-           }] != nil;
 }
 
 - (void)getPreferredLanguageCodes:(void (^)(NSArray<NSString *> *))completion {

--- a/Wikipedia/Code/MWKLanguageLinkController_Private.h
+++ b/Wikipedia/Code/MWKLanguageLinkController_Private.h
@@ -28,6 +28,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)resetPreferredLanguages;
 
+/**
+ *  Uniquely adds a new preferred language. The new language will be the first preferred language.
+ *
+ *  @param language the language to add
+ */
+- (void)addPreferredLanguage:(MWKLanguageLink *)language;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFSettingsMenuItem.m
+++ b/Wikipedia/Code/WMFSettingsMenuItem.m
@@ -1,6 +1,5 @@
 #import "WMFSettingsMenuItem.h"
 #import "Wikipedia-Swift.h"
-#import <WMF/MWKLanguageLinkController.h>
 
 @interface WMFSettingsMenuItem ()
 


### PR DESCRIPTION
This is some pre-work / code cleanup as part of the Chinese variants feature https://phabricator.wikimedia.org/T195265
It does not have a corresponding ticket.

### Notes
- Remove unused imports and @class declarations of MWKLanguageLinkController
- Remove two unused method from MWKLanguageLinkController
- Move testing-only method declaration to MWKLanguageLinkController private header

### Test Steps
1. Builds after a clean, none of the removed imports or methods are required to build.
2. MWKLanguageLinkControllerTests pass after the changes.
