### PR TITLE
Make WMFContentGroup and WMFArticle language variant-aware

### DIFF
--- a/WMF Framework/WMFArticle+Extensions.h
+++ b/WMF Framework/WMFArticle+Extensions.h
@@ -63,13 +63,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable WMFArticle *)fetchArticleWithURL:(nullable NSURL *)articleURL;
 
-- (nullable WMFArticle *)fetchArticleWithKey:(nullable NSString *)key;
+- (nullable WMFArticle *)fetchArticleWithKey:(nullable NSString *)key variant:(nullable NSString *)variant;
 
-- (nullable NSArray<WMFArticle *> *)fetchArticlesWithKey:(nullable NSString *)key error:(NSError **)error;
+- (nullable NSArray<WMFArticle *> *)fetchArticlesWithKey:(nullable NSString *)key variant:(nullable NSString *)variant error:(NSError **)error;
+- (nullable NSArray<WMFArticle *> *)fetchArticlesWithKey:(nullable NSString *)key error:(NSError **)error; // Temporary shim for ArticleSummary that is not yet variant-aware
 
-- (nullable WMFArticle *)createArticleWithKey:(nullable NSString *)key;
+- (nullable WMFArticle *)createArticleWithKey:(nullable NSString *)key variant:(nullable NSString *)variant;
+- (nullable WMFArticle *)createArticleWithKey:(nullable NSString *)key; // Temporary shim for ArticleSummary that is not yet variant-aware
 
-- (nullable WMFArticle *)fetchOrCreateArticleWithKey:(nullable NSString *)key;
+- (nullable WMFArticle *)fetchOrCreateArticleWithKey:(nullable NSString *)key variant:(nullable NSString *)variant;
 
 - (nullable WMFArticle *)fetchOrCreateArticleWithURL:(nullable NSURL *)articleURL;
 

--- a/WMF Framework/WMFArticle+Extensions.h
+++ b/WMF Framework/WMFArticle+Extensions.h
@@ -81,4 +81,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+// WMFDataSource maintains a temporary local NSCache of WMFArticle instances.
+// The database key is derived from the article URL which does not take language variants into account.
+// Instances of this class are used as the key in that cache
+@interface WMFArticleTemporaryCacheKey: NSObject
+-(instancetype) initWithDatabaseKey:(NSString *)databaseKey variant:(nullable NSString *)variant;
+-(instancetype) init NS_UNAVAILABLE;
+@property (readonly, nonatomic, copy) NSString *databaseKey;
+@property (readonly, nonatomic, copy) NSString *variant;
+@end
+
 NS_ASSUME_NONNULL_END

--- a/WMF Framework/WMFArticle+Extensions.m
+++ b/WMF Framework/WMFArticle+Extensions.m
@@ -120,6 +120,8 @@
 
 @end
 
+#pragma mark - NSManagedObjectContext Extensions
+
 @implementation NSManagedObjectContext (WMFArticle)
 
 - (nullable WMFArticle *)fetchArticleWithURL:(nullable NSURL *)articleURL {
@@ -227,6 +229,38 @@
         preview.imageHeight = feedPreview.imageHeight;
     }
     return preview;
+}
+
+@end
+
+#pragma mark - WMFArticleTemporaryCacheKey
+
+@interface WMFArticleTemporaryCacheKey ()
+@property (nonatomic, copy) NSString *databaseKey;
+@property (nonatomic, copy) NSString *variant;
+@end
+
+@implementation WMFArticleTemporaryCacheKey: NSObject
+-(instancetype) initWithDatabaseKey:(NSString *)databaseKey variant:(nullable NSString *)variant {
+    if (self = [super init]) {
+        self.databaseKey = databaseKey;
+        self.variant = variant;
+    }
+    return self;
+}
+
+WMF_SYNTHESIZE_IS_EQUAL(WMFArticleTemporaryCacheKey, isEqualToArticleTemporaryCacheKey:)
+
+- (BOOL)isEqualToArticleTemporaryCacheKey:(WMFArticleTemporaryCacheKey *)rhs {
+    return WMF_RHS_PROP_EQUAL(databaseKey, isEqualToString:) && WMF_RHS_PROP_EQUAL(variant, isEqualToString:);
+}
+
+- (NSUInteger)hash {
+    return self.databaseKey.hash ^ flipBitsWithAdditionalRotation(self.variant.hash, 1); // When variant is nil, the XOR flips the bits
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat: @"%@ databaseKey: %@, variant: %@", [super description], self.databaseKey, self.variant];
 }
 
 @end

