### PR TITLE
Retain edit summary when moving back and forth through edit preview

### DIFF
--- a/Wikipedia/Code/EditSaveViewController.swift
+++ b/Wikipedia/Code/EditSaveViewController.swift
@@ -67,6 +67,38 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
         }
     }
     private let wikiTextSectionUploader = WikiTextSectionUploader()
+
+    private var licenseTitleTextViewAttributedString: NSAttributedString {
+        let localizedString = WMFLocalizedString("wikitext-upload-save-terms-and-licenses", value: "By publishing changes, you agree to the %1$@Terms of Use%2$@, and you irrevocably agree to release your contribution under the %3$@CC BY-SA 3.0%4$@ License and the %5$@GFDL%6$@. You agree that a hyperlink or URL is sufficient attribution under the Creative Commons license.", comment: "Text for information about the Terms of Use and edit licenses. Parameters:\n* %1$@ - app-specific non-text formatting, %2$@ - app-specific non-text formatting, %3$@ - app-specific non-text formatting, %4$@ - app-specific non-text formatting, %5$@ - app-specific non-text formatting,  %6$@ - app-specific non-text formatting.")
+
+        let substitutedString = String.localizedStringWithFormat(
+            localizedString,
+            "<a href=\"\(Licenses.saveTermsURL?.absoluteString ?? "")\">",
+            "</a>",
+            "<a href=\"\(Licenses.CCBYSA3URL?.absoluteString ?? "")\">",
+            "</a>" ,
+            "<a href=\"\(Licenses.GFDLURL?.absoluteString ?? "")\">",
+            "</a>"
+        )
+
+        let attributedString = substitutedString.byAttributingHTML(with: .caption2, matching: traitCollection)
+
+        return attributedString
+    }
+
+    private var licenseLoginTextViewAttributedString: NSAttributedString {
+        let localizedString = WMFLocalizedString("wikitext-upload-save-anonymously-or-login", value: "Edits will be attributed to the IP address of your device. If you %1$@Log in%2$@ you will have more privacy.", comment: "Text informing user of draw-backs of not signing in before saving wikitext. Parameters:\n* %1$@ - app-specific non-text formatting, %2$@ - app-specific non-text formatting.")
+
+        let substitutedString = String.localizedStringWithFormat(
+            localizedString,
+            "<a href=\"#LOGIN_HREF\">", // "#LOGIN_HREF" ensures 'byAttributingHTML' doesn't strip the anchor. The entire text view uses a tap recognizer so the string itself is unimportant.
+            "</a>"
+        )
+
+        let attributedString = substitutedString.byAttributingHTML(with: .caption2, matching: traitCollection)
+
+        return attributedString
+    }
     
     private func updateNavigation(for mode: NavigationMode) {
         var backButton: UIBarButtonItem?
@@ -115,23 +147,9 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        navigationItem.title = WMFLocalizedString("wikitext-preview-save-changes-title", value: "Save changes", comment: "Title for edit preview screens")
-        
-        buttonX = UIBarButtonItem.wmf_buttonType(.X, target: self, action: #selector(self.goBack))
-        
-        buttonLeftCaret = UIBarButtonItem.wmf_buttonType(.caretLeft, target: self, action: #selector(self.goBack))
-        
-        buttonSave = UIBarButtonItem(title: CommonStrings.publishTitle, style: .done, target: self, action: #selector(self.goForward))
-        buttonSave?.tintColor = theme.colors.link
 
         mode = .preview
-        
-        minorEditLabel.text = WMFLocalizedString("edit-minor-text", value: "This is a minor edit", comment: "Text for minor edit label")
-        minorEditButton.setTitle(WMFLocalizedString("edit-minor-learn-more-text", value: "Learn more about minor edits", comment: "Text for minor edits learn more button"), for: .normal)
-
-        addToWatchlistLabel.text = WMFLocalizedString("edit-watch-this-page-text", value: "Watch this page", comment: "Text for watch this page label")
-        addToWatchlistButton.setTitle(WMFLocalizedString("edit-watch-list-learn-more-text", value: "Learn more about watch lists", comment: "Text for watch lists learn more button"), for: .normal)
+        setupButtonsAndTitle()
         
         for dividerHeightContraint in dividerHeightConstraits {
             dividerHeightContraint.constant = 1.0 / UIScreen.main.scale
@@ -146,38 +164,34 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
         }
         updateTextViews()
         apply(theme: theme)
+
+        captchaViewController?.captchaDelegate = self
+        captchaViewController?.apply(theme: theme)
+        wmf_add(childController: captchaViewController, andConstrainToEdgesOfContainerView: captchaContainer)
+
+        let vc = EditSummaryViewController(nibName: EditSummaryViewController.wmf_classStoryboardName(), bundle: nil)
+        vc.delegate = self
+        vc.apply(theme: theme)
+        wmf_add(childController: vc, andConstrainToEdgesOfContainerView: editSummaryVCContainer)
+
+        if dataStore?.authenticationManager.isLoggedIn ?? false {
+            licenseLoginTextView.isHidden = true
+        }
     }
 
-    private var licenseTitleTextViewAttributedString: NSAttributedString {
-        let localizedString = WMFLocalizedString("wikitext-upload-save-terms-and-licenses", value: "By publishing changes, you agree to the %1$@Terms of Use%2$@, and you irrevocably agree to release your contribution under the %3$@CC BY-SA 3.0%4$@ License and the %5$@GFDL%6$@. You agree that a hyperlink or URL is sufficient attribution under the Creative Commons license.", comment: "Text for information about the Terms of Use and edit licenses. Parameters:\n* %1$@ - app-specific non-text formatting, %2$@ - app-specific non-text formatting, %3$@ - app-specific non-text formatting, %4$@ - app-specific non-text formatting, %5$@ - app-specific non-text formatting,  %6$@ - app-specific non-text formatting.")
-        
-        let substitutedString = String.localizedStringWithFormat(
-            localizedString,
-            "<a href=\"\(Licenses.saveTermsURL?.absoluteString ?? "")\">",
-            "</a>",
-            "<a href=\"\(Licenses.CCBYSA3URL?.absoluteString ?? "")\">",
-            "</a>" ,
-            "<a href=\"\(Licenses.GFDLURL?.absoluteString ?? "")\">",
-            "</a>"
-        )
-        
-        let attributedString = substitutedString.byAttributingHTML(with: .caption2, matching: traitCollection)
-        
-        return attributedString
-    }
+    private func setupButtonsAndTitle() {
+        navigationItem.title = WMFLocalizedString("wikitext-preview-save-changes-title", value: "Save changes", comment: "Title for edit preview screens")
+        buttonX = UIBarButtonItem.wmf_buttonType(.X, target: self, action: #selector(self.goBack))
+        buttonLeftCaret = UIBarButtonItem.wmf_buttonType(.caretLeft, target: self, action: #selector(self.goBack))
 
-    private var licenseLoginTextViewAttributedString: NSAttributedString {
-        let localizedString = WMFLocalizedString("wikitext-upload-save-anonymously-or-login", value: "Edits will be attributed to the IP address of your device. If you %1$@Log in%2$@ you will have more privacy.", comment: "Text informing user of draw-backs of not signing in before saving wikitext. Parameters:\n* %1$@ - app-specific non-text formatting, %2$@ - app-specific non-text formatting.")
-        
-        let substitutedString = String.localizedStringWithFormat(
-            localizedString,
-            "<a href=\"#LOGIN_HREF\">", // "#LOGIN_HREF" ensures 'byAttributingHTML' doesn't strip the anchor. The entire text view uses a tap recognizer so the string itself is unimportant.
-            "</a>"
-        )
-        
-        let attributedString = substitutedString.byAttributingHTML(with: .caption2, matching: traitCollection)
-        
-        return attributedString
+        buttonSave = UIBarButtonItem(title: CommonStrings.publishTitle, style: .done, target: self, action: #selector(self.goForward))
+        buttonSave?.tintColor = theme.colors.link
+
+        minorEditLabel.text = WMFLocalizedString("edit-minor-text", value: "This is a minor edit", comment: "Text for minor edit label")
+        minorEditButton.setTitle(WMFLocalizedString("edit-minor-learn-more-text", value: "Learn more about minor edits", comment: "Text for minor edits learn more button"), for: .normal)
+
+        addToWatchlistLabel.text = WMFLocalizedString("edit-watch-this-page-text", value: "Watch this page", comment: "Text for watch this page label")
+        addToWatchlistButton.setTitle(WMFLocalizedString("edit-watch-list-learn-more-text", value: "Learn more about watch lists", comment: "Text for watch lists learn more button"), for: .normal)
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -189,25 +203,6 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
         licenseTitleTextView.attributedText = licenseTitleTextViewAttributedString
         licenseLoginTextView.attributedText = licenseLoginTextViewAttributedString
         applyThemeToTextViews()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        captchaViewController?.captchaDelegate = self
-        captchaViewController?.apply(theme: theme)
-        wmf_add(childController: captchaViewController, andConstrainToEdgesOfContainerView: captchaContainer)
-        
-        mode = .preview
-        
-        let vc = EditSummaryViewController(nibName: EditSummaryViewController.wmf_classStoryboardName(), bundle: nil)
-        vc.delegate = self
-        vc.apply(theme: theme)
-        wmf_add(childController: vc, andConstrainToEdgesOfContainerView: editSummaryVCContainer)
-        
-        if dataStore?.authenticationManager.isLoggedIn ?? false {
-            licenseLoginTextView.isHidden = true
-        }
-        
-        super.viewWillAppear(animated)
     }
     
     @IBAction public func licenseLoginLabelTapped(_ recognizer: UIGestureRecognizer?) {

--- a/Wikipedia/Code/EditSummaryViewController.swift
+++ b/Wikipedia/Code/EditSummaryViewController.swift
@@ -74,13 +74,18 @@ class EditSummaryViewController: UIViewController, Themeable {
     }
 
     @IBAction private func cannedSummaryButtonTapped(sender: UIButton) {
-        summaryTextField.text = sender.titleLabel?.text
-        notifyDelegateOfSummaryChange()
-        guard let buttonType = EditSummaryViewCannedButtonType(rawValue: sender.tag) else {
-            assertionFailure("Expected button type not found")
+        guard let senderLabel = sender.titleLabel?.text,
+              let buttonType = EditSummaryViewCannedButtonType(rawValue: sender.tag) else {
+            assertionFailure("Expected button information not found")
             return
         }
+        updateInputText(to: senderLabel)
         delegate?.cannedButtonTapped(type: buttonType)
+    }
+
+    func updateInputText(to text: String) {
+        summaryTextField.text = text
+        notifyDelegateOfSummaryChange()
     }
 
     public func apply(theme: Theme) {

--- a/Wikipedia/Code/SectionEditorViewController.swift
+++ b/Wikipedia/Code/SectionEditorViewController.swift
@@ -65,6 +65,8 @@ class SectionEditorViewController: ViewController {
     private var scriptMessageHandlers: [ScriptMessageHandler] = []
     
     private let findAndReplaceHeaderTitle = WMFLocalizedString("find-replace-header", value: "Find and replace", comment: "Find and replace header title.")
+
+    private var editConfirmationSavedData: EditSaveViewController.SaveData? = nil
     
     init(articleURL: URL, sectionID: Int, messagingController: SectionEditorWebViewMessagingController? = nil, dataStore: MWKDataStore, selectedTextEditInfo: SelectedTextEditInfo? = nil, theme: Theme = Theme.standard) {
         self.articleURL = articleURL
@@ -551,6 +553,10 @@ extension SectionEditorViewController: EditSaveViewControllerDelegate {
     func editSaveViewControllerDidSave(_ editSaveViewController: EditSaveViewController, result: Result<SectionEditorChanges, Error>) {
         delegate?.sectionEditorDidFinishEditing(self, result: result)
     }
+
+    func editSaveViewControllerWillCancel(_ saveData: EditSaveViewController.SaveData) {
+        editConfirmationSavedData = saveData
+    }
 }
 
 // MARK - EditPreviewViewControllerDelegate
@@ -560,6 +566,8 @@ extension SectionEditorViewController: EditPreviewViewControllerDelegate {
         guard let vc = EditSaveViewController.wmf_initialViewControllerFromClassStoryboard() else {
             return
         }
+
+        vc.savedData = editConfirmationSavedData
         vc.dataStore = dataStore
         vc.articleURL = self.articleURL
         vc.sectionID = self.sectionID


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T255490

### Notes
* From looking at the git history of this file, it was converted from ObjC to Swift a couple years ago, and hasn't seen much work since. At the time, Monte noted that it could use some love as it's a little sloppy. I did a small refactor to make it make a bit more sense. Also removed code from `viewWillAppear`, which fixes the bug in the next bullet point.
* * There is a bug currenty in there - if you enter some summary text on the final edit screen, then tap "Learn more", then  go back - the text disappears.
* The Edit flow could probably use some larger love. Delegates on delegates, and `SectionEditorViewController` (the first one a user sees) controls some of the remainder of this flow. (Also a bonus `EditSummaryVC` which is the textfield within the `EditSaveViewController`.)  I don't love this architecture, but I took advantage of it and added one more function to the delegate.
* I don't love how I'm persisting the state here. Open to other ideas.
* There is an unused "watch this page" toggle that has never been used. This code should allow us to persist that toggle as well, if it ever does get used.

### Test Steps
1. Edit some text. On the last page, add in an edit summary, maybe toggle the toggle - then go back a screen or two, then go back forward - your text/toggle should persist.