### PR TITLE
Update search languages bar button design

### DIFF
--- a/Wikipedia/Code/SearchLanguagesBarViewController.swift
+++ b/Wikipedia/Code/SearchLanguagesBarViewController.swift
@@ -90,9 +90,10 @@ class SearchLanguageButton: UnderlineButton {
     // MARK: - Configuration
 
     func apply(theme: Theme) {
-        setTitleColor(theme.colors.primaryText, for: .normal)
-        tintColor = theme.colors.link
-        languageCodeContainer.backgroundColor = theme.colors.link
+        setTitleColor(theme.colors.tertiaryText, for: .normal)
+        setTitleColor(theme.colors.link, for: .selected)
+        tintColor = isSelected ? theme.colors.link : theme.colors.tertiaryText
+        languageCodeContainer.backgroundColor = isSelected ? theme.colors.link : theme.colors.tertiaryText
         languageCodeLabel.textColor = theme.colors.paperBackground
     }
     

--- a/Wikipedia/Code/SearchLanguagesBarViewController.swift
+++ b/Wikipedia/Code/SearchLanguagesBarViewController.swift
@@ -11,7 +11,12 @@ class SearchLanguageButton: UnderlineButton {
     var contentLanguageCode: String?
     var languageCode: String? {
         didSet {
-            languageCodeLabel.text = languageCode?.localizedUppercase
+            // Truncate to a max of 4 characters, discarding any trailing punctuation
+            if let truncatedLanguageCode = languageCode?.localizedUppercase.prefix(4) {
+                languageCodeLabel.text = truncatedLanguageCode.last?.isPunctuation ?? false
+                    ? String(truncatedLanguageCode.dropLast())
+                    : String(truncatedLanguageCode)
+            }
         }
     }
     

--- a/Wikipedia/Code/SearchLanguagesBarViewController.xib
+++ b/Wikipedia/Code/SearchLanguagesBarViewController.xib
@@ -29,7 +29,7 @@
                         <constraint firstAttribute="height" constant="44" id="1Xh-Hy-U4t"/>
                     </constraints>
                 </view>
-                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" contentInsetAdjustmentBehavior="never" translatesAutoresizingMaskIntoConstraints="NO" id="Yuq-ja-3NK">
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" translatesAutoresizingMaskIntoConstraints="NO" id="Yuq-ja-3NK">
                     <rect key="frame" x="0.0" y="6" width="302" height="38"/>
                 </scrollView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jb0-vp-xHE" customClass="WMFGradientView">


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T277058

### Notes
Updates based on feedback from Carolyn:
- Removes the horizontal scrolling indicator which was previously clashing with the selected element's underline
- Updates the selected and deselected state color schemes
- Truncates displayed language codes to 4 characters max. The approach I took also included removing any trailing punctuation (something like `map-` looked odd). At least based on our current list of `languageCode`s, this approach seems ok.

### Test Steps
1. Confirm design of `SearchLanguageButton`s matches Phabricator task.
2. Confirm no language code "box" has more than 4 characters in it, and that they do not end with punctuation.
3. Confirm no horizontal scrolling indicator is visible when scrolling the languages bar.

### Screenshots
<img width="1191" alt="languages" src="https://user-images.githubusercontent.com/5652327/114110616-ca313d00-988c-11eb-8f1d-2ddcbe966174.png">
