### PR TITLE
Improve POTD size in explore feed

### DIFF
--- a/WMF Framework/WMFContentGroup+Display.swift
+++ b/WMF Framework/WMFContentGroup+Display.swift
@@ -10,14 +10,27 @@ extension WMFFeedDisplayType {
 }
 
 extension WMFContentGroup {
-    public func imageURLsCompatibleWithTraitCollection(_ traitCollection: UITraitCollection, dataStore: MWKDataStore) -> Set<URL>? {
+    public func imageURLsCompatibleWithTraitCollection(_ traitCollection: UITraitCollection, dataStore: MWKDataStore, viewSize: CGSize? = nil) -> Set<URL>? {
         switch contentGroupKind {
         case .pictureOfTheDay:
             guard let imageInfo = contentPreview as? WMFFeedImage else {
                 return nil
             }
-            let imageURL = URL(string: WMFChangeImageSourceURLSizePrefix(imageInfo.imageThumbURL.absoluteString, traitCollection.wmf_leadImageWidth)) ?? imageInfo.imageThumbURL
+            
+            let fallback: (WMFFeedImage, UITraitCollection) -> URL = { imageInfo, traitCollection in
+                let imageURL = URL(string: WMFChangeImageSourceURLSizePrefix(imageInfo.imageThumbURL.absoluteString, traitCollection.wmf_leadImageWidth)) ?? imageInfo.imageThumbURL
+                return imageURL
+            }
+            
+            guard let viewSize = viewSize else {
+                return [fallback(imageInfo, traitCollection)]
+            }
+            
+            let scaledViewSize = CGSize(width: UIScreen.main.scale * viewSize.width, height: UIScreen.main.scale * viewSize.height)
+            let imageURL = imageInfo.getImageURL(forWidth: Double(scaledViewSize.width), height: Double(scaledViewSize.height)) ??
+                fallback(imageInfo, traitCollection)
             return [imageURL]
+
         case .announcement:
             guard let announcement = contentPreview as? WMFAnnouncement else {
                 return nil

--- a/Wikipedia/Code/ExploreCardViewController.swift
+++ b/Wikipedia/Code/ExploreCardViewController.swift
@@ -290,7 +290,7 @@ class ExploreCardViewController: UIViewController, UICollectionViewDataSource, U
         guard let cell = cell as? ImageCollectionViewCell, let imageInfo = contentGroup?.contentPreview as? WMFFeedImage else {
             return
         }
-        if !layoutOnly, let imageURL = contentGroup?.imageURLsCompatibleWithTraitCollection(traitCollection, dataStore: dataStore)?.first {
+        if !layoutOnly, let imageURL = contentGroup?.imageURLsCompatibleWithTraitCollection(traitCollection, dataStore: dataStore, viewSize: view.bounds.size)?.first {
             cell.imageView.wmf_setImage(with: imageURL, detectFaces: true, onGPU: true, failure: WMFIgnoreErrorHandler, success: WMFIgnoreSuccessHandler)
         }
         if !imageInfo.imageDescription.isEmpty {


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T164642

### Notes
* We added extra logic in https://github.com/wikimedia/wikipedia-ios/pull/3716/files to choose a clearer POTD url for displaying in the iOS14 widget. This ticket uses that same helper method to choose a better image URL for the explore feed card.

### Test Steps
1. Map locally the https://en.wikipedia.org/api/rest_v1/feed/featured/2021/xx/xx endpoint (depending on which day you're testing) with the response at https://en.wikipedia.org/api/rest_v1/feed/featured/2017/05/04. That will allow you to directly test the image that the original bug was filed against.
2. General POTD explore feed regression testing without mapping locally.

### Screenshots/Videos *(if applicable)*
Before:
![IMG_0219](https://user-images.githubusercontent.com/3620196/106322776-f6509200-623b-11eb-80f2-8666b32ea138.PNG)

After:
![IMG_0220](https://user-images.githubusercontent.com/3620196/106322791-fb154600-623b-11eb-923f-1bd39857b689.PNG)
