### PR TITLE
Fix announcement modal bugs

### DIFF
--- a/WMF Framework/WMFContentGroup+Extensions.h
+++ b/WMF Framework/WMFContentGroup+Extensions.h
@@ -126,6 +126,8 @@ typedef NS_ENUM(int16_t, WMFContentGroupUndoType) {
 
 - (nullable NSArray<WMFContentGroup *> *)groupsOfKind:(WMFContentGroupKind)kind forDate:(NSDate *)date;
 
+- (nullable NSArray<WMFContentGroup *> *)orderedGroupsOfKind:(WMFContentGroupKind)kind withPredicate:(nonnull NSPredicate *)predicate;
+
 - (nullable WMFContentGroup *)locationContentGroupWithSiteURL:(nullable NSURL *)siteURL withinMeters:(CLLocationDistance)meters ofLocation:(CLLocation *)location;
 
 @end

--- a/WMF Framework/WMFContentGroup+Extensions.h
+++ b/WMF Framework/WMFContentGroup+Extensions.h
@@ -126,7 +126,7 @@ typedef NS_ENUM(int16_t, WMFContentGroupUndoType) {
 
 - (nullable NSArray<WMFContentGroup *> *)groupsOfKind:(WMFContentGroupKind)kind forDate:(NSDate *)date;
 
-- (nullable NSArray<WMFContentGroup *> *)orderedGroupsOfKind:(WMFContentGroupKind)kind withPredicate:(nonnull NSPredicate *)predicate;
+- (nullable NSArray<WMFContentGroup *> *)orderedGroupsOfKind:(WMFContentGroupKind)kind withPredicate:(nullable NSPredicate *)predicate;
 
 - (nullable WMFContentGroup *)locationContentGroupWithSiteURL:(nullable NSURL *)siteURL withinMeters:(CLLocationDistance)meters ofLocation:(CLLocation *)location;
 

--- a/WMF Framework/WMFContentGroup+Extensions.m
+++ b/WMF Framework/WMFContentGroup+Extensions.m
@@ -731,11 +731,16 @@
     return [contentGroups firstObject];
 }
 
-- (nullable NSArray<WMFContentGroup *> *)orderedGroupsOfKind:(WMFContentGroupKind)kind withPredicate:(nonnull NSPredicate *)predicate {
+- (nullable NSArray<WMFContentGroup *> *)orderedGroupsOfKind:(WMFContentGroupKind)kind withPredicate:(nullable NSPredicate *)predicate {
     NSPredicate *basePredicate = [NSPredicate predicateWithFormat:@"contentGroupKindInteger == %@", @(kind)];
-    NSCompoundPredicate *compoundPredicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[basePredicate, predicate]];
+    NSPredicate *finalPredicate= basePredicate;
+    if (predicate) {
+        NSCompoundPredicate *compoundPredicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[basePredicate, predicate]];
+        finalPredicate = compoundPredicate;
+    }
+    
     NSArray<NSSortDescriptor *> *sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"midnightUTCDate" ascending:NO], [NSSortDescriptor sortDescriptorWithKey:@"dailySortPriority" ascending:YES], [NSSortDescriptor sortDescriptorWithKey:@"date" ascending:NO]];
