### PR TITLE
Tweaks from User Testing prep

### DIFF
--- a/Wikipedia/Code/WikipediaLookup.swift
+++ b/Wikipedia/Code/WikipediaLookup.swift
@@ -20,9 +20,12 @@ import CocoaLumberjackSwift
         return allWikipedias.map { (wikipedia) -> MWKLanguageLink in
             var localizedName = wikipedia.localName
             if !wikipedia.languageCode.contains("-") {
-                // iOS will return less descriptive name for compound codes - ie "Chinese" for zh-yue which
-                // should be "Cantonese". It looks like iOS ignores anything after the "-".
+                
                 if let iOSLocalizedName = Locale.current.localizedString(forLanguageCode: wikipedia.languageCode) {
+                    localizedName = iOSLocalizedName
+                }
+            } else {
+                if let iOSLocalizedName = Locale.current.localizedString(forIdentifier: wikipedia.languageCode) {
                     localizedName = iOSLocalizedName
                 }
             }
@@ -42,9 +45,13 @@ import CocoaLumberjackSwift
             let entries = try JSONDecoder().decode([String : [WikipediaLanguageVariant]].self, from: data)
             return entries.mapValues { wikipediaLanguageVariants -> [MWKLanguageLink] in
                 wikipediaLanguageVariants.map { wikipediaLanguageVariant in
-                    // All language variant codes have compound codes. iOS returns a less descriptive localized name
-                    // for those, so not attempting to get localized name from iOS.
-                    MWKLanguageLink(languageCode: wikipediaLanguageVariant.languageCode, pageTitleText: "", name: wikipediaLanguageVariant.languageName, localizedName: wikipediaLanguageVariant.localName, languageVariantCode: wikipediaLanguageVariant.languageVariantCode)
+                    
+                    var localizedName = wikipediaLanguageVariant.localName
+                    if let iOSLocalizedName = Locale.current.localizedString(forIdentifier: wikipediaLanguageVariant.languageVariantCode) {
+                        localizedName = iOSLocalizedName
+                    }
+                    
+                    return MWKLanguageLink(languageCode: wikipediaLanguageVariant.languageCode, pageTitleText: "", name: wikipediaLanguageVariant.languageName, localizedName: localizedName, languageVariantCode: wikipediaLanguageVariant.languageVariantCode)
                 }
             }
         } catch let error {

--- a/Wikipedia/Code/WikipediaLookup.swift
+++ b/Wikipedia/Code/WikipediaLookup.swift
@@ -24,7 +24,7 @@ import CocoaLumberjackSwift
                 if let iOSLocalizedName = Locale.current.localizedString(forLanguageCode: wikipedia.languageCode) {
                     localizedName = iOSLocalizedName
                 }
-            } else {
+            } else if !Locale.current.isEnglish {
                 if let iOSLocalizedName = Locale.current.localizedString(forIdentifier: wikipedia.languageCode) {
                     localizedName = iOSLocalizedName
                 }
@@ -47,7 +47,8 @@ import CocoaLumberjackSwift
                 wikipediaLanguageVariants.map { wikipediaLanguageVariant in
                     
                     var localizedName = wikipediaLanguageVariant.localName
-                    if let iOSLocalizedName = Locale.current.localizedString(forIdentifier: wikipediaLanguageVariant.languageVariantCode) {
+                    if !Locale.current.isEnglish,
+                        let iOSLocalizedName = Locale.current.localizedString(forIdentifier: wikipediaLanguageVariant.languageVariantCode) {
                         localizedName = iOSLocalizedName
                     }
                     

--- a/Wikipedia/Code/wikipedia-language-variants.json
+++ b/Wikipedia/Code/wikipedia-language-variants.json
@@ -3,49 +3,49 @@
         {
             "languageVariantCode": "zh-hans",
             "languageName": "简体",
-            "localName": "Chinese, Simplified",
+            "localName": "Chinese (Simplified)",
             "languageCode": "zh"
         },
         {
             "languageVariantCode": "zh-hant",
             "languageName": "繁體",
-            "localName": "Chinese, Traditional",
+            "localName": "Chinese (Traditional)",
             "languageCode": "zh"
         },
         {
             "languageVariantCode": "zh-cn",
             "languageName": "大陆简体",
-            "localName": "Mainland Simplified",
+            "localName": "Chinese (Mainland Simplified)",
             "languageCode": "zh"
         },
         {
             "languageVariantCode": "zh-hk",
             "languageName": "香港繁體",
-            "localName": "Hong Kong Traditional",
+            "localName": "Chinese (Hong Kong Traditional)",
             "languageCode": "zh"
         },
         {
             "languageVariantCode": "zh-mo",
             "languageName": "澳門繁體",
-            "localName": "Macau Traditional",
+            "localName": "Chinese (Macau Traditional)",
             "languageCode": "zh"
         },
         {
             "languageVariantCode": "zh-my",
             "languageName": "大马简体",
-            "localName": "Malaysia Simplified",
+            "localName": "Chinese (Malaysia Simplified)",
             "languageCode": "zh"
         },
         {
             "languageVariantCode": "zh-sg",
             "languageName": "新加坡简体",
-            "localName": "Singapore Simplified",
+            "localName": "Chinese (Singapore Simplified)",
             "languageCode": "zh"
         },
         {
             "languageVariantCode": "zh-tw",
             "languageName": "臺灣正體",
-            "localName": "Taiwanese Traditional",
+            "localName": "Chinese (Taiwanese Traditional)",
             "languageCode": "zh"
         }
     ],


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T276280

### Notes
* These are tweaks that came up while preparing the User Testing build. This adjusts the Chinese variant phrasing in the language list to match the other variant patterns, as well as improving the automatic iOS localizedName translation logic for language codes containing hyphens.

### Test Steps
1. Set `languageVariantsEnabled = true` in WikipediaLookup.swift
2. Observe the Chinese variant subtitle patterns in the language list and on the Search page for a device with English as its main language. Confirm it fits the "Language (Variant)" pattern.
3. Switch your device primary language to non-EN. 
4. Confirm that variant subtitles in the language list and on the Search page are translated in your device primary language. On `main` they show as English.

### Screenshots/Videos *(if applicable)*
Before (with English as primary device language):
![Screen Shot 2021-03-08 at 3 20 44 PM](https://user-images.githubusercontent.com/3620196/110383976-b5118600-8022-11eb-856b-ae84cec6257b.png)
![Screen Shot 2021-03-08 at 3 22 03 PM](https://user-images.githubusercontent.com/3620196/110383997-b93da380-8022-11eb-923d-7aceb9260369.png)

After (with English and primary device language):
![Screen Shot 2021-03-08 at 3 23 06 PM](https://user-images.githubusercontent.com/3620196/110384060-c5c1fc00-8022-11eb-88a2-88be6861d0a5.png)
![Screen Shot 2021-03-08 at 3 22 46 PM](https://user-images.githubusercontent.com/3620196/110384086-ca86b000-8022-11eb-9f45-15c3be3128da.png)

Before (with Spanish as primary device language):
![Screen Shot 2021-03-08 at 3 26 06 PM](https://user-images.githubusercontent.com/3620196/110384132-d4101800-8022-11eb-9534-4c2640e6f588.png)
![Screen Shot 2021-03-08 at 3 25 51 PM](https://user-images.githubusercontent.com/3620196/110384138-d70b0880-8022-11eb-916b-1066cf6b7376.png)

After (with Spanish as primary device language):
![Screen Shot 2021-03-08 at 3 24 38 PM](https://user-images.githubusercontent.com/3620196/110384167-e1c59d80-8022-11eb-89f8-3eea4910fe3d.png)
![Screen Shot 2021-03-08 at 3 24 54 PM](https://user-images.githubusercontent.com/3620196/110384176-e5592480-8022-11eb-8824-30e74724062d.png)


