### PR TITLE
Update search and search bar to accomodate language variants

### DIFF
--- a/Wikipedia/Code/MWKLanguageLinkController.h
+++ b/Wikipedia/Code/MWKLanguageLinkController.h
@@ -73,7 +73,7 @@ typedef NS_ENUM(NSInteger, WMFPreferredLanguagesChangeType) {
  */
 - (void)removePreferredLanguage:(MWKLanguageLink *)language;
 
-- (nullable MWKLanguageLink *)languageForSiteURL:(NSURL *)siteURL;
+- (nullable MWKLanguageLink *)languageForContentLanguageCode:(NSString *)contentLanguageCode;
 
 + (void)migratePreferredLanguagesToManagedObjectContext:(NSManagedObjectContext *)moc;
 

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -71,9 +71,9 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
     return [MWKLanguageLinkController allLanguages];
 }
 
-- (nullable MWKLanguageLink *)languageForSiteURL:(NSURL *)siteURL {
+- (nullable MWKLanguageLink *)languageForContentLanguageCode:(NSString *)contentLanguageCode {
     return [self.allLanguages wmf_match:^BOOL(MWKLanguageLink *obj) {
-        return [obj.siteURL isEqual:siteURL];
+        return [obj.contentLanguageCode isEqual:contentLanguageCode];
     }];
 }
 

--- a/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
+++ b/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
@@ -252,28 +252,24 @@ let WMFSendUsageReports = "WMFSendUsageReports"
         }
     }
     
-    @objc func wmf_currentSearchLanguageDomain() -> URL? {
-        if let url = self.url(forKey: WMFSearchURLKey) {
-            return url
-        }else if let language = self.object(forKey: WMFSearchLanguageKey) as? String {
-            let url = NSURL.wmf_URL(withDefaultSiteAndlanguage: language)
-            self.wmf_setCurrentSearchLanguageDomain(url)
-            return url
-        }else{
+    @objc func wmf_currentSearchContentLanguageCode() -> String? {
+        // This is a temporary migration until the full language variant migration is in place.
+        // At that point, it should no longer be necessary to check WMFSearchURLKey
+        if let url = url(forKey: WMFSearchURLKey) {
+            let code = url.wmf_contentLanguageCode
+            wmf_setCurrentSearchContentLanguageCode(code)
+            removeObject(forKey: WMFSearchURLKey)
+            return code
+        } else if let contentLanguageCode = self.string(forKey: WMFSearchLanguageKey) {
+            return contentLanguageCode
+        } else{
             return nil
         }
     }
     
-    @objc func wmf_setCurrentSearchLanguageDomain(_ url: URL?) {
-        guard let url = url else{
-            self.removeObject(forKey: WMFSearchURLKey)
-            return
-        }
-        guard !url.wmf_isNonStandardURL else{
-            return;
-        }
-        
-        self.set(url, forKey: WMFSearchURLKey)
+    @objc func wmf_setCurrentSearchContentLanguageCode(_ code: String?) {
+        if let code = code { set(code, forKey: WMFSearchLanguageKey) }
+        else { removeObject(forKey: WMFSearchLanguageKey) }
     }
     
     @objc func wmf_setDidShowWIconPopover(_ shown: Bool) {

--- a/Wikipedia/Code/SearchLanguagesBarViewController.swift
+++ b/Wikipedia/Code/SearchLanguagesBarViewController.swift
@@ -33,7 +33,7 @@ class SearchLanguagesBarViewController: UIViewController, WMFPreferredLanguagesV
     
     @objc fileprivate(set) var currentlySelectedSearchLanguage: MWKLanguageLink? {
         get {
-            if let siteURL = UserDefaults.standard.wmf_currentSearchLanguageDomain(), let selectedLanguage = MWKDataStore.shared().languageLinkController.language(forSiteURL: siteURL) {
+            if let contentLanguageCode = UserDefaults.standard.wmf_currentSearchContentLanguageCode(), let selectedLanguage = MWKDataStore.shared().languageLinkController.language(forContentLanguageCode: contentLanguageCode) {
                 return selectedLanguage
             } else {
                 
@@ -47,7 +47,7 @@ class SearchLanguagesBarViewController: UIViewController, WMFPreferredLanguagesV
             }
         }
         set {
-            UserDefaults.standard.wmf_setCurrentSearchLanguageDomain(newValue?.siteURL)
+            UserDefaults.standard.wmf_setCurrentSearchContentLanguageCode(newValue?.contentLanguageCode)
             delegate?.searchLanguagesBarViewController(self, didChangeCurrentlySelectedSearchLanguage: newValue!)
             updateLanguageBarLanguageButtons()
         }
@@ -117,7 +117,7 @@ class SearchLanguagesBarViewController: UIViewController, WMFPreferredLanguagesV
             let button = languageButtons[index]
             button.setTitle(language.localizedName, for: .normal)
             if let selectedLanguage = currentlySelectedSearchLanguage {
-                button.isSelected = language.languageCode == selectedLanguage.languageCode
+                button.isSelected = language.contentLanguageCode == selectedLanguage.contentLanguageCode
             }else{
                 assertionFailure("selectedLanguage should have been set at this point")
                 button.isSelected = false

--- a/Wikipedia/Code/WMFSearchFunnel.m
+++ b/Wikipedia/Code/WMFSearchFunnel.m
@@ -47,8 +47,7 @@ static NSString *const kTimestampKey = @"event_dt";
 
 - (NSString *)searchLanguage {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    NSURL *currentSearchLanguageDomain = [userDefaults wmf_currentSearchLanguageDomain];
-    NSString *searchLanguage = currentSearchLanguageDomain.wmf_language;
+    NSString *searchLanguage = [userDefaults wmf_currentSearchContentLanguageCode];
     return searchLanguage;
 }
 


### PR DESCRIPTION
This is work towards the Chinese variants feature https://phabricator.wikimedia.org/T195265
It is not the entire feature/ticket.

### Notes
- Store contentLanguageCode instead of site URL for search language user default
- Update method in MWKLanguageLinkController to return language for contentLanguageCode
- Use updated defaults and method in SearchLanguagesBarViewController
- Update WMFSearchFunnel to send content language code

With the change to WMFSearchFunnel, the variant will be included, so "zh-hans" instead of "zh".
If it makes sense for the analytics to use the language alone, that is easily changed back.

### Test Steps
1. Without language variants turned on, behavior should be the same as before.
2. With language variants turned on, language variants will display in the Search language bar, selection between variants will work, and search request contains correct language variant in headers.

An existing issue where redirects in the response do not respect the language variant in the Accept-Language header prevents the correct language variant from displaying in the search results. This issue exists in the app now with the existing language variant support.

Note that tapping a search result will display the article using the correct variant.