### PR TITLE
Move from KVO to an explicit delegate for language changes

### DIFF
--- a/Wikipedia/Code/MWKLanguageFilter.h
+++ b/Wikipedia/Code/MWKLanguageFilter.h
@@ -4,20 +4,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol MWKLanguageFilterDataSourceDelegate
-- (void)noteLanguagesDidChange;
-@end
+// Notification sent by an MWKLanguageFilterDataSource when language array values change
+extern NSString *const MWKLanguageFilterDataSourceLanguagesDidChangeNotification;
 
 @protocol MWKLanguageFilterDataSource <NSObject>
 
-@property (nonatomic, weak, nullable) id <MWKLanguageFilterDataSourceDelegate> languageFilterDelegate;
 @property (readonly, copy, nonatomic) NSArray<MWKLanguageLink *> *allLanguages;
 @property (readonly, copy, nonatomic) NSArray<MWKLanguageLink *> *preferredLanguages;
 @property (readonly, copy, nonatomic) NSArray<MWKLanguageLink *> *otherLanguages;
 
 @end
 
-@interface MWKLanguageFilter : NSObject <MWKLanguageFilterDataSourceDelegate>
+@interface MWKLanguageFilter : NSObject
 
 - (instancetype)initWithLanguageDataSource:(id<MWKLanguageFilterDataSource>)dataSource;
 

--- a/Wikipedia/Code/MWKLanguageFilter.h
+++ b/Wikipedia/Code/MWKLanguageFilter.h
@@ -4,15 +4,20 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol MWKLanguageFilterDataSourceDelegate
+- (void)noteLanguagesDidChange;
+@end
+
 @protocol MWKLanguageFilterDataSource <NSObject>
 
+@property (nonatomic, weak, nullable) id <MWKLanguageFilterDataSourceDelegate> languageFilterDelegate;
 @property (readonly, copy, nonatomic) NSArray<MWKLanguageLink *> *allLanguages;
 @property (readonly, copy, nonatomic) NSArray<MWKLanguageLink *> *preferredLanguages;
 @property (readonly, copy, nonatomic) NSArray<MWKLanguageLink *> *otherLanguages;
 
 @end
 
-@interface MWKLanguageFilter : NSObject
+@interface MWKLanguageFilter : NSObject <MWKLanguageFilterDataSourceDelegate>
 
 - (instancetype)initWithLanguageDataSource:(id<MWKLanguageFilterDataSource>)dataSource;
 

--- a/Wikipedia/Code/MWKLanguageFilter.m
+++ b/Wikipedia/Code/MWKLanguageFilter.m
@@ -4,8 +4,6 @@
 #import <WMF/WMF-Swift.h>
 #import <WMF/WMFComparison.h>
 
-static const NSString *kvo_MWKLanguageFilter_dataSource_allLanguages = nil;
-
 @interface MWKLanguageFilter ()
 
 @property (nonatomic, strong, readwrite) id<MWKLanguageFilterDataSource> dataSource;
@@ -34,10 +32,9 @@ static const NSString *kvo_MWKLanguageFilter_dataSource_allLanguages = nil;
     if (_dataSource == dataSource) {
         return;
     }
-    NSString *keyPath = WMF_SAFE_KEYPATH(_dataSource, allLanguages);
-    [(id)_dataSource removeObserver:self forKeyPath:keyPath context:&kvo_MWKLanguageFilter_dataSource_allLanguages];
+    _dataSource.languageFilterDelegate = nil;
     _dataSource = dataSource;
