### PR TITLE
Variant-aware article summary keys

### DIFF
--- a/WMF Framework/ArticleSummary.swift
+++ b/WMF Framework/ArticleSummary.swift
@@ -56,8 +56,8 @@ public class ArticleSummary: NSObject, Codable {
         return URL(string: urlString)
     }
     
-    var key: String? {
-        return articleURL?.wmf_databaseKey // don't use contentURLs.desktop?.page directly as it needs to be standardized
+    var key: WMFInMemoryURLKey? {
+        return articleURL?.wmf_inMemoryKey // don't use contentURLs.desktop?.page directly as it needs to be standardized
     }
 }
 

--- a/WMF Framework/ArticleSummary.swift
+++ b/WMF Framework/ArticleSummary.swift
@@ -28,6 +28,7 @@ public class ArticleSummary: NSObject, Codable {
     let thumbnail: ArticleSummaryImage?
     let original: ArticleSummaryImage?
     @objc let coordinates: ArticleSummaryCoordinates?
+    var languageVariantCode: String?
     
     enum CodingKeys: String, CodingKey {
         case id = "pageid"
@@ -53,7 +54,9 @@ public class ArticleSummary: NSObject, Codable {
         guard let urlString = contentURLs.desktop?.page else {
             return nil
         }
-        return URL(string: urlString)
+        var articleURL = URL(string: urlString)
+        articleURL?.wmf_languageVariantCode = languageVariantCode
+        return articleURL
     }
     
     var key: WMFInMemoryURLKey? {

--- a/WMF Framework/ReadingListsAPIController.swift
+++ b/WMF Framework/ReadingListsAPIController.swift
@@ -112,8 +112,8 @@ extension APIReadingListEntry {
         return site.wmf_URL(withTitle: title)
     }
     
-    var articleKey: String? {
-        return articleURL?.wmf_databaseKey
+    var articleKey: WMFInMemoryURLKey? {
+        return articleURL?.wmf_inMemoryKey
     }
 }
 

--- a/WMF Framework/SummaryExtensions.swift
+++ b/WMF Framework/SummaryExtensions.swift
@@ -88,12 +88,12 @@ extension WMFArticle {
 }
 
 extension NSManagedObjectContext {
-    @objc public func wmf_createOrUpdateArticleSummmaries(withSummaryResponses summaryResponses: [String: ArticleSummary]) throws -> [String: WMFArticle] {
+    @objc public func wmf_createOrUpdateArticleSummmaries(withSummaryResponses summaryResponses: [WMFInMemoryURLKey: ArticleSummary]) throws -> [WMFInMemoryURLKey: WMFArticle] {
         guard !summaryResponses.isEmpty else {
             return [:]
         }
-        var keys: [String] = []
-        var reverseRedirectedKeys: [String: String] = [:]
+        var keys: [WMFInMemoryURLKey] = []
+        var reverseRedirectedKeys: [WMFInMemoryURLKey: WMFInMemoryURLKey] = [:]
         keys.reserveCapacity(summaryResponses.count)
         for (key, summary) in summaryResponses {
             guard
@@ -106,8 +106,8 @@ extension NSManagedObjectContext {
             reverseRedirectedKeys[summaryKey] = key
             keys.append(summaryKey)
             do {
-                let articlesWithKey = try fetchArticles(withKey: key)
-                let articlesWithSummaryKey = try fetchArticles(withKey: summaryKey)
+                let articlesWithKey = try fetchArticles(with: key.url)
+                let articlesWithSummaryKey = try fetchArticles(with: summaryKey.url)
                 guard let canonicalArticle = articlesWithSummaryKey.first ?? articlesWithKey.first else {
                     continue
                 }
@@ -119,7 +119,8 @@ extension NSManagedObjectContext {
                     canonicalArticle.merge(article)
                     delete(article)
                 }
-                canonicalArticle.key = summaryKey
+                canonicalArticle.key = summaryKey.databaseKey
+                canonicalArticle.variant = summaryKey.languageVariantCode
             } catch let error {
                 DDLogError("Error fetching articles for merge: \(error)")
             }
@@ -127,11 +128,11 @@ extension NSManagedObjectContext {
         var keysToCreate = Set(keys)
         let articlesToUpdateFetchRequest = WMFArticle.fetchRequest()
         articlesToUpdateFetchRequest.predicate = NSPredicate(format: "key IN %@", keys)
-        var articles: [String: WMFArticle] = [:]
+        var articles: [WMFInMemoryURLKey: WMFArticle] = [:]
         articles.reserveCapacity(keys.count)
         let fetchedArticles = try self.fetch(articlesToUpdateFetchRequest)
         for articleToUpdate in fetchedArticles {
-            guard let articleKey = articleToUpdate.key else {
+            guard let articleKey = articleToUpdate.inMemoryKey else {
                     continue
             }
             let requestedKey = reverseRedirectedKeys[articleKey] ?? articleKey
@@ -146,7 +147,7 @@ extension NSManagedObjectContext {
         for key in keysToCreate {
             let requestedKey = reverseRedirectedKeys[key] ?? key
             guard let result = summaryResponses[requestedKey], // responses are by requested key
-                let article = self.createArticle(withKey: key) else { // article should have redirected key
+                  let article = self.createArticle(with: key.url) else { // article should have redirected key
                     continue
             }
             article.update(withSummary: result)

--- a/WMF Framework/SummaryExtensions.swift
+++ b/WMF Framework/SummaryExtensions.swift
@@ -127,7 +127,7 @@ extension NSManagedObjectContext {
         }
         var keysToCreate = Set(keys)
         let articlesToUpdateFetchRequest = WMFArticle.fetchRequest()
-        articlesToUpdateFetchRequest.predicate = NSPredicate(format: "key IN %@", keys)
+        articlesToUpdateFetchRequest.predicate = articlePredicateForInMemoryURLKeys(keys)
         var articles: [WMFInMemoryURLKey: WMFArticle] = [:]
         articles.reserveCapacity(keys.count)
         let fetchedArticles = try self.fetch(articlesToUpdateFetchRequest)

--- a/WMF Framework/WMFArticle+Extensions.h
+++ b/WMF Framework/WMFArticle+Extensions.h
@@ -83,14 +83,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-// WMFDataSource maintains a temporary local NSCache of WMFArticle instances.
-// The database key is derived from the article URL which does not take language variants into account.
-// Instances of this class are used as the key in that cache
-@interface WMFArticleTemporaryCacheKey: NSObject
--(instancetype) initWithDatabaseKey:(NSString *)databaseKey variant:(nullable NSString *)variant;
--(instancetype) init NS_UNAVAILABLE;
-@property (readonly, nonatomic, copy) NSString *databaseKey;
-@property (readonly, nonatomic, copy) NSString *variant;
-@end
-
 NS_ASSUME_NONNULL_END

--- a/WMF Framework/WMFArticle+Extensions.h
+++ b/WMF Framework/WMFArticle+Extensions.h
@@ -2,6 +2,7 @@
 
 @class MWKSearchResult;
 @class WMFFeedArticlePreview;
+@class WMFInMemoryURLKey;
 
 typedef NS_ENUM(NSUInteger, WMFGeoType) {
     WMFGeoTypeUnknown = 0,
@@ -38,6 +39,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nullable) NSURL *URL;
 
+@property (nonatomic, readonly, nullable) WMFInMemoryURLKey *inMemoryKey;
+
 @property (nonatomic, copy, nonnull) NSString *displayTitleHTML;
 
 @property (nonatomic, readonly, nullable) NSString *capitalizedWikidataDescription;
@@ -65,9 +68,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable WMFArticle *)fetchArticleWithKey:(nullable NSString *)key variant:(nullable NSString *)variant;
 
+- (nullable NSArray<WMFArticle *> *)fetchArticlesWithURL:(nullable NSURL *)url error:(NSError **)error;
 - (nullable NSArray<WMFArticle *> *)fetchArticlesWithKey:(nullable NSString *)key variant:(nullable NSString *)variant error:(NSError **)error;
 - (nullable NSArray<WMFArticle *> *)fetchArticlesWithKey:(nullable NSString *)key error:(NSError **)error; // Temporary shim for ArticleSummary that is not yet variant-aware
 
+- (nullable WMFArticle *)createArticleWithURL:(nullable NSURL *)url;
 - (nullable WMFArticle *)createArticleWithKey:(nullable NSString *)key variant:(nullable NSString *)variant;
 - (nullable WMFArticle *)createArticleWithKey:(nullable NSString *)key; // Temporary shim for ArticleSummary that is not yet variant-aware
 

--- a/WMF Framework/WMFArticle+Extensions.h
+++ b/WMF Framework/WMFArticle+Extensions.h
@@ -86,6 +86,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable WMFArticle *)fetchArticleWithWikidataID:(nullable NSString *)wikidataID;
 
+- (NSPredicate *)articlePredicateForInMemoryURLKeys:(NSArray<WMFInMemoryURLKey *> *)urlKeys NS_SWIFT_NAME(articlePredicateForInMemoryURLKeys(_:));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WMF Framework/WMFArticle+Extensions.h
+++ b/WMF Framework/WMFArticle+Extensions.h
@@ -70,11 +70,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSArray<WMFArticle *> *)fetchArticlesWithURL:(nullable NSURL *)url error:(NSError **)error;
 - (nullable NSArray<WMFArticle *> *)fetchArticlesWithKey:(nullable NSString *)key variant:(nullable NSString *)variant error:(NSError **)error;
-- (nullable NSArray<WMFArticle *> *)fetchArticlesWithKey:(nullable NSString *)key error:(NSError **)error; // Temporary shim for ArticleSummary that is not yet variant-aware
 
 - (nullable WMFArticle *)createArticleWithURL:(nullable NSURL *)url;
 - (nullable WMFArticle *)createArticleWithKey:(nullable NSString *)key variant:(nullable NSString *)variant;
-- (nullable WMFArticle *)createArticleWithKey:(nullable NSString *)key; // Temporary shim for ArticleSummary that is not yet variant-aware
 
 - (nullable WMFArticle *)fetchOrCreateArticleWithKey:(nullable NSString *)key variant:(nullable NSString *)variant;
 

--- a/WMF Framework/WMFArticle+Extensions.m
+++ b/WMF Framework/WMFArticle+Extensions.m
@@ -241,35 +241,3 @@
 }
 
 @end
-
-#pragma mark - WMFArticleTemporaryCacheKey
-
-@interface WMFArticleTemporaryCacheKey ()
-@property (nonatomic, copy) NSString *databaseKey;
-@property (nonatomic, copy) NSString *variant;
-@end
-
-@implementation WMFArticleTemporaryCacheKey: NSObject
--(instancetype) initWithDatabaseKey:(NSString *)databaseKey variant:(nullable NSString *)variant {
-    if (self = [super init]) {
-        self.databaseKey = databaseKey;
-        self.variant = variant;
-    }
-    return self;
-}
-
-WMF_SYNTHESIZE_IS_EQUAL(WMFArticleTemporaryCacheKey, isEqualToArticleTemporaryCacheKey:)
-
-- (BOOL)isEqualToArticleTemporaryCacheKey:(WMFArticleTemporaryCacheKey *)rhs {
-    return WMF_RHS_PROP_EQUAL(databaseKey, isEqualToString:) && WMF_RHS_PROP_EQUAL(variant, isEqualToString:);
-}
-
-- (NSUInteger)hash {
-    return self.databaseKey.hash ^ flipBitsWithAdditionalRotation(self.variant.hash, 1); // When variant is nil, the XOR flips the bits
-}
-
-- (NSString *)description {
-    return [NSString stringWithFormat: @"%@ databaseKey: %@, variant: %@", [super description], self.databaseKey, self.variant];
-}
-
-@end

--- a/WMF Framework/WMFArticle+Extensions.m
+++ b/WMF Framework/WMFArticle+Extensions.m
@@ -137,10 +137,6 @@
     return [self fetchArticlesWithKey:url.wmf_databaseKey variant:url.wmf_languageVariantCode error:error];
 }
 
-- (nullable NSArray<WMFArticle *> *)fetchArticlesWithKey:(nullable NSString *)key error:(NSError **)error {
-    return [self fetchArticlesWithKey:key variant:nil error:error];
-}
-
 - (nullable NSArray<WMFArticle *> *)fetchArticlesWithKey:(nullable NSString *)key variant:(nullable NSString *)variant error:(NSError **)error {
     if (!key) {
         return @[];
@@ -176,10 +172,6 @@
 
 - (nullable WMFArticle *)createArticleWithURL:(nullable NSURL *)url {
     return [self createArticleWithKey:url.wmf_databaseKey variant:url.wmf_languageVariantCode];
-}
-
-- (nullable WMFArticle *)createArticleWithKey:(nullable NSString *)key {
-    return [self createArticleWithKey:key variant:nil];
 }
 
 - (nullable WMFArticle *)createArticleWithKey:(nullable NSString *)key variant:(nullable NSString *)variant {

--- a/WMF Framework/WMFArticle+Extensions.m
+++ b/WMF Framework/WMFArticle+Extensions.m
@@ -1,4 +1,5 @@
 #import <WMF/WMFArticle+Extensions.h>
+#import <WMF/NSURL+WMFLinkParsing.h>
 #import <WMF/WMF-Swift.h>
 
 @implementation WMFArticle (Extensions)
@@ -15,6 +16,10 @@
     NSURL *value = [NSURL URLWithString:key];
     value.wmf_languageVariantCode = self.variant;
     return value;
+}
+
+- (nullable WMFInMemoryURLKey *)inMemoryKey {
+    return self.URL.wmf_inMemoryKey;
 }
 
 #pragma clang diagnostic push
@@ -128,6 +133,10 @@
     return [self fetchArticleWithKey:articleURL.wmf_databaseKey variant:articleURL.wmf_languageVariantCode];
 }
 
+- (nullable NSArray<WMFArticle *> *)fetchArticlesWithURL:(nullable NSURL *)url error:(NSError **)error {
+    return [self fetchArticlesWithKey:url.wmf_databaseKey variant:url.wmf_languageVariantCode error:error];
+}
+
 - (nullable NSArray<WMFArticle *> *)fetchArticlesWithKey:(nullable NSString *)key error:(NSError **)error {
     return [self fetchArticlesWithKey:key variant:nil error:error];
 }
@@ -163,6 +172,10 @@
     request.predicate = [NSPredicate predicateWithFormat:@"wikidataID == %@", wikidataID];
     article = [[self executeFetchRequest:request error:nil] firstObject];
     return article;
+}
+
+- (nullable WMFArticle *)createArticleWithURL:(nullable NSURL *)url {
+    return [self createArticleWithKey:url.wmf_databaseKey variant:url.wmf_languageVariantCode];
 }
 
 - (nullable WMFArticle *)createArticleWithKey:(nullable NSString *)key {

--- a/WMF Framework/WMFArticle+Extensions.m
+++ b/WMF Framework/WMFArticle+Extensions.m
@@ -253,4 +253,13 @@
     return preview;
 }
 
+- (NSPredicate *)articlePredicateForInMemoryURLKeys:(NSArray<WMFInMemoryURLKey *> *)urlKeys {
+    NSMutableArray<NSPredicate *> *subpredicates = [[NSMutableArray alloc] init];
+    for (WMFInMemoryURLKey *urlKey in urlKeys) {
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"key == %@ && variant == %@", urlKey.databaseKey, urlKey.languageVariantCode];
+        [subpredicates addObject:predicate];
+    }
+    return [NSCompoundPredicate orPredicateWithSubpredicates:subpredicates];
+}
+
 @end

--- a/Wikipedia/Code/ArticleFetcher.swift
+++ b/Wikipedia/Code/ArticleFetcher.swift
@@ -462,7 +462,7 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
     }
     
     /// Fetches ArticleSummaries from the Page Content Service for the given articleKeys
-    @discardableResult public func fetchArticleSummaryResponsesForArticles(withKeys articleKeys: [String], cachePolicy: URLRequest.CachePolicy? = nil, completion: @escaping ([String: ArticleSummary]) -> Void) -> [URLSessionTask] {
+    @discardableResult public func fetchArticleSummaryResponsesForArticles(withKeys articleKeys: [WMFInMemoryURLKey], cachePolicy: URLRequest.CachePolicy? = nil, completion: @escaping ([WMFInMemoryURLKey: ArticleSummary]) -> Void) -> [URLSessionTask] {
         
         var tasks: [URLSessionTask] = []
         articleKeys.asyncMapToDictionary(block: { (articleKey, asyncMapCompletion) in
@@ -478,9 +478,9 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
     }
     
     /// Fetches a single ArticleSummary or the given articleKey from the Page Content Service
-    @discardableResult public func fetchSummaryForArticle(with articleKey: String, cachePolicy: URLRequest.CachePolicy? = nil, completion: @escaping (ArticleSummary?, URLResponse?, Error?) -> Swift.Void) -> URLSessionTask? {
+    @discardableResult public func fetchSummaryForArticle(with articleKey: WMFInMemoryURLKey, cachePolicy: URLRequest.CachePolicy? = nil, completion: @escaping (ArticleSummary?, URLResponse?, Error?) -> Swift.Void) -> URLSessionTask? {
         do {
-            guard let articleURL = URL(string: articleKey) else {
+            guard let articleURL = articleKey.url else {
                 throw Fetcher.invalidParametersError
             }
             let request = try summaryRequest(articleURL: articleURL)

--- a/Wikipedia/Code/ArticleFetcher.swift
+++ b/Wikipedia/Code/ArticleFetcher.swift
@@ -487,6 +487,7 @@ final public class ArticleFetcher: Fetcher, CacheFetching {
             return trackedJSONDecodableTask(with: request) { (result: Result<ArticleSummary, Error>, response) in
                 switch result {
                 case .success(let summary):
+                    summary.languageVariantCode = articleKey.languageVariantCode
                     completion(summary, response, nil)
                 case .failure(let error):
                     completion(nil, response, error)

--- a/Wikipedia/Code/ArticlePeekPreviewViewController.swift
+++ b/Wikipedia/Code/ArticlePeekPreviewViewController.swift
@@ -29,7 +29,7 @@ class ArticlePeekPreviewViewController: UIViewController, Peekable {
             return
         }
         isFetched = true
-        guard let key = articleURL.wmf_databaseKey else {
+        guard let key = articleURL.wmf_inMemoryKey else {
             completion?()
             return
         }

--- a/Wikipedia/Code/ArticleSummaryController.swift
+++ b/Wikipedia/Code/ArticleSummaryController.swift
@@ -11,7 +11,7 @@ public class ArticleSummaryController: NSObject {
         self.fetcher = ArticleFetcher(session: session, configuration: configuration)
     }
     
-    @discardableResult public func updateOrCreateArticleSummaryForArticle(withKey articleKey: String, cachePolicy: URLRequest.CachePolicy? = nil, completion: ((WMFArticle?, Error?) -> Void)? = nil) -> URLSessionTask? {
+    @discardableResult public func updateOrCreateArticleSummaryForArticle(withKey articleKey: WMFInMemoryURLKey, cachePolicy: URLRequest.CachePolicy? = nil, completion: ((WMFArticle?, Error?) -> Void)? = nil) -> URLSessionTask? {
         return fetcher.fetchSummaryForArticle(with: articleKey, cachePolicy: cachePolicy) { [weak self] (articleSummary, urlResponse, error) in
             DispatchQueue.main.async {
                 guard let articleSummary = articleSummary,
@@ -26,7 +26,7 @@ public class ArticleSummaryController: NSObject {
         }
     }
     
-    @discardableResult public func updateOrCreateArticleSummariesForArticles(withKeys articleKeys: [String], cachePolicy: URLRequest.CachePolicy? = nil, completion: (([String: WMFArticle], Error?) -> Void)? = nil) -> [URLSessionTask] {
+    @discardableResult public func updateOrCreateArticleSummariesForArticles(withKeys articleKeys: [WMFInMemoryURLKey], cachePolicy: URLRequest.CachePolicy? = nil, completion: (([WMFInMemoryURLKey: WMFArticle], Error?) -> Void)? = nil) -> [URLSessionTask] {
 
         return fetcher.fetchArticleSummaryResponsesForArticles(withKeys: articleKeys, cachePolicy: cachePolicy) { [weak self] (summaryResponses) in
             DispatchQueue.main.async {
@@ -35,7 +35,7 @@ public class ArticleSummaryController: NSObject {
         }
     }
     
-    private func processSummaryResponses(with summaryResponses: [String: ArticleSummary], completion: (([String: WMFArticle], Error?) -> Void)? = nil) {
+    private func processSummaryResponses(with summaryResponses: [WMFInMemoryURLKey: ArticleSummary], completion: (([WMFInMemoryURLKey: WMFArticle], Error?) -> Void)? = nil) {
         guard let moc = dataStore?.viewContext else {
             completion?([:], RequestError.invalidParameters)
             return

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -441,7 +441,7 @@ class ArticleViewController: ViewController, HintPresenting {
             self.articleLoadWaitGroup = nil
         }
         
-        guard let key = article.key else {
+        guard let key = article.inMemoryKey else {
             return
         }
         
@@ -459,7 +459,7 @@ class ArticleViewController: ViewController, HintPresenting {
                 }
                 self.article = article
                 // Handle redirects
-                guard let newKey = article.key, newKey != key, let newURL = article.url else {
+                guard let newKey = article.inMemoryKey, newKey != key, let newURL = article.url else {
                     return
                 }
                 self.articleURL = newURL

--- a/Wikipedia/Code/DisambiguationPagesViewController.swift
+++ b/Wikipedia/Code/DisambiguationPagesViewController.swift
@@ -40,7 +40,7 @@ class DisambiguationPagesViewController: ArticleFetchedResultsViewController {
     
     func fetch() {
         fakeProgressController.start()
-        let articleKeys = articleURLs.compactMap { $0.wmf_databaseKey }
+        let articleKeys = articleURLs.compactMap { $0.wmf_inMemoryKey }
         self.dataStore.articleSummaryController.updateOrCreateArticleSummariesForArticles(withKeys: articleKeys) { (_, error) in
             self.fakeProgressController.finish()
             if let error = error {

--- a/Wikipedia/Code/EditLinkViewController.swift
+++ b/Wikipedia/Code/EditLinkViewController.swift
@@ -97,7 +97,7 @@ class EditLinkViewController: ViewController {
 
     private func fetchArticle() {
         guard let article = dataStore.fetchArticle(with: articleURL) else {
-            guard let key = articleURL.wmf_databaseKey else {
+            guard let key = articleURL.wmf_inMemoryKey else {
                 return
             }
             dataStore.articleSummaryController.updateOrCreateArticleSummaryForArticle(withKey: key) { (article, _) in

--- a/Wikipedia/Code/MWKDataStore.h
+++ b/Wikipedia/Code/MWKDataStore.h
@@ -109,7 +109,6 @@ typedef NS_OPTIONS(NSUInteger, RemoteConfigOption) {
 - (nullable WMFArticle *)fetchArticleWithURL:(NSURL *)URL inManagedObjectContext:(NSManagedObjectContext *)moc;
 - (nullable WMFArticle *)fetchOrCreateArticleWithURL:(NSURL *)URL inManagedObjectContext:(NSManagedObjectContext *)moc;
 - (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key variant:(nullable NSString *)variant inManagedObjectContext:(NSManagedObjectContext *)moc;
-- (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key inManagedObjectContext:(NSManagedObjectContext *)moc; // Temporary shim for areas like reading lists that are not yet variant-aware
 
 - (nullable WMFArticle *)fetchArticleWithURL:(NSURL *)URL;         //uses the view context
 - (nullable WMFArticle *)fetchOrCreateArticleWithURL:(NSURL *)URL; //uses the view context

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -890,10 +890,6 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
     return [self fetchArticleWithKey:URL.wmf_databaseKey variant:URL.wmf_languageVariantCode inManagedObjectContext:moc];
 }
 
-- (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key inManagedObjectContext:(nonnull NSManagedObjectContext *)moc {
-    return [self fetchArticleWithKey:key variant:nil inManagedObjectContext:moc];
-}
-
 - (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key variant:(nullable NSString *)variant inManagedObjectContext:(nonnull NSManagedObjectContext *)moc {
     WMFArticle *article = nil;
     if (moc == _viewContext) { // use ivar to avoid main thread check

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -776,7 +776,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
             continue;
         }
         NSString *variant = article.variant;
-        WMFInMemoryURLKey *cacheKey = [[WMFInMemoryURLKey alloc] initWithDatabaseKey:key variant:variant];
+        WMFInMemoryURLKey *cacheKey = [[WMFInMemoryURLKey alloc] initWithDatabaseKey:key languageVariantCode:variant];
         [self.articleCache setObject:article forKey:cacheKey];
     }
 }
@@ -897,7 +897,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
 - (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key variant:(nullable NSString *)variant inManagedObjectContext:(nonnull NSManagedObjectContext *)moc {
     WMFArticle *article = nil;
     if (moc == _viewContext) { // use ivar to avoid main thread check
-        WMFInMemoryURLKey *cacheKey = [[WMFInMemoryURLKey alloc] initWithDatabaseKey:key variant:variant];
+        WMFInMemoryURLKey *cacheKey = [[WMFInMemoryURLKey alloc] initWithDatabaseKey:key languageVariantCode:variant];
         article = [self.articleCache objectForKey:cacheKey];
         if (article) {
             return article;
@@ -905,7 +905,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
     }
     article = [moc fetchArticleWithKey:key variant:variant];
     if (article && moc == _viewContext) { // use ivar to avoid main thread check
-        WMFInMemoryURLKey *cacheKey = [[WMFInMemoryURLKey alloc] initWithDatabaseKey:key variant:variant];
+        WMFInMemoryURLKey *cacheKey = [[WMFInMemoryURLKey alloc] initWithDatabaseKey:key languageVariantCode:variant];
         [self.articleCache setObject:article forKey:cacheKey];
     }
     return article;
@@ -928,7 +928,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
         article = [moc createArticleWithKey:key variant:variant];
         article.displayTitleHTML = article.displayTitle;
         if (moc == self.viewContext) {
-            WMFInMemoryURLKey *cacheKey = [[WMFInMemoryURLKey alloc] initWithDatabaseKey:key variant:variant];
+            WMFInMemoryURLKey *cacheKey = [[WMFInMemoryURLKey alloc] initWithDatabaseKey:key languageVariantCode:variant];
             [self.articleCache setObject:article forKey:cacheKey];
         }
     }

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -776,7 +776,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
             continue;
         }
         NSString *variant = article.variant;
-        WMFArticleTemporaryCacheKey *cacheKey = [[WMFArticleTemporaryCacheKey alloc] initWithDatabaseKey:key variant:variant];
+        WMFInMemoryURLKey *cacheKey = [[WMFInMemoryURLKey alloc] initWithDatabaseKey:key variant:variant];
         [self.articleCache setObject:article forKey:cacheKey];
     }
 }
@@ -897,7 +897,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
 - (nullable WMFArticle *)fetchArticleWithKey:(NSString *)key variant:(nullable NSString *)variant inManagedObjectContext:(nonnull NSManagedObjectContext *)moc {
     WMFArticle *article = nil;
     if (moc == _viewContext) { // use ivar to avoid main thread check
-        WMFArticleTemporaryCacheKey *cacheKey = [[WMFArticleTemporaryCacheKey alloc] initWithDatabaseKey:key variant:variant];
+        WMFInMemoryURLKey *cacheKey = [[WMFInMemoryURLKey alloc] initWithDatabaseKey:key variant:variant];
         article = [self.articleCache objectForKey:cacheKey];
         if (article) {
             return article;
@@ -905,7 +905,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
     }
     article = [moc fetchArticleWithKey:key variant:variant];
     if (article && moc == _viewContext) { // use ivar to avoid main thread check
-        WMFArticleTemporaryCacheKey *cacheKey = [[WMFArticleTemporaryCacheKey alloc] initWithDatabaseKey:key variant:variant];
+        WMFInMemoryURLKey *cacheKey = [[WMFInMemoryURLKey alloc] initWithDatabaseKey:key variant:variant];
         [self.articleCache setObject:article forKey:cacheKey];
     }
     return article;
@@ -928,7 +928,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
         article = [moc createArticleWithKey:key variant:variant];
         article.displayTitleHTML = article.displayTitle;
         if (moc == self.viewContext) {
-            WMFArticleTemporaryCacheKey *cacheKey = [[WMFArticleTemporaryCacheKey alloc] initWithDatabaseKey:key variant:variant];
+            WMFInMemoryURLKey *cacheKey = [[WMFInMemoryURLKey alloc] initWithDatabaseKey:key variant:variant];
             [self.articleCache setObject:article forKey:cacheKey];
         }
     }

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.h
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.h
@@ -233,10 +233,15 @@ extern NSString *const WMFEditPencil;
  * The key value in database entities is the value of wmf_databaseKey.
 */
 @interface WMFInMemoryURLKey: NSObject
--(instancetype) initWithDatabaseKey:(NSString *)databaseKey variant:(nullable NSString *)variant;
+-(instancetype) initWithDatabaseKey:(NSString *)databaseKey languageVariantCode:(nullable NSString *)languageVariantCode;
 -(instancetype) init NS_UNAVAILABLE;
 @property (readonly, nonatomic, copy) NSString *databaseKey;
-@property (readonly, nonatomic, copy) NSString *variant;
+@property (readonly, nonatomic, copy, nullable) NSString *languageVariantCode;
+@property (readonly, nonatomic, copy, nullable) NSURL *URL;
+@end
+
+@interface NSURL (WMFInMemoryURLKeyExtensions)
+@property (readonly, nonatomic, copy, nullable) WMFInMemoryURLKey *wmf_inMemoryKey;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.h
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.h
@@ -219,4 +219,24 @@ extern NSString *const WMFEditPencil;
 
 @end
 
+
+/**
+ * A number of places in the app need a unique in-memory key for a URL, typically an article URL:
+ * - WMFDataSource maintains a temporary local NSCache of WMFArticle instances.
+ * - ArticleSummary and reading list processing use a unique key for calcualting differences
+ *
+ * The value of wmf_databaseKey derived a URL does not take language variants into account.
+ * This key combines the value of wmf_databaseKey and wmf_languageVariantCode to form a unique key.
+ * This key should be used in instance of NSCache, as keys to dictionaries or other in-memory uses.
+ *
+ * For Core Data entities, the key and variant are maintained as separate properties.
+ * The key value in database entities is the value of wmf_databaseKey.
+*/
+@interface WMFInMemoryURLKey: NSObject
+-(instancetype) initWithDatabaseKey:(NSString *)databaseKey variant:(nullable NSString *)variant;
+-(instancetype) init NS_UNAVAILABLE;
+@property (readonly, nonatomic, copy) NSString *databaseKey;
+@property (readonly, nonatomic, copy) NSString *variant;
+@end
+
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.h
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.h
@@ -233,7 +233,8 @@ extern NSString *const WMFEditPencil;
  * The key value in database entities is the value of wmf_databaseKey.
 */
 @interface WMFInMemoryURLKey: NSObject
--(instancetype) initWithDatabaseKey:(NSString *)databaseKey languageVariantCode:(nullable NSString *)languageVariantCode;
+-(instancetype) initWithDatabaseKey:(NSString *)databaseKey languageVariantCode:(nullable NSString *)languageVariantCode NS_DESIGNATED_INITIALIZER;
+-(nullable instancetype) initWithURL:(NSURL *)url;
 -(instancetype) init NS_UNAVAILABLE;
 @property (readonly, nonatomic, copy) NSString *databaseKey;
 @property (readonly, nonatomic, copy, nullable) NSString *languageVariantCode;

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.h
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.h
@@ -215,14 +215,13 @@ extern NSString *const WMFEditPencil;
  *  Settable property for language variant code, defaults to nil
  *  Returns language variant code if present or nil if no code set
  */
-@property (nonatomic, copy, nullable)NSString *wmf_languageVariantCode;
+@property (nonatomic, copy, nullable) NSString *wmf_languageVariantCode;
 
 @end
 
-
 /**
  * A number of places in the app need a unique in-memory key for a URL, typically an article URL:
- * - WMFDataSource maintains a temporary local NSCache of WMFArticle instances.
+ * - WMFDataStore maintains a temporary local NSCache of WMFArticle instances.
  * - ArticleSummary and reading list processing use a unique key for calcualting differences
  *
  * The value of wmf_databaseKey derived a URL does not take language variants into account.
@@ -232,10 +231,10 @@ extern NSString *const WMFEditPencil;
  * For Core Data entities, the key and variant are maintained as separate properties.
  * The key value in database entities is the value of wmf_databaseKey.
 */
-@interface WMFInMemoryURLKey: NSObject
--(instancetype) initWithDatabaseKey:(NSString *)databaseKey languageVariantCode:(nullable NSString *)languageVariantCode NS_DESIGNATED_INITIALIZER;
--(nullable instancetype) initWithURL:(NSURL *)url;
--(instancetype) init NS_UNAVAILABLE;
+@interface WMFInMemoryURLKey : NSObject
+- (instancetype)initWithDatabaseKey:(NSString *)databaseKey languageVariantCode:(nullable NSString *)languageVariantCode NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithURL:(NSURL *)url;
+- (instancetype)init NS_UNAVAILABLE;
 @property (readonly, nonatomic, copy) NSString *databaseKey;
 @property (readonly, nonatomic, copy, nullable) NSString *languageVariantCode;
 @property (readonly, nonatomic, copy, nullable) NSURL *URL;

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.m
@@ -289,3 +289,36 @@ static id wmf_languageVariantAssociatedObjectKey;
 }
 
 @end
+
+#pragma mark - WMFInMemoryURLKey
+
+@interface WMFInMemoryURLKey ()
+@property (nonatomic, copy) NSString *databaseKey;
+@property (nonatomic, copy) NSString *variant;
+@end
+
+@implementation WMFInMemoryURLKey: NSObject
+-(instancetype) initWithDatabaseKey:(NSString *)databaseKey variant:(nullable NSString *)variant {
+    if (self = [super init]) {
+        self.databaseKey = databaseKey;
+        self.variant = variant;
+    }
+    return self;
+}
+
+WMF_SYNTHESIZE_IS_EQUAL(WMFInMemoryURLKey, isEqualToArticleTemporaryCacheKey:)
+
+- (BOOL)isEqualToArticleTemporaryCacheKey:(WMFInMemoryURLKey *)rhs {
+    return WMF_RHS_PROP_EQUAL(databaseKey, isEqualToString:) && WMF_RHS_PROP_EQUAL(variant, isEqualToString:);
+}
+
+- (NSUInteger)hash {
+    return self.databaseKey.hash ^ flipBitsWithAdditionalRotation(self.variant.hash, 1); // When variant is nil, the XOR flips the bits
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat: @"%@ databaseKey: %@, variant: %@", [super description], self.databaseKey, self.variant];
+}
+
+@end
+

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.m
@@ -306,6 +306,18 @@ static id wmf_languageVariantAssociatedObjectKey;
     return self;
 }
 
+-(nullable instancetype) initWithURL:(NSURL *)URL {
+    NSString *databaseKey = URL.wmf_databaseKey;
+    if (!databaseKey) { return nil; }
+    else { return [self initWithDatabaseKey:databaseKey languageVariantCode:URL.wmf_languageVariantCode]; }
+}
+
+- (nullable NSURL *)URL {
+    NSURL *URL = [NSURL URLWithString:self.databaseKey];
+    URL.wmf_languageVariantCode = self.languageVariantCode;
+    return URL;
+}
+
 WMF_SYNTHESIZE_IS_EQUAL(WMFInMemoryURLKey, isEqualToArticleTemporaryCacheKey:)
 
 - (BOOL)isEqualToArticleTemporaryCacheKey:(WMFInMemoryURLKey *)rhs {
@@ -320,5 +332,11 @@ WMF_SYNTHESIZE_IS_EQUAL(WMFInMemoryURLKey, isEqualToArticleTemporaryCacheKey:)
     return [NSString stringWithFormat: @"%@ databaseKey: %@, languageVariantCode: %@", [super description], self.databaseKey, self.languageVariantCode];
 }
 
+@end
+
+@implementation NSURL (WMFInMemoryURLKeyExtensions)
+- (nullable WMFInMemoryURLKey *)wmf_inMemoryKey {
+    return [[WMFInMemoryURLKey alloc] initWithURL:self];
+}
 @end
 

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.m
@@ -294,14 +294,14 @@ static id wmf_languageVariantAssociatedObjectKey;
 
 @interface WMFInMemoryURLKey ()
 @property (nonatomic, copy) NSString *databaseKey;
-@property (nonatomic, copy) NSString *variant;
+@property (nonatomic, copy, nullable) NSString *languageVariantCode;
 @end
 
 @implementation WMFInMemoryURLKey: NSObject
--(instancetype) initWithDatabaseKey:(NSString *)databaseKey variant:(nullable NSString *)variant {
+-(instancetype) initWithDatabaseKey:(NSString *)databaseKey languageVariantCode:(nullable NSString *)languageVariantCode {
     if (self = [super init]) {
         self.databaseKey = databaseKey;
-        self.variant = variant;
+        self.languageVariantCode = languageVariantCode;
     }
     return self;
 }
@@ -309,15 +309,15 @@ static id wmf_languageVariantAssociatedObjectKey;
 WMF_SYNTHESIZE_IS_EQUAL(WMFInMemoryURLKey, isEqualToArticleTemporaryCacheKey:)
 
 - (BOOL)isEqualToArticleTemporaryCacheKey:(WMFInMemoryURLKey *)rhs {
-    return WMF_RHS_PROP_EQUAL(databaseKey, isEqualToString:) && WMF_RHS_PROP_EQUAL(variant, isEqualToString:);
+    return WMF_RHS_PROP_EQUAL(databaseKey, isEqualToString:) && WMF_RHS_PROP_EQUAL(languageVariantCode, isEqualToString:);
 }
 
 - (NSUInteger)hash {
-    return self.databaseKey.hash ^ flipBitsWithAdditionalRotation(self.variant.hash, 1); // When variant is nil, the XOR flips the bits
+    return self.databaseKey.hash ^ flipBitsWithAdditionalRotation(self.languageVariantCode.hash, 1); // When languageVariantCode is nil, the XOR flips the bits
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat: @"%@ databaseKey: %@, variant: %@", [super description], self.databaseKey, self.variant];
+    return [NSString stringWithFormat: @"%@ databaseKey: %@, languageVariantCode: %@", [super description], self.databaseKey, self.languageVariantCode];
 }
 
 @end

--- a/Wikipedia/Code/PlaceSearchService.swift
+++ b/Wikipedia/Code/PlaceSearchService.swift
@@ -140,8 +140,8 @@ class PlaceSearchService
                     done()
                     return
                 }
-                let keys = savedPagesWithoutLocation.compactMap({ (article) -> String? in
-                    return article.key
+                let keys = savedPagesWithoutLocation.compactMap({ (article) -> WMFInMemoryURLKey? in
+                    return article.inMemoryKey
                 })
                 // Fetch summaries from the server and update WMFArticle objects
                 dataStore.articleSummaryController.updateOrCreateArticleSummariesForArticles(withKeys: keys) { (articles, _) in

--- a/Wikipedia/Code/ShareActivityController.swift
+++ b/Wikipedia/Code/ShareActivityController.swift
@@ -35,7 +35,7 @@ extension ShareableArticlesProvider where Self: UIViewController & EventLoggingE
     func share(article: WMFArticle?, articleURL: URL?, at indexPath: IndexPath, dataStore: MWKDataStore, theme: Theme, eventLoggingCategory: EventLoggingCategory? = nil, eventLoggingLabel: EventLoggingLabel? = nil, sourceView: UIView?) -> Bool {
         if let article = article {
             return createAndPresentShareActivityController(for: article, at: indexPath, dataStore: dataStore, theme: theme, eventLoggingCategory: eventLoggingCategory, eventLoggingLabel: eventLoggingLabel, sourceView: sourceView)
-        } else if let articleURL = articleURL, let key = articleURL.wmf_databaseKey {
+        } else if let articleURL = articleURL, let key = articleURL.wmf_inMemoryKey {
             dataStore.articleSummaryController.updateOrCreateArticleSummaryForArticle(withKey: key) { (article, _) in
                 guard let article = article else {
                     return

--- a/Wikipedia/Code/URL+LinkParsing.swift
+++ b/Wikipedia/Code/URL+LinkParsing.swift
@@ -71,6 +71,10 @@ extension URL {
         return (self as NSURL).wmf_databaseKey
     }
     
+    public var wmf_inMemoryKey: WMFInMemoryURLKey? {
+        return (self as NSURL).wmf_inMemoryKey
+    }
+    
     public var wmf_site: URL? {
         return (self as NSURL).wmf_site
     }

--- a/Wikipedia/Code/WMFRelatedPagesContentSource.m
+++ b/Wikipedia/Code/WMFRelatedPagesContentSource.m
@@ -196,7 +196,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Fetch
 
 - (void)extracted:(WMFArticle * _Nonnull)article completion:(dispatch_block_t _Nullable)completion date:(NSDate * _Nonnull)date groupURL:(NSURL *)groupURL moc:(NSManagedObjectContext * _Nonnull)moc {
-    [self.relatedSearchFetcher fetchRelatedArticlesForArticleWithURL:article.URL completion:^(NSError * _Nullable error, NSDictionary<NSString *, WMFArticleSummary *> * _Nullable summariesByKey) {
+    [self.relatedSearchFetcher fetchRelatedArticlesForArticleWithURL:article.URL completion:^(NSError * _Nullable error, NSDictionary<WMFInMemoryURLKey *, WMFArticleSummary *> * _Nullable summariesByKey) {
         if (error) {
             DDLogError(@"Failed to fetch related articles for %@: %@.",
                        article.URL, error.localizedDescription);
@@ -219,7 +219,7 @@ NS_ASSUME_NONNULL_BEGIN
             }
             [moc performBlock:^{
                 NSError *summaryError = nil;
-                NSDictionary<NSString *, WMFArticle *> *articles = [moc wmf_createOrUpdateArticleSummmariesWithSummaryResponses:summariesByKey error:&summaryError];
+                NSDictionary<WMFInMemoryURLKey *, WMFArticle *> *articles = [moc wmf_createOrUpdateArticleSummmariesWithSummaryResponses:summariesByKey error:&summaryError];
                 if (summaryError) {
                     DDLogError(@"Error creating or updating summaries: %@", summaryError);
                     completion();

--- a/WikipediaUnitTests/Code/WMFArticleTests.swift
+++ b/WikipediaUnitTests/Code/WMFArticleTests.swift
@@ -109,29 +109,29 @@ class WMFArticleTests: XCTestCase {
     
     func testArticleTemporaryCacheKey() {
         // Ensure WMFArticleTemporaryCacheKey works as expected as a key into the WMFArticle temporary cache
-        let articleCache = NSCache<WMFArticleTemporaryCacheKey, NSString>()
+        let articleCache = NSCache<WMFInMemoryURLKey, NSString>()
         
         let hantString: NSString = "ZH article with hant variant"
-        let hantKey = WMFArticleTemporaryCacheKey(databaseKey:"ZH article", variant:"hant")
+        let hantKey = WMFInMemoryURLKey(databaseKey:"ZH article", variant:"hant")
         articleCache.setObject(hantString, forKey:hantKey)
         
         let hansString: NSString = "ZH article with hans variant"
-        let hansKey = WMFArticleTemporaryCacheKey(databaseKey:"ZH article", variant:"hans")
+        let hansKey = WMFInMemoryURLKey(databaseKey:"ZH article", variant:"hans")
         articleCache.setObject(hansString, forKey:hansKey)
         
         let noVariantString: NSString = "ZH article with no variant"
-        let noVariantKey = WMFArticleTemporaryCacheKey(databaseKey:"ZH article", variant:nil)
+        let noVariantKey = WMFInMemoryURLKey(databaseKey:"ZH article", variant:nil)
         articleCache.setObject(noVariantString, forKey:noVariantKey)
         
-        let newHantKey = WMFArticleTemporaryCacheKey(databaseKey:"ZH article", variant:"hant")
+        let newHantKey = WMFInMemoryURLKey(databaseKey:"ZH article", variant:"hant")
         var hantValue = articleCache.object(forKey:newHantKey)
         XCTAssertEqual(hantValue, hantString)
         
-        let newHansKey = WMFArticleTemporaryCacheKey(databaseKey:"ZH article", variant:"hans")
+        let newHansKey = WMFInMemoryURLKey(databaseKey:"ZH article", variant:"hans")
         var hansValue = articleCache.object(forKey:newHansKey)
         XCTAssertEqual(hansValue, hansString)
         
-        let newNoVariantKey = WMFArticleTemporaryCacheKey(databaseKey:"ZH article", variant:nil)
+        let newNoVariantKey = WMFInMemoryURLKey(databaseKey:"ZH article", variant:nil)
         var noVariantValue = articleCache.object(forKey:newNoVariantKey)
         XCTAssertEqual(noVariantValue, noVariantString)
         

--- a/WikipediaUnitTests/Code/WMFArticleTests.swift
+++ b/WikipediaUnitTests/Code/WMFArticleTests.swift
@@ -112,26 +112,26 @@ class WMFArticleTests: XCTestCase {
         let articleCache = NSCache<WMFInMemoryURLKey, NSString>()
         
         let hantString: NSString = "ZH article with hant variant"
-        let hantKey = WMFInMemoryURLKey(databaseKey:"ZH article", variant:"hant")
+        let hantKey = WMFInMemoryURLKey(databaseKey:"ZH article", languageVariantCode:"hant")
         articleCache.setObject(hantString, forKey:hantKey)
         
         let hansString: NSString = "ZH article with hans variant"
-        let hansKey = WMFInMemoryURLKey(databaseKey:"ZH article", variant:"hans")
+        let hansKey = WMFInMemoryURLKey(databaseKey:"ZH article", languageVariantCode:"hans")
         articleCache.setObject(hansString, forKey:hansKey)
         
         let noVariantString: NSString = "ZH article with no variant"
-        let noVariantKey = WMFInMemoryURLKey(databaseKey:"ZH article", variant:nil)
+        let noVariantKey = WMFInMemoryURLKey(databaseKey:"ZH article", languageVariantCode:nil)
         articleCache.setObject(noVariantString, forKey:noVariantKey)
         
-        let newHantKey = WMFInMemoryURLKey(databaseKey:"ZH article", variant:"hant")
+        let newHantKey = WMFInMemoryURLKey(databaseKey:"ZH article", languageVariantCode:"hant")
         var hantValue = articleCache.object(forKey:newHantKey)
         XCTAssertEqual(hantValue, hantString)
         
-        let newHansKey = WMFInMemoryURLKey(databaseKey:"ZH article", variant:"hans")
+        let newHansKey = WMFInMemoryURLKey(databaseKey:"ZH article", languageVariantCode:"hans")
         var hansValue = articleCache.object(forKey:newHansKey)
         XCTAssertEqual(hansValue, hansString)
         
-        let newNoVariantKey = WMFInMemoryURLKey(databaseKey:"ZH article", variant:nil)
+        let newNoVariantKey = WMFInMemoryURLKey(databaseKey:"ZH article", languageVariantCode:nil)
         var noVariantValue = articleCache.object(forKey:newNoVariantKey)
         XCTAssertEqual(noVariantValue, noVariantString)
         


### PR DESCRIPTION
This is work towards the Chinese variants feature https://phabricator.wikimedia.org/T195265
It is not the entire feature/ticket.

Each commit is self-contained it is probably easiest to review them individually.

When processing fetched articles and article summaries, dictionaries are used to check for updates, match summaries to articles, etc. They keys currently used are wmf_databaseKey values, which do not take variants into account.

This PR updates all of those call stacks to use a compound key value. 

### Notes
**Commit 1**
Rename the existing WMFArticleTemporaryCacheKey to WMFInMemoryURLKey and move definition to NSURL category to reflect its more general usage. Update call sites.

**Commit 2**
Rename variant property to languageVariantCode to match the URL property naming. Mark the languageVariantCode nullable to correctly indicate it can be nil. Update call sites.

**Commit 3**
Add convenience methods and properties for WMFInMemoryURLKey to round trip to URL and for URL to return an in memory key. Will be used in upcoming commits.

**Commit 4**
Add convenience methods and properties in WMFArticle+Extensions which will make the intent of call sites when used more clear.

**Commit 5**
The main event! Update ArticleFetcher methods to use in-memory key instead of database key. Change all call stacks to use the new type. Move off of 'fetchWtihKey:' article fetching methods which are not variant-aware.

**Commit 6**
Update predicate in SummaryExtensions to take key and variant into account. Since this is a more complex predicate, add it as a method in WMFArticle+Extensions. It will be used more as more subsystems become variant-aware.

**Commit 7**
Remove shim 'fetchWtihKey:' article fetching methods that are no longer used after these changes. 

**Commit 8**
Add a partial fix for propagating language variant to ArticleSummary instances. This addresses the issue where navigating from the explore feed to an article using a variant and back to the explore feed would cause the incorrect variant to be displayed. It also addresses an issue where the other changes in this PR would cause a blank feed card after the same navigation pattern.

A more generalized approach for propagating language variants to Codable types will be in a future PR.

### Test Steps
1. With language variant feature turned off, app behavior should not change.
2. With language variants turned on, you can now navigate from the explore feed to an article and back and the correct variant information displays in the explore feed.