-    return [self groupsWithPredicate:compoundPredicate sortDescriptors:sortDescriptors];
+    return [self groupsWithPredicate:finalPredicate sortDescriptors:sortDescriptors];
 }
 
 - (nullable NSArray<WMFContentGroup *> *)groupsOfKind:(WMFContentGroupKind)kind forDate:(NSDate *)date {

--- a/WMF Framework/WMFContentGroup+Extensions.m
+++ b/WMF Framework/WMFContentGroup+Extensions.m
@@ -733,7 +733,7 @@
 
 - (nullable NSArray<WMFContentGroup *> *)orderedGroupsOfKind:(WMFContentGroupKind)kind withPredicate:(nullable NSPredicate *)predicate {
     NSPredicate *basePredicate = [NSPredicate predicateWithFormat:@"contentGroupKindInteger == %@", @(kind)];
-    NSPredicate *finalPredicate= basePredicate;
+    NSPredicate *finalPredicate = basePredicate;
     if (predicate) {
         NSCompoundPredicate *compoundPredicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[basePredicate, predicate]];
         finalPredicate = compoundPredicate;

--- a/WMF Framework/WMFContentGroup+Extensions.m
+++ b/WMF Framework/WMFContentGroup+Extensions.m
@@ -731,9 +731,24 @@
     return [contentGroups firstObject];
 }
 
+- (nullable NSArray<WMFContentGroup *> *)orderedGroupsOfKind:(WMFContentGroupKind)kind withPredicate:(nonnull NSPredicate *)predicate {
+    NSPredicate *basePredicate = [NSPredicate predicateWithFormat:@"contentGroupKindInteger == %@", @(kind)];
+    NSCompoundPredicate *compoundPredicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[basePredicate, predicate]];
+    NSArray<NSSortDescriptor *> *sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"midnightUTCDate" ascending:NO], [NSSortDescriptor sortDescriptorWithKey:@"dailySortPriority" ascending:YES], [NSSortDescriptor sortDescriptorWithKey:@"date" ascending:NO]];
+    return [self groupsWithPredicate:compoundPredicate sortDescriptors:sortDescriptors];
+}
+
 - (nullable NSArray<WMFContentGroup *> *)groupsOfKind:(WMFContentGroupKind)kind forDate:(NSDate *)date {
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"contentGroupKindInteger == %@ && midnightUTCDate == %@", @(kind), date.wmf_midnightUTCDateFromLocalDate];
+    return [self groupsWithPredicate:predicate sortDescriptors:nil];
+}
+
+- (nullable NSArray<WMFContentGroup *> *)groupsWithPredicate: (nonnull NSPredicate *)predicate sortDescriptors: (nullable  NSArray<NSSortDescriptor *> *)sortDescriptors {
     NSFetchRequest *fetchRequest = [WMFContentGroup fetchRequest];
-    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"contentGroupKindInteger == %@ && midnightUTCDate == %@", @(kind), date.wmf_midnightUTCDateFromLocalDate];
+    fetchRequest.predicate = predicate;
+    if (sortDescriptors) {
+        fetchRequest.sortDescriptors = sortDescriptors;
+    }
     NSError *fetchError = nil;
     NSArray *contentGroups = [self executeFetchRequest:fetchRequest error:&fetchError];
     if (fetchError) {

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -9,20 +9,19 @@ extension ArticleViewController {
         }
         let predicate = NSPredicate(format: "placement == 'article' && isVisible == YES")
         let contentGroups = dataStore.viewContext.orderedGroups(of: .announcement, with: predicate)
+        let currentDate = Date()
         
         //get the first content group with a valid date
         let contentGroup = contentGroups?.first(where: { (group) -> Bool in
-            let currentDate = Date()
             guard group.contentType == .announcement,
                   let announcement = group.contentPreview as? WMFAnnouncement,
                   let startDate = announcement.startTime,
-                  let endDate = announcement.endTime,
-                  (startDate...endDate).contains(currentDate)
+                  let endDate = announcement.endTime
                   else {
                 return false
             }
             
-            return true
+            return (startDate...endDate).contains(currentDate)
         })
         
         guard

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -4,22 +4,35 @@ import CocoaLumberjackSwift
 extension ArticleViewController {
     
     func showAnnouncementIfNeeded() {
-        guard UserDefaults.standard.shouldCheckForArticleAnnouncements,
-              ((isInValidSurveyCampaignAndArticleList && userHasSeenSurveyPrompt) || !isInValidSurveyCampaignAndArticleList) else {
+        guard ((isInValidSurveyCampaignAndArticleList && userHasSeenSurveyPrompt) || !isInValidSurveyCampaignAndArticleList) else {
             return
         }
-        let predicate = NSPredicate(format: "placement == 'article'")
-        let contentGroup = dataStore.viewContext.newestVisibleGroup(of: .announcement, with: predicate)
+        let predicate = NSPredicate(format: "placement == 'article' && isVisible == YES")
+        let contentGroups = dataStore.viewContext.orderedGroups(of: .announcement, with: predicate)
+        
+        //get the first content group with a valid date
+        let contentGroup = contentGroups?.first(where: { (group) -> Bool in
+            let currentDate = Date()
+            guard group.contentType == .announcement,
+                  let announcement = group.contentPreview as? WMFAnnouncement,
+                  let startDate = announcement.startTime,
+                  let endDate = announcement.endTime,
+                  (startDate...endDate).contains(currentDate)
+                  else {
+                return false
+            }
+            
+            return true
+        })
+        
         guard
             let contentGroupURL = contentGroup?.url,
             let announcement = contentGroup?.contentPreview as? WMFAnnouncement,
             let actionURL = announcement.actionURL
         else {
-            UserDefaults.standard.shouldCheckForArticleAnnouncements = false
             return
         }
         let dismiss = {
-            UserDefaults.standard.shouldCheckForArticleAnnouncements = false
             // re-fetch since time has elapsed
             let contentGroup = self.dataStore.viewContext.contentGroup(for: contentGroupURL)
             contentGroup?.markDismissed()

--- a/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
+++ b/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
@@ -40,7 +40,6 @@ let WMFSearchLanguageKey = "WMFSearchLanguageKey"
         static let didShowDescriptionPublishedPanel = "WMFDidShowDescriptionPublishedPanel"
         static let didShowEditingOnboarding = "WMFDidShowEditingOnboarding"
         static let autoSignTalkPageDiscussions = "WMFAutoSignTalkPageDiscussions"
-        static let shouldCheckForArticleAnnouncements = "WMFShouldCheckForArticleAnnouncements"
     }
 
     @objc func wmf_dateForKey(_ key: String) -> Date? {
@@ -448,15 +447,6 @@ let WMFSearchLanguageKey = "WMFSearchLanguageKey"
         }
         set {
             set(newValue, forKey: UserDefaults.Key.autoSignTalkPageDiscussions)
-        }
-    }
-
-    @objc var shouldCheckForArticleAnnouncements: Bool {
-        get {
-            return bool(forKey: UserDefaults.Key.shouldCheckForArticleAnnouncements)
-        }
-        set {
-            set(newValue, forKey: UserDefaults.Key.shouldCheckForArticleAnnouncements)
         }
     }
 #if UI_TEST

--- a/Wikipedia/Code/Session.swift
+++ b/Wikipedia/Code/Session.swift
@@ -546,6 +546,7 @@ public class Session: NSObject {
         var getRequest = request(with: url, method: .get)
         if ignoreCache {
             getRequest.cachePolicy = .reloadIgnoringLocalCacheData
+            getRequest.prefersPersistentCacheOverError = false
         }
         let task = jsonDictionaryTask(with: getRequest, completionHandler: completionHandler)
         task.resume()

--- a/Wikipedia/Code/WMFAnnouncementsContentSource.m
+++ b/Wikipedia/Code/WMFAnnouncementsContentSource.m
@@ -84,9 +84,6 @@
                                                     group.placement = obj.placement;
                                                 }];
             [group updateVisibilityForUserIsLoggedIn:isLoggedIn];
-            if (group.isVisible && [group.placement isEqualToString:@"article"]) {
-                NSUserDefaults.standardUserDefaults.shouldCheckForArticleAnnouncements = YES;
-            }
         }];
 
         [[WMFSurveyAnnouncementsController shared] setAnnouncements:announcements forSiteURL:self.siteURL dataStore:self.userDataStore];

