### PR TITLE
Scrolling: Ensure range is valid to fix crash

### DIFF
--- a/Wikipedia/Code/ArticleScrolling.swift
+++ b/Wikipedia/Code/ArticleScrolling.swift
@@ -72,7 +72,9 @@ extension ArticleScrolling where Self: ViewController {
         }
         let minYScrollPoint = 0 - scrollView.contentInset.top
         let largestY = scrollView.contentSize.height + scrollView.contentInset.bottom
-        let maxYScrollPoint = largestY - scrollView.bounds.height
+
+        /// If there is less than one screen of content, do not let this number be negative, to ensure the ranges below are valid.
+        let maxYScrollPoint = max(largestY - scrollView.bounds.height, 0)
 
         /// If y lies within the last screen, scroll should be to the final full screen.
         let yContentPoint = offset.y + adjustmentY


### PR DESCRIPTION
**Fixes Phabricator ticket:** N/A (crash found in beta)

### Notes
* All ranges in this function should now be valid.
* I'd love to refactor this into some functions for readability, but given that this is a last fix before a release, that seems too risky.

### Test Steps
1. Run app. Scroll down midway through an article.
2. Background app. Quit app.
3. Reopen app. Ensure article is at same scroll position.

