### PR TITLE
Push notifications subscription flow

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -256,6 +256,7 @@
 		670AF19026BDE6E7005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
 		670AF19126BDE6E8005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
 		670AF19226BDE6E9005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
+		670AF19F26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670AF19A26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift */; };
 		670F765F22B0C10600D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
 		670F766022B0C48E00D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
 		670F766122B0C48F00D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
@@ -3644,6 +3645,7 @@
 		6706A21822927D63004774E2 /* TalkPageHintViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageHintViewController.swift; sourceTree = "<group>"; };
 		6707C031237DBCEA0017E7B6 /* DiffRevisionTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffRevisionTransition.swift; sourceTree = "<group>"; };
 		6707C037237F0A6E0017E7B6 /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
+		670AF19A26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EchoSubscriptionFetcher.swift; sourceTree = "<group>"; };
 		670F765E22B0C10600D87545 /* FakeProgressLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeProgressLoading.swift; sourceTree = "<group>"; };
 		67146031243B885E008CE885 /* SurveyAnnouncementsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyAnnouncementsController.swift; sourceTree = "<group>"; usesTabs = 0; };
 		67146033243B8B4F008CE885 /* AnnouncementType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementType.swift; sourceTree = "<group>"; };
@@ -8743,6 +8745,7 @@
 				83E9C45A2419193C006BDBC2 /* WikipediaSiteInfo.swift */,
 				D85F56A1219C45C900AF3E13 /* URLComponents+Extensions.swift */,
 				835A042C223AD63000D4D758 /* ArticleSummaryController.swift */,
+				670AF19A26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift */,
 			);
 			name = Controllers;
 			path = ../Wikipedia/Code;
@@ -11155,6 +11158,7 @@
 				8330531F23EF051900123141 /* NSArray+WMFMapping.m in Sources */,
 				006694FC265D9F2900E23AE4 /* WidgetSettings.swift in Sources */,
 				0E728D1D1DAEE2B50074EB4B /* WMFFeedTopReadResponse.m in Sources */,
+				670AF19F26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift in Sources */,
 				7A0312FF215422960095C953 /* RemoteNotificationsMarkAsReadOperation.swift in Sources */,
 				B0B4237A1F0211AB00D3DC4C /* WMFFeedArticlePreview+DescriptionOrSnippet.swift in Sources */,
 				D8FA18BC1E1BD891009675C3 /* NSFileManager+WMFGroup.m in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -256,7 +256,7 @@
 		670AF19026BDE6E7005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
 		670AF19126BDE6E8005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
 		670AF19226BDE6E9005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
-		670AF19F26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670AF19A26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift */; };
+		670AF1CF26CD74A6005F76D0 /* EchoSubscriptionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670AF19A26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift */; };
 		670F765F22B0C10600D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
 		670F766022B0C48E00D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
 		670F766122B0C48F00D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
@@ -11158,7 +11158,7 @@
 				8330531F23EF051900123141 /* NSArray+WMFMapping.m in Sources */,
 				006694FC265D9F2900E23AE4 /* WidgetSettings.swift in Sources */,
 				0E728D1D1DAEE2B50074EB4B /* WMFFeedTopReadResponse.m in Sources */,
-				670AF19F26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift in Sources */,
+				670AF1CF26CD74A6005F76D0 /* EchoSubscriptionFetcher.swift in Sources */,
 				7A0312FF215422960095C953 /* RemoteNotificationsMarkAsReadOperation.swift in Sources */,
 				B0B4237A1F0211AB00D3DC4C /* WMFFeedArticlePreview+DescriptionOrSnippet.swift in Sources */,
 				D8FA18BC1E1BD891009675C3 /* NSFileManager+WMFGroup.m in Sources */,

--- a/Wikipedia/Code/AppDelegate.m
+++ b/Wikipedia/Code/AppDelegate.m
@@ -81,6 +81,7 @@ static NSString *const WMFBackgroundAppRefreshTaskIdentifier = @"org.wikimedia.w
 
     self.appNeedsResume = YES;
     WMFAppViewController *vc = [[WMFAppViewController alloc] init];
+    [[UIApplication sharedApplication] registerForRemoteNotifications];
     [UNUserNotificationCenter currentNotificationCenter].delegate = vc; // this needs to be set before the end of didFinishLaunchingWithOptions:
     [vc launchAppInWindow:self.window waitToResumeApp:self.appNeedsResume];
     self.appViewController = vc;
@@ -249,6 +250,17 @@ static NSString *const WMFBackgroundAppRefreshTaskIdentifier = @"org.wikimedia.w
             DDLogError(@"Unable to schedule background task: %@", taskSubmitError);
         }
     }
+}
+
+#pragma mark - Notifications
+
+- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+    DDLogError(@"Remote notification registration failure: %@", error.localizedDescription);
+    [self.appViewController setRemoteNotificationRegistrationStatusWithDeviceToken:nil error:error];
+}
+
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    [self.appViewController setRemoteNotificationRegistrationStatusWithDeviceToken:deviceToken error:nil];
 }
 
 @end

