### PR TITLE
fix crash on picture of the day

### DIFF
--- a/Wikipedia/Code/MWKImageInfoFetcher+PicOfTheDayInfo.m
+++ b/Wikipedia/Code/MWKImageInfoFetcher+PicOfTheDayInfo.m
@@ -61,7 +61,11 @@ static MWKImageInfoResolve addPictureOfTheDayToDescriptionForDate(NSDate *date) 
                           metadataLanguage:metadataLanguage
                                    failure:failure
                                    success:^(id _Nonnull object) {
-                                       success(addPictureOfTheDayToDescriptionForDate(date)(selectFirstImageInfo(date)(object)));
+                                       if ([selectFirstImageInfo(date)(object) isKindOfClass:[NSError class]]) {
+                                           failure(selectFirstImageInfo(date)(object));
+                                       } else {
+                                           success(addPictureOfTheDayToDescriptionForDate(date)(selectFirstImageInfo(date)(object)));
+                                       }
                                    }];
 }
 

--- a/Wikipedia/Code/WMFImageGalleryViewController.m
+++ b/Wikipedia/Code/WMFImageGalleryViewController.m
@@ -467,7 +467,10 @@ NS_ASSUME_NONNULL_BEGIN
     [self.infoFetcher fetchPicOfTheDayGalleryInfoForDate:date
         metadataLanguage:[[NSLocale currentLocale] objectForKey:NSLocaleLanguageCode]
         failure:^(NSError *_Nonnull error) {
-            //show error
+            UIViewController *vcToPresentError = [self presentingViewController];
+            [self dismissViewControllerAnimated:true completion:^{
+                [vcToPresentError wmf_showAlertWithError:error];
+            }];
         }
         success:^(id _Nonnull info) {
             @strongify(self);


### PR DESCRIPTION
**Fixes Phabricator ticket:** N/A

### Notes
* There were two issues here: One, this wasn't triggering an error. Two, an error in this flow wasn't actually doing anything.

### Test Steps
1. Run app. Tap picture of the day. Ensure you get a nice error message, rather than a crash.