--- a/WMF Framework/WMFArticle+Extensions.m
+++ b/WMF Framework/WMFArticle+Extensions.m
@@ -125,26 +125,30 @@
 @implementation NSManagedObjectContext (WMFArticle)
 
 - (nullable WMFArticle *)fetchArticleWithURL:(nullable NSURL *)articleURL {
-    return [self fetchArticleWithKey:[articleURL wmf_databaseKey]];
+    return [self fetchArticleWithKey:articleURL.wmf_databaseKey variant:articleURL.wmf_languageVariantCode];
 }
 
 - (nullable NSArray<WMFArticle *> *)fetchArticlesWithKey:(nullable NSString *)key error:(NSError **)error {
+    return [self fetchArticlesWithKey:key variant:nil error:error];
+}
+
+- (nullable NSArray<WMFArticle *> *)fetchArticlesWithKey:(nullable NSString *)key variant:(nullable NSString *)variant error:(NSError **)error {
     if (!key) {
         return @[];
     }
     NSFetchRequest *request = [WMFArticle fetchRequest];
-    request.predicate = [NSPredicate predicateWithFormat:@"key == %@", key];
+    request.predicate = [NSPredicate predicateWithFormat:@"key == %@ && variant == %@", key, variant];
     return [self executeFetchRequest:request error:nil];
 }
 
-- (nullable WMFArticle *)fetchArticleWithKey:(nullable NSString *)key {
+- (nullable WMFArticle *)fetchArticleWithKey:(nullable NSString *)key variant:(nullable NSString *)variant {
     if (!key) {
         return nil;
     }
     WMFArticle *article = nil;
     NSFetchRequest *request = [WMFArticle fetchRequest];
     request.fetchLimit = 1;
-    request.predicate = [NSPredicate predicateWithFormat:@"key == %@", key];
+    request.predicate = [NSPredicate predicateWithFormat:@"key == %@ && variant == %@", key, variant];
     article = [[self executeFetchRequest:request error:nil] firstObject];
     return article;
 }
@@ -162,24 +166,29 @@
 }
 
 - (nullable WMFArticle *)createArticleWithKey:(nullable NSString *)key {
+    return [self createArticleWithKey:key variant:nil];
+}
+
+- (nullable WMFArticle *)createArticleWithKey:(nullable NSString *)key variant:(nullable NSString *)variant {
     WMFArticle *article = [[WMFArticle alloc] initWithContext:self];
     article.key = key;
+    article.variant = variant;
     return article;
 }
 
