### PR TITLE
Loosen AaaLD test/control assignment survey identifiers

### DIFF
--- a/WMF Framework/SurveyAnnouncementsController.swift
+++ b/WMF Framework/SurveyAnnouncementsController.swift
@@ -37,7 +37,7 @@ public final class SurveyAnnouncementsController: NSObject {
         
         //assign and persist ab test bucket &  percentage
         //this works for now since we only have one experiment for this release but will likely need to change as we expand
-        if let articleAsLivingDocAnnouncement = surveyAnnouncements.first(where: { $0.identifier == "IOSSURVEY20IOSV4EN" }),
+        if let articleAsLivingDocAnnouncement = surveyAnnouncements.first(where: { ($0.identifier?.hasPrefix("IOSAAALDSURVEY")) ?? false }),
            let percentage = articleAsLivingDocAnnouncement.percentReceivingExperiment {
             
             do {

--- a/WMF Framework/WMFAnnouncementsFetcher.m
+++ b/WMF Framework/WMFAnnouncementsFetcher.m
@@ -79,7 +79,7 @@
         if (![obj isKindOfClass:[WMFAnnouncement class]]) {
             return NO;
         }
-        if ([obj.platforms containsObject:@"iOSAppV4"]) {
+        if ([obj.platforms containsObject:@"iOSAppV5"]) {
             return YES;
         } else {
             return NO;


### PR DESCRIPTION
**Fixes Phabricator ticket:** https://phabricator.wikimedia.org/T282189

### Notes
For the next round of the article as a living document experiment, we want to change the announcement object identifier in wikifeeds so that the survey prompt triggers again for all users. For background, the survey prompt didAlreadySee flag is a [user defaults flag](https://github.com/wikimedia/wikipedia-ios/blob/main/WMF%20Framework/SurveyAnnouncementsController.swift#L107) based on the announcement object identifier, hence an announcement identifier change resets this flag.

However I noticed we are very strict about how we determine the test/control bucket, meaning the bucket will not get recalculated if we change the announcement identifier and change the percentage.

In the future, we want to be able to change this announcement identifier AND the percentage, have the user get reassigned to a test/control bucket and be asked the survey prompt again. 

[may-announcements.txt](https://github.com/wikimedia/wikipedia-ios/files/6443802/may-announcements.txt)
[july-announcements.txt](https://github.com/wikimedia/wikipedia-ios/files/6443803/july-announcements.txt)
[sept-announcement.txt](https://github.com/wikimedia/wikipedia-ios/files/6443805/sept-announcement.txt)

I tried to simplify these test steps but they're still a little hairy. Here's how my testing announcements payloads are set up:
1. **may-announcements** - mimics how these were in December. The announcement article titles have "Joe Biden", with test percentage up to 100%. Campaign dates are in May.
2. **july-announcements** - here we added a brand new survey campaign with a AaaLD-specific announcement identifier, whose prefix we are targeting in this PR. Both campaigns have a dates of July and titles including Betty White. Both test percentages are 0%.
3. **september-announcement** - this looks the same as 2, except we have changed the suffix of the AaaLD-specific announcement identifier and changed the test percentages back to 100. Dates are in September and article title only has "Puppy cat".

### Test Steps

1. Be sure test device date is in may 2021. With may-announcements.txt locally mapped to the [https://en.wikipedia.org/api/rest_v1/feed/announcements](https://en.wikipedia.org/api/rest_v1/feed/announcements) call via a proxy, fresh install from the `releases/6.7.3` tag (i.e. the last release this survey was run on and when they had their survey user defaults set). Terminate and launch again to get to 2nd launch.
2. Go to Joe Biden on EN Wikipedia, you should see the living document experiment in the article content. Scroll down to the experiment insert in article view, wait 10 seconds and confirm you see survey prompt. Dismiss, terminate and revisit article, confirm you don't see survey prompt.
3. Change test device to July. Map locally to july-announcements and run from this branch. Go to Betty White article on EN Wikipedia. Now experiment is off but you DO get asked the survey again. This is correct because the july-announcements payload turned the test off by setting the percentage to 0. This doesn't work without this PR change.
4. Now simulate running this campaign again in the future. Change test device to September sometime. Map locally to sept-announcement. Relaunch from this PR branch and go to article "Puppy cat" on EN Wikipedia. Confirm you DO get asked the survey again, and you DO see the experiment (sept-announcement payload turned the test on again by setting the percentage to 100).     

### Screenshots/Videos *(if applicable)*
![IMG_0524 2](https://user-images.githubusercontent.com/3620196/117498253-2c8a6580-af3f-11eb-9751-e9c69b5ff892.PNG)
(What the survey prompt looks like)
