### PR TITLE
Language variant migration

### DIFF
--- a/WMF Framework/MWKDataStore+LanguageVariantMigration.swift
+++ b/WMF Framework/MWKDataStore+LanguageVariantMigration.swift
@@ -1,8 +1,75 @@
 import Foundation
+import CocoaLumberjackSwift
 
 extension MWKDataStore {
     @objc(migrateToLanguageVariantsForLanguageCodes:inManagedObjectContext:)
     public func migrateToLanguageVariants(for languageCodes: [String], in moc: NSManagedObjectContext) {
+        
+        // Map all languages with variants being migrated to the user's preferred variant
+        // Note that even if the user does not have any preferred languages that match,
+        // the user could have chosen to read or save an article in any language.
+        // The variant is therefore determined for all langauges being migrated.
+        let migrationMapping = languageCodes.reduce(into: [String:String]()) { (result, languageCode) in
+            guard let languageVariantCode = NSLocale.wmf_bestLanguageVariantCodeForLanguageCode(languageCode) else {
+                assertionFailure("No variant found for language code \(languageCode). Every language migrating to use language variants should return a language variant code")
+                return
+            }
+            result[languageCode] = languageVariantCode
+        }
+        
+        languageLinkController.migratePreferredLanguages(toLanguageVariants: migrationMapping, in: moc)
+        feedContentController.migrateExploreFeedSettings(toLanguageVariants: migrationMapping, in: moc)
+        migrateWikipediaEntities(toLanguageVariants: migrationMapping, in: moc)
+        
+    }
+    
+    private func migrateWikipediaEntities(toLanguageVariants languageMapping: [String:String], in moc: NSManagedObjectContext) {
+        for (languageCode, languageVariantCode) in languageMapping {
+            
+            guard let siteURLString = NSURL.wmf_URL(withDefaultSiteAndlanguage: languageCode)?.wmf_databaseKey else {
+                assertionFailure("Could not create URL from language code: '\(languageCode)'")
+                continue
+            }
+            
+            do {
+                // Update ContentGroups
+                let contentGroupFetchRequest: NSFetchRequest<WMFContentGroup> = WMFContentGroup.fetchRequest()
+                contentGroupFetchRequest.predicate = NSPredicate(format: "siteURLString == %@", siteURLString)
+                let groups = try moc.fetch(contentGroupFetchRequest)
+                for group in groups {
+                    group.variant = languageVariantCode
+                }
+                
+                // Update Articles and Gather Keys
+                var articleKeys: Set<String> = []
+                let articleFetchRequest: NSFetchRequest<WMFArticle> = WMFArticle.fetchRequest()
+                articleFetchRequest.predicate = NSPredicate(format: "key BEGINSWITH %@", siteURLString)
+                let articles = try moc.fetch(articleFetchRequest)
+                for article in articles {
+                    article.variant = languageVariantCode
+                    if let key = article.key {
+                        articleKeys.insert(key)
+                    }
+                }
 
+                // Update Reading List Entries
+                let entryFetchRequest: NSFetchRequest<ReadingListEntry> = ReadingListEntry.fetchRequest()
+                entryFetchRequest.predicate = NSPredicate(format: "articleKey IN %@", articleKeys)
+                let entries = try moc.fetch(entryFetchRequest)
+                for entry in entries {
+                    entry.variant = languageVariantCode
+                }
+            } catch let error {
+                DDLogError("Error migrating articles to variant '\(languageVariantCode)': \(error)")
+            }
+        }
+        
+        if moc.hasChanges {
+            do {
+                try moc.save()
+            } catch let error {
+                DDLogError("Error saving articles and readling list entry variant migrations: \(error)")
+            }
+        }
     }
 }

