### PR TITLE
Add new RemoteNotifications database with extension, remove old database on migration

### DIFF
--- a/WMF Framework/Remote Notifications/Operations/RemoteNotificationsFetchOperation.swift
+++ b/WMF Framework/Remote Notifications/Operations/RemoteNotificationsFetchOperation.swift
@@ -5,7 +5,7 @@ class RemoteNotificationsFetchOperation: RemoteNotificationsOperation {
         super.init(with: apiController, modelController: modelController)
     }
     override func execute() {
-        self.managedObjectContext.perform {
+        self.backgroundContext.perform {
             self.apiController.getAllUnreadNotifications(from: self.targetWikis) { fetchedNotifications, error in
                 if let error = error {
                     self.finish(with: error)

--- a/WMF Framework/Remote Notifications/Operations/RemoteNotificationsMarkAsReadOperation.swift
+++ b/WMF Framework/Remote Notifications/Operations/RemoteNotificationsMarkAsReadOperation.swift
@@ -1,6 +1,6 @@
 class RemoteNotificationsMarkAsReadOperation: RemoteNotificationsOperation {
     override func execute() {
-        self.managedObjectContext.perform {
+        self.backgroundContext.perform {
             self.modelController.getReadNotifications { readNotifications in
                 guard let readNotifications = readNotifications, !readNotifications.isEmpty else {
                     self.finish()

--- a/WMF Framework/Remote Notifications/Operations/RemoteNotificationsOperation.swift
+++ b/WMF Framework/Remote Notifications/Operations/RemoteNotificationsOperation.swift
@@ -1,12 +1,12 @@
 class RemoteNotificationsOperation: AsyncOperation {
     let apiController: RemoteNotificationsAPIController
     let modelController: RemoteNotificationsModelController
-    let managedObjectContext: NSManagedObjectContext
+    let backgroundContext: NSManagedObjectContext
 
     init(with apiController: RemoteNotificationsAPIController, modelController: RemoteNotificationsModelController) {
         self.apiController = apiController
         self.modelController = modelController
-        self.managedObjectContext = modelController.managedObjectContext
+        self.backgroundContext = modelController.backgroundContext
         super.init()
     }
 }

--- a/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
@@ -1,9 +1,19 @@
+import CocoaLumberjackSwift
+
 @objc public final class RemoteNotificationsController: NSObject {
     private let operationsController: RemoteNotificationsOperationsController
     
     @objc public required init(session: Session, configuration: Configuration, preferredLanguageCodesProvider: WMFPreferredLanguageInfoProvider) {
         operationsController = RemoteNotificationsOperationsController(session: session, configuration: configuration, preferredLanguageCodesProvider: preferredLanguageCodesProvider)
         super.init()
+    }
+    
+    @objc func deleteOldDatabaseFiles() {
+        do {
+            try operationsController.deleteOldDatabaseFiles()
+        } catch (let error) {
+            DDLogError("Failure deleting legacy RemoteNotifications database files: \(error)")
+        }
     }
 }
 

--- a/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
@@ -8,9 +8,9 @@ import CocoaLumberjackSwift
         super.init()
     }
     
-    @objc func deleteOldDatabaseFiles() {
+    @objc func deleteLegacyDatabaseFiles() {
         do {
-            try operationsController.deleteOldDatabaseFiles()
+            try operationsController.deleteLegacyDatabaseFiles()
         } catch (let error) {
             DDLogError("Failure deleting legacy RemoteNotifications database files: \(error)")
         }

--- a/WMF Framework/Remote Notifications/RemoteNotificationsOperationsController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsOperationsController.swift
@@ -40,16 +40,8 @@ class RemoteNotificationsOperationsController: NSObject {
         NotificationCenter.default.removeObserver(self)
     }
     
-    func deleteOldDatabaseFiles() throws {
-        let modelName = RemoteNotificationsModelController.modelName
-        let sharedAppContainerURL = FileManager.default.wmf_containerURL()
-        let legacyRemoteNotificationsStorageUrl = sharedAppContainerURL.appendingPathComponent(modelName)
-        let legecyJournalShmUrl = sharedAppContainerURL.appendingPathComponent("\(modelName)-shm")
-        let legecyJournalWalUrl = sharedAppContainerURL.appendingPathComponent("\(modelName)-wal")
-        
-        try FileManager.default.removeItem(at: legacyRemoteNotificationsStorageUrl)
-        try FileManager.default.removeItem(at: legecyJournalShmUrl)
-        try FileManager.default.removeItem(at: legecyJournalWalUrl)
+    func deleteLegacyDatabaseFiles() throws {
+        modelController?.deleteLegacyDatabaseFiles()
     }
 
     public func stop() {

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -460,7 +460,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
     }
     
     if (currentLibraryVersion < 14) {
-        [self.remoteNotificationsController deleteOldDatabaseFiles];
+        [self.remoteNotificationsController deleteLegacyDatabaseFiles];
         [moc wmf_setValue:@(14) forKey:WMFLibraryVersionKey];
         if ([moc hasChanges] && ![moc save:&migrationError]) {
             DDLogError(@"Error saving during migration: %@", migrationError);

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -13,7 +13,7 @@ NSString *const WMFFeedImportContextDidSave = @"WMFFeedImportContextDidSave";
 NSString *const WMFViewContextDidSave = @"WMFViewContextDidSave";
 
 NSString *const WMFLibraryVersionKey = @"WMFLibraryVersion";
-static const NSInteger WMFCurrentLibraryVersion = 13;
+static const NSInteger WMFCurrentLibraryVersion = 14;
 
 NSString *const MWKDataStoreValidImageSitePrefix = @"//upload.wikimedia.org/";
 
@@ -453,6 +453,15 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
     if (currentLibraryVersion < 13) {
         [self.languageLinkController migrateToUniquedPreferredLanguagesInManagedObjectContext:moc];
         [moc wmf_setValue:@(13) forKey:WMFLibraryVersionKey];
+        if ([moc hasChanges] && ![moc save:&migrationError]) {
+            DDLogError(@"Error saving during migration: %@", migrationError);
+            return;
+        }
+    }
+    
+    if (currentLibraryVersion < 14) {
+        [self.remoteNotificationsController deleteOldDatabaseFiles];
+        [moc wmf_setValue:@(14) forKey:WMFLibraryVersionKey];
         if ([moc hasChanges] && ![moc save:&migrationError]) {
             DDLogError(@"Error saving during migration: %@", migrationError);
             return;


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T287298

### Notes
I believe we had discussed before that there is no need to maintain old remote notification database records, so this PR deletes the old files upon library migration in `MWKDataStore`, and creates a new one by adding the `.sqlite` extension. I found I needed the `.sqlite` extension anyways to open and inspect it, so adding `.sqlite` as an extension while setting up the stack allows it to both be inspectable and to be seen as a new database that needs to be created. There is a brief time period before `performUpdatesFromLibraryVersion` is called where we have both the old database files and the new ones in the app container, but then the old ones are deleted after migration completes.

I am also changing the managed object contexts slightly. `managedObjectContext` (which was already a background context) becomes a more descriptive `backgroundContext`, which will be used as a "write" context (importing, refreshing, and marking as read will happen through here). The new `viewContext` will be used as a "read-only" context, that the views will reference. The `automaticallyMergesChangesFromParent` value and merge policy should allow it to automatically take in changes from the underlying store.

After review, please wait for https://github.com/wikimedia/wikipedia-ios/pull/4017 to be reviewed and merged. Then update this with `feature/notifications` and merge.

To confirm data makes it into the new database, there are a few changes I had to make to allow for more frequent polling and looser API parameters:

1. Return `true` in `isBeforeDeadline` in `RemoteNotificationsOperationsController` [here](https://github.com/wikimedia/wikipedia-ios/blob/T287298-2/WMF%20Framework/Remote%20Notifications/RemoteNotificationsOperationsController.swift#L167).
2. Replace `components.host` with `en.wikipedia.org` (or whatever subdomain you have generated the most notifications on) in `RemoteNotificationsAPIController` [here](https://github.com/wikimedia/wikipedia-ios/blob/T287298-2/WMF%20Framework/Remote%20Notifications/RemoteNotificationsAPIController.swift#L10).
3. Remove `notfilter` field and value from the dictionary in `RemoteNotificationsAPIController` [here](https://github.com/wikimedia/wikipedia-ios/blob/T287298-2/WMF%20Framework/Remote%20Notifications/RemoteNotificationsAPIController.swift#L282).
4. Change `notwikis` value from `wikis.joined(separator: "|")` to `*` in `RemoteNotificationsAPIController` [here](https://github.com/wikimedia/wikipedia-ios/blob/T287298-2/WMF%20Framework/Remote%20Notifications/RemoteNotificationsAPIController.swift#L285).

### Test Steps
1. Run app in simulator on `main`.
2. Switch to this PR branch and run. Open app container and confirm you only see one set of "RemoteNotifications" database files with the `sqlite` extension.
3. Wait for polling to occur (you can proxy if necessary for "notifications" in the url).
4. When you see a polling call, open the `RemoteNotifications.sqlite` database. Confirm you see data. We will capture and persist more fields in a followup PR.

### Screenshots/Videos

Before migration, notice two sets of `RemoteNotifications` database.
![Screen Shot 2021-08-16 at 3 55 56 PM](https://user-images.githubusercontent.com/3620196/129629760-c65d7b0f-cdbe-4b14-a561-962c0b2c0f70.png)

After migration, old database files are gone.
![Screen Shot 2021-08-16 at 3 56 09 PM](https://user-images.githubusercontent.com/3620196/129629776-05f6bf84-6c63-498b-949a-4eb12bf4ba2c.png)