### PR TITLE
Remove altISOCode check

### DIFF
--- a/Wikipedia/Code/MWKLanguageLinkController.h
+++ b/Wikipedia/Code/MWKLanguageLinkController.h
@@ -86,6 +86,23 @@ typedef NS_ENUM(NSInteger, WMFPreferredLanguagesChangeType) {
 
 - (nullable MWKLanguageLink *)languageForContentLanguageCode:(NSString *)contentLanguageCode;
 
+/**
+ *  Given an ISO language code, returns the correct Wikipedia language code for use in the app.
+ *
+ *  Used when creating article language links to use the correct Wikipedia language code for
+ *  use within the app when the returned ISO language code is different.
+ *
+ *  For example, the language links service returns 'nb' as the language code for Norwegian.
+ *  Within the app and in querying Norwegian Wikipedia, the code 'no' should be used.
+ *
+ *  For languages with an altISOCode value, returns the languageCode for the corresopnding altISOCode.
+ *  For all other values returns the same value passed in without validating if it is a valid ISO language code.
+ *  Returns nil for a nil ISO language code.
+ *  @param isoLanguageCode an ISO language code
+ *  @return The Wikipedia languageCode for the ISO language code. Usually the same value except for languages with an altISOCode.
+ */
++ (nullable NSString *)languageCodeForISOLanguageCode:(nullable NSString *)isoLanguageCode;
+
 + (void)migratePreferredLanguagesToManagedObjectContext:(NSManagedObjectContext *)moc;
 
 /// The expected dictionary uses language codes as the key with the value being the desired language variant code for that language.

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -96,6 +96,27 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
     return [NSLocale wmf_bestLanguageVariantCodeForLanguageCode:languageCode];
 }
 
++ (nullable NSString *)languageCodeForISOLanguageCode:(nullable NSString *)isoLanguageCode {
+    // Map altISOCodes to languageCodes once for fast lookups
+    static dispatch_once_t onceToken;
+    static NSDictionary<NSString *, NSString *> *languageCodesByAltISOCode;
+    dispatch_once(&onceToken, ^{
+        NSMutableDictionary *tempDict = [[NSMutableDictionary alloc] init];
+        for (MWKLanguageLink *language in self.allLanguages) {
+            if (language.altISOCode) {
+                tempDict[language.altISOCode] = language.languageCode;
+            }
+        }
+        languageCodesByAltISOCode = [tempDict copy];
+    });
+    if (!isoLanguageCode) {
+        return nil;
+    }
+    
+    NSString *languageCode = languageCodesByAltISOCode[isoLanguageCode];
+    return languageCode ? : isoLanguageCode; // If no alternative ISO code, use the original value
+}
+
 - (nullable MWKLanguageLink *)appLanguage {
     return [self.preferredLanguages firstObject];
 }

--- a/Wikipedia/Code/MWKLanguageLinkController.m
+++ b/Wikipedia/Code/MWKLanguageLinkController.m
@@ -104,12 +104,10 @@ static NSString *const WMFPreviousLanguagesKey = @"WMFPreviousSelectedLanguagesK
     NSArray *preferredLanguageCodes = [self readPreferredLanguageCodes];
     return [preferredLanguageCodes wmf_mapAndRejectNil:^id(NSString *langString) {
         return [self.allLanguages wmf_match:^BOOL(MWKLanguageLink *langLink) {
-            //Note, sometimes the device iOS language codes will return a code that doesn't line up with the Wikipedia language codes we have set,
-            //so we are also checking for a match against the altISOCode (currently only set for "no.wikipedia.org")
-            //Fixes https://phabricator.wikimedia.org/T276645
-            return [langLink.contentLanguageCode isEqualToString:langString] ||
-                   (langLink.altISOCode &&
-                    [langLink.altISOCode isEqualToString:langString]);
+            // The Norwegian language code 'nb' used by the OS should be automatically converted to 'no' used by Wikipedia during onboarding.
+            // Issue described in  https://phabricator.wikimedia.org/T276645
+            NSAssert(![langString isEqualToString:@"nb"], @"Inaccurate language code found in preferred language codes. Language code 'nb' should be 'no'.");
+            return [langLink.contentLanguageCode isEqualToString:langString];
         }];
     }];
 }

--- a/Wikipedia/Code/MWKLanguageLinkFetcher.m
+++ b/Wikipedia/Code/MWKLanguageLinkFetcher.m
@@ -2,6 +2,7 @@
 @import WMF.NSURL_WMFLinkParsing;
 @import WMF.Swift;
 @import WMF.MWKLanguageLink;
+@import WMF.MWKLanguageLinkController;
 @import WMF.WMFComparison;
 
 @implementation MWKLanguageLinkFetcher