--- a/Wikipedia/Code/WMFDatabaseHouseKeeper.swift
+++ b/Wikipedia/Code/WMFDatabaseHouseKeeper.swift
@@ -14,11 +14,11 @@ import Foundation
     }
     
     private func deleteStaleAnnouncements(_ moc: NSManagedObjectContext) throws {
-        guard let hiddenAnnouncementContentGroups = moc.orderedGroups(of: .announcement, with: nil) else {
+        guard let announcementContentGroups = moc.orderedGroups(of: .announcement, with: nil) else {
             return
         }
         let currentDate = Date()
-        for announcementGroup in hiddenAnnouncementContentGroups {
+        for announcementGroup in announcementContentGroups {
             guard let announcement = announcementGroup.contentPreview as? WMFAnnouncement,
                   let endDate = announcement.endTime,
                   currentDate > endDate else {

--- a/Wikipedia/Code/WMFDatabaseHouseKeeper.swift
+++ b/Wikipedia/Code/WMFDatabaseHouseKeeper.swift
@@ -14,8 +14,7 @@ import Foundation
     }
     
     private func deleteStaleAnnouncements(_ moc: NSManagedObjectContext) throws {
-        let predicate = NSPredicate(format: "isVisible == NO")
-        guard let hiddenAnnouncementContentGroups = moc.orderedGroups(of: .announcement, with: predicate) else {
+        guard let hiddenAnnouncementContentGroups = moc.orderedGroups(of: .announcement, with: nil) else {
             return
         }
         let currentDate = Date()


### PR DESCRIPTION
**Fixes Phabricator ticket:** 
Fundraising bug: https://phabricator.wikimedia.org/T242347
Investigation spike (see comments for notes): https://phabricator.wikimedia.org/T247976

### Notes
This PR fixes a few things that stood out as odd to me and could be the reason our announcements (both survey and fundraising) are still displaying on the article view.
1. As discussed in engineering sync, I simplified the logic in `ArticleViewController+Announcements.swift`. Now instead of relying solely on the content group's `isVisible` flag and UserDefault's `shouldCheckForArticleAnnouncements` flag being properly set, we are pulling all visible announcement content groups and checking the end time immediately before displaying. I suspect there was some sort of race condition where this code is being hit **before** the `isVisible` and `shouldCheckForArticleAnnouncements` flags are set from `WMFAnnouncementContentSource.m`. I could repro a fundraising banner displaying after the end time upon deep linking to an article, which supports that theory.
2. I noticed in offline mode, the fetcher would still return a cached announcements response from the last time it fetched announcements. This despite the fact that we are asking session to [ignoreCache](https://github.com/wikimedia/wikipedia-ios/blob/fe864305e128ceadb67da94fc37f2122d91eac91/WMF%20Framework/WMFAnnouncementsFetcher.m#L21. Digging in it looks like some of our caching code added from the mobile-html release in Session.swift takes over, so I have added a `prefersPersistentCacheOverError = false` to fix this. This could be one possible explanation for why the survey announcement is still being displayed despite us purposefully not saving to the database and checking against the end date before presentation.
3. I also noticed, after a `WMFContentGroup` announcement's end date is reached and it's visiblity flag is flipped, it still hangs around in the database. It's probably harmless since all of our presentation logic now checks for isVisible and the proper end date, but I still see no reason to keep these old announcements in the database past the end date. I added a housekeeper task to clean these out, which is triggered when the user backgrounds the app.

### Test Steps

#### Test fundraising modal
1. Map locally via proxy some announcements response with fundraising that ends sometime in the near future.
2. Terminate from simulator/device and launch a 2nd time to confirm announcements are fetched.
3. Terminate, stop mapping locally, change simulator/device date to a date after the announcement end date. 
4. Relaunch the app via an article deeplink (one not in the survey campaign, like https://en.wikipedia.org/wiki/Cat). Fundraising modal should not show on article user deep linked to. In `main` it does.

#### Test survey modal
1. Map locally via proxy some announcements with a survey that ends on sometime in the near future. 
2. Upon first launch, save an article in the campaign list. 
3. Terminate from simulator/device and launch a 2nd time to confirm announcements are fetched.
4. Terminate, stop mapping locally, and enter offline mode on device. Launch again and go to your saved article.
5. Survey modal should not show after `displayDelay` seconds from announcement. In `main` it does.

#### Do some light regression testing to confirm dismissal flags are remembered
1. Have locally mapped announcements that end in the near future, both fundraising and survey.
2. Go to 2nd launch so that announcements are fetched.
3. Go to article in campaign list, confirm you see survey modal after `displayDelay` seconds.
4. Dismiss modal, leave the article and terminate. Relaunch and return to the article. You should now see the fundraising modal. Dismiss modal, leave article and terminate. Relaunch and return to the article, you should now see no modals.

#### Inspect SQLLite db to confirm housekeeping works
1. Map locally via proxy some announcements response with fundraising that ends sometime in the near future.
2. After 2nd launch and announcements are fetched, inspect db. Note you see an announcement type `ZWMFCCONTENTGROUP` (you'll see "announcement" as a part of the ZKEY field) with ZISVISIBLE = 1.
3. Background, check db again. Confirm it's unchanged (announcement content group still there, zisvisible still there.
4. Change device/simulator date to after the announcement end date and relaunch. Check the db again. Confirm ZISVISIBLE now equals 0. Background the app. Check db. Confirm announcement content group row is now gone (cleaned out by housekeeper).