--- a/WMF Framework/MWKDataStore+LanguageVariantMigration.swift
+++ b/WMF Framework/MWKDataStore+LanguageVariantMigration.swift
@@ -19,8 +19,19 @@ extension MWKDataStore {
         
         languageLinkController.migratePreferredLanguages(toLanguageVariants: migrationMapping, in: moc)
         feedContentController.migrateExploreFeedSettings(toLanguageVariants: migrationMapping, in: moc)
+        migrateSearchLanguageSetting(toLanguageVariants: migrationMapping)
         migrateWikipediaEntities(toLanguageVariants: migrationMapping, in: moc)
         
+    }
+    
+    private func migrateSearchLanguageSetting(toLanguageVariants languageMapping: [String:String]) {
+        let defaults = UserDefaults.standard
+        if let url = defaults.url(forKey: WMFSearchURLKey),
+           let languageCode = url.wmf_language {
+            let searchLanguageCode = languageMapping[languageCode] ?? languageCode
+            defaults.wmf_setCurrentSearchContentLanguageCode(searchLanguageCode)
+            defaults.removeObject(forKey: WMFSearchURLKey)
+        }
     }
     
     private func migrateWikipediaEntities(toLanguageVariants languageMapping: [String:String], in moc: NSManagedObjectContext) {

--- a/WMF Framework/MWKDataStore+LanguageVariantMigration.swift
+++ b/WMF Framework/MWKDataStore+LanguageVariantMigration.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension MWKDataStore {
+    @objc(migrateToLanguageVariantsForLanguageCodes:inManagedObjectContext:)
+    public func migrateToLanguageVariants(for languageCodes: [String], in moc: NSManagedObjectContext) {
+
+    }
+}

--- a/WMF Framework/WMFExploreFeedContentController.h
+++ b/WMF Framework/WMFExploreFeedContentController.h
@@ -118,4 +118,9 @@ extern const NSInteger WMFExploreFeedMaximumNumberOfDays;
 
 @end
 
+@interface WMFExploreFeedContentController (LanguageVariantMigration)
+/// The expected dictionary uses language codes as the key with the value being the desired language variant code for that language.
+- (void)migrateExploreFeedSettingsToLanguageVariants:(NSDictionary<NSString *, NSString *> *)languageMapping inManagedObjectContext:(NSManagedObjectContext *)moc;
+@end
+
 NS_ASSUME_NONNULL_END

--- a/WMF Framework/WMFExploreFeedContentController.m
+++ b/WMF Framework/WMFExploreFeedContentController.m
@@ -448,11 +448,7 @@ NSString *const WMFNewExploreFeedPreferencesWereRejectedNotification = @"WMFNewE
     WMFKeyValue *keyValue = [moc wmf_keyValueForKey:WMFExploreFeedPreferencesKey];
     NSDictionary *exploreFeedPreferences = (NSDictionary *)keyValue.value;
     if (exploreFeedPreferences && [exploreFeedPreferences objectForKey:WMFExploreFeedPreferencesGlobalCardsKey]) {
-        if ([self exploreFeedPreferencesNeedMigration:exploreFeedPreferences]) {
-            return [self migrateExploreFeedPreferences:exploreFeedPreferences inManagedObjectContext:moc];
-        } else {
-            return exploreFeedPreferences;
-        }
+        return exploreFeedPreferences;
     }
     [moc wmf_setValue:[self defaultExploreFeedPreferences] forKey:WMFExploreFeedPreferencesKey];
     [self save:moc];
@@ -733,62 +729,6 @@ NSString *const WMFNewExploreFeedPreferencesWereRejectedNotification = @"WMFNewE
     }
 }
 