--- a/Wikipedia/Code/EchoSubscriptionFetcher.swift
+++ b/Wikipedia/Code/EchoSubscriptionFetcher.swift
@@ -1,0 +1,88 @@
+
+import Foundation
+
+@objc(WMFEchoSubscriptionFetcher)
+class EchoSubscriptionFetcher: Fetcher {
+    
+    @objc func subscribe(siteURL: URL?, deviceToken: NSData?, completion: @escaping (Error?) -> Void) {
+        guard let bundleID = Bundle.main.bundleIdentifier,
+              let siteURL = siteURL,
+              let deviceToken = deviceToken else {
+            completion(RequestError.invalidParameters)
+            return
+        }
+        
+        let deviceTokenString = deviceTokenStringFromDeviceToken(deviceToken)
+        let bodyParameters: [String: String] = [
+            "action": "echopushsubscriptions",
+            "format": "json",
+            "command": "create",
+            "provider": "apns",
+            "providertoken": deviceTokenString,
+            "topic": bundleID
+        ]
+    
+        self.performTokenizedMediaWikiAPIPOST(to: siteURL, with: bodyParameters) { result, response, error in
+            guard error == nil else {
+                completion(error)
+                return
+            }
+            
+            guard let response = response,
+                  response.statusCode == 200 else {
+                completion(RequestError.unexpectedResponse)
+                return
+            }
+            
+            if let responseError = RequestError.from(result?["error"] as? [String : Any]) {
+                completion(responseError)
+                return
+            }
+            
+            completion(nil)
+        }
+    }
+    
+    @objc func unsubscribe(siteURL: URL?, deviceToken: NSData?, completion: ((Error?) -> Void)?) {
+        
+        guard let siteURL = siteURL,
+              let deviceToken = deviceToken else {
+            completion?(RequestError.invalidParameters)
+            return
+        }
+        
+        let deviceTokenString = deviceTokenStringFromDeviceToken(deviceToken)
+        let bodyParameters: [String: String] = [
+            "action": "echopushsubscriptions",
+            "format": "json",
+            "command": "delete",
+            "providertoken": deviceTokenString
+        ]
+        
+        self.performTokenizedMediaWikiAPIPOST(to: siteURL, with: bodyParameters) { result, response, error in
+            guard error == nil else {
+                completion?(error)
+                return
+            }
+            
+            guard let response = response,
+                  response.statusCode == 200 else {
+                completion?(RequestError.unexpectedResponse)
+                return
+            }
+            
+            if let responseError = RequestError.from(result?["error"] as? [String : Any]) {
+                completion?(responseError)
+                return
+            }
+            
+            completion?(nil)
+        }
+    }
+    
+    private func deviceTokenStringFromDeviceToken(_ deviceToken: NSData) -> String {
+        let tokenComponents = deviceToken.map { data in String(format: "%02.2hhx", data) }
+        let deviceTokenString = tokenComponents.joined()
+        return deviceTokenString
+    }
+}

