### PR TITLE
add altISOCode to MWKLanguageLink to work around Norwegian bugs

### DIFF
--- a/Command Line Tools/Update Languages/WikipediaLanguageCommandLineUtilityAPI.swift
+++ b/Command Line Tools/Update Languages/WikipediaLanguageCommandLineUtilityAPI.swift
@@ -20,7 +20,7 @@ class WikipediaLanguageCommandLineUtilityAPI {
     //     ...
     // }
     func getSites() -> AnyPublisher<[Wikipedia], Error> {
-        let sitematrixURL = URL(string: "https://meta.wikimedia.org/w/api.php?action=sitematrix&format=json&formatversion=2&origin=*")!
+        let sitematrixURL = URL(string: "https://meta.wikimedia.org/w/api.php?action=sitematrix&smsiteprop=url%7Cdbname%7Ccode%7Csitename%7Clang&format=json&formatversion=2&origin=*")!
         return URLSession.shared
             .dataTaskPublisher(for: sitematrixURL)
             .tryMap { result -> [String: Any] in
@@ -44,10 +44,19 @@ class WikipediaLanguageCommandLineUtilityAPI {
                     else {
                         return nil
                 }
-                return Wikipedia(languageCode: code, languageName: name, localName: localname)
+                
+                guard code == "no" else {
+                    return Wikipedia(languageCode: code, languageName: name, localName: localname, altISOCode: nil)
+                }
+                
+                //Norwegian (Bokmål) has a different ISO code than it's subdomain, which is useful to reference in some instances (prepopulating preferredLanguages from iOS device languages, and choosing the correct alternative article language from the langlinks endpoint).
+                //https://phabricator.wikimedia.org/T276645
+                //https://phabricator.wikimedia.org/T272193
+                return Wikipedia(languageCode: code, languageName: name, localName: localname, altISOCode: "nb")
+                
             }
             // Add testwiki, it's not returned by the site matrix
-            wikipedias.append(Wikipedia(languageCode: "test", languageName: "Test", localName: "Test"))
+            wikipedias.append(Wikipedia(languageCode: "test", languageName: "Test", localName: "Test", altISOCode: nil))
             return wikipedias
         }.eraseToAnyPublisher()
     }

--- a/Command Line Tools/Update Languages/WikipediaLanguageCommandLineUtilityAPI.swift
+++ b/Command Line Tools/Update Languages/WikipediaLanguageCommandLineUtilityAPI.swift
@@ -45,15 +45,14 @@ class WikipediaLanguageCommandLineUtilityAPI {
                         return nil
                 }
                 
-                guard code == "no" else {
-                    return Wikipedia(languageCode: code, languageName: name, localName: localname, altISOCode: nil)
+                guard code != "no" else {
+                    //Norwegian (Bokmål) has a different ISO code than it's subdomain, which is useful to reference in some instances (prepopulating preferredLanguages from iOS device languages, and choosing the correct alternative article language from the langlinks endpoint).
+                    //https://phabricator.wikimedia.org/T276645
+                    //https://phabricator.wikimedia.org/T272193
+                    return Wikipedia(languageCode: code, languageName: name, localName: localname, altISOCode: "nb")
                 }
                 
-                //Norwegian (Bokmål) has a different ISO code than it's subdomain, which is useful to reference in some instances (prepopulating preferredLanguages from iOS device languages, and choosing the correct alternative article language from the langlinks endpoint).
-                //https://phabricator.wikimedia.org/T276645
-                //https://phabricator.wikimedia.org/T272193
-                return Wikipedia(languageCode: code, languageName: name, localName: localname, altISOCode: "nb")
-                
+                return Wikipedia(languageCode: code, languageName: name, localName: localname, altISOCode: nil)
             }
             // Add testwiki, it's not returned by the site matrix
             wikipedias.append(Wikipedia(languageCode: "test", languageName: "Test", localName: "Test", altISOCode: nil))

--- a/Wikipedia/Code/MWKLanguageLink.h
+++ b/Wikipedia/Code/MWKLanguageLink.h
@@ -19,11 +19,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// If representing a language variant, the language variant code. Otherwise nil.
 @property (readonly, copy, nonatomic, nullable) NSString *languageVariantCode;
 
+/// Alternative ISO code that is useful in some instances where the languageCode lookup fails. So far this is only set and in use for Norwegian (Bokmål) ("no" languageCode, "nb" altISOCode)
+@property (readonly, copy, nonatomic, nullable) NSString *altISOCode;
+
 - (instancetype)initWithLanguageCode:(nonnull NSString *)languageCode
                        pageTitleText:(nonnull NSString *)pageTitleText
                                 name:(nonnull NSString *)name
                        localizedName:(nonnull NSString *)localizedName
-                 languageVariantCode:(nullable NSString *)languageVariantCode NS_DESIGNATED_INITIALIZER;
+                 languageVariantCode:(nullable NSString *)languageVariantCode
+                          altISOCode:(nullable NSString *)altISOCode NS_DESIGNATED_INITIALIZER;
 
 ///
 /// @name Comparison

--- a/Wikipedia/Code/MWKLanguageLink.m
+++ b/Wikipedia/Code/MWKLanguageLink.m
@@ -10,6 +10,7 @@
 @property (readwrite, copy, nonatomic, nonnull) NSString *localizedName;
 @property (readwrite, copy, nonatomic, nonnull) NSString *name;
 @property (readwrite, copy, nonatomic, nullable) NSString *languageVariantCode;
+@property (readwrite, copy, nonatomic, nullable) NSString *altISOCode;
 
 @end
 
@@ -21,7 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
                        pageTitleText:(nonnull NSString *)pageTitleText
                                 name:(nonnull NSString *)name
                        localizedName:(nonnull NSString *)localizedName
-                 languageVariantCode:(nullable NSString *)languageVariantCode {
+                 languageVariantCode:(nullable NSString *)languageVariantCode
+                          altISOCode:(nullable NSString *)altISOCode {
     self = [super init];
     if (self) {
         self.languageCode = languageCode;
@@ -29,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
         self.name = name;
         self.localizedName = localizedName;
         self.languageVariantCode = languageVariantCode;
+        self.altISOCode = altISOCode;
     }
     return self;
 }
@@ -52,11 +55,12 @@ WMF_SYNTHESIZE_IS_EQUAL(MWKLanguageLink, isEqualToLanguageLink:)
                          @"%@ { \n"
                           "\tlanguageCode: %@, \n"
                           "\tlanguageVariantCode: %@, \n"
+                          "\altISOCode: %@, \n"
                           "\tpageTitleText: %@, \n"
                           "\tname: %@, \n"
                           "\tlocalizedName: %@ \n"
                           "}",
-                         [super description], self.languageCode, self.languageVariantCode, self.pageTitleText, self.name, self.localizedName];
+                         [super description], self.languageCode, self.languageVariantCode, self.altISOCode, self.pageTitleText, self.name, self.localizedName];
 }
 
 #pragma mark - Computed Properties