-- (nullable WMFArticle *)fetchOrCreateArticleWithKey:(nullable NSString *)key {
+- (nullable WMFArticle *)fetchOrCreateArticleWithKey:(nullable NSString *)key variant:(nullable NSString *)variant {
     if (!key) {
         return nil;
     }
-    WMFArticle *article = [self fetchArticleWithKey:key];
+    WMFArticle *article = [self fetchArticleWithKey:key variant:variant];
     if (!article) {
-        article = [self createArticleWithKey:key];
+        article = [self createArticleWithKey:key variant:variant];
     }
     return article;
 }
 
 - (nullable WMFArticle *)fetchOrCreateArticleWithURL:(nullable NSURL *)articleURL {
-    return [self fetchOrCreateArticleWithKey:[articleURL wmf_databaseKey]];
+    return [self fetchOrCreateArticleWithKey:articleURL.wmf_databaseKey variant:articleURL.wmf_languageVariantCode];
 }
 
 - (nullable WMFArticle *)fetchOrCreateArticleWithURL:(nullable NSURL *)articleURL updatedWithSearchResult:(nullable MWKSearchResult *)searchResult {

--- a/WMF Framework/WMFContentGroup+Extensions.h
+++ b/WMF Framework/WMFContentGroup+Extensions.h
@@ -67,11 +67,11 @@ typedef NS_ENUM(int16_t, WMFContentGroupUndoType) {
 + (nullable NSURL *)announcementURLForSiteURL:(NSURL *)siteURL identifier:(NSString *)identifier;
 + (nullable NSURL *)randomContentGroupURLForSiteURL:(NSURL *)url midnightUTCDate:(NSDate *)midnightUTCDate;
 + (nullable NSURL *)onThisDayContentGroupURLForSiteURL:(NSURL *)url midnightUTCDate:(NSDate *)midnightUTCDate;
-+ (nullable NSURL *)locationContentGroupURLForLocation:(CLLocation *)location;
-+ (nullable NSURL *)locationPlaceholderContentGroupURL;
-+ (nullable NSURL *)notificationContentGroupURL;
-+ (nullable NSURL *)themeContentGroupURL;
-+ (nullable NSURL *)readingListContentGroupURL;
++ (nullable NSURL *)locationContentGroupURLForLocation:(CLLocation *)location languageVariantCode:(NSString *)languageVariantCode;
++ (nullable NSURL *)locationPlaceholderContentGroupURLWithLanguageVariantCode:(NSString *)languageVariantCode;
++ (nullable NSURL *)notificationContentGroupURLWithLanguageVariantCode:(NSString *)languageVariantCode;
++ (nullable NSURL *)themeContentGroupURLWithLanguageVariantCode:(NSString *)languageVariantCode;
++ (nullable NSURL *)readingListContentGroupURLWithLanguageVariantCode:(NSString *)languageVariantCode;
 
 - (BOOL)isForLocalDate:(NSDate *)date;           //date is a date in the user's time zone
 @property (nonatomic, readonly) BOOL isForToday; //is for today in the user's time zone

--- a/WMF Framework/WMFContentGroup+Extensions.h
+++ b/WMF Framework/WMFContentGroup+Extensions.h
@@ -122,7 +122,7 @@ typedef NS_ENUM(int16_t, WMFContentGroupUndoType) {
 
 - (nullable WMFContentGroup *)groupOfKind:(WMFContentGroupKind)kind forDate:(NSDate *)date;
 
-- (nullable WMFContentGroup *)groupOfKind:(WMFContentGroupKind)kind forDate:(NSDate *)date siteURL:(NSURL *)url;
+- (nullable WMFContentGroup *)groupOfKind:(WMFContentGroupKind)kind forDate:(NSDate *)date siteURL:(NSURL *)siteURL;
 
 - (nullable NSArray<WMFContentGroup *> *)groupsOfKind:(WMFContentGroupKind)kind forDate:(NSDate *)date;
 

--- a/Wikipedia/Code/MWKDataStore.h
+++ b/Wikipedia/Code/MWKDataStore.h
@@ -118,12 +118,6 @@ typedef NS_OPTIONS(NSUInteger, RemoteConfigOption) {
 
 - (nullable WMFArticle *)fetchArticleWithWikidataID:(NSString *)wikidataID; //uses the view context
 
-- (BOOL)isArticleWithURLExcludedFromFeed:(NSURL *)articleURL inManagedObjectContext:(NSManagedObjectContext *)moc;
-- (void)setIsExcludedFromFeed:(BOOL)isExcludedFromFeed withArticleURL:(NSURL *)articleURL inManagedObjectContext:(NSManagedObjectContext *)moc;
-
-- (void)setIsExcludedFromFeed:(BOOL)isExcludedFromFeed withArticleURL:(NSURL *)articleURL;
-- (BOOL)isArticleWithURLExcludedFromFeed:(NSURL *)articleURL;
-
 - (BOOL)save:(NSError **)error;
 
 - (void)clearMemoryCache;

--- a/Wikipedia/Code/MWKDataStore.h
+++ b/Wikipedia/Code/MWKDataStore.h
@@ -107,12 +107,14 @@ typedef NS_OPTIONS(NSUInteger, RemoteConfigOption) {
 - (void)prefetchArticles; // fill the article cache to speed up initial feed load
 
 - (nullable WMFArticle *)fetchArticleWithURL:(NSURL *)URL inManagedObjectContext:(NSManagedObjectContext *)moc;
-- (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key inManagedObjectContext:(NSManagedObjectContext *)moc;
 - (nullable WMFArticle *)fetchOrCreateArticleWithURL:(NSURL *)URL inManagedObjectContext:(NSManagedObjectContext *)moc;
+- (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key variant:(nullable NSString *)variant inManagedObjectContext:(NSManagedObjectContext *)moc;
+- (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key inManagedObjectContext:(NSManagedObjectContext *)moc; // Temporary shim for areas like reading lists that are not yet variant-aware
 
 - (nullable WMFArticle *)fetchArticleWithURL:(NSURL *)URL;         //uses the view context
-- (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key;      //uses the view context
 - (nullable WMFArticle *)fetchOrCreateArticleWithURL:(NSURL *)URL; //uses the view context
+- (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key variant:(nullable NSString *)variant; //uses the view context
+- (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key; // Temporary shim for areas like reading lists that are not yet variant-aware
 
 - (nullable WMFArticle *)fetchArticleWithWikidataID:(NSString *)wikidataID; //uses the view context
 

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -775,7 +775,9 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
         if (!key) {
             continue;
         }
-        [self.articleCache setObject:article forKey:key];
+        NSString *variant = article.variant;
+        WMFArticleTemporaryCacheKey *cacheKey = [[WMFArticleTemporaryCacheKey alloc] initWithDatabaseKey:key variant:variant];
+        [self.articleCache setObject:article forKey:cacheKey];
     }
 }
 
@@ -885,20 +887,26 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
 }
 
 - (nullable WMFArticle *)fetchArticleWithURL:(NSURL *)URL inManagedObjectContext:(nonnull NSManagedObjectContext *)moc {
-    return [self fetchArticleWithKey:[URL wmf_databaseKey] inManagedObjectContext:moc];
+    return [self fetchArticleWithKey:URL.wmf_databaseKey variant:URL.wmf_languageVariantCode inManagedObjectContext:moc];
 }
 
 - (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key inManagedObjectContext:(nonnull NSManagedObjectContext *)moc {
+    return [self fetchArticleWithKey:key variant:nil inManagedObjectContext:moc];
+}
+
+- (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key variant:(nullable NSString *)variant inManagedObjectContext:(nonnull NSManagedObjectContext *)moc {
     WMFArticle *article = nil;
     if (moc == _viewContext) { // use ivar to avoid main thread check
-        article = [self.articleCache objectForKey:key];
+        WMFArticleTemporaryCacheKey *cacheKey = [[WMFArticleTemporaryCacheKey alloc] initWithDatabaseKey:key variant:variant];
+        article = [self.articleCache objectForKey:cacheKey];
         if (article) {
             return article;
         }
     }
-    article = [moc fetchArticleWithKey:key];
+    article = [moc fetchArticleWithKey:key variant:variant];
     if (article && moc == _viewContext) { // use ivar to avoid main thread check
-        [self.articleCache setObject:article forKey:key];
+        WMFArticleTemporaryCacheKey *cacheKey = [[WMFArticleTemporaryCacheKey alloc] initWithDatabaseKey:key variant:variant];
+        [self.articleCache setObject:article forKey:cacheKey];
     }
     return article;
 }
@@ -910,28 +918,34 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
 - (nullable WMFArticle *)fetchOrCreateArticleWithURL:(NSURL *)URL inManagedObjectContext:(NSManagedObjectContext *)moc {
     NSString *language = URL.wmf_language;
     NSString *title = URL.wmf_title;
-    NSString *key = [URL wmf_databaseKey];
+    NSString *key = URL.wmf_databaseKey;
     if (!language || !title || !key) {
         return nil;
     }
-    WMFArticle *article = [self fetchArticleWithKey:key inManagedObjectContext:moc];
+    NSString *variant = URL.wmf_languageVariantCode;
+    WMFArticle *article = [self fetchArticleWithKey:key variant: variant inManagedObjectContext:moc];
     if (!article) {
-        article = [moc createArticleWithKey:key];
+        article = [moc createArticleWithKey:key variant:variant];
         article.displayTitleHTML = article.displayTitle;
         if (moc == self.viewContext) {
-            [self.articleCache setObject:article forKey:key];
+            WMFArticleTemporaryCacheKey *cacheKey = [[WMFArticleTemporaryCacheKey alloc] initWithDatabaseKey:key variant:variant];
+            [self.articleCache setObject:article forKey:cacheKey];
         }
     }
     return article;
 }
 
 - (nullable WMFArticle *)fetchArticleWithURL:(NSURL *)URL {
-    return [self fetchArticleWithKey:[URL wmf_databaseKey]];
+    return [self fetchArticleWithKey:URL.wmf_databaseKey variant:URL.wmf_languageVariantCode];
 }
 
 - (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key {
+    return [self fetchArticleWithKey:key variant:nil];
+}
+
+- (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key variant:(nullable NSString *)variant {
     WMFAssertMainThread(@"Article fetch must be performed on the main thread.");
-    return [self fetchArticleWithKey:key inManagedObjectContext:self.viewContext];
+    return [self fetchArticleWithKey:key variant:variant inManagedObjectContext:self.viewContext];
 }
 
 - (nullable WMFArticle *)fetchOrCreateArticleWithURL:(NSURL *)URL {

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -953,36 +953,6 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
     return [self fetchOrCreateArticleWithURL:URL inManagedObjectContext:self.viewContext];
 }
 
-- (void)setIsExcludedFromFeed:(BOOL)isExcludedFromFeed withArticleURL:(NSURL *)articleURL inManagedObjectContext:(NSManagedObjectContext *)moc {
-    NSParameterAssert(articleURL);
-    if ([articleURL wmf_isNonStandardURL]) {
-        return;
-    }
-    if ([articleURL.wmf_title length] == 0) {
-        return;
-    }
-
-    WMFArticle *article = [self fetchOrCreateArticleWithURL:articleURL inManagedObjectContext:moc];
-    article.isExcludedFromFeed = isExcludedFromFeed;
-    [self save:nil];
-}
-
-- (BOOL)isArticleWithURLExcludedFromFeed:(NSURL *)articleURL inManagedObjectContext:(NSManagedObjectContext *)moc {
-    WMFArticle *article = [self fetchArticleWithURL:articleURL inManagedObjectContext:moc];
-    if (!article) {
-        return NO;
-    }
-    return article.isExcludedFromFeed;
-}
-
-- (void)setIsExcludedFromFeed:(BOOL)isExcludedFromFeed withArticleURL:(NSURL *)articleURL {
-    [self setIsExcludedFromFeed:isExcludedFromFeed withArticleURL:articleURL inManagedObjectContext:self.viewContext];
-}
-
-- (BOOL)isArticleWithURLExcludedFromFeed:(NSURL *)articleURL {
-    return [self isArticleWithURLExcludedFromFeed:articleURL inManagedObjectContext:self.viewContext];
-}
-
 #pragma mark - WMFAuthenticationManagerDelegate
 
 - (nullable NSURL*)loginSiteURL {

--- a/Wikipedia/Code/MWKSavedPageList.m
+++ b/Wikipedia/Code/MWKSavedPageList.m
@@ -46,11 +46,11 @@
 }
 
 - (nullable WMFArticle *)entryForURL:(NSURL *)url {
-    NSString *key = [url wmf_databaseKey];
+    NSString *key = url.wmf_databaseKey;
     if (!key) {
         return nil;
     }
-    WMFArticle *article = [self.dataStore fetchArticleWithKey:key];
+    WMFArticle *article = [self.dataStore fetchArticleWithKey:key variant:url.wmf_languageVariantCode];
     if (article.savedDate) {
         return article;
     } else {

--- a/Wikipedia/Code/RandomArticleFetcher.swift
+++ b/Wikipedia/Code/RandomArticleFetcher.swift
@@ -13,10 +13,13 @@ public final class RandomArticleFetcher: Fetcher {
                 completion(error, nil, nil)
                 return
             }
-            guard let articleURL = summary?.articleURL else {
+            guard var articleURL = summary?.articleURL else {
                 completion(Fetcher.unexpectedResponseError, nil, nil)
                 return
             }
+            // Temporary shim until ArticleSummary propagates language variants.
+            // Ensures Random cards display content when variants are turned on.
+            articleURL.wmf_languageVariantCode = siteURL.wmf_languageVariantCode
             completion(nil, articleURL, summary)
         }
     }

--- a/Wikipedia/Code/WMFAnnouncementsContentSource.m
+++ b/Wikipedia/Code/WMFAnnouncementsContentSource.m
@@ -104,7 +104,7 @@
     [moc removeAllContentGroupsOfKind:WMFContentGroupKindTheme];
 
     if (moc.wmf_isSyncRemotelyEnabled && !NSUserDefaults.standardUserDefaults.wmf_didShowReadingListCardInFeed && !self.fetcher.session.isAuthenticated) {
-        NSURL *readingListContentGroupURL = [WMFContentGroup readingListContentGroupURL];
+        NSURL *readingListContentGroupURL = [WMFContentGroup readingListContentGroupURLWithLanguageVariantCode:self.siteURL.wmf_languageVariantCode];
         [moc fetchOrCreateGroupForURL:readingListContentGroupURL ofKind:WMFContentGroupKindReadingList forDate:[NSDate date] withSiteURL:self.siteURL associatedContent:nil customizationBlock:NULL];
         NSUserDefaults.standardUserDefaults.wmf_didShowReadingListCardInFeed = YES;
     } else {

--- a/Wikipedia/Code/WMFFeedContentSource.m
+++ b/Wikipedia/Code/WMFFeedContentSource.m
@@ -341,7 +341,7 @@ NSInteger const WMFFeedInTheNewsNotificationViewCountDays = 5;
 - (void)addNewsNotificationGroupForNewsGroup:(WMFContentGroup *)newsGroup inManagedObjectContext:(NSManagedObjectContext *)moc {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     if (newsGroup && newsGroup.isVisible && ![userDefaults wmf_inTheNewsNotificationsEnabled] && ![userDefaults wmf_didShowNewsNotificationCardInFeed]) {
-        NSURL *URL = [WMFContentGroup notificationContentGroupURL];
+        NSURL *URL = [WMFContentGroup notificationContentGroupURLWithLanguageVariantCode:self.siteURL.wmf_languageVariantCode];
         [moc fetchOrCreateGroupForURL:URL ofKind:WMFContentGroupKindNotification forDate:newsGroup.date withSiteURL:self.siteURL associatedContent:nil customizationBlock:NULL];
         [userDefaults wmf_setDidShowNewsNotificationCardInFeed:YES];
     }

--- a/Wikipedia/Code/WMFNearbyContentSource.m
+++ b/Wikipedia/Code/WMFNearbyContentSource.m
@@ -142,7 +142,7 @@ static const CLLocationDistance WMFNearbyUpdateDistanceThresholdInMeters = 25000
         return;
     }
     [moc removeAllContentGroupsOfKind:WMFContentGroupKindLocation];
-    NSURL *placeholderURL = [WMFContentGroup locationPlaceholderContentGroupURL];
+    NSURL *placeholderURL = [WMFContentGroup locationPlaceholderContentGroupURLWithLanguageVariantCode:self.siteURL.wmf_languageVariantCode];
     NSDate *date = [NSDate date];
     // Check for group for date to re-use the same group if it was updated today
     WMFContentGroup *group = [moc newestGroupOfKind:WMFContentGroupKindLocationPlaceholder];

--- a/WikipediaUnitTests/Code/WMFArticleTests.swift
+++ b/WikipediaUnitTests/Code/WMFArticleTests.swift
@@ -106,4 +106,42 @@ class WMFArticleTests: XCTestCase {
         a.merge(b)
         XCTAssert(a.viewedDate != nil, "Viewed date should be set")
     }
+    
+    func testArticleTemporaryCacheKey() {
+        // Ensure WMFArticleTemporaryCacheKey works as expected as a key into the WMFArticle temporary cache
+        let articleCache = NSCache<WMFArticleTemporaryCacheKey, NSString>()
+        
+        let hantString: NSString = "ZH article with hant variant"
+        let hantKey = WMFArticleTemporaryCacheKey(databaseKey:"ZH article", variant:"hant")
+        articleCache.setObject(hantString, forKey:hantKey)
+        
+        let hansString: NSString = "ZH article with hans variant"
+        let hansKey = WMFArticleTemporaryCacheKey(databaseKey:"ZH article", variant:"hans")
+        articleCache.setObject(hansString, forKey:hansKey)
+        
+        let noVariantString: NSString = "ZH article with no variant"
+        let noVariantKey = WMFArticleTemporaryCacheKey(databaseKey:"ZH article", variant:nil)
+        articleCache.setObject(noVariantString, forKey:noVariantKey)
+        
+        let newHantKey = WMFArticleTemporaryCacheKey(databaseKey:"ZH article", variant:"hant")
+        var hantValue = articleCache.object(forKey:newHantKey)
+        XCTAssertEqual(hantValue, hantString)
+        
+        let newHansKey = WMFArticleTemporaryCacheKey(databaseKey:"ZH article", variant:"hans")
+        var hansValue = articleCache.object(forKey:newHansKey)
+        XCTAssertEqual(hansValue, hansString)
+        
+        let newNoVariantKey = WMFArticleTemporaryCacheKey(databaseKey:"ZH article", variant:nil)
+        var noVariantValue = articleCache.object(forKey:newNoVariantKey)
+        XCTAssertEqual(noVariantValue, noVariantString)
+        
+        hansValue = articleCache.object(forKey:hansKey)
+        XCTAssertEqual(hansValue, hansString)
+        
+        hantValue = articleCache.object(forKey:hantKey)
+        XCTAssertEqual(hantValue, hantString)
+        
+        noVariantValue = articleCache.object(forKey:noVariantKey)
+        XCTAssertEqual(noVariantValue, noVariantString)
+    }
 }


### PR DESCRIPTION
This is work towards the Chinese variants feature https://phabricator.wikimedia.org/T195265
It is not the entire feature/ticket.

Each commit is self-contained it is probably easiest to review them individually.

### Notes
**Commit 1**
In WMFContentGroup URL methods, propagates the language variant to the created URL.

In cases where an argument needed to be added, only the language variant is passed in, not a source URL. This is to indicate that those methods do not require a source URL, only the language variant.

Call sites are updated where necessary.

**Commit 2**
Update appropriate WMFContentGroup fetch methods to include the language variant as part of the predicate.

**Commit 3**
Clean up how the variant value is assigned in WMFContentGroup. Ensure URL, siteURL, and articleURL properties propagate the variant. Assert that any set URL value has the same variant value as the content group.

**Commit 4**
Add a class to serve as a compound key in the NSCache article cache in the MWKDataStore. Add a test to ensure it works as expected as a key.

**Commit 5**
Update WMFArticle and MWKDataStore to include the variant in fetches and use the new compound key for NSCache operations.

Note a few non-language variant-aware methods are left as temporary shims. Once those subsystems are variant-aware, the shim methods will be removed.

**Commit 6**
Refactor of opportunity. The deleted MWKDataStore methods are unused.

**Commit 7**
The 'contentPreview' property of WMFContentGroup and 'object' property of WMFContent are archived NSURLs, WMFMTLModel subclasses, or collections of those types. Since archived NSURLs have no notion of a language variant, the variant must be propagated to the unarchived objects. This is done in -awakeFromFetch so it only occurs for fetched objects once after fetch.

**Commit 8**
This commit makes sure Random articles do not appear as blank in the explore feed if you turn on language variants. It is a temporary shim until ArticleSummary is made variant-aware. This only has an effect if language variants are turned on.

### Test Steps
1. With variants turned off (current default) there should be no changes in app behavior.
2. With variants turned on, if you set multiple variants for the same language, you should see a set of explore feed cards for each variant. Content of cards should be visible on first launch and after quit and restart.
NOTE: The contents of the cards will not yet reflect the proper variant.