-    [(id)_dataSource addObserver:self forKeyPath:keyPath options:NSKeyValueObservingOptionNew context:&kvo_MWKLanguageFilter_dataSource_allLanguages];
+    _dataSource.languageFilterDelegate = self;
 }
 
 - (void)setLanguageFilter:(NSString *__nullable)filterString {
@@ -66,12 +63,8 @@ static const NSString *kvo_MWKLanguageFilter_dataSource_allLanguages = nil;
     }
 }
 
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey, id> *)change context:(void *)context {
-    if (context == &kvo_MWKLanguageFilter_dataSource_allLanguages) {
-        [self updateFilteredLanguages];
-    } else {
-        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
-    }
+- (void)noteLanguagesDidChange {
+    [self updateFilteredLanguages];
 }
 
 @end

--- a/Wikipedia/Code/MWKLanguageLinkController.h
+++ b/Wikipedia/Code/MWKLanguageLinkController.h
@@ -51,11 +51,6 @@ typedef NS_ENUM(NSInteger, WMFPreferredLanguagesChangeType) {
 @property (readonly, copy, nonatomic) NSArray<MWKLanguageLink *> *otherLanguages;
 
 /**
- * Language filter delegate to notify of changes
- */
-@property (nonatomic, weak, nullable) id <MWKLanguageFilterDataSourceDelegate> languageFilterDelegate;
-
-/**
  *  Uniquely appends a new preferred language. The new language will be the last preferred language.
  *
  *  @param language the language to append

--- a/Wikipedia/Code/MWKLanguageLinkController.h
+++ b/Wikipedia/Code/MWKLanguageLinkController.h
@@ -27,8 +27,6 @@ typedef NS_ENUM(NSInteger, WMFPreferredLanguagesChangeType) {
 
 /**
  * Returns all languages of the receiver, sorted by name, minus unsupported languages.
- *
- * Observe this property to be notifified of changes to the list of languages.
  */
 @property (readonly, copy, nonatomic) NSArray<MWKLanguageLink *> *allLanguages;
 
@@ -51,6 +49,11 @@ typedef NS_ENUM(NSInteger, WMFPreferredLanguagesChangeType) {
  * All the languages in the receiver minus @c preferredLanguages.
  */
 @property (readonly, copy, nonatomic) NSArray<MWKLanguageLink *> *otherLanguages;
+
+/**
+ * Language filter delegate to notify of changes
+ */
+@property (nonatomic, weak, nullable) id <MWKLanguageFilterDataSourceDelegate> languageFilterDelegate;
 
 /**
  *  Uniquely appends a new preferred language. The new language will be the last preferred language.

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -184,7 +184,6 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
 
 - (void)savePreferredLanguageCodes:(NSArray<NSString *> *)languageCodes changeType:(WMFPreferredLanguagesChangeType)changeType changedLanguage:(MWKLanguageLink *)changedLanguage {
     NSString *previousAppContentLanguageCode = self.appLanguage.contentLanguageCode;
-    [self willChangeValueForKey:WMF_SAFE_KEYPATH(self, allLanguages)];
     [self.moc performBlockAndWait:^{
         [self.moc wmf_setValue:languageCodes forKey:WMFPreviousLanguagesKey];
         NSError *preferredLanguageCodeSaveError = nil;
@@ -192,7 +191,7 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
             DDLogError(@"Error saving preferred languages: %@", preferredLanguageCodeSaveError);
         }
     }];
-    [self didChangeValueForKey:WMF_SAFE_KEYPATH(self, allLanguages)];
+    if (self.languageFilterDelegate) { [self.languageFilterDelegate noteLanguagesDidChange]; }
     NSDictionary *userInfo = @{WMFPreferredLanguagesChangeTypeKey: @(changeType), WMFPreferredLanguagesLastChangedLanguageKey: changedLanguage};
     [[NSNotificationCenter defaultCenter] postNotificationName:WMFPreferredLanguagesDidChangeNotification object:self userInfo:userInfo];
     if (self.appLanguage.contentLanguageCode && ![self.appLanguage.contentLanguageCode isEqualToString:previousAppContentLanguageCode]) {
@@ -202,11 +201,10 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
 
 // Reminder: "resetPreferredLanguages" is for testing only!
 - (void)resetPreferredLanguages {
-    [self willChangeValueForKey:WMF_SAFE_KEYPATH(self, allLanguages)];
     [self.moc performBlockAndWait:^{
         [self.moc wmf_setValue:nil forKey:WMFPreviousLanguagesKey];
     }];
-    [self didChangeValueForKey:WMF_SAFE_KEYPATH(self, allLanguages)];
+    if (self.languageFilterDelegate) { [self.languageFilterDelegate noteLanguagesDidChange]; }
     [[NSNotificationCenter defaultCenter] postNotificationName:WMFPreferredLanguagesDidChangeNotification object:self];
 }
 

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -191,7 +191,7 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
             DDLogError(@"Error saving preferred languages: %@", preferredLanguageCodeSaveError);
         }
     }];
-    if (self.languageFilterDelegate) { [self.languageFilterDelegate noteLanguagesDidChange]; }
+    [[NSNotificationCenter defaultCenter] postNotificationName:MWKLanguageFilterDataSourceLanguagesDidChangeNotification object: self];
     NSDictionary *userInfo = @{WMFPreferredLanguagesChangeTypeKey: @(changeType), WMFPreferredLanguagesLastChangedLanguageKey: changedLanguage};
     [[NSNotificationCenter defaultCenter] postNotificationName:WMFPreferredLanguagesDidChangeNotification object:self userInfo:userInfo];
     if (self.appLanguage.contentLanguageCode && ![self.appLanguage.contentLanguageCode isEqualToString:previousAppContentLanguageCode]) {
@@ -204,7 +204,7 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
     [self.moc performBlockAndWait:^{
         [self.moc wmf_setValue:nil forKey:WMFPreviousLanguagesKey];
     }];
-    if (self.languageFilterDelegate) { [self.languageFilterDelegate noteLanguagesDidChange]; }
+    [[NSNotificationCenter defaultCenter] postNotificationName:MWKLanguageFilterDataSourceLanguagesDidChangeNotification object: self];
     [[NSNotificationCenter defaultCenter] postNotificationName:WMFPreferredLanguagesDidChangeNotification object:self];
 }
 

--- a/Wikipedia/Code/MWKTitleLanguageController.h
+++ b/Wikipedia/Code/MWKTitleLanguageController.h
@@ -30,12 +30,6 @@ NS_ASSUME_NONNULL_BEGIN
  * All the languages in the receiver minus @c preferredLanguages.
  */
 @property (readonly, copy, nonatomic) NSArray<MWKLanguageLink *> *otherLanguages;
-
-/**
- * Language filter delegate to notify of changes
- */
-@property (nonatomic, weak, nullable) id <MWKLanguageFilterDataSourceDelegate> languageFilterDelegate;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/MWKTitleLanguageController.h
+++ b/Wikipedia/Code/MWKTitleLanguageController.h
@@ -17,8 +17,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Returns all languages of the receiver, with preferred languages listed first.
- *
- * Observe this property to be notifified of changes to the list of languages.
  */
 @property (readonly, copy, nonatomic) NSArray<MWKLanguageLink *> *allLanguages;
 
@@ -32,6 +30,12 @@ NS_ASSUME_NONNULL_BEGIN
  * All the languages in the receiver minus @c preferredLanguages.
  */
 @property (readonly, copy, nonatomic) NSArray<MWKLanguageLink *> *otherLanguages;
+
+/**
+ * Language filter delegate to notify of changes
+ */
+@property (nonatomic, weak, nullable) id <MWKLanguageFilterDataSourceDelegate> languageFilterDelegate;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/MWKTitleLanguageController.m
+++ b/Wikipedia/Code/MWKTitleLanguageController.m
@@ -76,6 +76,10 @@ NS_ASSUME_NONNULL_BEGIN
     }] wmf_map:^id(MWKLanguageLink *language) {
         return [self titleLanguageForLanguage:language];
     }];
