### PR TITLE
URL creation method language variant propagation

### DIFF
--- a/WMF Framework/Configuration.swift
+++ b/WMF Framework/Configuration.swift
@@ -174,10 +174,11 @@ public class Configuration: NSObject {
     
     /// The Page Content Service includes mobile-html and the associated endpoints. It can be run locally with this repository: https://gerrit.wikimedia.org/r/admin/projects/mediawiki/services/mobileapps
     /// On production, it is run through RESTBase at  https://en.wikipedia.org/api/rest_v1/ (works for all language wikis)
-    @objc(pageContentServiceAPIURLComponentsForHost:appendingPathComponents:)
-    public func pageContentServiceAPIURLComponentsForHost(_ host: String? = nil, appending pathComponents: [String] = [""]) -> URLComponents {
-        let builder = pageContentServiceAPIURLComponentsBuilderForHost(host)
-        return builder.components(byAppending: pathComponents)
+    @objc(pageContentServiceAPIURLForURL:appendingPathComponents:)
+    public func pageContentServiceAPIURLForURL(_ url: URL? = nil, appending pathComponents: [String] = [""]) -> URL? {
+        let builder = pageContentServiceAPIURLComponentsBuilderForHost(url?.host)
+        let components = builder.components(byAppending: pathComponents)
+        return components.wmf_URLWithLanguageVariantCode(url?.wmf_languageVariantCode)
     }
     
     /// Returns the default request headers for Page Content Service API requests

--- a/WMF Framework/Configuration.swift
+++ b/WMF Framework/Configuration.swift
@@ -206,10 +206,11 @@ public class Configuration: NSObject {
     
     /// Wikifeeds includes feed content and announcements. It can be run locally with this repository: https://gerrit.wikimedia.org/r/admin/projects/mediawiki/services/wikifeeds
     /// On production, it is run through RESTBase at  https://en.wikipedia.org/api/rest_v1/ (works for all language wikis)
-    @objc(wikiFeedsAPIURLComponentsForHost:appendingPathComponents:)
-    public func wikiFeedsAPIURLComponentsForHost(_ host: String? = nil, appending pathComponents: [String] = [""]) -> URLComponents {
-        let builder = wikiFeedsAPIURLComponentsBuilderForHost(host)
-        return builder.components(byAppending: pathComponents)
+    @objc(wikiFeedsAPIURLForURL:appendingPathComponents:)
+    public func wikiFeedsAPIURLForURL(_ url: URL?, appending pathComponents: [String] = [""]) -> URL? {
+        let builder = wikiFeedsAPIURLComponentsBuilderForHost(url?.host)
+        let components = builder.components(byAppending: pathComponents)
+        return components.wmf_URLWithLanguageVariantCode(url?.wmf_languageVariantCode)
     }
     
     public func mediaWikiAPIURForHost(_ host: String? = nil, appending pathComponents: [String] = [""]) -> URLComponents {

--- a/WMF Framework/Configuration.swift
+++ b/WMF Framework/Configuration.swift
@@ -227,9 +227,10 @@ public class Configuration: NSObject {
         return builder.components(queryParameters: queryParameters)
     }
 
-    public func mediaWikiRestAPIURLForHost(_ host: String? = nil, appending pathComponents: [String] = [""], queryParameters: [String: Any]? = nil) -> URLComponents {
-        let builder = mediaWikiRestAPIURLComponentsBuilderForHost(host)
-        return builder.components(byAppending: pathComponents, queryParameters: queryParameters)
+    public func mediaWikiRestAPIURLForURL(_ url: URL? = nil, appending pathComponents: [String] = [""], queryParameters: [String: Any]? = nil) -> URL? {
+        let builder = mediaWikiRestAPIURLComponentsBuilderForHost(url?.host)
+        let components = builder.components(byAppending: pathComponents, queryParameters: queryParameters)
+        return components.wmf_URLWithLanguageVariantCode(url?.wmf_languageVariantCode)
     }
     
     public func articleURLForHost(_ host: String, appending pathComponents: [String]) -> URLComponents {

--- a/WMF Framework/Configuration.swift
+++ b/WMF Framework/Configuration.swift
@@ -213,13 +213,13 @@ public class Configuration: NSObject {
         return components.wmf_URLWithLanguageVariantCode(url?.wmf_languageVariantCode)
     }
     
-    public func mediaWikiAPIURForHost(_ host: String? = nil, appending pathComponents: [String] = [""]) -> URLComponents {
-        let builder = mediaWikiAPIURLComponentsBuilderForHost(host)
-        return builder.components(byAppending: pathComponents)
+    @objc(mediaWikiAPIURLForURL:withQueryParameters:)
+    public func mediaWikiAPIURLForURL(_ url: URL?, with queryParameters: [String: Any]? = nil) -> URL? {
+        let components = mediaWikiAPIURLForHost(url?.host, with: queryParameters)
+        return components.wmf_URLWithLanguageVariantCode(url?.wmf_languageVariantCode)
     }
     
-    @objc(mediaWikiAPIURLComponentsForHost:withQueryParameters:)
-    public func mediaWikiAPIURLForHost(_ host: String? = nil, with queryParameters: [String: Any]? = nil) -> URLComponents {
+    private func mediaWikiAPIURLForHost(_ host: String? = nil, with queryParameters: [String: Any]? = nil) -> URLComponents {
         let builder = mediaWikiAPIURLComponentsBuilderForHost(host)
         guard let queryParameters = queryParameters else {
             return builder.components()

--- a/WMF Framework/Configuration.swift
+++ b/WMF Framework/Configuration.swift
@@ -233,9 +233,10 @@ public class Configuration: NSObject {
         return components.wmf_URLWithLanguageVariantCode(url?.wmf_languageVariantCode)
     }
     
-    public func articleURLForHost(_ host: String, appending pathComponents: [String]) -> URLComponents {
+    public func articleURLForHost(_ host: String, languageVariantCode: String?, appending pathComponents: [String]) -> URL? {
         let builder = articleURLComponentsBuilder(for: host)
-        return builder.components(byAppending: pathComponents)
+        let components = builder.components(byAppending: pathComponents)
+        return components.wmf_URLWithLanguageVariantCode(languageVariantCode)
     }
     
     public func mediaWikiAPIURLForWikiLanguage(_ wikiLanguage: String? = nil, with queryParameters: [String: Any]?) -> URLComponents {

--- a/WMF Framework/Fetcher.swift
+++ b/WMF Framework/Fetcher.swift
@@ -89,9 +89,9 @@ open class Fetcher: NSObject {
     
     @objc(performMediaWikiAPIPOSTForURL:withBodyParameters:cancellationKey:reattemptLoginOn401Response:completionHandler:)
     @discardableResult public func performMediaWikiAPIPOST(for URL: URL?, with bodyParameters: [String: String]?, cancellationKey: CancellationKey? = nil, reattemptLoginOn401Response: Bool = true, completionHandler: @escaping ([String: Any]?, HTTPURLResponse?, Error?) -> Swift.Void) -> URLSessionTask? {
-        let components = configuration.mediaWikiAPIURLForHost(URL?.host, with: nil)
+        let url = configuration.mediaWikiAPIURLForURL(URL, with: nil)
         let key = cancellationKey ?? UUID().uuidString
-        let task = session.postFormEncodedBodyParametersToURL(to: components.url, bodyParameters: bodyParameters, reattemptLoginOn401Response:reattemptLoginOn401Response) { (result, response, error) in
+        let task = session.postFormEncodedBodyParametersToURL(to: url, bodyParameters: bodyParameters, reattemptLoginOn401Response:reattemptLoginOn401Response) { (result, response, error) in
             completionHandler(result, response, error)
             self.untrack(taskFor: key)
         }
@@ -101,9 +101,9 @@ open class Fetcher: NSObject {
 
     @objc(performMediaWikiAPIGETForURL:withQueryParameters:cancellationKey:completionHandler:)
     @discardableResult public func performMediaWikiAPIGET(for URL: URL?, with queryParameters: [String: Any]?, cancellationKey: CancellationKey?, completionHandler: @escaping ([String: Any]?, HTTPURLResponse?, Error?) -> Swift.Void) -> URLSessionTask? {
-        let components = configuration.mediaWikiAPIURLForHost(URL?.host, with: queryParameters)
+        let url = configuration.mediaWikiAPIURLForURL(URL, with: queryParameters)
         let key = cancellationKey ?? UUID().uuidString
-        let task = session.getJSONDictionary(from: components.url) { (result, response, error) in
+        let task = session.getJSONDictionary(from: url) { (result, response, error) in
             let returnError = error ?? RequestError.from(result?["error"] as? [String : Any])
             completionHandler(result, response, returnError)
             self.untrack(taskFor: key)
@@ -126,9 +126,9 @@ open class Fetcher: NSObject {
     }
     
     @discardableResult public func performDecodableMediaWikiAPIGET<T: Decodable>(for URL: URL?, with queryParameters: [String: Any]?, cancellationKey: CancellationKey? = nil, completionHandler: @escaping (Result<T, Error>) -> Swift.Void) -> CancellationKey? {
-        let components = configuration.mediaWikiAPIURLForHost(URL?.host, with: queryParameters)
+        let url = configuration.mediaWikiAPIURLForURL(URL, with: queryParameters)
         let key = cancellationKey ?? UUID().uuidString
-        let task = session.jsonDecodableTask(with: components.url) { (result: T?, response: URLResponse?, error: Error?) in
+        let task = session.jsonDecodableTask(with: url) { (result: T?, response: URLResponse?, error: Error?) in
             guard let result = result else {
                 let error = error ?? RequestError.unexpectedResponse
                 completionHandler(.failure(error))

--- a/WMF Framework/RelatedSearchFetcher.swift
+++ b/WMF Framework/RelatedSearchFetcher.swift
@@ -16,7 +16,7 @@ final class RelatedSearchFetcher: Fetcher {
         }
 
         let pathComponents = ["page", "related", articleTitle]
-        guard let taskURL = configuration.pageContentServiceAPIURLComponentsForHost(articleURL.host, appending: pathComponents).url else {
+        guard let taskURL = configuration.pageContentServiceAPIURLForURL(articleURL, appending: pathComponents) else {
             completion(Fetcher.invalidParametersError, nil)
             return
         }

--- a/WMF Framework/Significant Events Endpoint/ArticleAsLivingDocViewModels.swift
+++ b/WMF Framework/Significant Events Endpoint/ArticleAsLivingDocViewModels.swift
@@ -1519,7 +1519,7 @@ public extension ArticleAsLivingDocViewModel.Event.Large {
             let isbnPrefix = "ISBN: "
             let mutableAttributedString = NSMutableAttributedString(string: "\(isbnPrefix + isbn)", attributes: attributes)
             let isbnTitle = "Special:BookSources"
-            let isbnURL = Configuration.current.articleURLForHost(Configuration.Domain.englishWikipedia, appending: [isbnTitle, isbn]).url
+            let isbnURL = Configuration.current.articleURLForHost(Configuration.Domain.englishWikipedia, languageVariantCode: nil, appending: [isbnTitle, isbn])
             let range = NSRange(location: 0, length: isbnPrefix.count + isbn.count)
             if let isbnURL = isbnURL {
                 mutableAttributedString.addAttributes([NSAttributedString.Key.link : isbnURL,
@@ -1712,7 +1712,7 @@ public extension ArticleAsLivingDocViewModel.Event.Large {
         let rangeValid = rangeOfUserName.location != NSNotFound && rangeOfUserName.location + rangeOfUserName.length <= userInfo.count
         
         guard let title = "User:\(userName)".percentEncodedPageTitleForPathComponents,
-              let userNameURL = Configuration.current.articleURLForHost(Configuration.Domain.englishWikipedia, appending: [title]).url,
+              let userNameURL = Configuration.current.articleURLForHost(Configuration.Domain.englishWikipedia, languageVariantCode: nil, appending: [title]),
               rangeValid else {
             let attributedString = NSAttributedString(string: userInfo, attributes: attributes)
             self.userInfo = attributedString

--- a/WMF Framework/URLComponents+Extensions.swift
+++ b/WMF Framework/URLComponents+Extensions.swift
@@ -79,4 +79,9 @@ extension URLComponents {
         #endif
         percentEncodedPath = fullComponents.joined(separator: "/") // NSString.path(with: components) removes the trailing slash that the reading list API needs
     }
+    
+    public func wmf_URLWithLanguageVariantCode(_ code: String?) -> URL? {
+        return (self as NSURLComponents).wmf_URL(withLanguageVariantCode: code)
+    }
+
 }

--- a/WMF Framework/WMFAnnouncementsFetcher.m
+++ b/WMF Framework/WMFAnnouncementsFetcher.m
@@ -14,9 +14,9 @@
     }
     
 #if WMF_LOCAL_ANNOUNCEMENTS
-    NSURL *url = [[WMFConfiguration.localWikiFeeds wikiFeedsAPIURLComponentsForHost:siteURL.host appendingPathComponents:@[@"feed", @"announcements"]] URL];
+    NSURL *url = [WMFConfiguration.localWikiFeeds wikiFeedsAPIURLForURL:siteURL appendingPathComponents:@[@"feed", @"announcements"]];
 #else
-    NSURL *url = [[self.configuration wikiFeedsAPIURLComponentsForHost:siteURL.host appendingPathComponents:@[@"feed", @"announcements"]] URL];
+    NSURL *url = [self.configuration wikiFeedsAPIURLForURL:siteURL appendingPathComponents:@[@"feed", @"announcements"]];
 #endif
     [self.session getJSONDictionaryFromURL:url ignoreCache:YES completionHandler:^(NSDictionary<NSString *,id> * _Nullable result, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error) {
         if (error) {

--- a/WMF Framework/WMFOnThisDayEventsFetcher.m
+++ b/WMF Framework/WMFOnThisDayEventsFetcher.m
@@ -29,8 +29,7 @@
     NSString *monthString = [NSString stringWithFormat:@"%lu", (unsigned long)month];
     NSString *dayString = [NSString stringWithFormat:@"%lu", (unsigned long)day];
     NSArray<NSString *> *path = @[@"feed", @"onthisday", @"events", monthString, dayString];
-    NSURLComponents *components = [self.configuration wikiFeedsAPIURLComponentsForHost:siteURL.host appendingPathComponents:path];
-    NSURL *url = components.URL;
+    NSURL *url = [self.configuration wikiFeedsAPIURLForURL:siteURL appendingPathComponents:path];
     [self.session getJSONDictionaryFromURL:url ignoreCache:YES completionHandler:^(NSDictionary<NSString *,id> * _Nullable result, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error) {
         if (error) {
             failure(error);

--- a/Wikipedia/Code/ArticleFetcher.swift
+++ b/Wikipedia/Code/ArticleFetcher.swift
@@ -162,7 +162,7 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
         guard
             let articleTitle = articleURL.wmf_title,
             let percentEncodedTitle = articleTitle.percentEncodedPageTitleForPathComponents,
-            let url = configuration.pageContentServiceAPIURLComponentsForHost(articleURL.host, appending: ["transform", "wikitext", "to", "mobile-html", percentEncodedTitle]).url
+            let url = configuration.pageContentServiceAPIURLForURL(articleURL, appending: ["transform", "wikitext", "to", "mobile-html", percentEncodedTitle])
         else {
             throw RequestError.invalidParameters
         }
@@ -181,11 +181,11 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
         
         #if WMF_LOCAL_PAGE_CONTENT_SERVICE || WMF_APPS_LABS_PAGE_CONTENT_SERVICE
         // As of April 2020, the /transform/wikitext/to/html/{article} endpoint is only available on production, not local or staging PCS.
-        guard let url = Configuration.production.pageContentServiceAPIURLComponentsForHost(articleURL.host, appending: ["transform", "wikitext", "to", "html", percentEncodedTitle]).url else {
+        guard let url = Configuration.production.pageContentServiceAPIURLForURL(articleURL, appending: ["transform", "wikitext", "to", "html", percentEncodedTitle]) else {
             throw RequestError.invalidParameters
         }
         #else
-        guard let url = configuration.pageContentServiceAPIURLComponentsForHost(articleURL.host, appending: ["transform", "wikitext", "to", "html", percentEncodedTitle]).url else {
+        guard let url = configuration.pageContentServiceAPIURLForURL(articleURL, appending: ["transform", "wikitext", "to", "html", percentEncodedTitle]) else {
             throw RequestError.invalidParameters
         }
         #endif
@@ -199,7 +199,7 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
         guard
             let articleTitle = articleURL.wmf_title,
             let percentEncodedTitle = articleTitle.percentEncodedPageTitleForPathComponents,
-            let url = configuration.pageContentServiceAPIURLComponentsForHost(articleURL.host, appending: ["transform", "html", "to", "mobile-html", percentEncodedTitle]).url
+            let url = configuration.pageContentServiceAPIURLForURL(articleURL, appending: ["transform", "html", "to", "mobile-html", percentEncodedTitle])
         else {
             throw RequestError.invalidParameters
         }
@@ -247,7 +247,7 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
             pathComponents.append("\(revisionID)")
         }
         
-        guard let mobileHTMLURL = configuration.pageContentServiceAPIURLComponentsForHost(articleURL.host, appending: pathComponents).url else {
+        guard let mobileHTMLURL = configuration.pageContentServiceAPIURLForURL(articleURL, appending: pathComponents) else {
             throw RequestError.invalidParameters
         }
         
@@ -258,7 +258,7 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
         guard
             let articleTitle = articleURL.wmf_title,
             let percentEncodedTitle = articleTitle.percentEncodedPageTitleForPathComponents,
-            let url = configuration.pageContentServiceAPIURLComponentsForHost(articleURL.host, appending: ["page", "media-list", percentEncodedTitle]).url
+            let url = configuration.pageContentServiceAPIURLForURL(articleURL, appending: ["page", "media-list", percentEncodedTitle])
         else {
             throw RequestError.invalidParameters
         }
@@ -281,7 +281,7 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
         guard
             let articleTitle = articleURL.wmf_title,
             let percentEncodedTitle = articleTitle.percentEncodedPageTitleForPathComponents,
-            let url = configuration.pageContentServiceAPIURLComponentsForHost(articleURL.host, appending: ["page", "mobile-html-offline-resources", percentEncodedTitle]).url
+            let url = configuration.pageContentServiceAPIURLForURL(articleURL, appending: ["page", "mobile-html-offline-resources", percentEncodedTitle])
         else {
             throw RequestError.invalidParameters
         }
@@ -443,7 +443,7 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
         guard
             let articleTitle = articleURL.wmf_title,
             let percentEncodedTitle = articleTitle.percentEncodedPageTitleForPathComponents,
-            let url = configuration.pageContentServiceAPIURLComponentsForHost(articleURL.host, appending: ["page", "summary", percentEncodedTitle]).url
+            let url = configuration.pageContentServiceAPIURLForURL(articleURL, appending: ["page", "summary", percentEncodedTitle])
         else {
             throw RequestError.invalidParameters
         }

--- a/Wikipedia/Code/ArticleViewController+ArticleWebMessageHandling.swift
+++ b/Wikipedia/Code/ArticleViewController+ArticleWebMessageHandling.swift
@@ -96,7 +96,7 @@ extension ArticleViewController: ArticleWebMessageHandling {
     
     func setupFooter() {
         // Always use Configuration.production for related articles
-        guard let baseURL = Configuration.production.pageContentServiceAPIURLComponentsForHost(articleURL.host, appending: []).url else {
+        guard let baseURL = Configuration.production.pageContentServiceAPIURLForURL(articleURL, appending: []) else {
             return
         }
         var menuItems: [PageContentService.Footer.Menu.Item] = [.talkPage, .lastEdited, .pageIssues, .disambiguation]

--- a/Wikipedia/Code/DiffFetcher.swift
+++ b/Wikipedia/Code/DiffFetcher.swift
@@ -95,7 +95,7 @@ class DiffFetcher: Fetcher {
     
     private func compareURL(fromRevisionId: Int, toRevisionId: Int, siteURL: URL) -> URL? {
         
-        guard let host = siteURL.host else {
+        guard siteURL.host != nil else {
             return nil
         }
 
@@ -103,8 +103,7 @@ class DiffFetcher: Fetcher {
         pathComponents.append("\(fromRevisionId)")
         pathComponents.append("compare")
         pathComponents.append("\(toRevisionId)")
-        let components = configuration.mediaWikiRestAPIURLForHost(host, appending: pathComponents)
-        return components.url
+        return configuration.mediaWikiRestAPIURLForURL(siteURL, appending: pathComponents)
     }
     
     enum FetchRevisionModelRequest {

--- a/Wikipedia/Code/EditPreviewViewController.swift
+++ b/Wikipedia/Code/EditPreviewViewController.swift
@@ -211,7 +211,7 @@ extension EditPreviewViewController: ArticleWebMessageHandling {
                 guard
                     let host = articleURL.host,
                     let encodedTitle = title.percentEncodedPageTitleForPathComponents,
-                    let newArticleURL = Configuration.current.articleURLForHost(host, appending: [encodedTitle]).url else {
+                    let newArticleURL = Configuration.current.articleURLForHost(host, languageVariantCode: articleURL.wmf_languageVariantCode, appending: [encodedTitle]) else {
                     showInternalLinkInAlert(link: href)
                     break
                 }

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -805,9 +805,10 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
     WMFTaskGroup *taskGroup = [[WMFTaskGroup alloc] init];
 
     // Site info
-    NSURLComponents *components = [self.configuration mediaWikiAPIURLComponentsForHost:@"meta.wikimedia.org" withQueryParameters:WikipediaSiteInfo.defaultRequestParameters];
+    NSURL *siteURL = [NSURL URLWithString:@"//meta.wikimedia.org"]; // Only the host of the URL is needed
+    NSURL *URL = [self.configuration mediaWikiAPIURLForURL:siteURL withQueryParameters:WikipediaSiteInfo.defaultRequestParameters];
     [taskGroup enter];
-    [self.session getJSONDictionaryFromURL:components.URL
+    [self.session getJSONDictionaryFromURL:URL
                                       ignoreCache:YES
                                 completionHandler:^(NSDictionary<NSString *, id> *_Nullable siteInfo, NSURLResponse *_Nullable response, NSError *_Nullable error) {
                                     dispatch_async(dispatch_get_main_queue(), ^{

--- a/Wikipedia/Code/MWKImageInfoFetcher.m
+++ b/Wikipedia/Code/MWKImageInfoFetcher.m
@@ -171,10 +171,8 @@ static CGSize MWKImageInfoSizeFromJSON(NSDictionary *json, NSString *widthKey, N
     
     NSDictionary *params = [self queryParametersForTitles:imageTitles fromSiteURL:siteURL thumbnailWidth:[NSNumber numberWithInteger:[[UIScreen mainScreen] wmf_articleImageWidthForScale]] extmetadataKeys:[MWKImageInfoFetcher galleryExtMetadataKeys] metadataLanguage:siteURL.wmf_language useGenerator:NO];
     
-    NSURLComponents *components = [[NSURLComponents alloc] initWithURL:siteURL resolvingAgainstBaseURL:NO];
-    
-    if (components.host) {
-        return [self.configuration mediaWikiAPIURLComponentsForHost:components.host withQueryParameters:params].URL;
+    if (siteURL.host) {
+        return [self.configuration mediaWikiAPIURLForURL:siteURL withQueryParameters:params];
     }
     
     return nil;
@@ -232,8 +230,8 @@ metadataLanguage:(nullable NSString *)metadataLanguage
 
     NSDictionary *params = [self queryParametersForTitles:titles fromSiteURL:siteURL thumbnailWidth:thumbnailWidth extmetadataKeys:extMetadataKeys metadataLanguage:metadataLanguage useGenerator:useGenerator];
     
-    NSURL *url = [self.fetcher.configuration mediaWikiAPIURLComponentsForHost:siteURL.host withQueryParameters:params].URL;
-    
+    NSURL *url = [self.fetcher.configuration mediaWikiAPIURLForURL:siteURL withQueryParameters:params];
+
     NSURLRequest *urlRequest = [self urlRequestForFromURL:url];
     
     return (id<MWKImageInfoRequest>)[self performMediaWikiAPIGETForURLRequest:urlRequest completionHandler:^(NSDictionary<NSString *, id> *_Nullable result, NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.m
@@ -93,7 +93,7 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
 - (NSURL *)wmf_URLWithTitle:(NSString *)title {
     NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:NO];
     components.wmf_title = title;
-    return components.URL;
+    return [components wmf_URLWithLanguageVariantCode:self.wmf_languageVariantCode];
 }
 
 - (NSURL *)wmf_URLWithTitle:(NSString *)title fragment:(nullable NSString *)fragment query:(nullable NSString *)query {
@@ -101,13 +101,13 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
     components.wmf_title = title;
     components.wmf_fragment = fragment;
     components.percentEncodedQuery = query;
-    return components.URL;
+    return [components wmf_URLWithLanguageVariantCode:self.wmf_languageVariantCode];
 }
 
 - (NSURL *)wmf_URLWithFragment:(nullable NSString *)fragment {
     NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:NO];
     components.wmf_fragment = fragment;
-    return components.URL;
+    return [components wmf_URLWithLanguageVariantCode:self.wmf_languageVariantCode];
 }
 
 - (NSURL *)wmf_URLWithPath:(NSString *)path isMobile:(BOOL)isMobile {
@@ -116,14 +116,14 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
     if (isMobile != self.wmf_isMobile) {
         components.host = [NSURLComponents wmf_hostWithDomain:self.wmf_domain language:self.wmf_language isMobile:isMobile];
     }
-    return components.URL;
+    return [components wmf_URLWithLanguageVariantCode:self.wmf_languageVariantCode];
 }
 
 - (NSURL *)wmf_siteURL {
     NSURLComponents *components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:NO];
     components.path = nil;
     components.fragment = nil;
-    return [components URL];
+    return [components wmf_URLWithLanguageVariantCode:self.wmf_languageVariantCode];
 }
 
 - (NSURL *)wmf_APIURL:(BOOL)isMobile {
@@ -234,7 +234,7 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
     components.host = [NSURLComponents wmf_hostWithDomain:self.wmf_domain language:self.wmf_language isMobile:NO];
     components.path = [components.path stringByRemovingPercentEncoding] ?: components.path;
     components.scheme = @"https";
-    return components.URL;
+    return [components wmf_URLWithLanguageVariantCode:self.wmf_languageVariantCode];
 }
 
 - (NSURL *)wmf_databaseURL {
@@ -244,7 +244,7 @@ NSString *const WMFEditPencil = @"WMFEditPencil";
     components.fragment = nil;
     components.query = nil;
     components.scheme = @"https";
-    return components.URL;
+    return [components wmf_URLWithLanguageVariantCode:self.wmf_languageVariantCode];
 }
 
 - (NSString *)wmf_databaseKey {

--- a/Wikipedia/Code/NSURLComponents+WMFLinkParsing.h
+++ b/Wikipedia/Code/NSURLComponents+WMFLinkParsing.h
@@ -110,6 +110,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSURLComponents *)wmf_componentsByRemovingQueryItemsNamed:(NSSet<NSString *> *)queryItemNames;
 - (nullable NSString *)wmf_valueForQueryItemNamed:(NSString *)queryItemName;
 
+/// Create an NSURL from the receiver's components and associates the provided @c languageVariantCode
+- (nullable NSURL *)wmf_URLWithLanguageVariantCode:(nullable NSString *)code;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/NSURLComponents+WMFLinkParsing.m
+++ b/Wikipedia/Code/NSURLComponents+WMFLinkParsing.m
@@ -141,4 +141,10 @@
     return [self wmf_componentsByRemovingQueryItemsNamed:[NSSet setWithObject:@"event_logging_label"]];
 }
 
+- (nullable NSURL *)wmf_URLWithLanguageVariantCode:(nullable NSString *)code {
+    NSURL *url = self.URL;
+    url.wmf_languageVariantCode = code;
+    return url;
+}
+
 @end

--- a/Wikipedia/Code/PageHistoryFetcher.swift
+++ b/Wikipedia/Code/PageHistoryFetcher.swift
@@ -126,7 +126,8 @@ public final class PageHistoryFetcher: WMFLegacyFetcher {
     }
 
     private func editCountsURL(for editCountType: EditCountType, pageTitle: String, pageURL: URL, from fromRevisionID: Int? = nil , to toRevisionID: Int? = nil) -> URL? {
-        guard let project = pageURL.wmf_site?.host,
+        guard let project = pageURL.wmf_site,
+              project.host != nil,
         let title = pageTitle.percentEncodedPageTitleForPathComponents else {
             return nil
         }
@@ -141,8 +142,7 @@ public final class PageHistoryFetcher: WMFLegacyFetcher {
         } else {
             queryParameters = nil
         }
-        let components = configuration.mediaWikiRestAPIURLForHost(project, appending: pathComponents, queryParameters: queryParameters)
-        return components.url
+        return configuration.mediaWikiRestAPIURLForURL(project, appending: pathComponents, queryParameters: queryParameters)
     }
 
     private struct EditCount: Decodable {

--- a/Wikipedia/Code/RandomArticleFetcher.swift
+++ b/Wikipedia/Code/RandomArticleFetcher.swift
@@ -4,7 +4,7 @@ import Foundation
 public final class RandomArticleFetcher: Fetcher {
     @objc public func fetchRandomArticle(withSiteURL siteURL: URL, completion: @escaping (Error?, URL?, ArticleSummary?) -> Void) {
         let pathComponents = ["page", "random", "summary"]
-        guard let taskURL = configuration.pageContentServiceAPIURLComponentsForHost(siteURL.host, appending: pathComponents).url else {
+        guard let taskURL = configuration.pageContentServiceAPIURLForURL(siteURL, appending: pathComponents) else {
             completion(Fetcher.invalidParametersError, nil, nil)
             return
         }

--- a/Wikipedia/Code/TalkPageFetcher.swift
+++ b/Wikipedia/Code/TalkPageFetcher.swift
@@ -222,8 +222,7 @@ private extension TalkPageFetcher {
             return nil
         }
         
-        let components = configuration.articleURLForHost(host, appending: [urlTitle])
-        return components.url
+        return configuration.articleURLForHost(host, languageVariantCode: siteURL.wmf_languageVariantCode, appending: [urlTitle])
     }
     
 }

--- a/Wikipedia/Code/TalkPageFetcher.swift
+++ b/Wikipedia/Code/TalkPageFetcher.swift
@@ -197,7 +197,7 @@ private extension TalkPageFetcher {
         
         assert(urlTitle.contains(":"), "Title must already be prefixed with namespace.")
         
-        guard let host = siteURL.host,
+        guard siteURL.host != nil,
             let percentEncodedUrlTitle = urlTitle.percentEncodedPageTitleForPathComponents else {
             return nil
         }
@@ -207,7 +207,7 @@ private extension TalkPageFetcher {
             pathComponents.append(String(revisionID))
         }
         
-        guard let taskURL = configuration.pageContentServiceAPIURLComponentsForHost(host, appending: pathComponents).url else {
+        guard let taskURL = configuration.pageContentServiceAPIURLForURL(siteURL, appending: pathComponents) else {
             return nil
         }
         

--- a/Wikipedia/Code/TalkPagesController.swift
+++ b/Wikipedia/Code/TalkPagesController.swift
@@ -210,8 +210,9 @@ private extension TalkPageController {
     
     func fetchLatestRevisionID(endingWithRevision revisionID: Int?, urlTitle: String, completion: @escaping (Result<Int, Error>) -> Void) {
         
-        guard let host = siteURL.host,
-            let revisionURL = Configuration.current.mediaWikiAPIURLForHost(host, with: nil).url?.wmf_URL(withTitle: urlTitle) else {
+        guard siteURL.host != nil,
+            let mediaWikiURL = Configuration.current.mediaWikiAPIURLForURL(siteURL, with: nil),
+            let revisionURL = mediaWikiURL.wmf_URL(withTitle: urlTitle) else {
             completion(.failure(TalkPageError.revisionUrlCreationFailure))
             return
         }

--- a/Wikipedia/Code/WMFFeedContentFetcher.m
+++ b/Wikipedia/Code/WMFFeedContentFetcher.m
@@ -54,7 +54,7 @@ static const NSInteger WMFFeedContentFetcherMinimumMaxAge = 18000; // 5 minutes
     } else {
         path = @[@"feed", @"featured"];
     }
-    return [[configuration wikiFeedsAPIURLComponentsForHost:siteURL.host appendingPathComponents:path] URL];
+    return [configuration wikiFeedsAPIURLForURL:siteURL appendingPathComponents:path];
 }
 
 + (NSRegularExpression *)cacheControlRegex {

--- a/Wikipedia/Code/WMFLocationSearchFetcher.m
+++ b/Wikipedia/Code/WMFLocationSearchFetcher.m
@@ -38,7 +38,7 @@ NSString *const WMFLocationSearchErrorDomain = @"org.wikimedia.location.search";
 
     NSDictionary *params = [self params:region searchTerm:searchTerm resultLimit:resultLimit sortStyle:sortStyle];
 
-    NSURL *url = [[self.configuration mediaWikiAPIURLComponentsForHost:siteURL.host withQueryParameters:params] URL];
+    NSURL *url = [self.configuration mediaWikiAPIURLForURL:siteURL withQueryParameters:params];
 
     assert(url);
 

--- a/Wikipedia/Code/WMFSearchFetcher.m
+++ b/Wikipedia/Code/WMFSearchFetcher.m
@@ -142,7 +142,8 @@ NSUInteger const WMFMaxSearchResultLimit = 24;
         appendToPreviousResults:(nullable WMFSearchResults *)results
                         failure:(WMFErrorHandler)failure
                         success:(WMFSearchResultsHandler)success {
-    NSURL *url = [self.configuration mediaWikiAPIURLComponentsForHost:@"commons.wikimedia.org" withQueryParameters:nil].URL;
+    NSURL *siteURL = [NSURL URLWithString:@"//commons.wikimedia.org"]; // Only the host of the URL is needed
+    NSURL *url = [self.configuration mediaWikiAPIURLForURL:siteURL withQueryParameters:nil];
     if (!url) {
         failure(WMFFetcher.invalidParametersError);
         return;

--- a/WikipediaUnitTests/Code/NSURL+WMFLinkParsingTests.m
+++ b/WikipediaUnitTests/Code/NSURL+WMFLinkParsingTests.m
@@ -1,5 +1,6 @@
 #import <XCTest/XCTest.h>
 #import <WMF/NSURL+WMFLinkParsing.h>
+#import <WMF/NSURLComponents+WMFLinkParsing.h>
 
 @interface NSURL_WMFLinkParsingTests : XCTestCase
 
@@ -72,6 +73,15 @@
     XCTAssertNil(url.wmf_languageVariantCode);
     NSString *languageVariantCode = @"zh-hant";
     url.wmf_languageVariantCode = languageVariantCode;
+    XCTAssertEqualObjects(url.wmf_languageVariantCode, languageVariantCode);
+}
+
+- (void)testLanguageVariantCodePropertyFromURLComponents {
+    NSURLComponents *components = [NSURLComponents componentsWithString:@"https://sr.wikipedia.org"];
+    NSString *languageVariantCode = @"sr-ec";
+    XCTAssertNotNil(components);
+    NSURL *url = [components wmf_URLWithLanguageVariantCode:languageVariantCode];
+    XCTAssertNotNil(url);
     XCTAssertEqualObjects(url.wmf_languageVariantCode, languageVariantCode);
 }
 

--- a/WikipediaUnitTests/Code/URLParsingAndRoutingTests.swift
+++ b/WikipediaUnitTests/Code/URLParsingAndRoutingTests.swift
@@ -206,5 +206,16 @@ class URLParsingAndRoutingTests: XCTestCase {
         url.wmf_languageVariantCode = ""
         XCTAssertEqual(url.wmf_contentLanguageCode, languageCode)
     }
+    
+    func testLanguageVariantCodePropertyFromURLComponents() {
+        let components = URLComponents(string: "https://sr.wikipedia.org")
+        let languageVariantCode = "sr-ec"
+        XCTAssertNotNil(components)
+        if let components = components {
+            let url = components.wmf_URLWithLanguageVariantCode(languageVariantCode)
+            XCTAssertNotNil(url)
+            XCTAssertEqual(url?.wmf_languageVariantCode, languageVariantCode)
+        }
+    }
 
 }


### PR DESCRIPTION
This is work towards the Chinese variants feature https://phabricator.wikimedia.org/T195265
It is not the entire feature/ticket.

### Notes
Conceptually, this PR does a few things:
- Converts methods that accepted a host name and returned URLComponents to methods that accept a URL and return a URL. The language variant code of the incoming URL is propagated to the returned URL.
- Updates call sites for these updated methods
- Adds a convenience method to NSURLComponents/URLComponents to return a URL from the components with the provided language variant code.
- Propagates the language variant code in all NSURL instance category methods that return an NSURL

I've broken it down into separate commits, so reviewing each commit should be pretty straightforward.

### Test Steps
1. All app tests should pass
2. No change in behavior of app
