### PR TITLE
Add nullability annotations to WMFLanguagesViewController.h

### DIFF
--- a/Wikipedia/Code/ArticleViewController+ArticleInformation.swift
+++ b/Wikipedia/Code/ArticleViewController+ArticleInformation.swift
@@ -1,9 +1,6 @@
 extension ArticleViewController {
     func showLanguages() {
-        guard let languagesVC = WMFArticleLanguagesViewController(articleURL: articleURL) else {
-            showGenericError()
-            return
-        }
+        let languagesVC = WMFArticleLanguagesViewController(articleURL: articleURL)
         themesPresenter.dismissReadingThemesPopoverIfActive(from: self)
         languagesVC.delegate = self
         presentEmbedded(languagesVC, style: .sheet)

--- a/Wikipedia/Code/SearchLanguagesBarViewController.swift
+++ b/Wikipedia/Code/SearchLanguagesBarViewController.swift
@@ -159,11 +159,11 @@ class SearchLanguagesBarViewController: UIViewController, WMFPreferredLanguagesV
     
     @IBAction fileprivate func openLanguagePicker() {
         let languagesVC = WMFPreferredLanguagesViewController.preferredLanguagesViewController()
-        languagesVC?.delegate = self
+        languagesVC.delegate = self
         if let themeable = languagesVC as Themeable? {
             themeable.apply(theme: self.theme)
         }
-        present(WMFThemeableNavigationController(rootViewController: languagesVC!, theme: self.theme), animated: true, completion: nil)
+        present(WMFThemeableNavigationController(rootViewController: languagesVC, theme: self.theme), animated: true, completion: nil)
     }
     
     func languagesController(_ controller: WMFLanguagesViewController, didSelectLanguage language: MWKLanguageLink) {

--- a/Wikipedia/Code/TalkPageContainerViewController.swift
+++ b/Wikipedia/Code/TalkPageContainerViewController.swift
@@ -281,11 +281,11 @@ private extension TalkPageContainerViewController {
     @objc func tappedLanguage(_ sender: UIButton) {
         
         let languagesVC = WMFPreferredLanguagesViewController.preferredLanguagesViewController()
-        languagesVC?.delegate = self
+        languagesVC.delegate = self
         if let themeable = languagesVC as Themeable? {
             themeable.apply(theme: self.theme)
         }
-        present(WMFThemeableNavigationController(rootViewController: languagesVC!, theme: self.theme), animated: true, completion: nil)
+        present(WMFThemeableNavigationController(rootViewController: languagesVC, theme: self.theme), animated: true, completion: nil)
     }
     
     var talkPageURL: URL? {

--- a/Wikipedia/Code/WMFLanguagesViewController.h
+++ b/Wikipedia/Code/WMFLanguagesViewController.h
@@ -4,9 +4,11 @@
 @class WMFLanguagesViewController;
 @protocol WMFLanguagesViewControllerDelegate;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface WMFLanguagesViewController : UIViewController <UITableViewDataSource, UITableViewDelegate, WMFThemeable>
 
-@property (nonatomic, weak) id<WMFLanguagesViewControllerDelegate> delegate;
+@property (nonatomic, weak, nullable) id<WMFLanguagesViewControllerDelegate> delegate;
 
 + (instancetype)languagesViewController;
 
@@ -39,6 +41,6 @@
 
 + (instancetype)articleLanguagesViewControllerWithArticleURL:(NSURL *)url;
 
-@property (nonatomic, strong, readonly) NSURL *articleURL;
-
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFLanguagesViewController.m
+++ b/Wikipedia/Code/WMFLanguagesViewController.m
@@ -559,6 +559,7 @@ static CGFloat const WMFLanguageHeaderHeight = 57.f;
 @interface WMFArticleLanguagesViewController ()
 
 @property (strong, nonatomic) MWKTitleLanguageController *titleLanguageController;
+@property (nonatomic, strong, readonly) NSURL *articleURL;
 
 @end
 

--- a/Wikipedia/Code/WMFWelcomeLanguageTableViewController.swift
+++ b/Wikipedia/Code/WMFWelcomeLanguageTableViewController.swift
@@ -61,12 +61,11 @@ class WMFWelcomeLanguageTableViewController: ThemeableViewController, WMFPreferr
     }
     
     @IBAction func addLanguages(withSender sender: AnyObject) {
-        if let langsVC = WMFPreferredLanguagesViewController.preferredLanguagesViewController() {
-            langsVC.showExploreFeedCustomizationSettings = false
-            langsVC.delegate = self
-            let navC = WMFThemeableNavigationController(rootViewController: langsVC, theme: self.theme)
-            present(navC, animated: true, completion: nil)
-        }
+        let langsVC = WMFPreferredLanguagesViewController.preferredLanguagesViewController()
+        langsVC.showExploreFeedCustomizationSettings = false
+        langsVC.delegate = self
+        let navC = WMFThemeableNavigationController(rootViewController: langsVC, theme: self.theme)
+        present(navC, animated: true, completion: nil)
     }
     
     func languagesController(_ controller: WMFPreferredLanguagesViewController, didUpdatePreferredLanguages languages:[MWKLanguageLink]){


### PR DESCRIPTION
This is a small refactor to support changes to address the remaining issues of:
https://phabricator.wikimedia.org/T270210

### Notes
- Add nullability annotations to WMFLanguagesViewController.h
- Adjust call sites that now can rely on non-null values
   -  Remove `if let`s / `guard let`s / forced unwrapping
- Make articleURL property private since it is only used internally.

### Test Steps
1. Displaying language view controller in its various incarnations should behave as before.
(Language settings, Add language in language settings, choose different language for article)

2. No change in behavior.