@@ -82,7 +86,8 @@ WMF_SYNTHESIZE_IS_EQUAL(MWKLanguageLink, isEqualToLanguageLink:)
                                            pageTitleText:pageTitleText
                                                     name:self.name
                                            localizedName:self.localizedName
-                                     languageVariantCode:self.languageVariantCode];
+                                     languageVariantCode:self.languageVariantCode
+                                              altISOCode:self.altISOCode];
 }
 
 @end

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -86,16 +86,15 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
     MWKLanguageLink *matchingLanguageLink = [self.preferredLanguages wmf_match:^BOOL(MWKLanguageLink *obj) {
         return [obj.languageCode isEqual:languageCode];
     }];
-    
+
     // If the matching link does not have a language variant code, the language does not have variants. Return nil.
     if (matchingLanguageLink) {
-        return matchingLanguageLink.languageVariantCode ? : nil;
+        return matchingLanguageLink.languageVariantCode ?: nil;
     }
-    
+
     // If not found in the app's preferred languages, get the best guess from the user's OS settings.
     return [NSLocale wmf_bestLanguageVariantCodeForLanguageCode:languageCode];
 }
-
 
 - (nullable MWKLanguageLink *)appLanguage {
     return [self.preferredLanguages firstObject];
@@ -105,7 +104,13 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
     NSArray *preferredLanguageCodes = [self readPreferredLanguageCodes];
     return [preferredLanguageCodes wmf_mapAndRejectNil:^id(NSString *langString) {
         return [self.allLanguages wmf_match:^BOOL(MWKLanguageLink *langLink) {
-            return [langLink.contentLanguageCode isEqualToString:langString];
+
+            //Note, sometimes the device iOS language codes will return a code that doesn't line up with the Wikipedia language codes we have set,
+            //so we are also checking for a match against the altISOCode (currently only set for "no.wikipedia.org")
+            //Fixes https://phabricator.wikimedia.org/T276645
+            return [langLink.contentLanguageCode isEqualToString:langString] ||
+                                                (langLink.altISOCode &&
+                                                [langLink.altISOCode isEqualToString:langString]);
         }];
     }];
 }

