### PR TITLE
Fix crash in FixRelatedSearchCrash

### DIFF
--- a/WMF Framework/RelatedSearchFetcher.swift
+++ b/WMF Framework/RelatedSearchFetcher.swift
@@ -6,7 +6,7 @@ final class RelatedSearchFetcher: Fetcher {
         let pages: [ArticleSummary]?
     }
     
-    @objc func fetchRelatedArticles(forArticleWithURL articleURL: URL?, completion: @escaping (Error?, [String: ArticleSummary]?) -> Void) {
+    @objc func fetchRelatedArticles(forArticleWithURL articleURL: URL?, completion: @escaping (Error?, [WMFInMemoryURLKey: ArticleSummary]?) -> Void) {
         guard
             let articleURL = articleURL,
             let articleTitle = articleURL.percentEncodedPageTitleForPathComponents
@@ -43,8 +43,9 @@ final class RelatedSearchFetcher: Fetcher {
                 return
             }
             
-            let summaryKeysWithValues: [(String, ArticleSummary)] = summaries.compactMap { (summary) -> (String, ArticleSummary)? in
-                guard let articleKey = summary.articleURL?.wmf_databaseKey else {
+            let summaryKeysWithValues: [(WMFInMemoryURLKey, ArticleSummary)] = summaries.compactMap { (summary) -> (WMFInMemoryURLKey, ArticleSummary)? in
+                summary.languageVariantCode = articleURL.wmf_languageVariantCode
+                guard let articleKey = summary.key else {
                     return nil
                 }
                 return (articleKey, summary)


### PR DESCRIPTION
This is work towards the Chinese variants feature https://phabricator.wikimedia.org/T195265
It is not the entire feature/ticket.

A prior PR missed this file (I would have thought the compiler would have failed or warned due to the type mismatch, but it did not).

This should address the crash Toni was seeing.

### Notes

- Update dictionary key to be of type WMFInMemoryURLKey
- Set the language variant code of each article summary from the requested articleURL's value
- Use 'key' property of ArticleSummary to return a WMFInMemoryURLKey

### Test Steps
1.  Fetching related pages should no longer crash

