### PR TITLE
Use language variant feature flag to preserve old behavior

### DIFF
--- a/WMF Framework/Configuration.swift
+++ b/WMF Framework/Configuration.swift
@@ -183,6 +183,20 @@ public class Configuration: NSObject {
     
     /// Returns the default request headers for Page Content Service API requests
     public func pageContentServiceHeaders(for url: URL) -> [String: String] {
+        
+        // If the language variants feature is not turned on, use the old behavior.
+        // This ensures the existing language variant behavior continues working.
+        // This guard statment can be removed when languageVariantsEnabled is removed.
+        guard WikipediaLookup.languageVariantsEnabled else {
+            guard let apiLanguage = url.wmf_language else {
+                return [:]
+            }
+            guard let preferredLanguage = Locale.preferredWikipediaLanguageVariant(wmf_language: apiLanguage) else {
+                return [:]
+            }
+            return ["Accept-Language": preferredLanguage]
+        }
+        
         // If the language supports variants, only send a single code with variant for that language.
         // This is a workaround for an issue with server-side Accept-Language header handling and
         // can be removed when https://phabricator.wikimedia.org/T256491 is fixed.

--- a/Wikipedia/Code/WikipediaLookup.swift
+++ b/Wikipedia/Code/WikipediaLookup.swift
@@ -31,7 +31,7 @@ import CocoaLumberjackSwift
     }()
 
     // Flag to be removed once language variants feature can be permanently turned on
-    private static let languageVariantsEnabled = false
+    public static let languageVariantsEnabled = false
     @objc static let allLanguageVariantsByWikipediaLanguageCode: [String:[MWKLanguageLink]] = {
         guard languageVariantsEnabled else { return [:] }
         guard let languagesFileURL = Bundle.wmf.url(forResource: "wikipedia-language-variants", withExtension: "json") else {


### PR DESCRIPTION
This is work towards the language variants feature https://phabricator.wikimedia.org/T195265 and https://phabricator.wikimedia.org/T268275.

It is not the entire feature/ticket.

### Notes
Working on supporting language variants in reading lists, I found that there was no clean path to preserving the existing behavior when the new feature is turned off.

This PR makes the feature flag public and adds guard statements in two places where the previous behavior needs to be maintained until the language variant feature is turned on.

A comment for each usage explains the entire guard statement can go once we remove the feature flag.

### Test Steps
1. No change in behavior except restoring the pre-existing behavior in fetching the correct variant if the feature flag is set to false.