### PR TITLE
Add searching via search tab

### DIFF
--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -17,6 +17,7 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
         view.bringSubviewToFront(resultsViewController.view)
         resultsViewController.view.isHidden = true
         useNavigationBarVisibleHeightForScrollViewInsets = true
+        handleBecomingFirstResponderAfterTappingOnSearchTab()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -402,6 +403,23 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
     lazy var fakeProgressController: FakeProgressController = {
         return FakeProgressController(progress: navigationBar, delegate: navigationBar)
     }()
+    
+    // MARK - Tab bar related
+    
+    private func handleBecomingFirstResponderAfterTappingOnSearchTab() {
+        guard let tabBarItemView = tabBarItem.value(forKey: "view") as? UIView else {
+            return
+        }
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTapOnTabBarItem))
+        tapGestureRecognizer.cancelsTouchesInView = false
+        tabBarItemView.addGestureRecognizer(tapGestureRecognizer)
+    }
+    
+    @objc func handleTapOnTabBarItem() {
+        if tabBarController?.selectedViewController is Self {
+            searchBar.becomeFirstResponder()
+        }
+    }
     
     // MARK - Recent Search Saving
     


### PR DESCRIPTION
**Phabricator: https://phabricator.wikimedia.org/T257708** 

### Notes
* Since TabBarItem is not inherited from UIView we cannot add gesture directly to it just calling by `addGestureRecognizer()` so that I have used `tabBarItem.value(forKey: "view")` to filter and find the view.

### Test Steps
1. Double-tapping on search tab directly when user switching from another tab gives the user the ability to search directly 
2. Enable searching , after tap on search tab bar item when user already in the search tab.

### Screenshots/Videos

iPhone

https://user-images.githubusercontent.com/50470084/128607873-68d16706-1dd3-4dbd-aebc-b2183b4adb21.mp4

iPad

https://user-images.githubusercontent.com/50470084/128607878-e141c6b0-3d99-4afd-b9fd-de1272f2b8d6.mp4