-#pragma mark - Language Variant Migration
-/* NOTE: The methods in this section are currently called from -exploreFeedPreferencesInManagedObjectContext:.
- * This is a way to bootstrap migration to the new method of storing these settings until the full one-time
- * language variant migration process is in place.
- */
- static BOOL preferencesNeedMigration;
-- (BOOL)exploreFeedPreferencesNeedMigration:(NSDictionary *)preferences {
-    // Check once to avoid rechecking repeatedly
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        preferencesNeedMigration = NO;
-        for (NSString *key in preferences.allKeys) {
-            if ([key isEqualToString:WMFExploreFeedPreferencesGlobalCardsKey]) {
-                continue;
-            } else if ([key hasPrefix:@"http"]) {
-                preferencesNeedMigration = YES;
-                break;
-            } else {
-                break;
-            }
-        }
-    });
-    return preferencesNeedMigration;
-}
-
-// Move from siteURL-based to contentLanguageCode-based keys to support language variants
-- (NSDictionary *)migrateExploreFeedPreferences:(NSDictionary *)originalPreferences inManagedObjectContext:(NSManagedObjectContext *)moc {
-    NSArray *preferedSiteURLs = self.preferredSiteURLs;
-    NSMutableDictionary *migratedPreferences = [[NSMutableDictionary alloc] init];
-    for (NSString *key in originalPreferences.allKeys) {
-        // Just pass the global key along as-is
-        if ([key isEqualToString:WMFExploreFeedPreferencesGlobalCardsKey]) {
-            [migratedPreferences setValue:[originalPreferences valueForKey:key] forKey:key];
-        }
-        else {
-            NSInteger foundIndex = [preferedSiteURLs indexOfObjectPassingTest:^BOOL(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-                BOOL isMatch = [[(NSURL *)obj wmf_databaseKey] isEqualToString:key];
-                *stop = isMatch;
-                return isMatch;
-            }];
-            if (foundIndex != NSNotFound) {
-                NSURL *foundURL = [preferedSiteURLs objectAtIndex:foundIndex];
-                NSString *newKey = foundURL.wmf_contentLanguageCode;
-                [migratedPreferences setValue:[originalPreferences valueForKey:key] forKey:newKey];
-            }
-        }
-    }
-    [moc wmf_setValue:migratedPreferences forKey:WMFExploreFeedPreferencesKey];
-    [self save:moc];
-    NSDictionary *preferences = (NSDictionary *)[moc wmf_keyValueForKey:WMFExploreFeedPreferencesKey].value;
-    assert(preferences);
-    preferencesNeedMigration = NO;
-    return preferences;
-}
-
-
 #pragma mark - Debug
 
 #if DEBUG
@@ -872,6 +812,48 @@ NSString *const WMFNewExploreFeedPreferencesWereRejectedNotification = @"WMFNewE
             completion();
         }
     }];
+}
+
+@end
+
+@implementation WMFExploreFeedContentController (LanguageVariantMigration)
+
+/// The expected dictionary uses language codes as the key with the value being the desired language variant code for that language.
+/// Move from siteURL-based to contentLanguageCode-based keys to support language variants
+- (void)migrateExploreFeedSettingsToLanguageVariants:(NSDictionary<NSString *, NSString *> *)languageMapping inManagedObjectContext:(NSManagedObjectContext *)moc{
+    
+    WMFKeyValue *keyValue = [moc wmf_keyValueForKey:WMFExploreFeedPreferencesKey];
+    NSDictionary *originalPreferences = (NSDictionary *)keyValue.value;
+
+    NSMutableDictionary *migratedPreferences = [[NSMutableDictionary alloc] init];
+    for (NSString *key in originalPreferences.allKeys) {
+        // Just pass the global key along as-is
+        if ([key isEqualToString:WMFExploreFeedPreferencesGlobalCardsKey]) {
+            [migratedPreferences setValue:[originalPreferences valueForKey:key] forKey:key];
+        }
+        else {
+            NSString *languageCode = nil;
+            // Remaining keys should be site URL strings prior to migration
+            if ([key hasPrefix:@"http"]) {
+                NSURL *oldKeyURL = [NSURL URLWithString:key];
+                languageCode = oldKeyURL.wmf_language;
+            }
+            // Interim code for migration may have been previously run
+            // Allow for that case as well
+            else {
+                languageCode = key;
+            }
+            if (languageCode) {
+                NSString *languageVariantCode = languageMapping[languageCode];
+                NSString *newKey = languageVariantCode ? : languageCode;
+                [migratedPreferences setValue:[originalPreferences valueForKey:key] forKey:newKey];
+            }
+        }
+    }
+    [moc wmf_setValue:migratedPreferences forKey:WMFExploreFeedPreferencesKey];
+    [self save:moc];
+    NSDictionary *preferences = (NSDictionary *)[moc wmf_keyValueForKey:WMFExploreFeedPreferencesKey].value;
+    assert(preferences);
 }
 
 @end

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		41FCAA3821C844CB001D8411 /* ReadingListEntryCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FCAA3521C844CB001D8411 /* ReadingListEntryCollectionViewController.swift */; };
 		41FCAA3921C844CB001D8411 /* ReadingListEntryCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FCAA3521C844CB001D8411 /* ReadingListEntryCollectionViewController.swift */; };
 		533AB8AE259792A9003A43D9 /* wikipedia-language-variants.json in Resources */ = {isa = PBXBuildFile; fileRef = 533AB8AD259792A9003A43D9 /* wikipedia-language-variants.json */; };