+    
+    if (self.languageFilterDelegate) {
+        [self.languageFilterDelegate noteLanguagesDidChange];
+    }
 }
 
 - (nullable MWKLanguageLink *)titleLanguageForLanguage:(MWKLanguageLink *)language {

--- a/Wikipedia/Code/MWKTitleLanguageController.m
+++ b/Wikipedia/Code/MWKTitleLanguageController.m
@@ -77,9 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
         return [self titleLanguageForLanguage:language];
     }];
     
-    if (self.languageFilterDelegate) {
-        [self.languageFilterDelegate noteLanguagesDidChange];
-    }
+    [[NSNotificationCenter defaultCenter] postNotificationName:MWKLanguageFilterDataSourceLanguagesDidChangeNotification object: self];
 }
 
 - (nullable MWKLanguageLink *)titleLanguageForLanguage:(MWKLanguageLink *)language {


### PR DESCRIPTION
This is prep work for https://phabricator.wikimedia.org/T273666 (Language Variant Migration)

### Notes
During language variant migration, it is necessary to *not* send notifications that the preferred languages have changed.

MWKLanguageLinkController ends up doing a KVO notification on 'allLanguages' whenever 'preferredLanguages' changes. This makes for ugly logic to suppress the notification, needing to skip `willChange` and `didChange` in different places in the method.

I've moved to an explicit delegate which is now used for both data sources for MWKLanguageFilter. This makes the dependencies much more clear and also removes an Obj-C-centric mechanism that makes the move to Swift more difficult.

- Current implementation was misusing KVO on allLanguages for changes to preferredLanguages
- Add MWKLanguageFilterDataSourceDelegate protocol
- Add languageFilterDelegate property to MWKLanguageFilterDataSource protocol and implementors
- Remove manual KVO triggering from MWKLanguageLinkController
- Add calls to delegate in MWKLanguageLinkController and MWKTitleLanguageController
- Replace KVO registration with delegate setting in MWKLanguageFilter
- Replace KVO observation method with delegate notification method in MWKLanguageFilter
- This change makes the dependency explicit
- It also eases transition to Swift w/o reliance on Obj-C properties

### Test Steps
1. Ran all tests
2. In Settings, choose Languages, add a language. Search and choose one. Choose to Add a language again, search, the language you just chose should no longer be available.
3. When viewing an article, tap the 'Change Language' button. Languages should appear after the list of that article in other languages has been fetched.