### PR TITLE
Always display recently searched terms when searching

### DIFF
--- a/Wikipedia/Code/EditLinkViewController.swift
+++ b/Wikipedia/Code/EditLinkViewController.swift
@@ -167,6 +167,7 @@ class EditLinkViewController: ViewController {
     @IBAction private func searchArticles(_ sender: UITapGestureRecognizer) {
         let searchViewController = SearchViewController()
         searchViewController.shouldSetTitleViewWhenRecentSearchesAreDisabled = false
+        searchViewController.shouldAdjustNavigationBarInsetHidingOnAppearance = false
         searchViewController.siteURL = siteURL
         searchViewController.shouldSetSearchVisible = false
         searchViewController.shouldBecomeFirstResponder = true

--- a/Wikipedia/Code/EditLinkViewController.swift
+++ b/Wikipedia/Code/EditLinkViewController.swift
@@ -171,7 +171,7 @@ class EditLinkViewController: ViewController {
         searchViewController.shouldSetSearchVisible = false
         searchViewController.shouldBecomeFirstResponder = true
         searchViewController.displayType = .backVisible
-        searchViewController.areRecentSearchesEnabled = false
+        searchViewController.areRecentSearchesEnabled = true
         searchViewController.dataStore = MWKDataStore.shared()
         searchViewController.shouldShowCancelButton = false
         searchViewController.delegate = self

--- a/Wikipedia/Code/InsertLinkViewController.swift
+++ b/Wikipedia/Code/InsertLinkViewController.swift
@@ -42,7 +42,7 @@ class InsertLinkViewController: UIViewController {
         searchViewController.delegate = self
         searchViewController.delegatesSelection = true
         searchViewController.showLanguageBar = false
-        searchViewController.search()
+		searchViewController.updateRecentlySearchedVisibility(searchText: nil)
         return searchViewController
     }()
 

--- a/Wikipedia/Code/InsertLinkViewController.swift
+++ b/Wikipedia/Code/InsertLinkViewController.swift
@@ -35,7 +35,7 @@ class InsertLinkViewController: UIViewController {
         searchViewController.dataStore = dataStore
         searchViewController.siteURL = siteURL
         searchViewController.searchTerm = link.page
-        searchViewController.areRecentSearchesEnabled = false
+        searchViewController.areRecentSearchesEnabled = true
         searchViewController.shouldBecomeFirstResponder = true
         searchViewController.dataStore = MWKDataStore.shared()
         searchViewController.shouldShowCancelButton = false

--- a/Wikipedia/Code/InsertMediaViewController.swift
+++ b/Wikipedia/Code/InsertMediaViewController.swift
@@ -184,6 +184,10 @@ final class InsertMediaViewController: ViewController {
     }
 
     var isAnimatingSearchBarState: Bool = false
+    
+    override var shouldAnimateWhileUpdatingScrollViewInsets: Bool {
+        return isAnimatingSearchBarState
+    }
 
     func focusSearch(_ focus: Bool, animated: Bool = true, additionalAnimations: (() -> Void)? = nil) {
         useNavigationBarVisibleHeightForScrollViewInsets = focus
@@ -207,7 +211,7 @@ final class InsertMediaViewController: ViewController {
             self.searchViewController.searchBar.setShowsCancelButton(focus, animated: animated)
             additionalAnimations?()
             self.view.layoutIfNeeded()
-            self.updateScrollViewInsets(preserveAnimation: true)
+            self.updateScrollViewInsets()
         }
         guard animated else {
             animations()

--- a/Wikipedia/Code/InsertMediaViewController.swift
+++ b/Wikipedia/Code/InsertMediaViewController.swift
@@ -186,7 +186,7 @@ final class InsertMediaViewController: ViewController {
     var isAnimatingSearchBarState: Bool = false
     
     override var shouldAnimateWhileUpdatingScrollViewInsets: Bool {
-        return isAnimatingSearchBarState
+        return true
     }
 
     func focusSearch(_ focus: Bool, animated: Bool = true, additionalAnimations: (() -> Void)? = nil) {

--- a/Wikipedia/Code/SearchTransition.swift
+++ b/Wikipedia/Code/SearchTransition.swift
@@ -36,7 +36,6 @@ class SearchTransition: NSObject, UIViewControllerAnimatedTransitioning {
             containerView.insertSubview(toViewController.view, belowSubview: fromViewController.view)
             exploreViewController.view.layoutIfNeeded()
             searchViewController.prepareForOutgoingTransition(with: exploreViewController.navigationBar)
-            searchViewController.nonSearchAlpha = 1
             exploreViewController.searchBar.alpha = 0
         }
 
@@ -46,14 +45,10 @@ class SearchTransition: NSObject, UIViewControllerAnimatedTransitioning {
             let relativeDuration: TimeInterval = 0.5
             let relativeStartTime: TimeInterval = self.isEnteringSearch ? 1 - relativeDuration : 0
             UIView.addKeyframe(withRelativeStartTime: relativeStartTime, relativeDuration: relativeDuration, animations: {
-                if self.isEnteringSearch {
-                    self.searchViewController.nonSearchAlpha = 1
-                } else {
-                    self.searchViewController.nonSearchAlpha = 0
-                }
+                self.searchViewController.beginTransitionFromExploreFeed(enteringSearch: self.isEnteringSearch)
             })
         }) { (finished) in
-            self.searchViewController.nonSearchAlpha = 1
+            self.searchViewController.completeTransitionFromExploreFeed(enteringSearch: self.isEnteringSearch)
             self.exploreViewController.searchBar.alpha = 1
             transitionContext.completeTransition(true)
         }

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -394,6 +394,7 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
     }
     
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        updateRecentlySearchedVisibility(searchText: searchText)
         search(for: searchBar.text, suggested: false)
     }
 
@@ -438,6 +439,10 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
     }
     
     // Recent
+
+    func updateRecentlySearchedVisibility(searchText: String) {
+        resultsViewController.view.isHidden = searchText.isEmpty
+    }
 
     var recentSearches: MWKRecentSearchList? {
         return self.dataStore.recentSearchList

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -155,7 +155,7 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
             }
         }
         
-        let sucess = { (results: WMFSearchResults, type: WMFSearchType) in
+        let success = { (results: WMFSearchResults, type: WMFSearchType) in
             DispatchQueue.main.async {
                 guard searchTerm == self.searchBar.text else {
                     return
@@ -178,14 +178,14 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
         fetcher.fetchArticles(forSearchTerm: searchTerm, siteURL: siteURL, resultLimit: WMFMaxSearchResultLimit, failure: { (error) in
             failure(error, .prefix)
         }) { (results) in
-            sucess(results, .prefix)
+            success(results, .prefix)
             guard let resultsArray = results.results, resultsArray.count < 12 else {
                 return
             }
             self.fetcher.fetchArticles(forSearchTerm: searchTerm, siteURL: siteURL, resultLimit: WMFMaxSearchResultLimit, fullTextSearch: true, appendToPreviousResults: results, failure: { (error) in
                 failure(error, .full)
             }) { (results) in
-                sucess(results, .full)
+                success(results, .full)
             }
         }
     }

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -16,6 +16,7 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
         navigationBar.addUnderNavigationBarView(searchBarContainerView)
         view.bringSubviewToFront(resultsViewController.view)
         resultsViewController.view.isHidden = true
+        useNavigationBarVisibleHeightForScrollViewInsets = true
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -290,6 +290,11 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
     private var navigationBarTopSpacing: CGFloat = 0
 
     var searchLanguageBarViewController: SearchLanguagesBarViewController?
+    
+    override var shouldAnimateWhileUpdatingScrollViewInsets: Bool {
+        return isAnimatingSearchBarState
+    }
+    
     private var _isSearchVisible: Bool = false
     private func setSearchVisible(_ visible: Bool, animated: Bool) {
         _isSearchVisible = visible

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -243,6 +243,7 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
     
     @objc func clear() {
         didCancelSearch()
+        updateRecentlySearchedVisibility(searchText: searchBar.text)
     }
     
     lazy var searchBarContainerView: UIView = {

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -294,7 +294,6 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
         _isSearchVisible = visible
         navigationBar.isAdjustingHidingFromContentInsetChangesEnabled  = false
         let completion = { (finished: Bool) in
-            self.resultsViewController.view.isHidden = !visible
             self.isAnimatingSearchBarState = false
             self.navigationBar.isTitleShrinkingEnabled = true
             self.navigationBar.isAdjustingHidingFromContentInsetChangesEnabled  = true
@@ -316,7 +315,6 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
             self.navigationBar.isBarHidingEnabled = false
             self.navigationBar.isTopSpacingHidingEnabled = !visible
             self.navigationBar.shadowAlpha = visible ? 1 : self.searchLanguageBarViewController != nil ? 0 : self.navigationBarShadowAlpha
-            self.resultsViewController.view.alpha = visible ? 1 : 0
             if self.shouldShowCancelButton {
                 self.searchBar.setShowsCancelButton(visible, animated: animated)
             }
@@ -328,8 +326,6 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
             return
         }
         isAnimatingSearchBarState = true
-        self.resultsViewController.view.alpha = visible ? 0 : 1
-        self.resultsViewController.view.isHidden = false
         self.view.layoutIfNeeded()
         UIView.animate(withDuration: 0.3, animations: animations, completion: completion)
     }

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -418,6 +418,7 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
             didCancelSearch()
         }
         deselectAll(animated: true)
+		updateRecentlySearchedVisibility(searchText: searchBar.text)
     }
     
     @objc func makeSearchBarBecomeFirstResponder() {
@@ -441,7 +442,12 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
     
     // Recent
 
-    func updateRecentlySearchedVisibility(searchText: String) {
+    func updateRecentlySearchedVisibility(searchText: String?) {
+		guard let searchText = searchText else {
+			resultsViewController.view.isHidden = true
+			return
+		}
+
         resultsViewController.view.isHidden = searchText.isEmpty
     }
 

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -542,6 +542,8 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
         guard let recentSearch = recentSearches?.entry(at: UInt(indexPath.item)) else {
             return
         }
+        updateRecentlySearchedVisibility(searchText: recentSearch.searchTerm)
+        collectionView.deselectItem(at: indexPath, animated: true)
         searchBar.text = recentSearch.searchTerm
         searchBar.becomeFirstResponder()
         search()

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -6,9 +6,9 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationBar.displayType = displayType
-        title = CommonStrings.searchTitle
         if !areRecentSearchesEnabled, shouldSetTitleViewWhenRecentSearchesAreDisabled {
             navigationItem.titleView = UIView()
+            title = CommonStrings.searchTitle
         }
         navigationBar.isTitleShrinkingEnabled = true
         navigationBar.isShadowHidingEnabled = false

--- a/Wikipedia/Code/ViewController.swift
+++ b/Wikipedia/Code/ViewController.swift
@@ -259,7 +259,12 @@ class ViewController: PreviewingViewController, NavigationBarHiderDelegate {
     
     var useNavigationBarVisibleHeightForScrollViewInsets: Bool = false
     
-    public final func updateScrollViewInsets(preserveAnimation: Bool = false) {
+    //override if needed to preserve scroll view inset animation
+    public var shouldAnimateWhileUpdatingScrollViewInsets: Bool {
+        return false
+    }
+    
+    public final func updateScrollViewInsets() {
         guard let scrollView = scrollView, scrollView.contentInsetAdjustmentBehavior == .never else {
             return
         }
@@ -297,7 +302,7 @@ class ViewController: PreviewingViewController, NavigationBarHiderDelegate {
             top += rc.frame.height
         }
         let contentInset = UIEdgeInsets(top: top, left: scrollView.contentInset.left, bottom: bottom, right: scrollView.contentInset.right)
-        if scrollView.setContentInset(contentInset, scrollIndicatorInsets: scrollIndicatorInsets, preserveContentOffset: navigationBar.isAdjustingHidingFromContentInsetChangesEnabled, preserveAnimation: preserveAnimation) {
+        if scrollView.setContentInset(contentInset, scrollIndicatorInsets: scrollIndicatorInsets, preserveContentOffset: navigationBar.isAdjustingHidingFromContentInsetChangesEnabled, preserveAnimation: shouldAnimateWhileUpdatingScrollViewInsets) {
             scrollViewInsetsDidChange()
         }
     }

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1932,7 +1932,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
     } else {
         searchVC = [[SearchViewController alloc] init];
         searchVC.shouldBecomeFirstResponder = YES;
-        searchVC.areRecentSearchesEnabled = NO;
+        searchVC.areRecentSearchesEnabled = YES;
         [searchVC applyTheme:self.theme];
         searchVC.dataStore = self.dataStore;
     }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T238863

### Notes
Displays user's saved recently searched terms in all presentations of the search view controller. 

I wasn't immediately able to resolve the strange collection view content inset issues I was noticing when animating between in search and out of search states with a longer list of terms, so I applied some animation to hopefully make the experience less jarring. I'm unhappy about my solution though. Feel free to destroy my gross overlay/animation stuff if you figure out what was up with the insets, or if not I hope we can try and improve it in the future. I really dislike these new spaghetti state variables, but so far this mix has provided the best in-use balance of usability and presentation for all known (to me at least) displays of the short and long lists of recent terms in search controllers in the app.

### Test Steps
Confirm these entries into search display your saved recently searched terms when the search bar is empty, repeating with a list that contains only a few terms and one that contains more than a screen full:
- From "Explore" tab
- From "Search" tab
- From reading an article, then tapping Search in top right
    - Also, then tapping Search again on a selected article
- From article editor, inserting new link from toolbar 
- From article editor, tap existing link, then tap link in toolbar
- From long pressing app icon on Home screen and tapping search