--- a/Wikipedia/Code/ExploreCardViewController.swift
+++ b/Wikipedia/Code/ExploreCardViewController.swift
@@ -597,7 +597,7 @@ extension ExploreCardViewController: AnnouncementCollectionViewCellDelegate {
             LoginFunnel.shared.logLoginStartInFeed()
             dismissAnnouncementCell(cell)
         case .notification:
-            dataStore.notificationsController.requestAuthenticationIfNecessary { (granted, error) in
+            dataStore.notificationsController.requestPermissionsIfNecessary { (granted, error) in
                 if let error = error {
                     self.wmf_showAlertWithError(error as NSError)
                 }

--- a/Wikipedia/Code/NotificationSettingsViewController.swift
+++ b/Wikipedia/Code/NotificationSettingsViewController.swift
@@ -17,16 +17,43 @@ struct NotificationSettingsButtonItem: NotificationSettingsItem {
     let buttonAction: () -> Void
 }
 
+struct NotificationSettingsInfoItem: NotificationSettingsItem {
+    let title: String
+}
+
 struct NotificationSettingsSection {
     let headerTitle:String
     let items: [NotificationSettingsItem]
 }
+
+//TODO: These are just here to prevent localization diffs. Reinstate if needed once notifications type screen is complete.
+/*
+ WMFLocalizedString("settings-notifications-learn-more", value:"Learn more about notifications", comment:"A title for a button to learn more about notifications")
+ WMFLocalizedString("welcome-notifications-tell-me-more-title", value:"More about notifications", comment:"Title for detailed notification explanation")
+ WMFLocalizedString("welcome-notifications-tell-me-more-storage", value:"Notification preferences are stored on device and not based on personal information or activity.", comment:"An explanation of how notifications are stored")
+ WMFLocalizedString("welcome-notifications-tell-me-more-creation", value:"Notifications are created and delivered on your device by the app, not from our (or third party) servers.", comment:"An explanation of how notifications are created")
+ WMFLocalizedString("settings-notifications-info", value:"Be alerted to trending and top read articles on Wikipedia with our push notifications. All provided with respect to privacy and up to the minute data.", comment:"A short description of notifications shown in settings")
+ WMFLocalizedString("settings-notifications-trending", value:"Trending current events", comment:"Title for the setting for trending notifications")
+ WMFLocalizedString("settings-notifications-info", value:"Be alerted to trending and top read articles on Wikipedia with our push notifications. All provided with respect to privacy and up to the minute data.", comment:"A short description of notifications shown in settings")
+ */
 
 @objc(WMFNotificationSettingsViewController)
 class NotificationSettingsViewController: SubSettingsViewController {
     
     var sections = [NotificationSettingsSection]()
     var observationToken: NSObjectProtocol?
+    private let authManager: WMFAuthenticationManager
+    private let notificationsController: WMFNotificationsController
+    
+    @objc init(authManager: WMFAuthenticationManager, notificationsController: WMFNotificationsController) {
+        self.authManager = authManager
+        self.notificationsController = notificationsController
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -48,36 +75,23 @@ class NotificationSettingsViewController: SubSettingsViewController {
        updateSections()
     }
     
-    func sectionsForSystemSettingsAuthorized() -> [NotificationSettingsSection] {
+    func sectionsForPermissionsNotDetermined() -> [NotificationSettingsSection] {
         var updatedSections = [NotificationSettingsSection]()
         
-        let infoItems: [NotificationSettingsItem] = [NotificationSettingsButtonItem(title: WMFLocalizedString("settings-notifications-learn-more", value:"Learn more about notifications", comment:"A title for a button to learn more about notifications"), buttonAction: { [weak self] in
-            let title = WMFLocalizedString("welcome-notifications-tell-me-more-title", value:"More about notifications", comment:"Title for detailed notification explanation")
-            let message = "\(WMFLocalizedString("welcome-notifications-tell-me-more-storage", value:"Notification preferences are stored on device and not based on personal information or activity.", comment:"An explanation of how notifications are stored"))\n\n\(WMFLocalizedString("welcome-notifications-tell-me-more-creation", value:"Notifications are created and delivered on your device by the app, not from our (or third party) servers.", comment:"An explanation of how notifications are created"))"
-            let alertController = UIAlertController(title: title, message: message, preferredStyle: UIAlertController.Style.alert)
-            alertController.addAction(UIAlertAction(title: CommonStrings.gotItButtonTitle, style: UIAlertAction.Style.default, handler: { (action) in
-            }))
-            self?.present(alertController, animated: true, completion: nil)
-        })]
-        
-        let infoSection = NotificationSettingsSection(headerTitle: WMFLocalizedString("settings-notifications-info", value:"Be alerted to trending and top read articles on Wikipedia with our push notifications. All provided with respect to privacy and up to the minute data.", comment:"A short description of notifications shown in settings"), items: infoItems)
-        updatedSections.append(infoSection)
-        
-        let notificationSettingsItems: [NotificationSettingsItem] = [NotificationSettingsSwitchItem(title: WMFLocalizedString("settings-notifications-trending", value:"Trending current events", comment:"Title for the setting for trending notifications"), switchChecker: { () -> Bool in
-            return UserDefaults.standard.wmf_inTheNewsNotificationsEnabled()
+        //TODO: Temporary permissions logic, use proper localized string for title when non-temporary
+        let notificationSettingsItems: [NotificationSettingsItem] = [NotificationSettingsSwitchItem(title: "Authorize notifications", switchChecker: { () -> Bool in
+            return false
             }, switchAction: { [weak self] (isOn) in
-                //This (and everything else that references UNUserNotificationCenter in this class) should be moved into WMFNotificationsController
                 if (isOn) {
-                    // SINGLETONTODO
-                    MWKDataStore.shared().notificationsController.requestAuthenticationIfNecessary(completionHandler: { [weak self] (granted, error) in
-                        if let error = error as NSError? {
-                            self?.wmf_showAlertWithError(error)
+                    self?.notificationsController.requestPermissionsIfNecessary { isAllowed, error in
+                        DispatchQueue.main.async {
+                            if let error = error as NSError? {
+                                self?.wmf_showAlertWithError(error)
+                            }
+                            self?.updateSections()
                         }
-                    })
-                } else {
-                    UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+                    }
                 }
-                UserDefaults.standard.wmf_setInTheNewsNotificationsEnabled(isOn)
         })]
         let notificationSettingsSection = NotificationSettingsSection(headerTitle: WMFLocalizedString("settings-notifications-push-notifications", value:"Push notifications", comment:"A title for a list of Push notifications"), items: notificationSettingsItems)
         
@@ -85,34 +99,82 @@ class NotificationSettingsViewController: SubSettingsViewController {
         return updatedSections
     }
     
-    func sectionsForSystemSettingsUnauthorized()  -> [NotificationSettingsSection] {
+    //TODO: Temporary login logic, use proper localized string for titles when non-temporary
+    func sectionsForNotLoggedIn() -> [NotificationSettingsSection] {
+        let logInItem: NotificationSettingsItem = NotificationSettingsButtonItem(title: "Log in", buttonAction: {
+            self.wmf_showLoginOrCreateAccountToThankRevisionAuthorPanel(theme: self.theme, dismissHandler: nil, loginSuccessCompletion: {
+                self.updateSections()
+            }, loginDismissedCompletion: nil)
+        })
+        
+        return [NotificationSettingsSection(headerTitle: "Please log in first.", items: [logInItem])]
+    }
+    
+    func sectionsForPermissionsDenied() -> [NotificationSettingsSection] {
         let unauthorizedItems: [NotificationSettingsItem] = [NotificationSettingsButtonItem(title: WMFLocalizedString("settings-notifications-system-turn-on", value:"Turn on Notifications", comment:"Title for a button for turnining on notifications in the system settings"), buttonAction: {
             guard let URL = URL(string: UIApplication.openSettingsURLString) else {
                 return
             }
             UIApplication.shared.open(URL, options: [:], completionHandler: nil)
         })]
-        return [NotificationSettingsSection(headerTitle: WMFLocalizedString("settings-notifications-info", value:"Be alerted to trending and top read articles on Wikipedia with our push notifications. All provided with respect to privacy and up to the minute data.", comment:"A short description of notifications shown in settings"), items: unauthorizedItems)]
+        return [NotificationSettingsSection(headerTitle: "", items: unauthorizedItems)]
+    }
+    
+    //TODO: Temporary subscription failure logic, use proper localized string for titles when non-temporary
+    func sectionsForSubscriptionFailure() -> [NotificationSettingsSection] {
+        let subscriptionFailureItem: NotificationSettingsItem = NotificationSettingsInfoItem(title: "Something failed while attempting to set up notifications on your device. Please try again later.")
+        return [NotificationSettingsSection(headerTitle: "", items: [subscriptionFailureItem])]
+    }
+    
+    //TODO: Temporary permissions allowed logic, use proper localized string for titles when non-temporary
+    func sectionsForPermissionsAllowed() -> [NotificationSettingsSection] {
+        let allowedItems: [NotificationSettingsItem] = [NotificationSettingsButtonItem(title: "Notifications are enabled. Go to iOS settings to disable notifications", buttonAction: {
+            guard let URL = URL(string: UIApplication.openSettingsURLString) else {
+                return
+            }
+            UIApplication.shared.open(URL, options: [:], completionHandler: nil)
+        })]
+        return [NotificationSettingsSection(headerTitle: "", items: allowedItems)]
     }
     
     func updateSections() {
         tableView.reloadData()
-        UNUserNotificationCenter.current().getNotificationSettings { (settings) in
-            DispatchQueue.main.async(execute: {
-                switch settings.authorizationStatus {
-                case .authorized:
-                    fallthrough
-                case .notDetermined:
-                    self.sections = self.sectionsForSystemSettingsAuthorized()
-                    break
+        
+        guard authManager.isLoggedIn else {
+            sections = self.sectionsForNotLoggedIn()
+            tableView.reloadData()
+            return
+        }
+        
+        guard notificationsController.remoteRegistrationDeviceToken != nil else {
+            sections = self.sectionsForSubscriptionFailure()
+            tableView.reloadData()
+            return
+        }
+        
+        notificationsController.notificationPermissionsStatus { [weak self] status in
+            
+            DispatchQueue.main.async {
+                guard let self = self else {
+                    return
+                }
+                
+                switch status {
                 case .denied:
-                    self.sections = self.sectionsForSystemSettingsUnauthorized()
+                    self.sections = self.sectionsForPermissionsDenied()
+                    break
+                case .notDetermined:
+                    self.sections = self.sectionsForPermissionsNotDetermined()
+                    break
+                case .authorized, .provisional, .ephemeral:
+                    self.sections = self.sectionsForPermissionsAllowed()
                     break
                 default:
                     break
                 }
+                
                 self.tableView.reloadData()
-            })
+            }
         }
     }
     
@@ -141,17 +203,18 @@ class NotificationSettingsViewController: SubSettingsViewController {
             cell.disclosureType = .switch
             cell.disclosureSwitch.isOn = switchItem.switchChecker()
             cell.disclosureSwitch.addTarget(self, action: #selector(self.handleSwitchValueChange(_:)), for: .valueChanged)
+        } else if item is NotificationSettingsInfoItem {
+            cell.disclosureType = .none
         } else {
             cell.disclosureType = .viewController
         }
-        
         
         return cell
     }
     
     @objc func handleSwitchValueChange(_ sender: UISwitch) {
         // FIXME: hardcoded item below
-        let item = sections[1].items[0]
+        let item = sections[0].items[0]
         if let switchItem = item as? NotificationSettingsSwitchItem {
             switchItem.switchAction(sender.isOn)
         }
@@ -184,7 +247,6 @@ class NotificationSettingsViewController: SubSettingsViewController {
         item.buttonAction()
         tableView.deselectRow(at: indexPath, animated: true)
     }
-    
     
     @objc func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
         return sections[indexPath.section].items[indexPath.item] as? NotificationSettingsSwitchItem == nil

--- a/Wikipedia/Code/WMFAppViewController.h
+++ b/Wikipedia/Code/WMFAppViewController.h
@@ -32,6 +32,8 @@ extern NSString *const WMFLanguageVariantAlertsLibraryVersion; // NSNumber
 
 - (void)showSearchInCurrentNavigationController;
 
+- (void)setRemoteNotificationRegistrationStatusWithDeviceToken: (nullable NSData *)deviceToken error: (nullable NSError *)error;
+
 /// Returning WMFArticleViewController (which is ArticleViewController in Swift) makes this not work from Swift
 - (void)swiftCompatibleShowArticleWithURL:(NSURL *)articleURL animated:(BOOL)animated completion:(nonnull dispatch_block_t)completion;
 

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -2024,6 +2024,10 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 
 #pragma mark - Remote Notifications
 
+- (void)setRemoteNotificationRegistrationStatusWithDeviceToken: (nullable NSData *)deviceToken error: (nullable NSError *)error{
+    [self.notificationsController setRemoteNotificationRegistrationStatusWithDeviceToken:deviceToken error:error];
+}
+
 - (void)remoteNotificationsModelDidChange:(NSNotification *)note {
     self.remoteNotificationsModelChangeResponseCoordinator = (RemoteNotificationsModelChangeResponseCoordinator *)note.object;
     assert(self.remoteNotificationsModelChangeResponseCoordinator);

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -362,7 +362,6 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
     [self.periodicWorkerController start];
     [self.savedArticlesFetcher start];
     [self.mobileViewToMobileHTMLMigrationController start];
-    self.notificationsController.applicationActive = YES;
 }
 
 - (void)performTasksThatShouldOccurAfterAnnouncementsUpdated {
@@ -970,7 +969,6 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
 
     [[NSUserDefaults standardUserDefaults] wmf_setDidShowSyncDisabledPanel:NO];
 
-    self.notificationsController.applicationActive = NO;
     [self.reachabilityNotifier stop];
     [self.periodicWorkerController stop];
     [self.savedArticlesFetcher stop];
@@ -1353,7 +1351,6 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
 
 - (WMFNotificationsController *)notificationsController {
     WMFNotificationsController *controller = self.dataStore.notificationsController;
-    controller.applicationActive = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
     return controller;
 }
 

--- a/Wikipedia/Code/WMFNotificationsController.h
+++ b/Wikipedia/Code/WMFNotificationsController.h
@@ -19,11 +19,11 @@ extern NSString *const WMFNotificationInfoArticleExtractKey;
 extern NSString *const WMFNotificationInfoViewCountsKey;
 extern NSString *const WMFNotificationInfoFeedNewsStoryKey;
 
-@class MWKDataStore;
+@class MWKDataStore, MWKLanguageLinkController;
 
 @interface WMFNotificationsController : NSObject
 
-- (instancetype)initWithDataStore:(MWKDataStore *)dataStore NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDataStore:(MWKDataStore *)dataStore languageLinkController:(MWKLanguageLinkController *)languageLinkController NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, readonly, copy, nullable) NSData  *remoteRegistrationDeviceToken;
 @property (nonatomic, readonly, strong, nullable) NSError *remoteRegistrationError;
@@ -36,6 +36,14 @@ extern NSString *const WMFNotificationInfoFeedNewsStoryKey;
 /// Checks and returns UNNotificationCenter's authorization status asynchronously.
 /// @param completionHandler Completion handler to call when authorization state has been determined. Passes back UNAuthorizationStatus from UNUserNotificationCenter
 - (void)notificationPermissionsStatusWithCompletionHandler:(void (^)(UNAuthorizationStatus  status))completionHandler;
+
+/// Posts device token to server, so server can begin sending push notifications to APNS
+/// @param completionHandler Called when subscription completes with success flag and error with more details
+- (void)subscribeToEchoNotificationsWithCompletionHandler:(nullable void (^)(NSError *__nullable error))completionHandler;
+
+/// Asks server to remove device token, so server can stop sending push notifications to APNS
+/// @param completionHandler Called when unsubscribe call completes with success flag and error with more details
+- (void)unsubscribeFromEchoNotificationsWithCompletionHandler:(nullable void (^)(NSError *__nullable error))completionHandler;
 
 - (void)sendNotificationWithTitle:(NSString *)title body:(NSString *)body categoryIdentifier:(NSString *)categoryIdentifier userInfo:(NSDictionary *)userInfo atDateComponents:(nullable NSDateComponents *)dateComponents; //null date components will send the notification ASAP
 

--- a/Wikipedia/Code/WMFNotificationsController.h
+++ b/Wikipedia/Code/WMFNotificationsController.h
@@ -26,6 +26,8 @@ extern NSString *const WMFNotificationInfoFeedNewsStoryKey;
 
 @property (nonatomic, readonly, getter=isAuthorized) BOOL authorized;
 @property (nonatomic, getter=isApplicationActive) BOOL applicationActive;
+@property (nonatomic, readonly, copy, nullable) NSData  *remoteRegistrationDeviceToken;
+@property (nonatomic, readonly, strong, nullable) NSError *remoteRegistrationError;
 
 - (void)requestAuthenticationIfNecessaryWithCompletionHandler:(void (^)(BOOL granted, NSError *__nullable error))completionHandler;
 
@@ -33,6 +35,8 @@ extern NSString *const WMFNotificationInfoFeedNewsStoryKey;
 
 /// Registers notification categories for the app. Should only be called once at launch.
 - (void)updateCategories;
+
+- (void)setRemoteNotificationRegistrationStatusWithDeviceToken: (nullable NSData *)deviceToken error: (nullable NSError *)error;
 
 @end
 

--- a/Wikipedia/Code/WMFNotificationsController.h
+++ b/Wikipedia/Code/WMFNotificationsController.h
@@ -1,4 +1,5 @@
 @import Foundation;
+@import UserNotifications;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -24,12 +25,17 @@ extern NSString *const WMFNotificationInfoFeedNewsStoryKey;
 
 - (instancetype)initWithDataStore:(MWKDataStore *)dataStore NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, readonly, getter=isAuthorized) BOOL authorized;
-@property (nonatomic, getter=isApplicationActive) BOOL applicationActive;
 @property (nonatomic, readonly, copy, nullable) NSData  *remoteRegistrationDeviceToken;
 @property (nonatomic, readonly, strong, nullable) NSError *remoteRegistrationError;
 
-- (void)requestAuthenticationIfNecessaryWithCompletionHandler:(void (^)(BOOL granted, NSError *__nullable error))completionHandler;
+
+/// Checks and returns UNNotificationCenter's authorization status asynchronously. If state is .notDetermined, asks permissions from user and returns result.
+/// @param completionHandler Completion handler to call when authorization state has been requested (if needed) and determined. isAllowed = true if it's any state besides UNAuthorizationStatusDenied.
+- (void)requestPermissionsIfNecessaryWithCompletionHandler:(void (^)(BOOL isAllowed, NSError *__nullable error))completionHandler;
+
+/// Checks and returns UNNotificationCenter's authorization status asynchronously.
+/// @param completionHandler Completion handler to call when authorization state has been determined. Passes back UNAuthorizationStatus from UNUserNotificationCenter
+- (void)notificationPermissionsStatusWithCompletionHandler:(void (^)(UNAuthorizationStatus  status))completionHandler;
 
 - (void)sendNotificationWithTitle:(NSString *)title body:(NSString *)body categoryIdentifier:(NSString *)categoryIdentifier userInfo:(NSDictionary *)userInfo atDateComponents:(nullable NSDateComponents *)dateComponents; //null date components will send the notification ASAP
 

--- a/Wikipedia/Code/WMFNotificationsController.h
+++ b/Wikipedia/Code/WMFNotificationsController.h
@@ -25,9 +25,8 @@ extern NSString *const WMFNotificationInfoFeedNewsStoryKey;
 
 - (instancetype)initWithDataStore:(MWKDataStore *)dataStore languageLinkController:(MWKLanguageLinkController *)languageLinkController NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, readonly, copy, nullable) NSData  *remoteRegistrationDeviceToken;
+@property (nonatomic, readonly, copy, nullable) NSData *remoteRegistrationDeviceToken;
 @property (nonatomic, readonly, strong, nullable) NSError *remoteRegistrationError;
-
 
 /// Checks and returns UNNotificationCenter's authorization status asynchronously. If state is .notDetermined, asks permissions from user and returns result.
 /// @param completionHandler Completion handler to call when authorization state has been requested (if needed) and determined. isAllowed = true if it's any state besides UNAuthorizationStatusDenied.
@@ -35,7 +34,7 @@ extern NSString *const WMFNotificationInfoFeedNewsStoryKey;
 
 /// Checks and returns UNNotificationCenter's authorization status asynchronously.
 /// @param completionHandler Completion handler to call when authorization state has been determined. Passes back UNAuthorizationStatus from UNUserNotificationCenter
-- (void)notificationPermissionsStatusWithCompletionHandler:(void (^)(UNAuthorizationStatus  status))completionHandler;
+- (void)notificationPermissionsStatusWithCompletionHandler:(void (^)(UNAuthorizationStatus status))completionHandler;
 
 /// Posts device token to server, so server can begin sending push notifications to APNS
 /// @param completionHandler Called when subscription completes with success flag and error with more details
@@ -50,7 +49,7 @@ extern NSString *const WMFNotificationInfoFeedNewsStoryKey;
 /// Registers notification categories for the app. Should only be called once at launch.
 - (void)updateCategories;
 
-- (void)setRemoteNotificationRegistrationStatusWithDeviceToken: (nullable NSData *)deviceToken error: (nullable NSError *)error;
+- (void)setRemoteNotificationRegistrationStatusWithDeviceToken:(nullable NSData *)deviceToken error:(nullable NSError *)error;
 
 @end
 

--- a/Wikipedia/Code/WMFNotificationsController.m
+++ b/Wikipedia/Code/WMFNotificationsController.m
@@ -27,15 +27,19 @@ NSString *const WMFNotificationInfoFeedNewsStoryKey = @"feedNewsStory";
 @property (weak, nonatomic) MWKDataStore *dataStore;
 @property (nonatomic, readwrite, copy, nullable) NSData *remoteRegistrationDeviceToken;
 @property (nonatomic, readwrite, strong, nullable) NSError *remoteRegistrationError;
+@property (nonatomic, strong) WMFEchoSubscriptionFetcher *echoSubscriptionFetcher;
+@property (nonatomic, strong) MWKLanguageLinkController *languageLinkController;
 
 @end
 
 @implementation WMFNotificationsController
 
-- (instancetype)initWithDataStore:(MWKDataStore *)dataStore {
+- (instancetype)initWithDataStore:(MWKDataStore *)dataStore languageLinkController:(MWKLanguageLinkController *)languageLinkController {
     self = [super init];
     if (self) {
         self.dataStore = dataStore;
+        self.languageLinkController = languageLinkController;
+        self.echoSubscriptionFetcher = [[WMFEchoSubscriptionFetcher alloc] initWithSession:dataStore.session configuration:dataStore.configuration];
     }
     return self;
 }
@@ -77,6 +81,15 @@ NSString *const WMFNotificationInfoFeedNewsStoryKey = @"feedNewsStory";
 - (void)setRemoteNotificationRegistrationStatusWithDeviceToken: (nullable NSData *)deviceToken error: (nullable NSError *)error {
     self.remoteRegistrationDeviceToken = deviceToken;
     self.remoteRegistrationError = error;
+}
+
+- (void)subscribeToEchoNotificationsWithCompletionHandler:(nullable void (^)(NSError *__nullable error))completionHandler {
+
+    [self.echoSubscriptionFetcher subscribeWithSiteURL:self.languageLinkController.appLanguage.siteURL deviceToken:self.remoteRegistrationDeviceToken completion:completionHandler];
+}
+
+- (void)unsubscribeFromEchoNotificationsWithCompletionHandler:(nullable void (^)(NSError *__nullable error))completionHandler {
+    [self.echoSubscriptionFetcher unsubscribeWithSiteURL:self.languageLinkController.appLanguage.siteURL deviceToken:self.remoteRegistrationDeviceToken completion:completionHandler];
 }
 
 - (void)updateCategories {

--- a/Wikipedia/Code/WMFNotificationsController.m
+++ b/Wikipedia/Code/WMFNotificationsController.m
@@ -44,7 +44,7 @@ NSString *const WMFNotificationInfoFeedNewsStoryKey = @"feedNewsStory";
     return self;
 }
 
-- (void)notificationPermissionsStatusWithCompletionHandler:(void (^)(UNAuthorizationStatus  status))completionHandler {
+- (void)notificationPermissionsStatusWithCompletionHandler:(void (^)(UNAuthorizationStatus status))completionHandler {
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
     [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *_Nonnull settings) {
         completionHandler(settings.authorizationStatus);
@@ -52,10 +52,6 @@ NSString *const WMFNotificationInfoFeedNewsStoryKey = @"feedNewsStory";
 }
 
 - (void)requestPermissionsIfNecessaryWithCompletionHandler:(void (^)(BOOL isAllowed, NSError *__nullable error))completionHandler {
-    if (![UNUserNotificationCenter class]) {
-        completionHandler(NO, nil);
-        return;
-    }
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
     [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *_Nonnull settings) {
         switch (settings.authorizationStatus) {
@@ -78,7 +74,7 @@ NSString *const WMFNotificationInfoFeedNewsStoryKey = @"feedNewsStory";
     }];
 }
 
-- (void)setRemoteNotificationRegistrationStatusWithDeviceToken: (nullable NSData *)deviceToken error: (nullable NSError *)error {
+- (void)setRemoteNotificationRegistrationStatusWithDeviceToken:(nullable NSData *)deviceToken error:(nullable NSError *)error {
     self.remoteRegistrationDeviceToken = deviceToken;
     self.remoteRegistrationError = error;
 }
@@ -152,9 +148,6 @@ NSString *const WMFNotificationInfoFeedNewsStoryKey = @"feedNewsStory";
 }
 
 - (void)sendNotificationWithTitle:(NSString *)title body:(NSString *)body categoryIdentifier:(NSString *)categoryIdentifier userInfo:(NSDictionary *)userInfo atDateComponents:(nullable NSDateComponents *)dateComponents {
-    if (![UNUserNotificationCenter class]) {
-        return;
-    }
 
     NSString *thumbnailURLString = userInfo[WMFNotificationInfoThumbnailURLStringKey];
     if (!thumbnailURLString) {
@@ -242,7 +235,6 @@ NSString *const WMFNotificationInfoFeedNewsStoryKey = @"feedNewsStory";
                         [self sendNotificationWithTitle:title body:body categoryIdentifier:categoryIdentifier userInfo:userInfo atDateComponents:dateComponents withAttachements:imageAttachements];
                     }
                 }];
-
         }];
 }
 

--- a/Wikipedia/Code/WMFNotificationsController.m
+++ b/Wikipedia/Code/WMFNotificationsController.m
@@ -29,6 +29,8 @@ NSString *const WMFNotificationInfoFeedNewsStoryKey = @"feedNewsStory";
 
 @property (nonatomic, readwrite, getter=isAuthorized) BOOL authorized;
 @property (weak, nonatomic) MWKDataStore *dataStore;
+@property (nonatomic, readwrite, copy, nullable) NSData *remoteRegistrationDeviceToken;
+@property (nonatomic, readwrite, strong, nullable) NSError *remoteRegistrationError;
 
 @end
 
@@ -70,6 +72,11 @@ NSString *const WMFNotificationInfoFeedNewsStoryKey = @"feedNewsStory";
                 break;
         }
     }];
+}
+
+- (void)setRemoteNotificationRegistrationStatusWithDeviceToken: (nullable NSData *)deviceToken error: (nullable NSError *)error {
+    self.remoteRegistrationDeviceToken = deviceToken;
+    self.remoteRegistrationError = error;
 }
 
 - (void)updateCategories {

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -431,7 +431,7 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
 #pragma mark - Notifications
 
 - (void)showNotifications {
-    WMFNotificationSettingsViewController *notificationSettingsVC = [[WMFNotificationSettingsViewController alloc] init];
+    WMFNotificationSettingsViewController *notificationSettingsVC = [[WMFNotificationSettingsViewController alloc] initWithAuthManager: self.dataStore.authenticationManager notificationsController:self.dataStore.notificationsController];
     [notificationSettingsVC applyTheme:self.theme];
     [self.navigationController pushViewController:notificationSettingsVC animated:YES];
 }

--- a/Wikipedia/Wikipedia.entitlements
+++ b/Wikipedia/Wikipedia.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:*.wikipedia.org</string>


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T287305

### Notes
This PR is meant to lay the groundwork for getting push notifications to appear in the app. It involves subscribing the device token from the notifications framework to our echo backend, as well as asking users for notifications permissions.

Also note the changes to `NotificationSettingsViewController` are meant to be rather temporary and are just a happy path to get to an enabled permissions and subscription state. Fine-tuning to it will be made when https://phabricator.wikimedia.org/T288688 is tackled.

It's probably easiest to review this commit-by-commit. The commit messages are hopefully clear enough.

After review, please wait for #4010 to be reviewed and merged. Then update this with feature/notifications and merge.

### Test Steps
1. First update [this line](https://github.com/wikimedia/wikipedia-ios/blob/T288297/WMF%20Framework/Configuration.swift#L47) with `return Configuration.staging(options: [.betaCluster])`. We're going to temporarily force the Experimental scheme to point to the beta cluster (the sandbox flow so far only pushes to the Experimental bundle ID).
2. Create two accounts on the [beta cluster](https://en.wikipedia.beta.wmflabs.org/wiki/Main_Page). Log in on desktop with the first one. Go into preferences and make sure all web and apps column checkmarks are checked. Make an edit to any article.
3. Fresh install this app on a device running the Experimental scheme.
4. Go to Settings > Notifications.
5. ~~Proxy here to watch calls, you will reference device token posted here in later step.~~ Log in to your first account if needed here, then toggle ON and allow OS push permissions. ~~Make a note of `providertoken` value and `topic` value in call made to `action=echopushsubscriptions&command=create`.~~
6. Background the app. Now on desktop, log in to your 2nd account you made in step 2. Go to the article that your first account edited, tap into history, and thank the first account for that edit.
7. ~~Temporary step because sandbox flow is [broken again](https://phabricator.wikimedia.org/T287897#7302176): Go to push notification utility and send a visible using the device token and topic noted in step 5~~. Actually this step shouldn't be necessary anymore. The sandbox flow should be back in place now without the need to trigger via the push utility.
8. Your device should display a "checkEchoV1" push notification.