+		535F16D625CE11A300875AAD /* MWKDataStore+LanguageVariantMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535F16D525CE11A300875AAD /* MWKDataStore+LanguageVariantMigration.swift */; };
 		670063AF22540AC500E4CE3B /* SectionEditorFindAndReplaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670063AE22540AC500E4CE3B /* SectionEditorFindAndReplaceTests.swift */; };
 		67059DB52260D034009811AA /* SchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67059DB42260D034009811AA /* SchemeHandler.swift */; };
 		67059DB62260D619009811AA /* SchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67059DB42260D034009811AA /* SchemeHandler.swift */; };
@@ -3589,6 +3590,7 @@
 		41FCAA3521C844CB001D8411 /* ReadingListEntryCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListEntryCollectionViewController.swift; sourceTree = "<group>"; };
 		533AB8AD259792A9003A43D9 /* wikipedia-language-variants.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wikipedia-language-variants.json"; sourceTree = "<group>"; };
 		53478DE425AF8CB900F31DC2 /* Wikipedia 5.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Wikipedia 5.xcdatamodel"; sourceTree = "<group>"; };
+		535F16D525CE11A300875AAD /* MWKDataStore+LanguageVariantMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MWKDataStore+LanguageVariantMigration.swift"; sourceTree = "<group>"; };
 		53BAB79925DDDEE100A5ED4E /* Wikipedia 6.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Wikipedia 6.xcdatamodel"; sourceTree = "<group>"; };
 		670063AE22540AC500E4CE3B /* SectionEditorFindAndReplaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionEditorFindAndReplaceTests.swift; sourceTree = "<group>"; };
 		67059DB42260D034009811AA /* SchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemeHandler.swift; sourceTree = "<group>"; };
@@ -5940,6 +5942,7 @@
 				7A06020D20EAAF5A00FBB71D /* ExploreFeedPreferencesUpdateCoordinator.swift */,
 				B0E807C11C0CF04A0065EBC0 /* MWKDataStore.h */,
 				B0E807C21C0CF04A0065EBC0 /* MWKDataStore.m */,
+				535F16D525CE11A300875AAD /* MWKDataStore+LanguageVariantMigration.swift */,
 				B0E807B41C0CF0180065EBC0 /* MWKSavedPageList.h */,
 				B0E807B51C0CF0180065EBC0 /* MWKSavedPageList.m */,
 				D8C41DDA23FC09EE00353DCE /* NSManagedObjectContext+History.swift */,
@@ -11059,6 +11062,7 @@
 				0042809225E6E395004945B3 /* MTLReflection.m in Sources */,
 				67D6C0212405B3D2005709B1 /* CacheGroup+CoreDataProperties.swift in Sources */,
 				7A96C4BA2155413E00E8E0C1 /* RemoteNotification+CoreDataProperties.swift in Sources */,
+				535F16D625CE11A300875AAD /* MWKDataStore+LanguageVariantMigration.swift in Sources */,
 				83ACAAA224E6E38A003B3035 /* Wikipedia.swift in Sources */,
 				6779D45323F6EC2D002840CA /* CacheFetching.swift in Sources */,
 				D844D9C21D6CB7D20042D692 /* MWKImageInfo.m in Sources */,

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -447,6 +447,15 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
         }
     }
 
