### PR TITLE
Languages view controller changes

### DIFF
--- a/Wikipedia/Code/MWKLanguageFilter.h
+++ b/Wikipedia/Code/MWKLanguageFilter.h
@@ -31,7 +31,14 @@ extern NSString *const MWKLanguageFilterDataSourceLanguagesDidChangeNotification
 @property (copy, nullable, nonatomic) NSString *languageFilter;
 
 /**
- * Returns all languages of the languageController, with preferred languages listed first.
+ * Returns all languages of the languageController. If the data source preferred languages contains one or more
+ * language variants, the variants for those languages will appear first in the array.
+ *
+ * Note that this property is currently only used in the 'Add Langugages' configuration of WMFLanguagesViewController.
+ * That view controller requires this particular sorting scheme.
+ *
+ * If additional clients in the future require a different sorting scheme, a per-instance configuration property
+ * that specifies a sorting style would probably be the best approach.
  *
  * The languages returned by this property will be filtered if @c languageFilter is non-nil.
  */

--- a/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
+++ b/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
@@ -122,13 +122,21 @@
     XCTAssertEqualObjects(articleURL.wmf_languageVariantCode, languageVariantCode);
 }
 
+/* Note that this test relies on the OS *not* having Uzbek set as a preferred language.
+ * Since there is no way to change OS language settings from a test, to check the fallback
+ * setting if a language is not found in the app or the OS preferred languages, the tested
+ * language cannot be one of the OS preferred langugages.
+ *
+ * Choosing Uzbek since it is a less frequently used language and because it has the most
+ * fallback choices of any variant-aware language except for Chinese.
+ */
 - (void)testPreferredLanguageVariantForLanguageCode {
     // Only run test if language variants are enabled
     if (!WikipediaLookup.languageVariantsEnabled) {
         return;
     }
     NSString *chineseLanguageVariantCode = @"zh-my";
-    NSString *serbianLanguageVariantCode = @"sr-ec";
+    NSString *serbianLanguageVariantCode = @"uz-latin";
 
     MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:@"zh" pageTitleText:@"" name:@"Malaysia Simplified" localizedName:@"大马简体" languageVariantCode:chineseLanguageVariantCode altISOCode:nil];
     
@@ -142,7 +150,7 @@
     XCTAssertEqualObjects(chineseResult, chineseLanguageVariantCode);
 
     // Test fallback not in app preferences or OS preferences
-    NSString *serbianResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"sr"];
+    NSString *serbianResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"uz"];
     XCTAssertEqualObjects(serbianResult, serbianLanguageVariantCode);
 
     // Test non-variant languages not found in app or OS preferences

--- a/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
+++ b/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
@@ -144,7 +144,7 @@
     }
     
     NSString *chineseLanguageVariantCode = @"zh-my";
-    NSString *serbianLanguageVariantCode = @"uz-latin";
+    NSString *uzbekLanguageVariantCode = @"uz-latin";
 
     MWKLanguageLink *link = [[MWKLanguageLink alloc] initWithLanguageCode:@"zh" pageTitleText:@"" name:@"Malaysia Simplified" localizedName:@"大马简体" languageVariantCode:chineseLanguageVariantCode altISOCode:nil];
     
@@ -158,8 +158,8 @@
     XCTAssertEqualObjects(chineseResult, chineseLanguageVariantCode);
 
     // Test fallback not in app preferences or OS preferences
-    NSString *serbianResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"uz"];
-    XCTAssertEqualObjects(serbianResult, serbianLanguageVariantCode);
+    NSString *uzbekResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"uz"];
+    XCTAssertEqualObjects(uzbekResult, uzbekLanguageVariantCode);
 
     // Test non-variant languages not found in app or OS preferences
     NSString *englishResult = [self.controller preferredLanguageVariantCodeForLanguageCode:@"en"];

--- a/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
+++ b/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
@@ -135,6 +135,14 @@
     if (!WikipediaLookup.languageVariantsEnabled) {
         return;
     }
+    
+    NSInteger foundIndex = [NSLocale.preferredLanguages indexOfObjectPassingTest:^BOOL(NSString * _Nonnull languageCode, NSUInteger idx, BOOL * _Nonnull stop) {
+        return [languageCode hasPrefix:@"uz"];
+    }];
+    if (foundIndex != NSNotFound) {
+        XCTFail(@"Test being run with Uzbek included in OS preferred languages: '%@'", NSLocale.preferredLanguages[foundIndex]);
+    }
+    
     NSString *chineseLanguageVariantCode = @"zh-my";
     NSString *serbianLanguageVariantCode = @"uz-latin";
 


### PR DESCRIPTION
**Fixes Phabricator ticket:** 
https://phabricator.wikimedia.org/T277073
https://phabricator.wikimedia.org/T277071

### Notes
There are three commits.

**Commit 1**
The first commit adds a `showAllLanguages` option to the languages view controller. This option is what will now be used by the 'Add another language' view controller.

The rest of the code changes are essentially adding the correct behavior for the `showAllLanguages` setting.

Note that this new option is mutually exclusive with the `showPreferredLanguages` option and assertions are added to ensure they are not used together.

Also note that it is likely that any more divergence in behavior between the three use cases for the languages view controller would probably mean they should be refactored to have less interdependent options. It did not seem to be absolutely necessary for this change though.

**Commit 2**
Is to make a test pass. The simulator I was testing with included a variant of Serbian which was making this test fail. It is impossible to test the fall-back mechanism for variants if the variant exists in the user's OS languages. This chooses Uzbek 'uz' for that testing.

**Commit 3**
This adjusts the MWKLanguageFilter to ensure all language variants of a given language are at the beginning of the `filteredLanguages` array, when a language variant of that language is present in the `preferredLanguages` array of the filter's data source.

Note that `filteredLanguages` had no clients before this PR, so the sorting is always done. The comment on the property is updated to reflect the new sorting (the old description of its sorting behavior was also incorrect) and to suggest adding a sorting style property if future clients need a different sorting behavior.

I had considered making the sorting of `filteredLanguages` lazy, since only the 'Add new language' version of the view controller uses the property. If there seems to be a performance issue, that could be done in a future PR. There did not seem to be a noticeable issue in my testing.

**Commit 4**
I added one more commit after posting the PR. This adds a check that formally adds a precondition for Uzbek not being present in the OS preferred languages, so it is easier to notice there is a test device configuration issue instead of a failure of the code being tested.
### Test Steps
Test Checkmark (T277071):
1. During onboarding or in app settings, view the preferred languages settings.
2. Tap the "Add another language" button
3. Scroll through the list or search for the languages already on the preferred languages list.
4. A checkmark should be present in those rows 
5. Tapping those rows should not trigger dismissal, but have no effect
6. Tapping other rows should dismiss the view controller and add the selected language.

Test Variants At Top (T277073):
1. Ensure at least one language variant is included in the preferred languages list.
2. Tap the "Add another language" button
3. All of the variants for that language should appear at the top of the list of languages.
4. The variant already in the preferred list should have a check mark next to it.

Multiple Variants:
1. Add more than one language that supports variants to the preferred languages list.
2. Tap the "Add another language" button
3. The variants for each language should appear at the top of the languages list.
4. The order of the sets of variants should be the same as the order of the variants in the preferred languages list.
