### PR TITLE
Ensure ISO code 'nb' becomes wiki language code 'no' within the app

### DIFF
--- a/WMF Framework/MWKDataStore+LanguageVariantMigration.swift
+++ b/WMF Framework/MWKDataStore+LanguageVariantMigration.swift
@@ -52,9 +52,13 @@ extension MWKDataStore {
             result[languageCode] = languageVariantCode
         }
         
-        languageLinkController.migratePreferredLanguages(toLanguageVariants: migrationMapping, in: moc)
-        feedContentController.migrateExploreFeedSettings(toLanguageVariants: migrationMapping, in: moc)
-        migrateSearchLanguageSetting(toLanguageVariants: migrationMapping)
+        // Ensure any settings that currently use 'nb' are updated to use 'no'
+        var languageCodeMigrationMapping = migrationMapping
+        languageCodeMigrationMapping["nb"] = "no"
+        
+        languageLinkController.migratePreferredLanguages(toLanguageVariants: languageCodeMigrationMapping, in: moc)
+        feedContentController.migrateExploreFeedSettings(toLanguageVariants: languageCodeMigrationMapping, in: moc)
+        migrateSearchLanguageSetting(toLanguageVariants: languageCodeMigrationMapping)
         migrateWikipediaEntities(toLanguageVariants: migrationMapping, in: moc)
     }
     

--- a/WMF Framework/MediaWikiAcceptLanguageMapping.json
+++ b/WMF Framework/MediaWikiAcceptLanguageMapping.json
@@ -79,5 +79,10 @@
         "latn": {
             "default": "uz-latin",
         }
+    },
+    "nb": {
+        "default": {
+            "default": "no",
+        }
     }
 }

--- a/Wikipedia/Code/MWKLanguageLink.m
+++ b/Wikipedia/Code/MWKLanguageLink.m
@@ -55,7 +55,7 @@ WMF_SYNTHESIZE_IS_EQUAL(MWKLanguageLink, isEqualToLanguageLink:)
                          @"%@ { \n"
                           "\tlanguageCode: %@, \n"
                           "\tlanguageVariantCode: %@, \n"
-                          "\altISOCode: %@, \n"
+                          "\taltISOCode: %@, \n"
                           "\tpageTitleText: %@, \n"
                           "\tname: %@, \n"
                           "\tlocalizedName: %@ \n"


### PR DESCRIPTION
**Fixes Phabricator ticket:** 
This is a refinement of the fix for https://phabricator.wikimedia.org/T276645

### Notes
This change ensures two things:
1. During onboarding, if the user has Norwegian set as a language, the Locale identifier 'nb' will be mapped to the wikimedia language code of 'no'

2. When migrating from a previous version of the app, various language-related settings are being updated to support language variants. Essentially the language code, such as 'zh' is being replaced with a variant language code such as 'zh-hans'.

This change adds the mapping "nb"->"no" to ensure any setting that use the ISO code are updated to use the wikipedia language code.

- Add mapping from locale 'nb' to wikimedia language code 'no'
- Add mapping from 'nb' to 'no' as part of language variant settings migration
- Fix typo in description string of MWKLangaugeLink.m
