### PR TITLE
Variant aware explore layout

### DIFF
--- a/WMF Framework/WMFContentGroup+Display.swift
+++ b/WMF Framework/WMFContentGroup+Display.swift
@@ -140,14 +140,14 @@ extension WMFContentGroup {
         }
     }
     
-    public var previewArticleKeys: Set<String> {
+    public var previewArticleKeys: Set<WMFInMemoryURLKey> {
         guard countOfPreviewItems > 0 else {
             return []
         }
-        var articleKeys: Set<String> = []
+        var articleKeys: Set<WMFInMemoryURLKey> = []
         articleKeys.reserveCapacity(countOfPreviewItems)
         for i in 0...countOfPreviewItems {
-            guard let key = previewArticleURLForItemAtIndex(i)?.wmf_databaseKey else {
+            guard let key = previewArticleURLForItemAtIndex(i)?.wmf_inMemoryKey else {
                 continue
             }
             articleKeys.insert(key)

--- a/WMF Framework/WMFContentGroup+Extensions.h
+++ b/WMF Framework/WMFContentGroup+Extensions.h
@@ -2,6 +2,8 @@
 
 @import CoreLocation;
 
+@class WMFInMemoryURLKey;
+
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(int16_t, WMFContentType) {
@@ -55,6 +57,8 @@ typedef NS_ENUM(int16_t, WMFContentGroupUndoType) {
 @property (nonatomic, strong, nullable) NSURL *URL;
 @property (nonatomic, strong, nullable) NSURL *articleURL;
 @property (nonatomic, strong, nullable) NSURL *siteURL;
+
+@property (nonatomic, readonly, nullable) WMFInMemoryURLKey *inMemoryKey;
 
 - (void)updateKey; //Sets key property based on content group kind
 - (void)updateContentType;

--- a/WMF Framework/WMFContentGroup+Extensions.m
+++ b/WMF Framework/WMFContentGroup+Extensions.m
@@ -258,6 +258,10 @@
     self.siteURLString = siteURL.wmf_databaseKey;
 }
 
+- (nullable WMFInMemoryURLKey *)inMemoryKey {
+    return self.URL.wmf_inMemoryKey;
+}
+
 - (void)setFullContentObject:(NSObject<NSCoding> *)fullContentObject {
     NSManagedObjectContext *moc = self.managedObjectContext;
     NSAssert(moc != nil, @"nil moc");

--- a/Wikipedia/Code/ColumnarCollectionViewControllerLayoutCache.swift
+++ b/Wikipedia/Code/ColumnarCollectionViewControllerLayoutCache.swift
@@ -7,14 +7,14 @@ private extension CGFloat {
 class ColumnarCollectionViewControllerLayoutCache {
     private var cachedHeights: [String: [Int: CGFloat]] = [:]
     private var cacheKeysByGroupKey: [WMFInMemoryURLKey: Set<String>] = [:]
-    private var cacheKeysByArticleKey: [String: Set<String>] = [:]
-    private var groupKeysByArticleKey: [String: Set<WMFInMemoryURLKey>] = [:]
+    private var cacheKeysByArticleKey: [WMFInMemoryURLKey: Set<String>] = [:]
+    private var groupKeysByArticleKey: [WMFInMemoryURLKey: Set<WMFInMemoryURLKey>] = [:]
     
     private func cacheKeyForCellWithIdentifier(_ identifier: String, userInfo: String) -> String {
         return "\(identifier)-\(userInfo)"
     }
     
-    public func setHeight(_ height: CGFloat, forCellWithIdentifier identifier: String, columnWidth: CGFloat, groupKey: WMFInMemoryURLKey? = nil, articleKey: String? = nil, userInfo: String) {
+    public func setHeight(_ height: CGFloat, forCellWithIdentifier identifier: String, columnWidth: CGFloat, groupKey: WMFInMemoryURLKey? = nil, articleKey: WMFInMemoryURLKey? = nil, userInfo: String) {
         let cacheKey = cacheKeyForCellWithIdentifier(identifier, userInfo: userInfo)
         if let groupKey = groupKey {
             cacheKeysByGroupKey[groupKey, default: []].insert(cacheKey)
@@ -44,7 +44,7 @@ class ColumnarCollectionViewControllerLayoutCache {
         cacheKeysByGroupKey.removeAll(keepingCapacity: true)
     }
     
-    @discardableResult public func invalidateArticleKey(_ articleKey: String?) -> Bool {
+    @discardableResult public func invalidateArticleKey(_ articleKey: WMFInMemoryURLKey?) -> Bool {
         guard let articleKey = articleKey else {
             return false
         }

--- a/Wikipedia/Code/ColumnarCollectionViewControllerLayoutCache.swift
+++ b/Wikipedia/Code/ColumnarCollectionViewControllerLayoutCache.swift
@@ -6,15 +6,15 @@ private extension CGFloat {
 }
 class ColumnarCollectionViewControllerLayoutCache {
     private var cachedHeights: [String: [Int: CGFloat]] = [:]
-    private var cacheKeysByGroupKey: [String: Set<String>] = [:]
+    private var cacheKeysByGroupKey: [WMFInMemoryURLKey: Set<String>] = [:]
     private var cacheKeysByArticleKey: [String: Set<String>] = [:]
-    private var groupKeysByArticleKey: [String: Set<String>] = [:]
+    private var groupKeysByArticleKey: [String: Set<WMFInMemoryURLKey>] = [:]
     
     private func cacheKeyForCellWithIdentifier(_ identifier: String, userInfo: String) -> String {
         return "\(identifier)-\(userInfo)"
     }
     
-    public func setHeight(_ height: CGFloat, forCellWithIdentifier identifier: String, columnWidth: CGFloat, groupKey: String? = nil, articleKey: String? = nil, userInfo: String) {
+    public func setHeight(_ height: CGFloat, forCellWithIdentifier identifier: String, columnWidth: CGFloat, groupKey: WMFInMemoryURLKey? = nil, articleKey: String? = nil, userInfo: String) {
         let cacheKey = cacheKeyForCellWithIdentifier(identifier, userInfo: userInfo)
         if let groupKey = groupKey {
             cacheKeysByGroupKey[groupKey, default: []].insert(cacheKey)
@@ -67,7 +67,7 @@ class ColumnarCollectionViewControllerLayoutCache {
         return true
     }
     
-    public func invalidateGroupKey(_ groupKey: String?) {
+    public func invalidateGroupKey(_ groupKey: WMFInMemoryURLKey?) {
         guard let groupKey = groupKey, let cacheKeys = cacheKeysByGroupKey[groupKey] else {
             return
         }

--- a/Wikipedia/Code/ExploreCardViewController.swift
+++ b/Wikipedia/Code/ExploreCardViewController.swift
@@ -435,11 +435,11 @@ class ExploreCardViewController: UIViewController, UICollectionViewDataSource, U
         let reuseIdentifier = resuseIdentifierFor(displayType)
         let key: String?
         let articleKey: String? = self.article(at: indexPath)?.key
-        let groupKey: String? = contentGroup?.key
+        let groupKey: WMFInMemoryURLKey? = contentGroup?.inMemoryKey
         if displayType == .story || displayType == .event, let contentGroupKey = contentGroup?.key {
             key = "\(contentGroupKey)-\(indexPath.row)"
         } else {
-            key = articleKey ?? groupKey
+            key = articleKey ?? groupKey?.databaseKey
         }
         let userInfo = "\(key ?? "")-\(displayType.rawValue)"
         if let height = delegate?.layoutCache.cachedHeightForCellWithIdentifier(reuseIdentifier, columnWidth: columnWidth, userInfo: userInfo) {

--- a/Wikipedia/Code/ExploreCardViewController.swift
+++ b/Wikipedia/Code/ExploreCardViewController.swift
@@ -60,12 +60,12 @@ class ExploreCardViewController: UIViewController, UICollectionViewDataSource, U
         self.collectionView.dataSource = self
     }
     
-    public func savedStateDidChangeForArticleWithKey(_ changedArticleKey: String) {
+    public func savedStateDidChangeForArticleWithKey(_ changedArticleKey: WMFInMemoryURLKey) {
         for i in 0..<numberOfItems {
             let indexPath = IndexPath(item: i, section: 0)
             guard
                 let articleURL = articleURL(at: indexPath),
-                let articleKey = articleURL.wmf_databaseKey,
+                let articleKey = articleURL.wmf_inMemoryKey,
                 changedArticleKey == articleKey,
                 let cell = collectionView.cellForItem(at: indexPath)
             else {
@@ -434,12 +434,12 @@ class ExploreCardViewController: UIViewController, UICollectionViewDataSource, U
         let displayType = displayTypeAt(indexPath)
         let reuseIdentifier = resuseIdentifierFor(displayType)
         let key: String?
-        let articleKey: String? = self.article(at: indexPath)?.key
+        let articleKey: WMFInMemoryURLKey? = self.article(at: indexPath)?.inMemoryKey
         let groupKey: WMFInMemoryURLKey? = contentGroup?.inMemoryKey
         if displayType == .story || displayType == .event, let contentGroupKey = contentGroup?.key {
             key = "\(contentGroupKey)-\(indexPath.row)"
         } else {
-            key = articleKey ?? groupKey?.databaseKey
+            key = articleKey?.databaseKey ?? groupKey?.databaseKey
         }
         let userInfo = "\(key ?? "")-\(displayType.rawValue)"
         if let height = delegate?.layoutCache.cachedHeightForCellWithIdentifier(reuseIdentifier, columnWidth: columnWidth, userInfo: userInfo) {

--- a/Wikipedia/Code/ExploreCardViewController.swift
+++ b/Wikipedia/Code/ExploreCardViewController.swift
@@ -436,10 +436,10 @@ class ExploreCardViewController: UIViewController, UICollectionViewDataSource, U
         let key: String?
         let articleKey: WMFInMemoryURLKey? = self.article(at: indexPath)?.inMemoryKey
         let groupKey: WMFInMemoryURLKey? = contentGroup?.inMemoryKey
-        if displayType == .story || displayType == .event, let contentGroupKey = contentGroup?.key {
-            key = "\(contentGroupKey)-\(indexPath.row)"
+        if displayType == .story || displayType == .event, let contentGroupKey = contentGroup?.inMemoryKey {
+            key = "\(contentGroupKey.userInfoString)-\(indexPath.row)"
         } else {
-            key = articleKey?.databaseKey ?? groupKey?.databaseKey
+            key = articleKey?.userInfoString ?? groupKey?.userInfoString
         }
         let userInfo = "\(key ?? "")-\(displayType.rawValue)"
         if let height = delegate?.layoutCache.cachedHeightForCellWithIdentifier(reuseIdentifier, columnWidth: columnWidth, userInfo: userInfo) {

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -559,7 +559,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
             return ColumnarCollectionViewLayoutHeightEstimate(precalculated: true, height: 0)
         }
         let identifier = ExploreCardCollectionViewCell.identifier
-        let userInfo = "evc-cell-\(group.key ?? "")"
+        let userInfo = "evc-cell-\(group.inMemoryKey?.userInfoString ?? "")"
         if let cachedHeight = layoutCache.cachedHeightForCellWithIdentifier(identifier, columnWidth: columnWidth, userInfo: userInfo) {
             return ColumnarCollectionViewLayoutHeightEstimate(precalculated: true, height: cachedHeight)
         }

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -283,8 +283,8 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         return frc.object(at: indexPath)
     }
     
-    private func groupKey(at indexPath: IndexPath) -> String? {
-        return group(at: indexPath)?.key
+    private func groupKey(at indexPath: IndexPath) -> WMFInMemoryURLKey? {
+        return group(at: indexPath)?.inMemoryKey
     }
     
     lazy var saveButtonsController: SaveButtonsController = {
@@ -570,7 +570,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         configure(cell: placeholderCell, forItemAt: indexPath, layoutOnly: true)
         estimate.height = placeholderCell.sizeThatFits(CGSize(width: columnWidth, height: UIView.noIntrinsicMetric), apply: false).height
         estimate.precalculated = true
-        layoutCache.setHeight(estimate.height, forCellWithIdentifier: identifier, columnWidth: columnWidth, groupKey: group.key, userInfo: userInfo)
+        layoutCache.setHeight(estimate.height, forCellWithIdentifier: identifier, columnWidth: columnWidth, groupKey: group.inMemoryKey, userInfo: userInfo)
         return estimate
     }
     

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -886,7 +886,7 @@ extension ExploreViewController: ExploreCardCollectionViewCellDelegate {
     @objc func articleDidChange(_ note: Notification) {
         guard
             let article = note.object as? WMFArticle,
-            let articleKey = article.key
+            let articleKey = article.inMemoryKey
         else {
             return
         }
@@ -923,7 +923,7 @@ extension ExploreViewController: ExploreCardCollectionViewCellDelegate {
     }
     
     @objc func articleDeleted(_ note: Notification) {
-        guard let articleKey = note.userInfo?[WMFArticleDeletedNotificationUserInfoArticleKeyKey] as? String else {
+        guard let articleKey = note.userInfo?[WMFArticleDeletedNotificationUserInfoArticleKeyKey] as? WMFInMemoryURLKey else {
             return
         }
         layoutCache.invalidateArticleKey(articleKey)

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -245,7 +245,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
         for (NSManagedObject *object in changedObjects) {
             if ([object isKindOfClass:[WMFArticle class]]) {
                 WMFArticle *article = (WMFArticle *)object;
-                NSString *articleKey = article.key;
+                WMFInMemoryURLKey *articleKey = article.inMemoryKey;
                 NSURL *articleURL = article.URL;
                 if (!articleKey || !articleURL) {
                     continue;

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.h
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.h
@@ -239,6 +239,7 @@ extern NSString *const WMFEditPencil;
 @property (readonly, nonatomic, copy) NSString *databaseKey;
 @property (readonly, nonatomic, copy, nullable) NSString *languageVariantCode;
 @property (readonly, nonatomic, copy, nullable) NSURL *URL;
+@property (readonly, nonatomic, copy) NSString *userInfoString; // A unique string for this database key + variant code pair suitable for incorporation in key strings.
 @end
 
 @interface NSURL (WMFInMemoryURLKeyExtensions)

--- a/Wikipedia/Code/NSURL+WMFLinkParsing.m
+++ b/Wikipedia/Code/NSURL+WMFLinkParsing.m
@@ -332,6 +332,10 @@ WMF_SYNTHESIZE_IS_EQUAL(WMFInMemoryURLKey, isEqualToInMemoryURLKey:)
     return [NSString stringWithFormat: @"%@ databaseKey: %@, languageVariantCode: %@", [super description], self.databaseKey, self.languageVariantCode];
 }
 
+- (NSString *)userInfoString {
+    return self.languageVariantCode ? [NSString stringWithFormat:@"%@__%@", self.databaseKey, self.languageVariantCode] : self.databaseKey;
+}
+
 @end
 
 @implementation NSURL (WMFInMemoryURLKeyExtensions)


### PR DESCRIPTION
This is work towards the language variants feature https://phabricator.wikimedia.org/T195265 and https://phabricator.wikimedia.org/T268275.

It is not the entire feature/ticket.

### Notes
Overall, making sure that the layout cache for columnar layout heights uses unique keys.

Commit 1 adds a property to WMKContentGroup to return an in-memory key
Commit 2 updates the group key used in the layout cache
Commit 3 updates the article key used in the layout cache
Commit 4 adds a method to WMKContentGroup to get a unique userInfoString
                  and updates the user info string generation to use it.

### Test Steps
1. With variants off, no change in behavior
2. With variants on, odd layout issues when hiding/showing cards in explore feed should no longer be present.