--- a/Wikipedia/Code/MWKLanguageLinkFetcher.m
+++ b/Wikipedia/Code/MWKLanguageLinkFetcher.m
@@ -38,7 +38,8 @@
                                                                         pageTitleText:jsonLink[@"*"]
                                                                                  name:jsonLink[@"autonym"]
                                                                         localizedName:jsonLink[@"langname"]
-                                                                  languageVariantCode:nil];
+                                                                  languageVariantCode:nil
+                                                                           altISOCode:nil];
                              }];
                          }] wmf_reject:^BOOL(id key, id obj) {
                              return WMF_IS_EQUAL(obj, [NSNull null]);

--- a/Wikipedia/Code/Wikipedia.swift
+++ b/Wikipedia/Code/Wikipedia.swift
@@ -12,4 +12,5 @@ struct WikipediaLanguageVariant: Codable {
     let languageVariantCode: String
     let languageName: String
     let localName: String
+    let altISOCode: String?
 }

--- a/Wikipedia/Code/Wikipedia.swift
+++ b/Wikipedia/Code/Wikipedia.swift
@@ -4,6 +4,7 @@ struct Wikipedia: Codable {
     let languageCode: String
     let languageName: String
     let localName: String
+    let altISOCode: String?
 }
 
 struct WikipediaLanguageVariant: Codable {

--- a/Wikipedia/Code/WikipediaLookup.swift
+++ b/Wikipedia/Code/WikipediaLookup.swift
@@ -26,7 +26,7 @@ import CocoaLumberjackSwift
                     localizedName = iOSLocalizedName
                 }
             }
-            return MWKLanguageLink(languageCode: wikipedia.languageCode, pageTitleText: "", name: wikipedia.languageName, localizedName: localizedName, languageVariantCode: nil)
+            return MWKLanguageLink(languageCode: wikipedia.languageCode, pageTitleText: "", name: wikipedia.languageName, localizedName: localizedName, languageVariantCode: nil, altISOCode: wikipedia.altISOCode)
         }
     }()
 
@@ -44,7 +44,7 @@ import CocoaLumberjackSwift
                 wikipediaLanguageVariants.map { wikipediaLanguageVariant in
                     // All language variant codes have compound codes. iOS returns a less descriptive localized name
                     // for those, so not attempting to get localized name from iOS.
-                    MWKLanguageLink(languageCode: wikipediaLanguageVariant.languageCode, pageTitleText: "", name: wikipediaLanguageVariant.languageName, localizedName: wikipediaLanguageVariant.localName, languageVariantCode: wikipediaLanguageVariant.languageVariantCode)
+                    MWKLanguageLink(languageCode: wikipediaLanguageVariant.languageCode, pageTitleText: "", name: wikipediaLanguageVariant.languageName, localizedName: wikipediaLanguageVariant.localName, languageVariantCode: wikipediaLanguageVariant.languageVariantCode, altISOCode: nil)
                 }
             }
         } catch let error {

--- a/Wikipedia/Code/WikipediaLookup.swift
+++ b/Wikipedia/Code/WikipediaLookup.swift
@@ -52,7 +52,7 @@ import CocoaLumberjackSwift
                         localizedName = iOSLocalizedName
                     }
                     
