### PR TITLE
MWKLanguageLinkController Refactoring

### DIFF
--- a/FeaturedArticleWidget/FeaturedArticleWidget.swift
+++ b/FeaturedArticleWidget/FeaturedArticleWidget.swift
@@ -87,7 +87,7 @@ class FeaturedArticleWidget: ExtensionViewController, NCWidgetProviding {
     func widgetPerformUpdate(completionHandler: @escaping (NCUpdateResult) -> Void) {
         WidgetController.shared.startWidgetUpdateTask(completionHandler) { (dataStore, completion) in
             let moc = dataStore.viewContext
-            let siteURL = dataStore.languageLinkController.appLanguage?.siteURL()
+            let siteURL = dataStore.primarySiteURL
             moc.perform {
                 guard let featuredContentGroup = moc.newestGroup(of: .featuredArticle, forSiteURL: siteURL),
                     let articleURL = featuredContentGroup.contentPreview as? URL else {

--- a/TopReadWidget/WMFTodayTopReadWidgetViewController.swift
+++ b/TopReadWidget/WMFTodayTopReadWidgetViewController.swift
@@ -159,7 +159,7 @@ class WMFTodayTopReadWidgetViewController: ExtensionViewController, NCWidgetProv
         }
         
         var language: String? = nil
-        let siteURL = dataStore.languageLinkController.appLanguage?.siteURL()
+        let siteURL = dataStore.primarySiteURL
         if let languageCode = siteURL?.wmf_language {
             language = Locale.current.localizedString(forLanguageCode: languageCode)
         }

--- a/WMF Framework/ReadingListsSyncOperation.swift
+++ b/WMF Framework/ReadingListsSyncOperation.swift
@@ -390,7 +390,7 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
                     
                     if !englishOnly {
                         if let randomLanguage = dataStore.languageLinkController.allLanguages.randomElement() {
-                            maybeSiteURL = randomLanguage.siteURL()
+                            maybeSiteURL = randomLanguage.siteURL
                         }
                     }
                     

--- a/WMF Framework/WidgetController.swift
+++ b/WMF Framework/WidgetController.swift
@@ -65,7 +65,7 @@ public final class WidgetController: NSObject {
     private func fetchCachedWidgetContentGroup(with kind: WMFContentGroupKind, isAnyLanguageAllowed: Bool, in dataStore: MWKDataStore, completion:  @escaping (WMFContentGroup?) -> Void) {
         assert(Thread.isMainThread, "Cached widget content group must be fetched from the main queue")
         let moc = dataStore.viewContext
-        let siteURL = isAnyLanguageAllowed ? dataStore.languageLinkController.appLanguage?.siteURL() : nil
+        let siteURL = isAnyLanguageAllowed ? dataStore.primarySiteURL : nil
         completion(moc.newestGroup(of: kind, forSiteURL: siteURL))
     }
     

--- a/Widgets/Widgets/OnThisDayWidget.swift
+++ b/Widgets/Widgets/OnThisDayWidget.swift
@@ -116,7 +116,7 @@ final class OnThisDayData {
         let articleSnippet = WMFLocalizedString("widget-onthisday-placeholder-article-snippet", language: language?.languageCode, value: "Free online encyclopedia that anyone can edit", comment: "Placeholder text for On This Day widget: Article description for an article about Wikipedia")
 
         // It seems that projects whose article is not titled "Wikipedia" (Arabic, for instance) all redirect this URL appropriately.
-        let articleURL = URL(string: ((language?.siteURL().absoluteString ?? "https://en.wikipedia.org") + "/wiki/Wikipedia"))
+        let articleURL = URL(string: ((language?.siteURL.absoluteString ?? "https://en.wikipedia.org") + "/wiki/Wikipedia"))
 
         let entry: OnThisDayEntry = OnThisDayEntry(isRTLLanguage: isRTL,
                                           error: nil,

--- a/Wikipedia/Code/AccountViewController.swift
+++ b/Wikipedia/Code/AccountViewController.swift
@@ -113,8 +113,7 @@ class AccountViewController: SubSettingsViewController {
             showLogoutAlert()
         case .talkPage:
             if let username = dataStore.authenticationManager.loggedInUsername,
-               let language = dataStore.languageLinkController.appLanguage {
-                let siteURL = language.siteURL()
+               let siteURL = dataStore.primarySiteURL {
                 let title = TalkPageType.user.titleWithCanonicalNamespacePrefix(title: username, siteURL: siteURL)
                 
                 let loadingFlowController = TalkPageContainerViewController.talkPageContainer(title: title, siteURL: siteURL,  type: .user, dataStore: dataStore, theme: theme)

--- a/Wikipedia/Code/ArticleViewController+ArticleInformation.swift
+++ b/Wikipedia/Code/ArticleViewController+ArticleInformation.swift
@@ -70,7 +70,7 @@ extension ArticleViewController {
 extension ArticleViewController: WMFLanguagesViewControllerDelegate {
     func languagesController(_ controller: WMFLanguagesViewController, didSelectLanguage language: MWKLanguageLink) {
         dismiss(animated: true) {
-            self.navigate(to: language.articleURL())
+            self.navigate(to: language.articleURL)
         }
     }
 }

--- a/Wikipedia/Code/BaseExploreFeedSettingsViewController.swift
+++ b/Wikipedia/Code/BaseExploreFeedSettingsViewController.swift
@@ -111,7 +111,7 @@ class ExploreFeedSettingsLanguage: ExploreFeedSettingsItem {
         title = languageLink.localizedName
         subtitle = languageLink.languageCode.uppercased()
         self.controlTag = controlTag
-        siteURL = languageLink.siteURL()
+        siteURL = languageLink.siteURL
         updateIsOn(for: displayType)
     }
 
@@ -334,7 +334,7 @@ fileprivate extension MWKLanguageLink {
      Returns false if there are no content sources in this language visible in the feed.
      */
     var isInFeed: Bool {
-        feedContentController.anyContentGroupsVisibleInTheFeed(forSiteURL: siteURL())
+        feedContentController.anyContentGroupsVisibleInTheFeed(forSiteURL: siteURL)
     }
     
     /**

--- a/Wikipedia/Code/EditLinkViewController.swift
+++ b/Wikipedia/Code/EditLinkViewController.swift
@@ -42,7 +42,7 @@ class EditLinkViewController: ViewController {
 
     init?(link: Link, siteURL: URL?, dataStore: MWKDataStore) {
         guard
-            let siteURL = siteURL ?? MWKDataStore.shared().languageLinkController.appLanguage?.siteURL() ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale(),
+            let siteURL = siteURL ?? MWKDataStore.shared().primarySiteURL ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale(),
             let articleURL = link.articleURL(for: siteURL)
         else {
             return nil

--- a/Wikipedia/Code/MWKDataStore.h
+++ b/Wikipedia/Code/MWKDataStore.h
@@ -89,6 +89,11 @@ typedef NS_OPTIONS(NSUInteger, RemoteConfigOption) {
 @property (nonatomic, strong, readonly) NSManagedObjectContext *viewContext;
 @property (nonatomic, strong, readonly) NSManagedObjectContext *feedImportContext;
 
+/**
+ * Returns the siteURL of the user's first preferred language.
+ */
+@property (readonly, copy, nonatomic, nullable) NSURL *primarySiteURL;
+
 #pragma mark - Caching
 
 @property (readonly, strong, nonatomic) MobileviewToMobileHTMLConverter *mobileviewConverter;

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -604,13 +604,17 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
     [self clearMemoryCache];
 }
 
-#pragma - Accessors
+#pragma mark - Accessors
 
 - (MWKRecentSearchList *)recentSearchList {
     if (!_recentSearchList) {
         _recentSearchList = [[MWKRecentSearchList alloc] initWithDataStore:self];
     }
     return _recentSearchList;
+}
+
+- (nullable NSURL*)primarySiteURL {
+    return self.languageLinkController.appLanguage.siteURL;
 }
 
 #pragma mark - History and Saved Page List
@@ -968,7 +972,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
 #pragma mark - WMFAuthenticationManagerDelegate
 
 - (nullable NSURL*)loginSiteURL {
-    return self.languageLinkController.appLanguage.siteURL;
+    return self.primarySiteURL;
 }
 
 - (void)authenticationManagerDidLogin {

--- a/Wikipedia/Code/MWKLanguageLink.h
+++ b/Wikipedia/Code/MWKLanguageLink.h
@@ -35,10 +35,10 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 
 /// @return A url with the default Wikipedia domain and the receiver's @c languageCode.
-- (NSURL *)siteURL;
+@property (readonly, copy, nonatomic, nonnull) NSURL *siteURL;
 
 /// @return A url whose domain & path are derived from the receiver's @c languageCode and @c pageTitleText.
-- (NSURL *)articleURL;
+@property (readonly, copy, nonatomic, nonnull) NSURL *articleURL;
 
 @end
 

--- a/Wikipedia/Code/MWKLanguageLinkController.h
+++ b/Wikipedia/Code/MWKLanguageLinkController.h
@@ -2,7 +2,6 @@
 #import <WMF/WMFPreferredLanguageCodesProviding.h>
 @class NSManagedObjectContext;
 @class MWKLanguageLink;
-@class MWKDataStore;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -18,8 +18,6 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
 
 @implementation MWKLanguageLinkController
 
-static id _sharedInstance;
-
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)moc {
     if (self = [super init]) {
         self.moc = moc;
@@ -121,7 +119,7 @@ static id _sharedInstance;
 #pragma mark - Reading/Saving Preferred Language Codes
 
 - (NSArray<NSString *>
-   *)readPreferredLanguageCodesWithoutOSPreferredLanguages {
+   *)readSavedPreferredLanguageCodes {
     __block NSArray<NSString *> *preferredLanguages = nil;
     [self.moc performBlockAndWait:^{
         preferredLanguages = [self.moc wmf_arrayValueForKey:WMFPreviousLanguagesKey] ?: @[];
@@ -129,20 +127,11 @@ static id _sharedInstance;
     return preferredLanguages;
 }
 
-- (NSArray<NSString *> *)readOSPreferredLanguageCodes {
-    NSArray<NSString *> *osLanguages = [[NSLocale preferredLanguages] wmf_mapAndRejectNil:^NSString *(NSString *languageCode) {
-        NSLocale *locale = [NSLocale localeWithLocaleIdentifier:languageCode];
-        // use language code when determining if a langauge is preferred (e.g. "en_US" is preferred if "en" was selected)
-        return [locale objectForKey:NSLocaleLanguageCode];
-    }];
-    return osLanguages;
-}
-
 - (NSArray<NSString *> *)readPreferredLanguageCodes {
-    NSMutableArray<NSString *> *preferredLanguages = [[self readPreferredLanguageCodesWithoutOSPreferredLanguages] mutableCopy];
-    NSArray<NSString *> *osLanguages = [self readOSPreferredLanguageCodes];
+    NSMutableArray<NSString *> *preferredLanguages = [[self readSavedPreferredLanguageCodes] mutableCopy];
 
     if (preferredLanguages.count == 0) {
+        NSArray<NSString *> *osLanguages = NSLocale.wmf_preferredLocaleLanguageCodes;
         [osLanguages enumerateObjectsWithOptions:0
                                       usingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
                                           if (![preferredLanguages containsObject:obj]) {

--- a/Wikipedia/Code/MWKLanguageLinkController_Private.h
+++ b/Wikipedia/Code/MWKLanguageLinkController_Private.h
@@ -6,12 +6,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Reads previously selected languages from storage.
- * @return The preferred languages, or an empty array of none were previously added to the preferred list.
+ * @return The preferred languages, or an empty array if none were previously added to the preferred list.
  */
-- (NSArray<NSString *> *)readPreferredLanguageCodesWithoutOSPreferredLanguages;
+- (NSArray<NSString *> *)readSavedPreferredLanguageCodes;
 
 /**
- * The same as above, but adds OS preferred languages if they are not in the array
+ * The same as above, but adds OS preferred languages if the saved array is empty
  * @return The preferred languages.
  */
 - (NSArray<NSString *> *)readPreferredLanguageCodes;

--- a/Wikipedia/Code/NSLocale+WMFExtras.swift
+++ b/Wikipedia/Code/NSLocale+WMFExtras.swift
@@ -142,4 +142,9 @@ extension NSLocale {
     @objc public static let wmf_preferredLanguageCodes: [String] =
         Locale.uniqueWikipediaLanguages(with: preferredLanguages)
     
+    @objc public static var wmf_preferredLocaleLanguageCodes: [String] {
+        // use language code when determining if a langauge is preferred (e.g. "en_US" is preferred if "en" was selected)
+        preferredLanguages.compactMap { NSLocale(localeIdentifier: $0).languageCode }
+    }
+    
 }

--- a/Wikipedia/Code/PlacesViewController.swift
+++ b/Wikipedia/Code/PlacesViewController.swift
@@ -44,7 +44,7 @@ class PlacesViewController: ViewController, UISearchBarDelegate, ArticlePopoverV
     fileprivate var searchSuggestionController: PlaceSearchSuggestionController!
 
     fileprivate var siteURL: URL {
-        return MWKDataStore.shared().languageLinkController.appLanguage?.siteURL() ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale()!
+        return MWKDataStore.shared().primarySiteURL ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale()!
     }
     
     fileprivate var currentGroupingPrecision: QuadKeyPrecision = 1

--- a/Wikipedia/Code/SearchLanguagesBarViewController.swift
+++ b/Wikipedia/Code/SearchLanguagesBarViewController.swift
@@ -47,7 +47,7 @@ class SearchLanguagesBarViewController: UIViewController, WMFPreferredLanguagesV
             }
         }
         set {
-            UserDefaults.standard.wmf_setCurrentSearchLanguageDomain(newValue?.siteURL())
+            UserDefaults.standard.wmf_setCurrentSearchLanguageDomain(newValue?.siteURL)
             delegate?.searchLanguagesBarViewController(self, didChangeCurrentlySelectedSearchLanguage: newValue!)
             updateLanguageBarLanguageButtons()
         }

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -103,7 +103,7 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
 
     var siteURL: URL? {
         get {
-            return _siteURL ?? searchLanguageBarViewController?.currentlySelectedSearchLanguage?.siteURL() ?? MWKDataStore.shared().languageLinkController.appLanguage?.siteURL() ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale()
+            return _siteURL ?? searchLanguageBarViewController?.currentlySelectedSearchLanguage?.siteURL ?? MWKDataStore.shared().primarySiteURL ?? NSURL.wmf_URLWithDefaultSiteAndCurrentLocale()
         }
         set {
             _siteURL = newValue

--- a/Wikipedia/Code/TalkPageContainerViewController.swift
+++ b/Wikipedia/Code/TalkPageContainerViewController.swift
@@ -758,7 +758,7 @@ extension TalkPageContainerViewController: EmptyViewControllerDelegate {
 
 extension TalkPageContainerViewController: WMFPreferredLanguagesViewControllerDelegate {
     func languagesController(_ controller: WMFLanguagesViewController, didSelectLanguage language: MWKLanguageLink) {
-        let newSiteURL = language.siteURL()
+        let newSiteURL = language.siteURL
         if siteURL != newSiteURL {
                 siteURL = newSiteURL
                 changeLanguage(siteURL: siteURL)

--- a/Wikipedia/Code/ViewControllerRouter.swift
+++ b/Wikipedia/Code/ViewControllerRouter.swift
@@ -91,7 +91,7 @@ class ViewControllerRouter: NSObject {
             return presentOrPush(talkPageVC, with: completion)
         case .onThisDay(let indexOfSelectedEvent):
             let dataStore = appViewController.dataStore
-            guard let contentGroup = dataStore.viewContext.newestVisibleGroup(of: .onThisDay, forSiteURL: dataStore.languageLinkController.appLanguage?.siteURL()), let onThisDayVC = contentGroup.detailViewControllerWithDataStore(dataStore, theme: theme) as? OnThisDayViewController else {
+            guard let contentGroup = dataStore.viewContext.newestVisibleGroup(of: .onThisDay, forSiteURL: dataStore.primarySiteURL), let onThisDayVC = contentGroup.detailViewControllerWithDataStore(dataStore, theme: theme) as? OnThisDayViewController else {
                 completion()
                 return false
             }

--- a/Wikipedia/Code/WMFAccountCreationViewController.swift
+++ b/Wikipedia/Code/WMFAccountCreationViewController.swift
@@ -114,7 +114,7 @@ class WMFAccountCreationViewController: WMFScrollViewController, WMFCaptchaViewC
     
     fileprivate func getCaptcha() {
         let failure: WMFErrorHandler = {error in }
-        let siteURL = dataStore.languageLinkController.appLanguage?.siteURL()
+        let siteURL = dataStore.primarySiteURL
         accountCreationInfoFetcher.fetchAccountCreationInfoForSiteURL(siteURL!, success: { info in
             DispatchQueue.main.async {
                 self.captchaViewController?.captcha = info.captcha
@@ -207,7 +207,7 @@ class WMFAccountCreationViewController: WMFScrollViewController, WMFCaptchaViewC
     }
     
     public func captchaSiteURL() -> URL {
-        return (dataStore.languageLinkController.appLanguage?.siteURL())!
+        return (dataStore.primarySiteURL)!
     }
     
     public func captchaHideSubtitle() -> Bool {
@@ -325,7 +325,7 @@ class WMFAccountCreationViewController: WMFScrollViewController, WMFCaptchaViewC
         }
         
         self.setViewControllerUserInteraction(enabled: false)
-        let siteURL = dataStore.languageLinkController.appLanguage?.siteURL()
+        let siteURL = dataStore.primarySiteURL
         accountCreator.createAccount(username: usernameField.text!, password: passwordField.text!, retypePassword: passwordRepeatField.text!, email: emailField.text!, captchaID: captchaViewController?.captcha?.captchaID, captchaWord: captchaViewController?.solution, siteURL: siteURL!, success: {_ in
             DispatchQueue.main.async {
                 self.login()

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -264,7 +264,7 @@ static const NSString *kvo_SavedArticlesFetcher_progress = @"kvo_SavedArticlesFe
 }
 
 - (NSURL *)siteURL {
-    return [[self.dataStore.languageLinkController appLanguage] siteURL];
+    return self.dataStore.primarySiteURL;
 }
 
 #pragma mark - Setup

--- a/Wikipedia/Code/WMFForgotPasswordViewController.swift
+++ b/Wikipedia/Code/WMFForgotPasswordViewController.swift
@@ -89,7 +89,7 @@ class WMFForgotPasswordViewController: WMFScrollViewController, Themeable {
     }
     
     func sendPasswordResetEmail(userName: String?, email: String?) {
-        guard let siteURL = MWKDataStore.shared().languageLinkController.appLanguage?.siteURL() else {
+        guard let siteURL = MWKDataStore.shared().primarySiteURL else {
             WMFAlertManager.sharedInstance.showAlert("No site url", sticky: true, dismissPreviousAlerts: true, tapCallBack: nil)
             return
         }

--- a/Wikipedia/Code/WMFLoginViewController.swift
+++ b/Wikipedia/Code/WMFLoginViewController.swift
@@ -292,7 +292,7 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
                 self.funnel?.logError(error.localizedDescription)
             }
         }
-        let siteURL = dataStore.languageLinkController.appLanguage?.siteURL()
+        let siteURL = dataStore.primarySiteURL
         loginInfoFetcher.fetchLoginInfoForSiteURL(siteURL!, success: { info in
             DispatchQueue.main.async {
                 self.captchaViewController?.captcha = info.captcha
@@ -311,7 +311,7 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
     }
     
     public func captchaSiteURL() -> URL {
-        return (dataStore.languageLinkController.appLanguage?.siteURL())!
+        return (dataStore.primarySiteURL)!
     }
     
     func captchaKeyboardReturnKeyTapped() {

--- a/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
+++ b/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
@@ -30,9 +30,9 @@
     [self.controller resetPreferredLanguages];
 }
 
-//- (void)testReadPreviouslySelectedLanguagesReturnsEmpty {
-//    assertThat([self.controller readPreferredLanguageCodesWithoutOSPreferredLanguages], hasCountOf(0));
-//}
+- (void)testReadPreviouslySelectedLanguagesReturnsEmpty {
+    XCTAssertEqual([[self.controller readSavedPreferredLanguageCodes] count], 0);
+}
 
 - (void)testDefaultsToDevicePreferredLanguages {
     /*


### PR DESCRIPTION
This is some pre-work / code cleanup as part of the Chinese variants feature https://phabricator.wikimedia.org/T195265
It does not have a corresponding ticket.

### Notes
#### • Add `primarySiteURL` convenience property to MWKDataStore and update call sites

The path `dataStore.lanaguageLinkController.appLanguage?.siteURL` is used throughout the app. This change makes each call site `dataStore.primarySiteURL` which is much more concise and better indicates what is happening. It also begins to clarify the many API with 'siteURL' in the name. Note that MWKDataStore already has a `loginSiteURL` property that returns this same information, so it seemed reasonable to add the property and make the call sites more clear.
 
#### • Make MWKLanguageLink siteURL and articleURL true Obj-C properties and update call sites

Just a small cleanup where the call sites look very weird in Swift since they come across as functions.


#### • Move NSLocale processing method to NSLocale extension

The goal is to consolidate methods that only depend on NSLocale in the NSLocale extension  

#### • Remove unused class declaration and static shared instance variable from MWKLanguageLinkController

#### • Rename readPreferredLanguageCodesWithoutOSPreferredLanguages
Moving the locale manipulation method to an NSLocale extension made the with/without naming distinction less useful. The shorter name `-readSavedPreferredLanguageCodes` still conveys that this reads only the saved value.

#### • In -readPreferredLanguageCodes only read NSLocale language codes when needed

### Test Steps
1. No changes in app behavior.
2. All test pass.