@@ -34,7 +35,8 @@
                          NSDictionary *pagesByID = result[@"query"][@"pages"];
                          NSDictionary *indexedLanguageLinks = [[pagesByID wmf_map:^id(id key, NSDictionary *result) {
                              return [result[@"langlinks"] wmf_map:^MWKLanguageLink *(NSDictionary *jsonLink) {
-                                 return [[MWKLanguageLink alloc] initWithLanguageCode:jsonLink[@"lang"]
+                                 NSString *languageCode = [MWKLanguageLinkController languageCodeForISOLanguageCode:jsonLink[@"lang"]];
+                                 return [[MWKLanguageLink alloc] initWithLanguageCode:languageCode
                                                                         pageTitleText:jsonLink[@"*"]
                                                                                  name:jsonLink[@"autonym"]
                                                                         localizedName:jsonLink[@"langname"]

--- a/Wikipedia/Code/MWKTitleLanguageController.m
+++ b/Wikipedia/Code/MWKTitleLanguageController.m
@@ -81,24 +81,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable MWKLanguageLink *)titleLanguageForLanguage:(MWKLanguageLink *)language {
-    MWKLanguageLink *titleLanguage = [self.availableLanguages wmf_match:^BOOL(MWKLanguageLink *availableLanguage) {
-        
-        //Note: the langlinks endpoint returns "nb" for it's language code rather than "no", which messes up our matching with app language codes.
-        //So here we are checking the altISOCode of our stored languages against the lanklinks language code for a match.
-        //Currently "no.wikipedia.org" is the only MWKLanguageLink app language that has an altISOCode populated (see wikipedia-languages.json).
-        //Fixes https://phabricator.wikimedia.org/T272193
-        return [language.contentLanguageCode isEqualToString:availableLanguage.contentLanguageCode] ||
-                                    (language.altISOCode &&
-                                     [language.altISOCode isEqualToString:availableLanguage.contentLanguageCode]);
+    return [self.availableLanguages wmf_match:^BOOL(MWKLanguageLink *availableLanguage) {
+        return [language.contentLanguageCode isEqualToString:availableLanguage.contentLanguageCode];
     }];
-
-    //If match was found via altISOCode, replace the title language with the expected languageCode.
-    //Without this, the title language VC will attempt to serve up a mobile-html page at https://nb.wikipedia.org/api/rest_v1/page/mobile-html/{title}, which fails as not found
-    if ([titleLanguage.contentLanguageCode isEqualToString:language.altISOCode]) {
-        return [[MWKLanguageLink alloc] initWithLanguageCode:language.languageCode pageTitleText:titleLanguage.pageTitleText name:titleLanguage.name localizedName:titleLanguage.localizedName languageVariantCode:titleLanguage.languageVariantCode altISOCode:language.altISOCode];
-    }
-
-    return titleLanguage;
 }
 
 - (BOOL)languageIsAvailable:(MWKLanguageLink *)language {

--- a/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
+++ b/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
@@ -164,6 +164,29 @@
     XCTAssertNil(frenchResult);
 }
 
+- (void)testLanguageCodeForISOLanguageCode {
+    
+    // Test the single case where the ISO language code does not match the Wikipedia language code
+    NSString *norwegianISOCode = @"nb";
+    NSString *norwegianLanguageCode = @"no";
+
+    NSString *norwegianResult = [MWKLanguageLinkController languageCodeForISOLanguageCode:norwegianISOCode];
+    XCTAssertEqualObjects(norwegianResult, norwegianLanguageCode);
+    
+    // Test that other language codes are returned just as passed in
+    // Note that the method does not check if the passed in code is a valid language code
+    NSArray<NSString *> *identicalLanguageCodes = @[@"de", @"ja", @"en", @"es", @"zh", @"uz"];
+    
+    for (NSString *currentLanguageCode in identicalLanguageCodes) {
+        NSString *result = [MWKLanguageLinkController languageCodeForISOLanguageCode:currentLanguageCode];
+        XCTAssertEqualObjects(result, currentLanguageCode);
+    }
+    
+    // Test that if a nil value is passed in, nil is returned
+    NSString *expectingNil = [MWKLanguageLinkController languageCodeForISOLanguageCode:nil];
+    XCTAssertNil(expectingNil);
+}
+
 #pragma mark - Utils
 
 - (void)verifyAllLanguageArrayProperties {


### PR DESCRIPTION
**Fixes Phabricator ticket:** 
https://phabricator.wikimedia.org/T280269

### Notes
There are two main logical pieces to this PR:

1. Remove the `altISOCode` logic from the MWKLanguageLinkController `-preferredLanguages` method.

Since we took steps to ensure that the desired value 'no' is present in preferred languages settings and 'nb' never makes it into preferred language settings, this check is no longer needed.

I added an NSAssert to catch if somehow an 'nb' made it through.


2. Switch to the correct code as soon a possible for links to articles in other languages.

In the 6.8 implementation, we create a MWKLanguageLink with the incorrect language code in the MWKLangaugeLinkFetcher and then use an `altISOCode` check in MWKTitleLanguageController to replace that instance with one with the correct code.

This PR makes the initial MWKLanguageLink that is created in MWKLangaugeLinkFetcher  correct. It also encapsulates the `altISOCode` mapping to `languageCode` in MWKLanguageLinkController.

This replaces the existing check in MWKTitleLanguageController.


### Test Steps
1. Set Norwegian as a language in the OS
2. Do a fresh install of the app
3. Accept the default languages suggested in onboarding
4. Norwegian should work as expected and assertion should not be hit

1. In a language that *isn't* Norwegian search for the article 'Dog'.
2. From the article 'Dog' tap the 'Change Language' button
3. Norwegian should appear as a language choice
4. Tapping Norwegian should display the article correctly
