### PR TITLE
Ensure language variants alerts are displayed only once per language

### DIFF
--- a/WMF Framework/MWKDataStore+LanguageVariantMigration.swift
+++ b/WMF Framework/MWKDataStore+LanguageVariantMigration.swift
@@ -135,9 +135,11 @@ extension MWKDataStore {
         guard !addedVariantLanguageCodes.isEmpty else {
             return []
         }
+        var uniqueLanguageCodes: Set<String> = []
         return languageLinkController.preferredLanguages
             .map { $0.languageCode }
             .filter { addedVariantLanguageCodes.contains($0) }
+            .filter { uniqueLanguageCodes.insert($0).inserted }
     }
     
     // Returns an array of language codes for all languages that have added variant support


### PR DESCRIPTION
**Fixes Phabricator ticket:** 
https://phabricator.wikimedia.org/T279300

### Notes
- Uniques language codes before returning array of those requiring alerts
- Preserves the original preference order of the returned langauge codes

### Test Steps
1. Follow test steps in Phab ticket.
2. The issue will no longer reproduce.

OR
1. If building in development mode, change WMFAppViewController+Extensions.swift, line 14 to`let savedLibraryVersion = 0` to trigger the variant alerts.
2. Ensure more than one variant per language is selected in the app's preferred languages
3. Only one variant alert will appear per variant-supporting language

