### PR TITLE
Variant-aware save buttons and list

### DIFF
--- a/FeaturedArticleWidget/FeaturedArticleWidget.swift
+++ b/FeaturedArticleWidget/FeaturedArticleWidget.swift
@@ -191,7 +191,7 @@ class FeaturedArticleWidget: ExtensionViewController, NCWidgetProviding {
             DDLogDebug("Widget did finish: \(done)")
         } _: { (dataStore, completion) in
             dataStore.viewContext.perform {
-                let isSaved = dataStore.savedPageList.toggleSavedPage(forKey: articleKey)
+                let isSaved = dataStore.savedPageList.toggleSavedPage(forKey: articleKey, variant: self.articleURL?.wmf_languageVariantCode)
                 self.expandedArticleView.saveButton.saveButtonState = isSaved ? .longSaved : .longSave
                 completion(isSaved)
             }

--- a/FeaturedArticleWidget/FeaturedArticleWidget.swift
+++ b/FeaturedArticleWidget/FeaturedArticleWidget.swift
@@ -135,7 +135,7 @@ class FeaturedArticleWidget: ExtensionViewController, NCWidgetProviding {
             group.leave()
         }
         expandedArticleView.tintColor = theme.colors.link
-        expandedArticleView.saveButton.saveButtonState = article.savedDate == nil ? .longSave : .longSaved
+        expandedArticleView.saveButton.saveButtonState = article.isAnyVariantSaved ? .longSaved : .longSave
         updateView()
         
         group.notify(queue: .main) {

--- a/WMF Framework/ReadingListsAPIController.swift
+++ b/WMF Framework/ReadingListsAPIController.swift
@@ -104,6 +104,18 @@ enum APIReadingListRequestType: String {
     case setup, teardown
 }
 
+/* Note that because the reading list API does not support language variants,
+ * the articleURL will always have a nil language variant.
+ *
+ * The RemoteReadingListArticleKey type is a type alias for String.
+ * Since ReadingListsSyncOperation handles remote entries that don't have a variant,
+ * and local entries that do have a variant, this type makes it more clear when
+ * a non-variant aware key is being used.
+ *
+ * Also, if the remote API adds variant support, it should be straightforward to
+ * update the type alias from String to WMFInMemoryURLKey.
+*/
+typealias RemoteReadingListArticleKey = String
 extension APIReadingListEntry {
     var articleURL: URL? {
         guard let site = URL(string: project) else {
@@ -112,8 +124,8 @@ extension APIReadingListEntry {
         return site.wmf_URL(withTitle: title)
     }
     
-    var articleKey: WMFInMemoryURLKey? {
-        return articleURL?.wmf_inMemoryKey
+    var articleKey: RemoteReadingListArticleKey? {
+        return articleURL?.wmf_databaseKey
     }
 }
 

--- a/WMF Framework/ReadingListsSyncOperation.swift
+++ b/WMF Framework/ReadingListsSyncOperation.swift
@@ -742,7 +742,7 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
         let group = WMFTaskGroup()
         let semaphore = DispatchSemaphore(value: 1)
         var remoteEntriesToCreateLocallyByArticleKey: [WMFInMemoryURLKey: APIReadingListEntry] = [:]
-        var requestedArticleKeys: Set<WMFInMemoryURLKey> = []
+        var requestedArticleKeys: Set<RemoteReadingListArticleKey> = []
         var articleSummariesByArticleKey: [WMFInMemoryURLKey: ArticleSummary] = [:]
         var entryCount = 0
         var articlesByKey: [WMFInMemoryURLKey: WMFArticle] = [:]
@@ -752,14 +752,14 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
                 guard !isDeleted else {
                     return
                 }
-                guard let articleURL = remoteEntry.articleURL, let articleKey = articleURL.wmf_inMemoryKey else {
+                guard let articleURL = remoteEntry.articleURL, let articleKey = articleURL.wmf_inMemoryKey, let remoteArticleKey = remoteEntry.articleKey else {
                     return
                 }
                 remoteEntriesToCreateLocallyByArticleKey[articleKey] = remoteEntry
-                guard !requestedArticleKeys.contains(articleKey) else {
+                guard !requestedArticleKeys.contains(remoteArticleKey) else {
                     return
                 }
-                requestedArticleKeys.insert(articleKey)
+                requestedArticleKeys.insert(remoteArticleKey)
                 if let article = dataStore.fetchArticle(with: articleURL, in: moc) {
                     articlesByKey[articleKey] = article
                 } else {
@@ -835,9 +835,9 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
                 entry.update(with: remoteEntry)
     
                 // if there's a key mismatch, locally delete the bad entry and create a new one with the correct key
-                if remoteEntry.articleKey != article.inMemoryKey {
+                if remoteEntry.articleKey != article.key {
                     entry.list = readingList
-                    entry.articleKey = remoteEntry.articleKey?.databaseKey
+                    entry.articleKey = remoteEntry.articleKey
                     try? readingListsController.markLocalDeletion(for: [entry])
                     entry = ReadingListEntry(context: moc)
                     entry.update(with: remoteEntry)
@@ -966,7 +966,7 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
         }
         var createdOrUpdatedReadingListEntriesCount = 0
         // Arrange remote list entries by ID and key for merging with local lists
-        var remoteReadingListEntriesByReadingListID: [Int64: [WMFInMemoryURLKey: APIReadingListEntry]] = [:]
+        var remoteReadingListEntriesByReadingListID: [Int64: [RemoteReadingListArticleKey: APIReadingListEntry]] = [:]
         
         if let readingListID = readingListID {
             remoteReadingListEntriesByReadingListID[readingListID] = [:]
@@ -992,9 +992,9 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
                 let localReadingListEntries = localReadingLists.first?.entries?.filter { !$0.isDeletedLocally } ?? []
                 
                 var localEntriesMissingRemotely: [ReadingListEntry] = []
-                var remoteEntriesMissingLocally: [WMFInMemoryURLKey: APIReadingListEntry] = readingListEntriesByKey
+                var remoteEntriesMissingLocally: [RemoteReadingListArticleKey: APIReadingListEntry] = readingListEntriesByKey
                 for localReadingListEntry in localReadingListEntries {
-                    guard let articleKey = localReadingListEntry.articleURL?.wmf_inMemoryKey else {
+                    guard let articleKey = localReadingListEntry.articleKey else {
                         moc.delete(localReadingListEntry)
                         createdOrUpdatedReadingListEntriesCount += 1
                         continue

--- a/WMF Framework/ReadingListsSyncOperation.swift
+++ b/WMF Framework/ReadingListsSyncOperation.swift
@@ -819,7 +819,7 @@ internal class ReadingListsSyncOperation: ReadingListsOperation {
                 
                 var fetchedArticle = articlesByKey[articleKey]
                 if fetchedArticle == nil {
-                    if let newArticle = moc.wmf_fetchOrCreate(objectForEntityName: "WMFArticle", withValue: articleKey, forKey: "key") as? WMFArticle {
+                    if let newArticle = dataStore.fetchArticle(withKey: articleKey.databaseKey, variant: articleKey.languageVariantCode, in: moc) {
                         if newArticle.displayTitleHTML == "" {
                             newArticle.displayTitleHTML = remoteEntry.title
                         }

--- a/WMF Framework/SummaryExtensions.swift
+++ b/WMF Framework/SummaryExtensions.swift
@@ -126,11 +126,9 @@ extension NSManagedObjectContext {
             }
         }
         var keysToCreate = Set(keys)
-        let articlesToUpdateFetchRequest = WMFArticle.fetchRequest()
-        articlesToUpdateFetchRequest.predicate = articlePredicateForInMemoryURLKeys(keys)
         var articles: [WMFInMemoryURLKey: WMFArticle] = [:]
         articles.reserveCapacity(keys.count)
-        let fetchedArticles = try self.fetch(articlesToUpdateFetchRequest)
+        let fetchedArticles = try self.fetchArticlesWithInMemoryURLKeys(keys)
         for articleToUpdate in fetchedArticles {
             guard let articleKey = articleToUpdate.inMemoryKey else {
                     continue

--- a/WMF Framework/WMFArticle+Extensions.h
+++ b/WMF Framework/WMFArticle+Extensions.h
@@ -72,6 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSArray<WMFArticle *> *)fetchArticlesWithURL:(nullable NSURL *)url error:(NSError **)error;
 - (nullable NSArray<WMFArticle *> *)fetchArticlesWithKey:(nullable NSString *)key variant:(nullable NSString *)variant error:(NSError **)error;
+- (nullable NSArray<WMFArticle *> *)fetchArticlesWithInMemoryURLKeys:(NSArray<WMFInMemoryURLKey *> *)urlKeys error:(NSError **)error NS_SWIFT_NAME(fetchArticlesWithInMemoryURLKeys(_:));
 
 - (nullable WMFArticle *)createArticleWithURL:(nullable NSURL *)url;
 - (nullable WMFArticle *)createArticleWithKey:(nullable NSString *)key variant:(nullable NSString *)variant;
@@ -85,8 +86,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable WMFArticle *)fetchOrCreateArticleWithURL:(nullable NSURL *)articleURL updatedWithFeedPreview:(nullable WMFFeedArticlePreview *)feedPreview pageViews:(nullable NSDictionary<NSDate *, NSNumber *> *)pageViews;
 
 - (nullable WMFArticle *)fetchArticleWithWikidataID:(nullable NSString *)wikidataID;
-
-- (NSPredicate *)articlePredicateForInMemoryURLKeys:(NSArray<WMFInMemoryURLKey *> *)urlKeys NS_SWIFT_NAME(articlePredicateForInMemoryURLKeys(_:));
 
 @end
 

--- a/Wikipedia/Code/ArticleCollectionViewController.swift
+++ b/Wikipedia/Code/ArticleCollectionViewController.swift
@@ -75,14 +75,14 @@ class ArticleCollectionViewController: ColumnarCollectionViewController, Editabl
         else {
             return false
         }
-        return !dataStore.savedPageList.isSaved(articleURL)
+        return !dataStore.savedPageList.isAnyVariantSaved(articleURL)
     }
     
     open func canUnsave(at indexPath: IndexPath) -> Bool {
         guard let articleURL = articleURL(at: indexPath) else {
             return false
         }
-        return dataStore.savedPageList.isSaved(articleURL)
+        return dataStore.savedPageList.isAnyVariantSaved(articleURL)
     }
     
     open func canShare(at indexPath: IndexPath) -> Bool {

--- a/Wikipedia/Code/ArticlePopoverViewController.swift
+++ b/Wikipedia/Code/ArticlePopoverViewController.swift
@@ -89,12 +89,12 @@ class ArticlePopoverViewController: UIViewController {
     
     public func update() {
         saveButton.showTitle = showSaveAndShareTitles
-        saveButton.saveButtonState = article.savedDate == nil ? .shortSave : .shortSaved
+        saveButton.saveButtonState = article.isAnyVariantSaved ? .shortSaved : .shortSave
         if !saveButton.showTitle {
             saveButton.imageEdgeInsets = .zero
         }
 
-        let saveTitle = article.savedDate == nil ? CommonStrings.shortSaveTitle : CommonStrings.shortUnsaveTitle
+        let saveTitle = article.isAnyVariantSaved ? CommonStrings.shortUnsaveTitle : CommonStrings.shortSaveTitle
         let saveAction = UIAccessibilityCustomAction(name: saveTitle, target: self, selector: #selector(save))
         let shareAction = UIAccessibilityCustomAction(name: ArticlePopoverViewController.shareActionString, target: self, selector: #selector(share))
         

--- a/Wikipedia/Code/ArticleViewController+LinkPreviewing.swift
+++ b/Wikipedia/Code/ArticleViewController+LinkPreviewing.swift
@@ -36,7 +36,7 @@ extension ArticleViewController: ArticleContextMenuPresenting, WKUIDelegate {
             }
             vc.articlePreviewingDelegate?.readMoreArticlePreviewActionSelected(with: vc)
         })
-        let saveActionTitle = article.isSaved ? WMFLocalizedString("button-saved-remove", value: "Remove from saved", comment: "Remove from saved button text used in various places.") : CommonStrings.saveTitle
+        let saveActionTitle = article.isAnyVariantSaved ? WMFLocalizedString("button-saved-remove", value: "Remove from saved", comment: "Remove from saved button text used in various places.") : CommonStrings.saveTitle
         let saveAction = UIPreviewAction(title: saveActionTitle, style: .default) { (action, vc) in
             guard let vc = vc as? ArticleViewController else {
                 return

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -911,7 +911,7 @@ private extension ArticleViewController {
     }
     
     @objc func didReceiveArticleUpdatedNotification(_ notification: Notification) {
-        toolbarController.setSavedState(isSaved: article.isSaved)
+        toolbarController.setSavedState(isSaved: article.isAnyVariantSaved)
     }
     
     @objc func applicationWillResignActive(_ notification: Notification) {
@@ -1016,7 +1016,7 @@ private extension ArticleViewController {
     func setupToolbar() {
         enableToolbar()
         toolbarController.apply(theme: theme)
-        toolbarController.setSavedState(isSaved: article.isSaved)
+        toolbarController.setSavedState(isSaved: article.isAnyVariantSaved)
         setToolbarHidden(false, animated: false)
     }
     

--- a/Wikipedia/Code/ExploreCardViewController.swift
+++ b/Wikipedia/Code/ExploreCardViewController.swift
@@ -525,10 +525,10 @@ extension ExploreCardViewController: ActionDelegate, ShareableArticlesProvider {
         
         var actions: [Action] = []
         
-        if article.savedDate == nil {
-            actions.append(ActionType.save.action(with: self, indexPath: indexPath))
-        } else {
+        if article.isAnyVariantSaved {
             actions.append(ActionType.unsave.action(with: self, indexPath: indexPath))
+        } else {
+            actions.append(ActionType.save.action(with: self, indexPath: indexPath))
         }
         
         actions.append(ActionType.share.action(with: self, indexPath: indexPath))

--- a/Wikipedia/Code/MWKLanguageLinkController.h
+++ b/Wikipedia/Code/MWKLanguageLinkController.h
@@ -74,6 +74,18 @@ typedef NS_ENUM(NSInteger, WMFPreferredLanguagesChangeType) {
  */
 - (void)removePreferredLanguage:(MWKLanguageLink *)language;
 
+/**
+ *  Given a language code, return the preferred language variant code if the language supports variants.
+ *  Returns nil for languages without variants.
+ *  This first looks for the preferred variant in the receiver's preferredLanguages.
+ *  If none is found, for the preferred variant based on the OS language settings.
+ *  If none is found, uses a default language variant for that language.
+ *  Returns nil for a nil language code.
+ *  @param languageCode the language code to find the language variant code for
+ *  @return The preferred language variant code for if the language supports variants
+ */
+- (nullable NSString *)preferredLanguageVariantCodeForLanguageCode:(nullable NSString *)languageCode;
+
 - (nullable MWKLanguageLink *)languageForContentLanguageCode:(NSString *)contentLanguageCode;
 
 + (void)migratePreferredLanguagesToManagedObjectContext:(NSManagedObjectContext *)moc;

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -77,6 +77,26 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
     }];
 }
 
+- (nullable NSString *)preferredLanguageVariantCodeForLanguageCode:(nullable NSString *)languageCode {
+    if (!languageCode) {
+        return nil;
+    }
+
+    // Find first with matching language code in app preferred languages
+    MWKLanguageLink *matchingLanguageLink = [self.preferredLanguages wmf_match:^BOOL(MWKLanguageLink *obj) {
+        return [obj.languageCode isEqual:languageCode];
+    }];
+    
+    // If the matching link does not have a language variant code, the language does not have variants. Return nil.
+    if (matchingLanguageLink) {
+        return matchingLanguageLink.languageVariantCode ? : nil;
+    }
+    
+    // If not found in the app's preferred languages, get the best guess from the user's OS settings.
+    return [NSLocale wmf_bestLanguageVariantCodeForLanguageCode:languageCode];
+}
+
+
 - (nullable MWKLanguageLink *)appLanguage {
     return [self.preferredLanguages firstObject];
 }

--- a/Wikipedia/Code/MWKSavedPageList.h
+++ b/Wikipedia/Code/MWKSavedPageList.h
@@ -17,11 +17,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable WMFArticle *)mostRecentEntry;
 
 - (nullable WMFArticle *)entryForURL:(NSURL *)url;
-- (nullable WMFArticle *)entryForKey:(NSString *)key;
+
+// This method retrieves whichever variant of the article specified by the key is currently saved
+// Even if a different article variant is being shown to the user, it is the variant that is actually saved
+// that will be removed.
+- (nullable WMFArticle *)articleToUnsaveForKey:(NSString *)key;
 
 - (void)enumerateItemsWithBlock:(void (^)(WMFArticle *_Nonnull entry, BOOL *stop))block;
 
-- (BOOL)isSaved:(NSURL *)url;
+- (BOOL)isAnyVariantSaved:(NSURL *)url;
 
 #pragma mark - Update Methods
 
@@ -29,9 +33,10 @@ NS_ASSUME_NONNULL_BEGIN
  * Toggle the save state for the article with `key`.
  *
  * @param key to toggle state for, either saving or un-saving it. Key is a standardized version of the article URL obtained by the key property on WMFArticle or from a URL with wmf_databaseKey
+ * @param variant to toggle state for. Variant is a language variant code.
  * @return whether or not the key is now saved
  */
-- (BOOL)toggleSavedPageForKey:(NSString *)key;
+- (BOOL)toggleSavedPageForKey:(NSString *)key variant:(nullable NSString *)variant;
 
 /**
  * Toggle the save state for `url`.

--- a/Wikipedia/Code/SaveButtonsController.swift
+++ b/Wikipedia/Code/SaveButtonsController.swift
@@ -37,7 +37,7 @@ class SaveButtonsController: NSObject, SaveButtonDelegate {
             return
         }
         let tag = key.hash
-        saveButton.saveButtonState = article.savedDate == nil ? .longSave : .longSaved
+        saveButton.saveButtonState = article.isAnyVariantSaved ? .longSaved : .longSave
         saveButton.tag = tag
         saveButton.addTarget(self, action: #selector(saveButtonPressed(sender:)), for: .touchUpInside)
         saveButton.saveButtonDelegate = self
@@ -106,7 +106,7 @@ class SaveButtonsController: NSObject, SaveButtonDelegate {
                 return
             }
             for saveButton in saveButtons {
-                saveButton.saveButtonState = article.savedDate == nil ? .longSave : .longSaved
+                saveButton.saveButtonState = article.isAnyVariantSaved ? .longSaved : .longSave
             }
         }
         updatedArticle = article

--- a/Wikipedia/Code/SaveButtonsController.swift
+++ b/Wikipedia/Code/SaveButtonsController.swift
@@ -126,7 +126,7 @@ class SaveButtonsController: NSObject, SaveButtonDelegate {
         activeKey = key
         activeSender = sender
         
-        if let articleToUnsave = dataStore.savedPageList.entry(forKey: key.databaseKey) {
+        if let articleToUnsave = dataStore.savedPageList.articleToUnsave(forKey: key.databaseKey) {
             delegate?.willUnsaveArticle(articleToUnsave, userInfo: visibleUserInfo[sender.tag])
             return // don't unsave immediately, wait for a callback from WMFReadingListActionSheetControllerDelegate
         }
@@ -139,7 +139,7 @@ class SaveButtonsController: NSObject, SaveButtonDelegate {
             return
         }
 
-        let isSaved = dataStore.savedPageList.toggleSavedPage(forKey: key.databaseKey)
+        let isSaved = dataStore.savedPageList.toggleSavedPage(forKey: key.databaseKey, variant: key.languageVariantCode)
         
         if isSaved {
             savedPagesFunnel.logSaveNew(withArticleURL: updatedArticle?.url)

--- a/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
+++ b/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
@@ -121,6 +121,32 @@
     XCTAssertEqualObjects(articleURL.wmf_languageVariantCode, languageVariantCode);
 }
 
+- (void)testPreferredLanguageVariantForLanguageCode {
+    // Only run test if language variants are enabled
+    if (!WikipediaLookup.languageVariantsEnabled) {
+        return;
+    }
+    NSString *chineseLanguageVariantCode = @"zh-my";
+    NSString *serbianLanguageVariantCode = @"sr-ec";
+    MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:@"zh" pageTitleText:@"" name:@"Malaysia Simplified" localizedName:@"大马简体" languageVariantCode:chineseLanguageVariantCode];
+    [self.controller appendPreferredLanguage:link];
+    
+    // Test finding in app preferences
+    NSString *chineseResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"zh"];
+    XCTAssertEqualObjects(chineseResult, chineseLanguageVariantCode);
+    
+    // Test fallback not in app preferences or OS preferences
+    NSString *serbianResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"sr"];
+    XCTAssertEqualObjects(serbianResult, serbianLanguageVariantCode);
+    
+    // Test non-variant languages not found in app or OS preferences
+    NSString *englishResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"en"];
+    XCTAssertNil(englishResult);
+    
+    NSString *frenchResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"fr"];
+    XCTAssertNil(frenchResult);
+}
+
 
 #pragma mark - Utils
 


### PR DESCRIPTION
This is work towards the language variants feature https://phabricator.wikimedia.org/T195265 and https://phabricator.wikimedia.org/T268275.

It is not the entire feature/ticket.

It is probably best reviewed commit by commit.

### Notes
This PR has a few commits that are prep-work for future PRs and then updates to SaveButtonsController and MWKSavedPageList to handle variants.

*Note that there are more changes needed to get saved pages / reading lists working when language variants are turned on. These changes should keep behavior the same when language variants are turned off.*

**Commit 1**
Add methods to MWKLanguageLinkController and NSLocale to make a best guess of language variant when an article comes in from a synched reading list.

The language link controller method searches for a match in the user's app preferred languages, if none found returns the value of the NSLocale method.

The NSLocale method searches the user's OS languages settings for a preferred variant. If no preferred variant is found, uses a default variant value.

Added a test, but only runs if language variants are turned on.

**Commit 2**
In an upcoming PR, need to fetch articles by inMemoryKey. We already do this in one place in the code.
Added a fetch method and made the method that returns the appropriate predicate private.
This is straight refactoring. No logic change.

**Commit 3**
Update SaveButtonsController to use in-memory keys. Does not change behavior. Note, it still calls into non-variant aware APIs. This is expected for this commit.

**Commit 4**
Add a way to track all visible save buttons for the same article across all variants. This will enable keeping the save buttons in sync across different variants of the same article in the explore feed. No change in behavior when language variants are turned off.

**Commit 5**
Use isAnyVariantSaved property for state of saved buttons.
Update all cases where save button state is set. Note many call sites were using `saveDate == nil` which indicates *unsaved* so the results needed to flip in those cases.

**Commit 6**
Make MWKSavedPageList variant-aware. This is a change to three methods.

**Commit 7**
Revert to using the string articleKey when coordinating between remote and local reading list entries.
Create a typealias `RemoteReadingListArticleKey` for `String`. Using that type as the key for various tracking dictionaries where appropriate makes it less error prone than both variant and non-variant-aware keys using `MWKInMemoryURLKey`.

### Test Steps
1. With language variants turned off, behavior of saved buttons, saved list and reading lists should remain unchanged.

