### PR TITLE
Fix incorrect Top read caption font weight

### DIFF
--- a/Widgets/Widgets/TopReadWidget.swift
+++ b/Widgets/Widgets/TopReadWidget.swift
@@ -389,7 +389,7 @@ struct TopReadOverlayView: View {
         VStack(alignment: .leading, spacing: 5) {
             Text(TopReadWidget.LocalizedStrings.widgetTitle)
                 .font(.caption2)
-                .fontWeight(.heavy)
+                .fontWeight(.bold)
                 .aspectRatio(contentMode: .fit)
                 .foregroundColor(primaryTextColor)
                 .readableShadow(intensity: isExpandedStyle ? 0 : 0.8)


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
In auditing the Featured article widget, I noticed I had used the incorrect font weight for the title caption in the Top read small size class widget. This PR simply corrects the font weight, so it now visually matches when observed alongside other similarly designed widgets (like the small Featured article widget).

### Test Steps
Observe the "Top read" font weight in the small class Top read widget, confirm it matches the `After` screenshot below.

### Screenshots

![font_before_after](https://user-images.githubusercontent.com/5652327/123702053-83157100-d817-11eb-9897-139ad007c342.jpg)