+    if (currentLibraryVersion < 13) {
+        [self migrateToLanguageVariantsForLanguageCodes:@[@"crh", @"gan", @"iu", @"kk", @"ku", @"sr", @"tg", @"uz", @"zh"] inManagedObjectContext:(NSManagedObjectContext *)moc];
+        [moc wmf_setValue:@(13) forKey:WMFLibraryVersionKey];
+        if ([moc hasChanges] && ![moc save:&migrationError]) {
+            DDLogError(@"Error saving during migration: %@", migrationError);
+            return;
+        }
+    }
+
     // IMPORTANT: When adding a new library version and migration, update WMFCurrentLibraryVersion to the latest version number
 }
 

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -13,7 +13,7 @@ NSString *const WMFFeedImportContextDidSave = @"WMFFeedImportContextDidSave";
 NSString *const WMFViewContextDidSave = @"WMFViewContextDidSave";
 
 NSString *const WMFLibraryVersionKey = @"WMFLibraryVersion";
-static const NSInteger WMFCurrentLibraryVersion = 13;
+static const NSInteger WMFCurrentLibraryVersion = 12;
 
 NSString *const MWKDataStoreValidImageSitePrefix = @"//upload.wikimedia.org/";
 
@@ -440,16 +440,8 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
     
     if (currentLibraryVersion < 12) {
         [[WMFEventLoggingService sharedInstance] migrateShareUsageAndInstallIDToUserDefaults];
-        [moc wmf_setValue:@(12) forKey:WMFLibraryVersionKey];
-        if ([moc hasChanges] && ![moc save:&migrationError]) {
-            DDLogError(@"Error saving during migration: %@", migrationError);
-            return;
-        }
-    }
-
-    if (currentLibraryVersion < 13) {
         [self migrateToLanguageVariantsForLanguageCodes:@[@"crh", @"gan", @"iu", @"kk", @"ku", @"sr", @"tg", @"uz", @"zh"] inManagedObjectContext:(NSManagedObjectContext *)moc];
-        [moc wmf_setValue:@(13) forKey:WMFLibraryVersionKey];
+        [moc wmf_setValue:@(12) forKey:WMFLibraryVersionKey];
         if ([moc hasChanges] && ![moc save:&migrationError]) {
             DDLogError(@"Error saving during migration: %@", migrationError);
             return;

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -13,7 +13,7 @@ NSString *const WMFFeedImportContextDidSave = @"WMFFeedImportContextDidSave";
 NSString *const WMFViewContextDidSave = @"WMFViewContextDidSave";
 
 NSString *const WMFLibraryVersionKey = @"WMFLibraryVersion";
-static const NSInteger WMFCurrentLibraryVersion = 12;
+static const NSInteger WMFCurrentLibraryVersion = 13;
 
 NSString *const MWKDataStoreValidImageSitePrefix = @"//upload.wikimedia.org/";
 

--- a/Wikipedia/Code/MWKLanguageLinkController.h
+++ b/Wikipedia/Code/MWKLanguageLinkController.h
@@ -88,6 +88,9 @@ typedef NS_ENUM(NSInteger, WMFPreferredLanguagesChangeType) {
 
 + (void)migratePreferredLanguagesToManagedObjectContext:(NSManagedObjectContext *)moc;
 
+/// The expected dictionary uses language codes as the key with the value being the desired language variant code for that language.
+- (void)migratePreferredLanguagesToLanguageVariants:(NSDictionary<NSString *, NSString *> *)languageMapping inManagedObjectContext:(NSManagedObjectContext *)moc;
+
 @end
 
 /// This category is specific to processing MWKLanguageLink instances that represent articles

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -157,9 +157,13 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
 #pragma mark - Reading/Saving Preferred Language Codes
 
 - (NSArray<NSString *> *)readSavedPreferredLanguageCodes {
+    return [self readSavedPreferredLanguageCodesInManagedObjectContext:self.moc];
+}
+    
+- (NSArray<NSString *> *)readSavedPreferredLanguageCodesInManagedObjectContext:(NSManagedObjectContext *)moc {
     __block NSArray<NSString *> *preferredLanguages = nil;
-    [self.moc performBlockAndWait:^{
-        preferredLanguages = [self.moc wmf_arrayValueForKey:WMFPreviousLanguagesKey] ?: @[];
+    [moc performBlockAndWait:^{
+        preferredLanguages = [moc wmf_arrayValueForKey:WMFPreviousLanguagesKey] ?: @[];
     }];
     return preferredLanguages;
 }
@@ -183,19 +187,28 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
 }
 
 - (void)savePreferredLanguageCodes:(NSArray<NSString *> *)languageCodes changeType:(WMFPreferredLanguagesChangeType)changeType changedLanguage:(MWKLanguageLink *)changedLanguage {
+    [self savePreferredLanguageCodes:languageCodes changeType:changeType changedLanguage:changedLanguage inManagedObjectContext:self.moc];
+}
+
+- (void)savePreferredLanguageCodes:(NSArray<NSString *> *)languageCodes changeType:(WMFPreferredLanguagesChangeType)changeType changedLanguage:(nullable MWKLanguageLink *)changedLanguage inManagedObjectContext:(NSManagedObjectContext *)moc {
     NSString *previousAppContentLanguageCode = self.appLanguage.contentLanguageCode;
-    [self.moc performBlockAndWait:^{
-        [self.moc wmf_setValue:languageCodes forKey:WMFPreviousLanguagesKey];
+    [moc performBlockAndWait:^{
+        [moc wmf_setValue:languageCodes forKey:WMFPreviousLanguagesKey];
         NSError *preferredLanguageCodeSaveError = nil;
-        if (![self.moc save:&preferredLanguageCodeSaveError]) {
+        if (![moc save:&preferredLanguageCodeSaveError]) {
             DDLogError(@"Error saving preferred languages: %@", preferredLanguageCodeSaveError);
         }
     }];
-    [[NSNotificationCenter defaultCenter] postNotificationName:MWKLanguageFilterDataSourceLanguagesDidChangeNotification object: self];
-    NSDictionary *userInfo = @{WMFPreferredLanguagesChangeTypeKey: @(changeType), WMFPreferredLanguagesLastChangedLanguageKey: changedLanguage};
-    [[NSNotificationCenter defaultCenter] postNotificationName:WMFPreferredLanguagesDidChangeNotification object:self userInfo:userInfo];
-    if (self.appLanguage.contentLanguageCode && ![self.appLanguage.contentLanguageCode isEqualToString:previousAppContentLanguageCode]) {
-        [[NSNotificationCenter defaultCenter] postNotificationName:WMFAppLanguageDidChangeNotification object:self];
+    
+    // Send notifications only if there is a change type and changed language
+    // Used to avoid sending notifications during language variant migration
+    if (changeType && changedLanguage) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:MWKLanguageFilterDataSourceLanguagesDidChangeNotification object: self];
+        NSDictionary *userInfo = @{WMFPreferredLanguagesChangeTypeKey: @(changeType), WMFPreferredLanguagesLastChangedLanguageKey: changedLanguage};
+        [[NSNotificationCenter defaultCenter] postNotificationName:WMFPreferredLanguagesDidChangeNotification object:self userInfo:userInfo];
+        if (self.appLanguage.contentLanguageCode && ![self.appLanguage.contentLanguageCode isEqualToString:previousAppContentLanguageCode]) {
+            [[NSNotificationCenter defaultCenter] postNotificationName:WMFAppLanguageDidChangeNotification object:self];
+        }
     }
 }
 
@@ -218,6 +231,26 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
 + (void)migratePreferredLanguagesToManagedObjectContext:(NSManagedObjectContext *)moc {
     NSArray *preferredLanguages = [[NSUserDefaults standardUserDefaults] arrayForKey:WMFPreviousLanguagesKey];
     [moc wmf_setValue:preferredLanguages forKey:WMFPreviousLanguagesKey];
+}
+
+- (void)migratePreferredLanguagesToLanguageVariants:(NSDictionary<NSString *, NSString *> *)languageMapping  inManagedObjectContext:(NSManagedObjectContext *)moc {
+    NSArray<NSString *> *preferredLanguageCodes = [[self readSavedPreferredLanguageCodesInManagedObjectContext:moc] copy];
+    NSMutableArray<NSString *> *updatedLanguageCodes = [preferredLanguageCodes mutableCopy];
+    BOOL languageCodesChanged = NO;
+    NSInteger currentIndex = 0;
+    for (NSString *languageCode in preferredLanguageCodes) {
+        NSString *migratedLanguageCode = languageMapping[languageCode];
+        if (migratedLanguageCode) {
+            [updatedLanguageCodes replaceObjectAtIndex:currentIndex withObject:languageMapping[languageCode]];
+            languageCodesChanged = YES;
+        }
+        currentIndex++;
+    }
+    
+    if (languageCodesChanged) {
+        // No changeType and nil changedLanguage will skip sending of notifications that preferred languages changed
+        [self savePreferredLanguageCodes:updatedLanguageCodes changeType:0 changedLanguage:nil inManagedObjectContext:moc];
+    }
 }
 
 @end

--- a/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
+++ b/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
@@ -253,18 +253,7 @@ let WMFSendUsageReports = "WMFSendUsageReports"
     }
     
     @objc func wmf_currentSearchContentLanguageCode() -> String? {
-        // This is a temporary migration until the full language variant migration is in place.
-        // At that point, it should no longer be necessary to check WMFSearchURLKey
-        if let url = url(forKey: WMFSearchURLKey) {
-            let code = url.wmf_contentLanguageCode
-            wmf_setCurrentSearchContentLanguageCode(code)
-            removeObject(forKey: WMFSearchURLKey)
-            return code
-        } else if let contentLanguageCode = self.string(forKey: WMFSearchLanguageKey) {
-            return contentLanguageCode
-        } else{
-            return nil
-        }
+        self.string(forKey: WMFSearchLanguageKey)
     }
     
     @objc func wmf_setCurrentSearchContentLanguageCode(_ code: String?) {

--- a/Wikipedia/Code/WikipediaLookup.swift
+++ b/Wikipedia/Code/WikipediaLookup.swift
@@ -34,7 +34,7 @@ import CocoaLumberjackSwift
     }()
 
     // Flag to be removed once language variants feature can be permanently turned on
-    @objc public static let languageVariantsEnabled = false
+    @objc public static let languageVariantsEnabled = true
     @objc static let allLanguageVariantsByWikipediaLanguageCode: [String:[MWKLanguageLink]] = {
         guard languageVariantsEnabled else { return [:] }
         guard let languagesFileURL = Bundle.wmf.url(forResource: "wikipedia-language-variants", withExtension: "json") else {

--- a/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
+++ b/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
@@ -129,7 +129,11 @@
     NSString *chineseLanguageVariantCode = @"zh-my";
     NSString *serbianLanguageVariantCode = @"sr-ec";
     MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:@"zh" pageTitleText:@"" name:@"Malaysia Simplified" localizedName:@"大马简体" languageVariantCode:chineseLanguageVariantCode];
+    
+    // Add langugage link and reorder to the front, so that regardless of the
+    // system langauge settings, this link is the first found variant for this language
     [self.controller appendPreferredLanguage:link];
+    [self.controller reorderPreferredLanguage:link toIndex:0];
     
     // Test finding in app preferences
     NSString *chineseResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"zh"];


### PR DESCRIPTION
**Fixes Phabricator ticket:** 
https://phabricator.wikimedia.org/T273666

### Notes
This PR adds the various migration necessary to convert various settings, preferences, and database records to use language variants. It also removes any interim migration code added while the language variant feature was in development.

Finally, it turns on the migration by bumping the library version and turns on language variants by setting the internal flag to true.
(Flag and spots that use it will be removed in a future PR)

The PR is broken down into commits, but is probably small enough to be reviewed all at once.

### Test Steps
- Build and run a version of the app without this PR included.
- Set up one or more languages, including those with variants
- Browse, add articles to reading lists, especially languages such as Chinese and Serbian

- Build and run a version of the app with the PR
- No immediate behavior change should be visible on launch
- In app settings, preferred language list should now list variants for languages with variants.
-   If a variant for that language is set in OS language settings, that should be the variant chosen in the app
-   If no variant is set in OS language settings, the variant should be Simplified Chinese for Chinese and Cyrillic Serbian for Serbian.

Besides seeing specific variants in settings for preferred languages, explore feed settings, and selected search language, no other interface changes should be present.

(NOTE: UI alerting the user of the new variant capability is not part of this PR)