-                    return MWKLanguageLink(languageCode: wikipediaLanguageVariant.languageCode, pageTitleText: "", name: wikipediaLanguageVariant.languageName, localizedName: localizedName, languageVariantCode: wikipediaLanguageVariant.languageVariantCode, altISOCode: nil)
+                    return MWKLanguageLink(languageCode: wikipediaLanguageVariant.languageCode, pageTitleText: "", name: wikipediaLanguageVariant.languageName, localizedName: localizedName, languageVariantCode: wikipediaLanguageVariant.languageVariantCode, altISOCode: wikipediaLanguageVariant.languageVariantCode)
                 }
             }
         } catch let error {

--- a/Wikipedia/Code/wikipedia-languages.json
+++ b/Wikipedia/Code/wikipedia-languages.json
@@ -1015,6 +1015,7 @@
     "localName" : "Norwegian Nynorsk"
   },
   {
+    "altISOCode" : "nb",
     "languageCode" : "no",
     "languageName" : "norsk",
     "localName" : "Norwegian"

--- a/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
+++ b/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
@@ -47,7 +47,7 @@
     //    NSAssert(![[self preferredLanguageCodes] containsObject:@"test"],
     //             @"'test' shouldn't be a default member of preferred languages!");
 
-    MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:@"test" pageTitleText:@"test" name:@"test" localizedName:@"test" languageVariantCode:@"test"];
+    MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:@"test" pageTitleText:@"test" name:@"test" localizedName:@"test" languageVariantCode:@"test" altISOCode:nil];
     [self.controller appendPreferredLanguage:link];
 
     XCTAssert([[self preferredLanguageCodes] containsObject:@"test"]);
@@ -55,7 +55,7 @@
 }
 
 - (void)testUniqueAppendToPreferredLanguages {
-    MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:@"test" pageTitleText:@"test" name:@"test" localizedName:@"test" languageVariantCode:@"test"];
+    MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:@"test" pageTitleText:@"test" name:@"test" localizedName:@"test" languageVariantCode:@"test" altISOCode:nil];
     [self.controller appendPreferredLanguage:link];
     NSArray *firstAppend = [self.controller.preferredLanguages copy];
 
@@ -77,10 +77,11 @@
 
 - (void)testBasicFiltering {
     self.filter.languageFilter = @"en";
-    
+
     XCTAssert([self.filter.filteredLanguages wmf_reject:^BOOL(MWKLanguageLink *langLink) {
-                   return [langLink.name wmf_caseInsensitiveContainsString:@"en"] || [langLink.localizedName wmf_caseInsensitiveContainsString:@"en"];
-               }].count == 0, @"All filtered languages have a name or localized name containing filter ignoring case");
+                  return [langLink.name wmf_caseInsensitiveContainsString:@"en"] || [langLink.localizedName wmf_caseInsensitiveContainsString:@"en"];
+              }].count == 0,
+              @"All filtered languages have a name or localized name containing filter ignoring case");
     [self verifyAllLanguageArrayProperties];
 }
 
@@ -92,31 +93,31 @@
 - (void)testContentLanguageCodeProperty {
     NSString *languageCode = @"zh";
     NSString *languageVariantCode = @"zh-hans";
-    
+
     // If languageVariantCode is non-nil and non-empty string, contentLanguageCode returns languageVariantCode
-    MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:languageCode pageTitleText:@"test" name:@"test" localizedName:@"test" languageVariantCode:languageVariantCode];
+    MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:languageCode pageTitleText:@"test" name:@"test" localizedName:@"test" languageVariantCode:languageVariantCode altISOCode:nil];
     XCTAssertEqualObjects(link.contentLanguageCode, languageVariantCode);
-    
+
     // If languageVariantCode is nil, contentLanguageCode returns languageCode
-    link = [[MWKLanguageLink alloc] initWithLanguageCode:languageCode pageTitleText:@"test" name:@"test" localizedName:@"test" languageVariantCode:nil];
+    link = [[MWKLanguageLink alloc] initWithLanguageCode:languageCode pageTitleText:@"test" name:@"test" localizedName:@"test" languageVariantCode:nil altISOCode:nil];
     XCTAssertEqualObjects(link.contentLanguageCode, languageCode);
-    
+
     // If languageVariantCode is an empty string, contentLanguageCode returns languageCode
-    link = [[MWKLanguageLink alloc] initWithLanguageCode:languageCode pageTitleText:@"test" name:@"test" localizedName:@"test" languageVariantCode:@""];
+    link = [[MWKLanguageLink alloc] initWithLanguageCode:languageCode pageTitleText:@"test" name:@"test" localizedName:@"test" languageVariantCode:@"" altISOCode:nil];
     XCTAssertEqualObjects(link.contentLanguageCode, languageCode);
 }
 
 - (void)testLanguageVariantCodeURLPropagation {
     NSString *languageCode = @"sr";
     NSString *languageVariantCode = @"sr-el";
-    
+
     // The languageVariantCode property should propagate to the siteURL.
-    MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:languageCode pageTitleText:@"test" name:@"test" localizedName:@"test" languageVariantCode:languageVariantCode];
+    MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:languageCode pageTitleText:@"test" name:@"test" localizedName:@"test" languageVariantCode:languageVariantCode altISOCode:nil];
     NSURL *siteURL = link.siteURL;
     XCTAssertEqualObjects(siteURL.wmf_languageVariantCode, languageVariantCode);
