### PR TITLE
allow scrolling to final screen in a scrollview

### DIFF
--- a/Wikipedia/Code/ArticleScrolling.swift
+++ b/Wikipedia/Code/ArticleScrolling.swift
@@ -70,14 +70,16 @@ extension ArticleScrolling where Self: ViewController {
         } else {
             adjustmentY = overlayTop
         }
-        let y = offset.y + adjustmentY
         let minY = 0 - scrollView.contentInset.top
-        guard y > minY else {
+        let maxY = scrollView.contentSize.height - scrollView.bounds.height + scrollView.contentInset.bottom
+
+        /// If y lies within the last screen, scroll should be to the final full screen.
+        let y = min(offset.y + adjustmentY, maxY)
+        guard y >= minY else {
             completion?(false)
             return
         }
-        let maxY = scrollView.contentSize.height - scrollView.bounds.height + scrollView.contentInset.bottom
-        guard y < maxY else {
+        guard y <= maxY else {
             completion?(false)
             return
         }

--- a/Wikipedia/Code/ArticleScrolling.swift
+++ b/Wikipedia/Code/ArticleScrolling.swift
@@ -70,16 +70,15 @@ extension ArticleScrolling where Self: ViewController {
         } else {
             adjustmentY = overlayTop
         }
-        let minY = 0 - scrollView.contentInset.top
-        let maxY = scrollView.contentSize.height - scrollView.bounds.height + scrollView.contentInset.bottom
+        let minYScrollPoint = 0 - scrollView.contentInset.top
+        let largestY = scrollView.contentSize.height + scrollView.contentInset.bottom
+        let maxYScrollPoint = largestY - scrollView.bounds.height
 
         /// If y lies within the last screen, scroll should be to the final full screen.
-        let y = min(offset.y + adjustmentY, maxY)
-        guard y >= minY else {
-            completion?(false)
-            return
-        }
-        guard y <= maxY else {
+        let yContentPoint = offset.y + adjustmentY
+        let y = (maxYScrollPoint...largestY).contains(yContentPoint) ? maxYScrollPoint : yContentPoint
+
+        guard (minYScrollPoint...maxYScrollPoint).contains(y) else {
             completion?(false)
             return
         }


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T280063

### Notes
* [This PR](https://github.com/wikimedia/wikipedia-ios/pull/3664) introduced a bug. We checked if the scroll offset was reasonable, and didn't scroll if it wasn't. However, we were discarding any scroll offsets in the final screen of a scrollview - such as `Read More`. 

### Test Steps
1. Run app. Scroll to "Read More" section via Table of Contents. Scroll back to an earlier section via Table of Contents. Ensure scrolls work.
