### PR TITLE
Renamed all remaining mentions of develop branch to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,6 @@ We welcome volunteers to contribute to the Wikipedia iOS app codebase.
 ## Development instructions
 Before developing, please read the [setup instructions](README.md).
 
-We do all of our active development on the [develop](https://github.com/wikimedia/wikipedia-ios) branch. Your pull requests will automatically be targeted at that branch by Github. To make merging easier, be sure you create your branches based on the develop branch.
-
 Once your contributions are ready for review, add yourself in alphabetical order under contributors in `Code/AboutViewController.plist` and post a pull request on GitHub. One of the maintainers will review the PR. Thanks for contributing! 🎉
 
 ## What can I work on?

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 The official Wikipedia iOS app.
 
 [![Wikipedia](https://circleci.com/gh/wikimedia/wikipedia-ios.svg?style=shield)](https://github.com/wikimedia/wikipedia-ios)
-[![MIT license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/wikimedia/wikipedia-ios/develop/LICENSE.txt)
+[![MIT license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/wikimedia/wikipedia-ios/main/LICENSE.txt)
 
 * License: MIT License
 * Source repo: https://github.com/wikimedia/wikipedia-ios

--- a/Wikipedia/Code/AboutViewController.plist
+++ b/Wikipedia/Code/AboutViewController.plist
@@ -7,7 +7,7 @@
 		<key>sharealike</key>
 		<string>https://creativecommons.org/licenses/by-sa/3.0/</string>
 		<key>mit</key>
-		<string>https://raw.githubusercontent.com/wikimedia/wikipedia-ios/develop/LICENSE.txt</string>
+		<string>https://raw.githubusercontent.com/wikimedia/wikipedia-ios/main/LICENSE.txt</string>
 		<key>tsg</key>
 		<string>https://tsgteam.org</string>
 		<key>feedback</key>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,7 +49,7 @@ platform :ios do
      ensure_git_status_clean if ENV['FL_ENSURE_CLEAN']
   end
 
-  desc "Checks out the sha specified in the environment variables or the develop branch"
+  desc "Checks out the sha specified in the environment variables or the main branch"
   lane :checkout do
     sha = ENV['SHA']
     if sha != nil

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -20,7 +20,7 @@ or alternatively using `brew install fastlane`
 ```
 fastlane ios checkout
 ```
-Checks out the sha specified in the environment variables or the develop branch
+Checks out the sha specified in the environment variables or the main branch
 ### ios analyze
 ```
 fastlane ios analyze


### PR DESCRIPTION
Around 14 July 2020 development was changed from the _develop_ branch to the _main_ branch.

However, `CONTRIBUTING.md` still contains a reference to a _develop_ branch, which I think is not needed anymore because _main_ is now the default branch. Please correct me if I'm wrong.

This pull request removes this sentence and also renames all other mentions of the _develop_ branch I could find (ran ripgrep over the whole repo) which fixes two dead links to `LICENSE.txt`.