-    
+
     // The languageVariantCode property should propagate to the articleURL.
-    link = [[MWKLanguageLink alloc] initWithLanguageCode:languageCode pageTitleText:@"PageTitle" name:@"test" localizedName:@"test" languageVariantCode:languageVariantCode];
+    link = [[MWKLanguageLink alloc] initWithLanguageCode:languageCode pageTitleText:@"PageTitle" name:@"test" localizedName:@"test" languageVariantCode:languageVariantCode altISOCode:nil];
     NSURL *articleURL = link.articleURL;
     XCTAssertEqualObjects(articleURL.wmf_languageVariantCode, languageVariantCode);
 }
@@ -128,25 +129,24 @@
     }
     NSString *chineseLanguageVariantCode = @"zh-my";
     NSString *serbianLanguageVariantCode = @"sr-ec";
-    MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:@"zh" pageTitleText:@"" name:@"Malaysia Simplified" localizedName:@"大马简体" languageVariantCode:chineseLanguageVariantCode];
+    MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:@"zh" pageTitleText:@"" name:@"Malaysia Simplified" localizedName:@"大马简体" languageVariantCode:chineseLanguageVariantCode altISOCode:nil];
     [self.controller appendPreferredLanguage:link];
-    
+
     // Test finding in app preferences
     NSString *chineseResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"zh"];
     XCTAssertEqualObjects(chineseResult, chineseLanguageVariantCode);
-    
+
     // Test fallback not in app preferences or OS preferences
     NSString *serbianResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"sr"];
     XCTAssertEqualObjects(serbianResult, serbianLanguageVariantCode);
-    
+
     // Test non-variant languages not found in app or OS preferences
     NSString *englishResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"en"];
     XCTAssertNil(englishResult);
-    
+
     NSString *frenchResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"fr"];
     XCTAssertNil(frenchResult);
 }
-
 
 #pragma mark - Utils
 
@@ -168,7 +168,7 @@
                                         [self.controller.preferredLanguages
                                             arrayByAddingObjectsFromArray:self.controller.otherLanguages]];
 
-    XCTAssert(joinedLanguages.count ==  self.controller.otherLanguages.count + self.controller.preferredLanguages.count);
+    XCTAssert(joinedLanguages.count == self.controller.otherLanguages.count + self.controller.preferredLanguages.count);
 
     XCTAssertEqualObjects([NSSet setWithArray:self.controller.allLanguages], joinedLanguages);
 }


### PR DESCRIPTION
**Fixes Phabricator tickets:** https://phabricator.wikimedia.org/T276645, https://phabricator.wikimedia.org/T272193

### Notes
This ain't pretty but I believe this fixes the Norwegian bugs without causing regression. I tried to avoid any explicit callout to "no" or "nb" so that this could be a more generic fix that possibly fixed any other similar issues on other wikis, but I found that those other wikis acted inconsistently in the langlinks endpoint, so a completely generic fix wasn't possible. Since we only have complaints with Norwegian it's probably a good idea to limit the fix to that language for now anyways.

I also decided against changing the `languageCode` for Norwegian in the app from "no" to "nb". There are lots of assumptions in the app that the subdomain is the language code (for example, our `wmf_language` extension on NSURL), so I felt it safer to leave it as-is. I am instead adding an optional `altISOCode` to `MWKLanguageLink` to serve as basically just another code to check, but only as band-aids in the area of these two bugs.

### Test Steps
1. Change device language to **ONLY** Norwegian (Bokmål), no secondary languages.
2. Fresh install the app and launch. Confirm you see a Norwegian language chosen in Onboarding (it's blank on `main`). Confirm the Explore feed is fetched and populates (it's blank on `main`). Search for an article and tap into it. Confirm article loads. This concludes testing for https://phabricator.wikimedia.org/T276645.
3. On Norwegian, search for any article that's common enough to be listed in other languages (I chose USA). Go to that article, choose the language picker, and open article in another language. Choose language picker from that article, and confirm you see Norwegian Bokmål listed at the top as a language option. On `main` Norwegian does not show in this case because the language codes do not line up. This concludes the test for https://phabricator.wikimedia.org/T272193.