### PR TITLE
Add build script support for Carthage on Apple Silicon

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -9754,7 +9754,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+			shellScript = "export PATH=/usr/local/bin:/opt/homebrew/bin:$PATH\ncarthage copy-frameworks\n";
 		};
 		D87021721EBA69B7000D02D6 /* Update Localizations */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
Currently, Carthage's installation path is hard coded as `/usr/local/bin/carthage` in the Xcode build script for Carthage. As per the [Homebrew Installation doc](https://docs.brew.sh/Installation), the preferred install location for Intel-based Macs remains that path above, but for Apple Silicon Macs the default is different. An Intel Carthage installation via Homebrew would default to `/usr/local/bin` but an Apple Silicon one would default to `/opt/homebrew/bin`. This means that currently, building this project on an Apple Silicon machine would likely fail.

Since the Xcode shell environment doesn't appear to take the user's `profile` into account, it doesn't include the path variables to run just `carthage copy-frameworks` regardless of installation location. This PR adds both of the recommended Homebrew install paths to remove the script failure after compilation.

I don't noodle with these Xcode shell scripts much (I tried a few "smarter" approaches before getting here) so I'm totally open to changing this solution if there's a wiser or more accepted way to accomplish the same thing! 

### Test Steps
1. Ensure CircleCI still builds and passes
2. Ensure project still builds to device on Intel Mac
3. Ensure project still builds to device on Apple Silicon device (I can vouch for this one 💻)

(BTW, still seems like there's a bit more to go for proper Apple Silicon Mac support – mostly surrounding issues building to Simulator with our current dependency setup)
