### PR TITLE
Save additional notification fields in RemoteNotifications database

### DIFF
--- a/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataClass.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataClass.swift
@@ -24,27 +24,4 @@ public class RemoteNotification: NSManagedObject {
         }
         return RemoteNotificationCategory(stringValue: categoryString)
     }
-
-    public enum State: Int16 {
-        case seen
-        case read
-        case excluded
-
-        public var number: NSNumber {
-            return NSNumber(value: rawValue)
-        }
-    }
-
-    public var state: State? {
-        get {
-            return State(rawValue: stateNumber)
-        }
-        set {
-            guard let value = newValue?.rawValue else {
-                return
-            }
-            stateNumber = value
-        }
-    }
-
 }

--- a/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataClass.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataClass.swift
@@ -1,10 +1,8 @@
 import Foundation
 import CoreData
-
 @objc public enum RemoteNotificationCategory: Int {
     case editReverted
     case unknown
-
     init(stringValue: String) {
         switch stringValue {
         case "reverted":
@@ -14,10 +12,8 @@ import CoreData
         }
     }
 }
-
 @objc(RemoteNotification)
 public class RemoteNotification: NSManagedObject {
-
     public var category: RemoteNotificationCategory {
         guard let categoryString = categoryString else {
             return .unknown

--- a/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataClass.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataClass.swift
@@ -30,23 +30,20 @@ public class RemoteNotification: NSManagedObject {
         case read
         case excluded
 
-        public var number: NSNumber{
+        public var number: NSNumber {
             return NSNumber(value: rawValue)
         }
     }
 
     public var state: State? {
         get {
-            guard let value = stateNumber?.int16Value else {
-                return nil
-            }
-            return State(rawValue: value)
+            return State(rawValue: stateNumber)
         }
         set {
             guard let value = newValue?.rawValue else {
                 return
             }
-            stateNumber = NSNumber(value: value)
+            stateNumber = value
         }
     }
 

--- a/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataProperties.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataProperties.swift
@@ -9,15 +9,23 @@ extension RemoteNotification {
         return NSFetchRequest<RemoteNotification>(entityName: "RemoteNotification")
     }
 
-    @NSManaged public var affectedPageID: String?
-    @NSManaged public var agent: String?
+    @NSManaged public var titleFull: String?
+    @NSManaged public var agentName: String?
     @NSManaged public var categoryString: String?
     @NSManaged public var date: Date?
     @NSManaged public var id: String?
     @NSManaged public var key: String?
-    @NSManaged public var message: String?
+    @NSManaged public var messageHeader: String?
     @NSManaged public var typeString: String?
     @NSManaged public var wiki: String?
     @NSManaged public var isRead: Bool
+    @NSManaged public var messageLinks: RemoteNotificationLinks?
+    @NSManaged public var titleNamespace: String?
+    @NSManaged public var titleNamespaceKey: Int16
+    @NSManaged public var titleText: String?
+    @NSManaged public var agentId: String?
+    @NSManaged public var utcUnixString: String?
+    @NSManaged public var messageBody: String?
+    @NSManaged public var section: String?
 
 }

--- a/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataProperties.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataProperties.swift
@@ -1,5 +1,7 @@
+
 import Foundation
 import CoreData
+
 
 extension RemoteNotification {
 
@@ -7,14 +9,15 @@ extension RemoteNotification {
         return NSFetchRequest<RemoteNotification>(entityName: "RemoteNotification")
     }
 
-    @NSManaged public var agent: String?
     @NSManaged public var affectedPageID: String?
+    @NSManaged public var agent: String?
     @NSManaged public var categoryString: String?
-    @NSManaged public var date: NSDate?
+    @NSManaged public var date: Date?
     @NSManaged public var id: String?
     @NSManaged public var message: String?
+    @NSManaged public var stateNumber: Int16
     @NSManaged public var typeString: String?
     @NSManaged public var wiki: String?
-    @NSManaged public var stateNumber: NSNumber?
+    @NSManaged public var key: String?
 
 }

--- a/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataProperties.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataProperties.swift
@@ -14,10 +14,10 @@ extension RemoteNotification {
     @NSManaged public var categoryString: String?
     @NSManaged public var date: Date?
     @NSManaged public var id: String?
+    @NSManaged public var key: String?
     @NSManaged public var message: String?
-    @NSManaged public var stateNumber: Int16
     @NSManaged public var typeString: String?
     @NSManaged public var wiki: String?
-    @NSManaged public var key: String?
+    @NSManaged public var isRead: Bool
 
 }

--- a/WMF Framework/Remote Notifications/Model/RemoteNotificationLinks.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotificationLinks.swift
@@ -44,7 +44,7 @@ public class RemoteNotificationLink: NSObject, NSSecureCoding, Codable {
         let type = decoder.decodeObject(of: NSString.self, forKey: "type")
         let urlString = decoder.decodeObject(of: NSString.self, forKey: "url")
         let label = decoder.decodeObject(of: NSString.self, forKey: "label")
-        let url = urlString == nil ? nil : URL(string: urlString! as String)
+        let url = URL(string: urlString as String? ?? "")
         self.init(type: type, url: url, label: label)
     }
 

--- a/WMF Framework/Remote Notifications/Model/RemoteNotificationLinks.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotificationLinks.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+@objc(RemoteNotificationLinks)
+public class RemoteNotificationLinks: NSObject, NSSecureCoding, Codable {
+    public static var supportsSecureCoding: Bool = true
+    
+    let primary: RemoteNotificationLink?
+    let secondary: [RemoteNotificationLink]?
+
+    init(primary: RemoteNotificationLink?, secondary: [RemoteNotificationLink]?) {
+        self.primary = primary
+        self.secondary = secondary
+    }
+
+    public required convenience init(coder decoder: NSCoder) {
+        
+        let primary = decoder.decodeObject(of: RemoteNotificationLink.self, forKey: "primary")
+        let classes = [NSArray.classForCoder(), RemoteNotificationLink.classForCoder()]
+        let secondary = decoder.decodeObject(of: classes, forKey: "secondary") as? [RemoteNotificationLink]
+        self.init(primary: primary, secondary: secondary)
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(primary, forKey: "primary")
+        coder.encode(secondary, forKey: "secondary")
+    }
+}
+
+@objc(RemoteNotificationLink)
+public class RemoteNotificationLink: NSObject, NSSecureCoding, Codable {
+    public static var supportsSecureCoding: Bool = true
+    
+    let type: String?
+    let url: URL?
+    let label: String?
+
+    init(type: NSString?, url: URL?, label: NSString?) {
+        self.type = type as String?
+        self.url = url
+        self.label = label as String?
+    }
+
+    public required convenience init(coder decoder: NSCoder) {
+        let type = decoder.decodeObject(of: NSString.self, forKey: "type")
+        let urlString = decoder.decodeObject(of: NSString.self, forKey: "url")
+        let label = decoder.decodeObject(of: NSString.self, forKey: "label")
+        let url = urlString == nil ? nil : URL(string: urlString! as String)
+        self.init(type: type, url: url, label: label)
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(type, forKey: "type")
+        let urlString = url?.absoluteString
+        coder.encode(urlString, forKey: "url")
+        coder.encode(label, forKey: "label")
+    }
+}

--- a/WMF Framework/Remote Notifications/Model/RemoteNotifications.xcdatamodeld/.xccurrentversion
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotifications.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>RemoteNotifications 2.xcdatamodel</string>
+	<string>RemoteNotifications 3.xcdatamodel</string>
 </dict>
 </plist>

--- a/WMF Framework/Remote Notifications/Model/RemoteNotifications.xcdatamodeld/RemoteNotifications 3.xcdatamodel/contents
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotifications.xcdatamodeld/RemoteNotifications 3.xcdatamodel/contents
@@ -6,13 +6,13 @@
         <attribute name="categoryString" attributeType="String"/>
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" attributeType="String"/>
+        <attribute name="isRead" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <attribute name="key" attributeType="String"/>
         <attribute name="message" optional="YES" attributeType="String"/>
-        <attribute name="stateNumber" optional="YES" attributeType="Integer 16" usesScalarValueType="YES"/>
         <attribute name="typeString" attributeType="String"/>
         <attribute name="wiki" attributeType="String"/>
         <fetchIndex name="byPropertyIndex">
-            <fetchIndexElement property="stateNumber" type="Binary" order="ascending"/>
+            <fetchIndexElement property="key" type="Binary" order="ascending"/>
         </fetchIndex>
         <uniquenessConstraints>
             <uniquenessConstraint>

--- a/WMF Framework/Remote Notifications/Model/RemoteNotifications.xcdatamodeld/RemoteNotifications 3.xcdatamodel/contents
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotifications.xcdatamodeld/RemoteNotifications 3.xcdatamodel/contents
@@ -1,15 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20F71" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="RemoteNotification" representedClassName="RemoteNotification" syncable="YES">
-        <attribute name="affectedPageID" optional="YES" attributeType="String"/>
-        <attribute name="agent" optional="YES" attributeType="String"/>
+        <attribute name="agentId" optional="YES" attributeType="String"/>
+        <attribute name="agentName" optional="YES" attributeType="String"/>
         <attribute name="categoryString" attributeType="String"/>
-        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="isRead" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <attribute name="key" attributeType="String"/>
-        <attribute name="message" optional="YES" attributeType="String"/>
+        <attribute name="messageBody" optional="YES" attributeType="String"/>
+        <attribute name="messageHeader" optional="YES" attributeType="String"/>
+        <attribute name="messageLinks" optional="YES" attributeType="Transformable" valueTransformerName="WMFSecureUnarchiveFromDataTransformer" customClassName="RemoteNotificationLinks"/>
+        <attribute name="section" optional="YES" attributeType="String"/>
+        <attribute name="titleFull" optional="YES" attributeType="String"/>
+        <attribute name="titleNamespace" optional="YES" attributeType="String"/>
+        <attribute name="titleNamespaceKey" optional="YES" attributeType="Integer 16" usesScalarValueType="YES"/>
+        <attribute name="titleText" optional="YES" attributeType="String"/>
         <attribute name="typeString" attributeType="String"/>
+        <attribute name="utcUnixString" optional="YES" attributeType="String"/>
         <attribute name="wiki" attributeType="String"/>
         <fetchIndex name="byPropertyIndex">
             <fetchIndexElement property="key" type="Binary" order="ascending"/>
@@ -32,7 +40,7 @@
         </fetchIndex>
     </entity>
     <elements>
-        <element name="RemoteNotification" positionX="-63" positionY="-18" width="128" height="179"/>
+        <element name="RemoteNotification" positionX="-63" positionY="-18" width="128" height="299"/>
         <element name="WMFKeyValue" positionX="-63" positionY="54" width="128" height="103"/>
     </elements>
 </model>

--- a/WMF Framework/Remote Notifications/Model/RemoteNotifications.xcdatamodeld/RemoteNotifications 3.xcdatamodel/contents
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotifications.xcdatamodeld/RemoteNotifications 3.xcdatamodel/contents
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20F71" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="RemoteNotification" representedClassName="RemoteNotification" syncable="YES">
+        <attribute name="affectedPageID" optional="YES" attributeType="String"/>
+        <attribute name="agent" optional="YES" attributeType="String"/>
+        <attribute name="categoryString" attributeType="String"/>
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="String"/>
+        <attribute name="key" attributeType="String"/>
+        <attribute name="message" optional="YES" attributeType="String"/>
+        <attribute name="stateNumber" optional="YES" attributeType="Integer 16" usesScalarValueType="YES"/>
+        <attribute name="typeString" attributeType="String"/>
+        <attribute name="wiki" attributeType="String"/>
+        <fetchIndex name="byPropertyIndex">
+            <fetchIndexElement property="stateNumber" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="key"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="WMFKeyValue" representedClassName="WMFKeyValue" syncable="YES">
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="group" optional="YES" attributeType="String"/>
+        <attribute name="key" optional="YES" attributeType="String"/>
+        <attribute name="value" optional="YES" attributeType="Transformable" valueTransformerName="WMFSecureUnarchiveFromDataTransformer"/>
+        <fetchIndex name="compoundIndex">
+            <fetchIndexElement property="key" type="Binary" order="ascending"/>
+            <fetchIndexElement property="group" type="Binary" order="ascending"/>
+            <fetchIndexElement property="date" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <elements>
+        <element name="RemoteNotification" positionX="-63" positionY="-18" width="128" height="179"/>
+        <element name="WMFKeyValue" positionX="-63" positionY="54" width="128" height="103"/>
+    </elements>
+</model>

--- a/WMF Framework/Remote Notifications/Model/RemoteNotificationsModelController.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotificationsModelController.swift
@@ -160,19 +160,16 @@ final class RemoteNotificationsModelController: NSObject {
     // inside the perform(_:) or the performAndWait(_:) methods.
     // https://developer.apple.com/documentation/coredata/using_core_data_in_the_background
     private func createNewNotification(from notification: RemoteNotificationsAPIController.NotificationsResult.Notification) {
-        guard let date = date(from: notification.timestamp?.utciso8601) else {
+        guard let date = date(from: notification.timestamp.utciso8601) else {
             assertionFailure("Notification should have a date")
-            return
-        }
-        guard let id = notification.id else {
-            assertionFailure("Notification must have an id")
             return
         }
 
         let message = notification.message?.header?.wmf_stringByRemovingHTML()
         let _ = backgroundContext.wmf_create(entityNamed: "RemoteNotification",
-                                                withKeysAndValues: ["id": id,
+                                                withKeysAndValues: ["id": notification.id,
                                                                     "categoryString" : notification.category,
+                                                                    "key": notification.key,
                                                                     "typeString": notification.type,
                                                                     "agent": notification.agent?.name,
                                                                     "affectedPageID": notification.affectedPageID?.full,
@@ -204,12 +201,8 @@ final class RemoteNotificationsModelController: NSObject {
             }
 
             for notification in notificationsFetchedFromTheServer {
-                guard let id = notification.id else {
-                    assertionFailure("Expected notification to have id")
-                    continue
-                }
-                guard !commonIDs.contains(id) else {
-                    if let savedNotification = savedNotifications.first(where: { $0.id == id }) {
+                guard !commonIDs.contains(notification.id) else {
+                    if let savedNotification = savedNotifications.first(where: { $0.id == notification.id }) {
                         // Update notifications that weren't seen so that moc is notified of the update
                         savedNotification.state = .read
                     }

--- a/WMF Framework/Remote Notifications/Model/RemoteNotificationsModelController.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotificationsModelController.swift
@@ -157,16 +157,25 @@ final class RemoteNotificationsModelController: NSObject {
 
         let isRead = notification.readString == nil ? NSNumber(booleanLiteral: false) : NSNumber(booleanLiteral: true)
         let _ = backgroundContext.wmf_create(entityNamed: "RemoteNotification",
-                                                withKeysAndValues: ["id": notification.id,
-                                                                    "categoryString" : notification.category,
-                                                                    "key": notification.key,
-                                                                    "typeString": notification.type,
-                                                                    "agent": notification.agent?.name,
-                                                                    "affectedPageID": notification.affectedPageID?.full,
-                                                                    "message": notification.message?.header,
-                                                                    "isRead" : isRead,
-                                                                    "wiki": notification.wiki,
-                                                                    "date": date])
+                                                withKeysAndValues: [
+                                                    "wiki": notification.wiki,
+                                                    "id": notification.id,
+                                                    "key": notification.key,
+                                                    "typeString": notification.type,
+                                                    "categoryString" : notification.category,
+                                                    "section" : notification.section,
+                                                    "date": date,
+                                                    "utcUnixString": notification.timestamp.utcunix,
+                                                    "titleFull": notification.title?.full,
+                                                    "titleNamespace": notification.title?.namespace,
+                                                    "titleNamespaceKey": notification.title?.namespaceKey,
+                                                    "titleText": notification.title?.text,
+                                                    "agentId": notification.agent?.id,
+                                                    "agentName": notification.agent?.name,
+                                                    "isRead" : isRead,
+                                                    "messageHeader": notification.message?.header,
+                                                    "messageBody": notification.message?.body,
+                                                    "messageLinks": notification.message?.links])
     }
 
     private func date(from dateString: String?) -> Date? {

--- a/WMF Framework/Remote Notifications/Model/RemoteNotificationsModelController.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotificationsModelController.swift
@@ -30,15 +30,6 @@ import CocoaLumberjackSwift
     func markAsRead(notificationWithID notificationID: String) {
         modelController.markAsRead(notificationWithID: notificationID)
     }
-
-    @objc func markAsExcluded(_ notification: RemoteNotification) {
-        modelController.markAsExcluded(notification)
-    }
-
-    @objc(markAsSeenNotificationWithID:)
-    func markAsSeen(notificationWithID notificationID: String) {
-        modelController.markAsSeen(notificationWithID: notificationID)
-    }
 }
 
 final class RemoteNotificationsModelController: NSObject {
@@ -110,12 +101,11 @@ final class RemoteNotificationsModelController: NSObject {
     typealias ResultHandler = (Set<RemoteNotification>?) -> Void
 
     public func getUnreadNotifications(_ completion: @escaping ResultHandler) {
-        return notifications(with: NSPredicate(format: "stateNumber == nil"), completion: completion)
+        return notifications(with: NSPredicate(format: "isRead == %@", NSNumber(value: false)), completion: completion)
     }
 
     public func getReadNotifications(_ completion: @escaping ResultHandler) {
-        let read = RemoteNotification.State.read.number
-        return notifications(with: NSPredicate(format: "stateNumber == %@", read), completion: completion)
+        return notifications(with: NSPredicate(format: "isRead == %@", NSNumber(value: true)), completion: completion)
     }
 
     public func getAllNotifications(_ completion: @escaping ResultHandler) {
@@ -165,7 +155,7 @@ final class RemoteNotificationsModelController: NSObject {
             return
         }
 
-        let message = notification.message?.header?.wmf_stringByRemovingHTML()
+        let isRead = notification.readString == nil ? NSNumber(booleanLiteral: false) : NSNumber(booleanLiteral: true)
         let _ = backgroundContext.wmf_create(entityNamed: "RemoteNotification",
                                                 withKeysAndValues: ["id": notification.id,
                                                                     "categoryString" : notification.category,
@@ -173,7 +163,8 @@ final class RemoteNotificationsModelController: NSObject {
                                                                     "typeString": notification.type,
                                                                     "agent": notification.agent?.name,
                                                                     "affectedPageID": notification.affectedPageID?.full,
-                                                                    "message": message,
+                                                                    "message": notification.message?.header,
+                                                                    "isRead" : isRead,
                                                                     "wiki": notification.wiki,
                                                                     "date": date])
     }
@@ -204,7 +195,7 @@ final class RemoteNotificationsModelController: NSObject {
                 guard !commonIDs.contains(notification.id) else {
                     if let savedNotification = savedNotifications.first(where: { $0.id == notification.id }) {
                         // Update notifications that weren't seen so that moc is notified of the update
-                        savedNotification.state = .read
+                        savedNotification.isRead = true
                     }
                     continue
                 }
@@ -220,32 +211,14 @@ final class RemoteNotificationsModelController: NSObject {
 
     public func markAsRead(_ notification: RemoteNotification) {
         self.backgroundContext.perform {
-            notification.state = .read
+            notification.isRead = true
             self.save()
         }
     }
 
     public func markAsRead(notificationWithID notificationID: String) {
         processNotificationWithID(notificationID) { (notification) in
-            notification.state = .read
-        }
-    }
-
-    // MARK: Mark as excluded
-
-    public func markAsExcluded(_ notification: RemoteNotification) {
-        let moc = backgroundContext
-        moc.perform {
-            notification.state = .excluded
-            self.save()
-        }
-    }
-
-    // MARK: Mark as seen
-
-    public func markAsSeen(notificationWithID notificationID: String) {
-        processNotificationWithID(notificationID) { (notification) in
-            notification.state = .seen
+            notification.isRead = true
         }
     }
 

--- a/WMF Framework/Remote Notifications/RemoteNotificationsAPIController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsAPIController.swift
@@ -20,14 +20,86 @@ class RemoteNotificationsAPIController: Fetcher {
     }
 
     struct NotificationsResult: Decodable {
+        
+        struct Query: Decodable {
+            
+            struct Notifications: Decodable {
+                let list: [Notification]
+            }
+            
+            let notifications: Notifications?
+        }
+        
+        let error: ResultError?
+        let query: Query?
+        
         struct Notification: Decodable, Hashable {
+            
+            struct Timestamp: Decodable, Hashable {
+                let utciso8601: String
+                let utcunix: String
+                
+                enum CodingKeys: String, CodingKey {
+                    case utciso8601
+                    case utcunix
+                }
+                
+                init(from decoder: Decoder) throws {
+                    let values = try decoder.container(keyedBy: CodingKeys.self)
+                    utciso8601 = try values.decode(String.self, forKey: .utciso8601)
+                    do {
+                        utcunix = String(try values.decode(Int.self, forKey: .utcunix))
+                    } catch {
+                        utcunix = try values.decode(String.self, forKey: .utcunix)
+                    }
+                }
+            }
+            struct Agent: Decodable, Hashable {
+                let id: String?
+                let name: String?
+                
+                enum CodingKeys: String, CodingKey {
+                    case id
+                    case name
+                }
+                
+                init(from decoder: Decoder) throws {
+                    let values = try decoder.container(keyedBy: CodingKeys.self)
+                    name = try values.decode(String.self, forKey: .name)
+                    do {
+                        id = String(try values.decode(Int.self, forKey: .id))
+                    } catch {
+                        id = try values.decode(String.self, forKey: .id)
+                    }
+                }
+            }
+            struct Title: Decodable, Hashable {
+                let full: String?
+                let namespace: String?
+                let namespaceKey: Int?
+                let text: String?
+                
+                enum CodingKeys: String, CodingKey {
+                    case full
+                    case namespace
+                    case namespaceKey = "namespace-key"
+                    case text
+                }
+            }
+            
+            struct Message: Decodable, Hashable {
+                let header: String?
+                let body: String?
+                let links: RemoteNotificationLinks?
+            }
+            
             let wiki: String
             let id: String
             let type: String
             let category: String
             let section: String
             let timestamp: Timestamp
-            let affectedPageID: AffectedPageID?
+            let title: Title?
             let agent: Agent?
             let readString: String?
             let message: Message?
@@ -43,7 +115,7 @@ class RemoteNotificationsAPIController: Fetcher {
                 case category
                 case section
                 case timestamp
-                case affectedPageID = "title"
+                case title = "title"
                 case agent
                 case readString = "read"
                 case message = "*"
@@ -61,32 +133,12 @@ class RemoteNotificationsAPIController: Fetcher {
                 category = try values.decode(String.self, forKey: .category)
                 section = try values.decode(String.self, forKey: .section)
                 timestamp = try values.decode(Timestamp.self, forKey: .timestamp)
-                affectedPageID = try? values.decode(AffectedPageID.self, forKey: .affectedPageID)
+                title = try? values.decode(Title.self, forKey: .title)
                 agent = try? values.decode(Agent.self, forKey: .agent)
                 readString = try? values.decode(String.self, forKey: .readString)
                 message = try? values.decode(Message.self, forKey: .message)
             }
         }
-        struct Notifications: Decodable {
-            let list: [Notification]
-        }
-        struct Query: Decodable {
-            let notifications: Notifications?
-        }
-        struct Message: Decodable, Hashable {
-            let header: String?
-        }
-        struct Timestamp: Decodable, Hashable {
-            let utciso8601: String
-        }
-        struct Agent: Decodable, Hashable {
-            let name: String?
-        }
-        struct AffectedPageID: Decodable, Hashable {
-            let full: String?
-        }
-        let error: ResultError?
-        let query: Query?
     }
 
     // MARK: Decodable: MarkReadResult

--- a/WMF Framework/Remote Notifications/RemoteNotificationsAPIController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsAPIController.swift
@@ -29,6 +29,7 @@ class RemoteNotificationsAPIController: Fetcher {
             let timestamp: Timestamp
             let affectedPageID: AffectedPageID?
             let agent: Agent?
+            let readString: String?
             let message: Message?
             
             var key: String {
@@ -44,6 +45,7 @@ class RemoteNotificationsAPIController: Fetcher {
                 case timestamp
                 case affectedPageID = "title"
                 case agent
+                case readString = "read"
                 case message = "*"
             }
 
@@ -60,8 +62,9 @@ class RemoteNotificationsAPIController: Fetcher {
                 section = try values.decode(String.self, forKey: .section)
                 timestamp = try values.decode(Timestamp.self, forKey: .timestamp)
                 affectedPageID = try? values.decode(AffectedPageID.self, forKey: .affectedPageID)
-                agent = try values.decode(Agent.self, forKey: .agent)
-                message = try values.decode(Message.self, forKey: .message)
+                agent = try? values.decode(Agent.self, forKey: .agent)
+                readString = try? values.decode(String.self, forKey: .readString)
+                message = try? values.decode(Message.self, forKey: .message)
             }
         }
         struct Notifications: Decodable {

--- a/WMF Framework/Remote Notifications/RemoteNotificationsAPIController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsAPIController.swift
@@ -21,40 +21,47 @@ class RemoteNotificationsAPIController: Fetcher {
 
     struct NotificationsResult: Decodable {
         struct Notification: Decodable, Hashable {
-            let wiki: String?
-            let type: String?
-            let category: String?
-            let id: String?
-            let message: Message?
-            let timestamp: Timestamp?
-            let agent: Agent?
+            let wiki: String
+            let id: String
+            let type: String
+            let category: String
+            let section: String
+            let timestamp: Timestamp
             let affectedPageID: AffectedPageID?
+            let agent: Agent?
+            let message: Message?
+            
+            var key: String {
+                return "\(wiki)-\(id)"
+            }
 
             enum CodingKeys: String, CodingKey {
                 case wiki
+                case id
                 case type
                 case category
-                case id
-                case message = "*"
+                case section
                 case timestamp
-                case agent
                 case affectedPageID = "title"
+                case agent
+                case message = "*"
             }
 
             init(from decoder: Decoder) throws {
                 let values = try decoder.container(keyedBy: CodingKeys.self)
                 wiki = try values.decode(String.self, forKey: .wiki)
-                type = try values.decode(String.self, forKey: .type)
-                category = try values.decode(String.self, forKey: .category)
                 do {
                     id = String(try values.decode(Int.self, forKey: .id))
                 } catch {
-                    id = try? values.decode(String.self, forKey: .id)
+                    id = try values.decode(String.self, forKey: .id)
                 }
-                message = try values.decode(Message.self, forKey: .message)
+                type = try values.decode(String.self, forKey: .type)
+                category = try values.decode(String.self, forKey: .category)
+                section = try values.decode(String.self, forKey: .section)
                 timestamp = try values.decode(Timestamp.self, forKey: .timestamp)
-                agent = try values.decode(Agent.self, forKey: .agent)
                 affectedPageID = try? values.decode(AffectedPageID.self, forKey: .affectedPageID)
+                agent = try values.decode(Agent.self, forKey: .agent)
+                message = try values.decode(Message.self, forKey: .message)
             }
         }
         struct Notifications: Decodable {
@@ -67,7 +74,7 @@ class RemoteNotificationsAPIController: Fetcher {
             let header: String?
         }
         struct Timestamp: Decodable, Hashable {
-            let utciso8601: String?
+            let utciso8601: String
         }
         struct Agent: Decodable, Hashable {
             let name: String?

--- a/WMF Framework/WMFSecureUnarchiveFromDataTransformer.swift
+++ b/WMF Framework/WMFSecureUnarchiveFromDataTransformer.swift
@@ -4,6 +4,6 @@ import Foundation
 @objc(WMFSecureUnarchiveFromDataTransformer)
 class SecureUnarchiveFromDataTransformer: NSSecureUnarchiveFromDataTransformer {
     override class var allowedTopLevelClasses: [AnyClass] {
-        return  super.allowedTopLevelClasses + [WMFMTLModel.self, NSSet.self, CLLocation.self, CLPlacemark.self]
+        return  super.allowedTopLevelClasses + [WMFMTLModel.self, NSSet.self, CLLocation.self, CLPlacemark.self, RemoteNotificationLinks.self, RemoteNotificationLink.self]
     }
 }

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -257,7 +257,8 @@
 		670AF19126BDE6E8005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
 		670AF19226BDE6E9005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
 		670AF1CF26CD74A6005F76D0 /* EchoSubscriptionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670AF19A26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift */; };
-		670AF1C226C7034B005F76D0 /* RemoteNotification+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670AF1C126C7034B005F76D0 /* RemoteNotification+CoreDataProperties.swift */; };
+		670AF1CC26CA13DC005F76D0 /* RemoteNotification+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670AF1CB26CA13DC005F76D0 /* RemoteNotification+CoreDataProperties.swift */; };
+		670AF1CE26CA188B005F76D0 /* RemoteNotificationLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670AF1CD26CA188B005F76D0 /* RemoteNotificationLinks.swift */; };
 		670F765F22B0C10600D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
 		670F766022B0C48E00D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
 		670F766122B0C48F00D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
@@ -3647,7 +3648,8 @@
 		6707C037237F0A6E0017E7B6 /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
 		670AF19A26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EchoSubscriptionFetcher.swift; sourceTree = "<group>"; };
 		670AF1B826C573EB005F76D0 /* RemoteNotifications 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "RemoteNotifications 3.xcdatamodel"; sourceTree = "<group>"; };
-		670AF1C126C7034B005F76D0 /* RemoteNotification+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteNotification+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		670AF1CB26CA13DC005F76D0 /* RemoteNotification+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteNotification+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		670AF1CD26CA188B005F76D0 /* RemoteNotificationLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationLinks.swift; sourceTree = "<group>"; };
 		670F765E22B0C10600D87545 /* FakeProgressLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeProgressLoading.swift; sourceTree = "<group>"; };
 		67146031243B885E008CE885 /* SurveyAnnouncementsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyAnnouncementsController.swift; sourceTree = "<group>"; usesTabs = 0; };
 		67146033243B8B4F008CE885 /* AnnouncementType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementType.swift; sourceTree = "<group>"; };
@@ -6838,7 +6840,8 @@
 			children = (
 				7A9133A822B162E7002AEBCF /* RemoteNotifications.xcdatamodeld */,
 				7A96C4B72155413E00E8E0C1 /* RemoteNotification+CoreDataClass.swift */,
-				670AF1C126C7034B005F76D0 /* RemoteNotification+CoreDataProperties.swift */,
+				670AF1CD26CA188B005F76D0 /* RemoteNotificationLinks.swift */,
+				670AF1CB26CA13DC005F76D0 /* RemoteNotification+CoreDataProperties.swift */,
 				7A0312F62153C4990095C953 /* RemoteNotificationsModelController.swift */,
 			);
 			path = Model;
@@ -11068,7 +11071,7 @@
 				83D5EC871F755E1F003DE6F2 /* SwipeableCell.swift in Sources */,
 				7A96C4B92155413E00E8E0C1 /* RemoteNotification+CoreDataClass.swift in Sources */,
 				B0B423481EF1FEE000D3DC4C /* WMFFeedOnThisDayEvent.m in Sources */,
-				670AF1C226C7034B005F76D0 /* RemoteNotification+CoreDataProperties.swift in Sources */,
+				670AF1CC26CA13DC005F76D0 /* RemoteNotification+CoreDataProperties.swift in Sources */,
 				83EE477020D01A9A00A21F34 /* ExploreCardCollectionViewCell.swift in Sources */,
 				D84C36411F3245CD00895FA1 /* ArticleCollectionViewCell+WMFFeedContentDisplaying.swift in Sources */,
 				D84448591DDCE49D00425630 /* WMFContentGroup+CoreDataClass.m in Sources */,
@@ -11167,6 +11170,7 @@
 				D844D97D1D6CB29B0042D692 /* MWKDataObject.m in Sources */,
 				678C7C3623BE7779001AC4D5 /* FileManager+CacheExtensions.swift in Sources */,
 				0E728D471DAEEE880074EB4B /* CLLocation+WMFComparison.m in Sources */,
+				670AF1CE26CA188B005F76D0 /* RemoteNotificationLinks.swift in Sources */,
 				678C7C3423BE75F9001AC4D5 /* CacheFileWriterHelper.swift in Sources */,
 				8338AF8E21F7B33E000C4055 /* WMFLegacyFetcher.m in Sources */,
 				6771299D24FF8CC000E89CA5 /* ArticleAsLivingDocViewModels.swift in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -257,7 +257,7 @@
 		670AF19126BDE6E8005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
 		670AF19226BDE6E9005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
 		670AF1CF26CD74A6005F76D0 /* EchoSubscriptionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670AF19A26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift */; };
-		670AF1BC26C58E27005F76D0 /* RemoteNotification+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670AF1BB26C58E27005F76D0 /* RemoteNotification+CoreDataProperties.swift */; };
+		670AF1C226C7034B005F76D0 /* RemoteNotification+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670AF1C126C7034B005F76D0 /* RemoteNotification+CoreDataProperties.swift */; };
 		670F765F22B0C10600D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
 		670F766022B0C48E00D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
 		670F766122B0C48F00D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
@@ -3647,7 +3647,7 @@
 		6707C037237F0A6E0017E7B6 /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
 		670AF19A26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EchoSubscriptionFetcher.swift; sourceTree = "<group>"; };
 		670AF1B826C573EB005F76D0 /* RemoteNotifications 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "RemoteNotifications 3.xcdatamodel"; sourceTree = "<group>"; };
-		670AF1BB26C58E27005F76D0 /* RemoteNotification+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteNotification+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		670AF1C126C7034B005F76D0 /* RemoteNotification+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteNotification+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		670F765E22B0C10600D87545 /* FakeProgressLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeProgressLoading.swift; sourceTree = "<group>"; };
 		67146031243B885E008CE885 /* SurveyAnnouncementsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyAnnouncementsController.swift; sourceTree = "<group>"; usesTabs = 0; };
 		67146033243B8B4F008CE885 /* AnnouncementType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementType.swift; sourceTree = "<group>"; };
@@ -6838,7 +6838,7 @@
 			children = (
 				7A9133A822B162E7002AEBCF /* RemoteNotifications.xcdatamodeld */,
 				7A96C4B72155413E00E8E0C1 /* RemoteNotification+CoreDataClass.swift */,
-				670AF1BB26C58E27005F76D0 /* RemoteNotification+CoreDataProperties.swift */,
+				670AF1C126C7034B005F76D0 /* RemoteNotification+CoreDataProperties.swift */,
 				7A0312F62153C4990095C953 /* RemoteNotificationsModelController.swift */,
 			);
 			path = Model;
@@ -11068,7 +11068,7 @@
 				83D5EC871F755E1F003DE6F2 /* SwipeableCell.swift in Sources */,
 				7A96C4B92155413E00E8E0C1 /* RemoteNotification+CoreDataClass.swift in Sources */,
 				B0B423481EF1FEE000D3DC4C /* WMFFeedOnThisDayEvent.m in Sources */,
-				670AF1BC26C58E27005F76D0 /* RemoteNotification+CoreDataProperties.swift in Sources */,
+				670AF1C226C7034B005F76D0 /* RemoteNotification+CoreDataProperties.swift in Sources */,
 				83EE477020D01A9A00A21F34 /* ExploreCardCollectionViewCell.swift in Sources */,
 				D84C36411F3245CD00895FA1 /* ArticleCollectionViewCell+WMFFeedContentDisplaying.swift in Sources */,
 				D84448591DDCE49D00425630 /* WMFContentGroup+CoreDataClass.m in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 		670AF19126BDE6E8005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
 		670AF19226BDE6E9005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
 		670AF1CF26CD74A6005F76D0 /* EchoSubscriptionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670AF19A26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift */; };
+		670AF1BC26C58E27005F76D0 /* RemoteNotification+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670AF1BB26C58E27005F76D0 /* RemoteNotification+CoreDataProperties.swift */; };
 		670F765F22B0C10600D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
 		670F766022B0C48E00D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
 		670F766122B0C48F00D87545 /* FakeProgressLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670F765E22B0C10600D87545 /* FakeProgressLoading.swift */; };
@@ -1005,7 +1006,6 @@
 		7A9524DE22669A8B00C55CDC /* InsertMediaSettingsButtonView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7A9524D622669A8B00C55CDC /* InsertMediaSettingsButtonView.xib */; };
 		7A9524DF22669A8B00C55CDC /* InsertMediaSettingsButtonView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7A9524D622669A8B00C55CDC /* InsertMediaSettingsButtonView.xib */; };
 		7A96C4B92155413E00E8E0C1 /* RemoteNotification+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A96C4B72155413E00E8E0C1 /* RemoteNotification+CoreDataClass.swift */; };
-		7A96C4BA2155413E00E8E0C1 /* RemoteNotification+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A96C4B82155413E00E8E0C1 /* RemoteNotification+CoreDataProperties.swift */; };
 		7A96EBA922CFDA4B0037C8A8 /* PageNamespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4170D8229EFC2A00251582 /* PageNamespace.swift */; };
 		7A998AC11FE20F3B007FE06E /* CollectionViewEditControllerNavigationDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A998AC01FE20F3B007FE06E /* CollectionViewEditControllerNavigationDelegate+Extensions.swift */; };
 		7A998AC21FE20F3B007FE06E /* CollectionViewEditControllerNavigationDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A998AC01FE20F3B007FE06E /* CollectionViewEditControllerNavigationDelegate+Extensions.swift */; };
@@ -3646,6 +3646,8 @@
 		6707C031237DBCEA0017E7B6 /* DiffRevisionTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffRevisionTransition.swift; sourceTree = "<group>"; };
 		6707C037237F0A6E0017E7B6 /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
 		670AF19A26C1CA38005F76D0 /* EchoSubscriptionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EchoSubscriptionFetcher.swift; sourceTree = "<group>"; };
+		670AF1B826C573EB005F76D0 /* RemoteNotifications 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "RemoteNotifications 3.xcdatamodel"; sourceTree = "<group>"; };
+		670AF1BB26C58E27005F76D0 /* RemoteNotification+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteNotification+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		670F765E22B0C10600D87545 /* FakeProgressLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeProgressLoading.swift; sourceTree = "<group>"; };
 		67146031243B885E008CE885 /* SurveyAnnouncementsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyAnnouncementsController.swift; sourceTree = "<group>"; usesTabs = 0; };
 		67146033243B8B4F008CE885 /* AnnouncementType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementType.swift; sourceTree = "<group>"; };
@@ -3890,7 +3892,6 @@
 		7A9524D522669A8B00C55CDC /* InsertMediaSettingsButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsertMediaSettingsButtonView.swift; sourceTree = "<group>"; };
 		7A9524D622669A8B00C55CDC /* InsertMediaSettingsButtonView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InsertMediaSettingsButtonView.xib; sourceTree = "<group>"; };
 		7A96C4B72155413E00E8E0C1 /* RemoteNotification+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteNotification+CoreDataClass.swift"; sourceTree = "<group>"; };
-		7A96C4B82155413E00E8E0C1 /* RemoteNotification+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteNotification+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		7A998AC01FE20F3B007FE06E /* CollectionViewEditControllerNavigationDelegate+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionViewEditControllerNavigationDelegate+Extensions.swift"; sourceTree = "<group>"; };
 		7A9A611721124CF500403154 /* CreateNewReadingListButtonView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CreateNewReadingListButtonView.xib; sourceTree = "<group>"; };
 		7A9A611D21124D0E00403154 /* CreateNewReadingListButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewReadingListButtonView.swift; sourceTree = "<group>"; };
@@ -6837,7 +6838,7 @@
 			children = (
 				7A9133A822B162E7002AEBCF /* RemoteNotifications.xcdatamodeld */,
 				7A96C4B72155413E00E8E0C1 /* RemoteNotification+CoreDataClass.swift */,
-				7A96C4B82155413E00E8E0C1 /* RemoteNotification+CoreDataProperties.swift */,
+				670AF1BB26C58E27005F76D0 /* RemoteNotification+CoreDataProperties.swift */,
 				7A0312F62153C4990095C953 /* RemoteNotificationsModelController.swift */,
 			);
 			path = Model;
@@ -11067,6 +11068,7 @@
 				83D5EC871F755E1F003DE6F2 /* SwipeableCell.swift in Sources */,
 				7A96C4B92155413E00E8E0C1 /* RemoteNotification+CoreDataClass.swift in Sources */,
 				B0B423481EF1FEE000D3DC4C /* WMFFeedOnThisDayEvent.m in Sources */,
+				670AF1BC26C58E27005F76D0 /* RemoteNotification+CoreDataProperties.swift in Sources */,
 				83EE477020D01A9A00A21F34 /* ExploreCardCollectionViewCell.swift in Sources */,
 				D84C36411F3245CD00895FA1 /* ArticleCollectionViewCell+WMFFeedContentDisplaying.swift in Sources */,
 				D84448591DDCE49D00425630 /* WMFContentGroup+CoreDataClass.m in Sources */,
@@ -11180,7 +11182,6 @@
 				D84C361D1F32404700895FA1 /* SideScrollingCollectionViewCell.swift in Sources */,
 				0042809225E6E395004945B3 /* MTLReflection.m in Sources */,
 				67D6C0212405B3D2005709B1 /* CacheGroup+CoreDataProperties.swift in Sources */,
-				7A96C4BA2155413E00E8E0C1 /* RemoteNotification+CoreDataProperties.swift in Sources */,
 				535F16D625CE11A300875AAD /* MWKDataStore+LanguageVariantMigration.swift in Sources */,
 				83ACAAA224E6E38A003B3035 /* Wikipedia.swift in Sources */,
 				6779D45323F6EC2D002840CA /* CacheFetching.swift in Sources */,
@@ -19308,10 +19309,11 @@
 		7A9133A822B162E7002AEBCF /* RemoteNotifications.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				670AF1B826C573EB005F76D0 /* RemoteNotifications 3.xcdatamodel */,
 				83703A7724DC44C600EE98EA /* RemoteNotifications 2.xcdatamodel */,
 				7A9133A922B162E8002AEBCF /* RemoteNotifications.xcdatamodel */,
 			);
-			currentVersion = 83703A7724DC44C600EE98EA /* RemoteNotifications 2.xcdatamodel */;
+			currentVersion = 670AF1B826C573EB005F76D0 /* RemoteNotifications 3.xcdatamodel */;
 			path = RemoteNotifications.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T287298

### Notes
Building off of work in https://github.com/wikimedia/wikipedia-ios/pull/4018, this PR captures as much data as I think we will need from the notifications objects returned from the API. This also updates fields that do not need to be optional. A couple of callouts worth noting:

1. Previously we ignored the server-side `read` flag and maintained a local read / seen / excluded state. Now we are simplifying into a single `isRead` flag that is powered off of the API value. I think it's good to keep this simple for now, and add back in a local read / seen / excluded flag later if we find we need it.
2. This also stores the links dictionary from the notifications object as a transformable field in the database. To me this seemed simpler than maintaining a complicated separate set of links managed objects with primary and secondary relationships. It decodes into a `RemoteNotificationsLinks` object.

After review, please wait for #4018 to be reviewed and merged. Then update this with `feature/notifications` and merge.

It would probably help to add the code changes mentioned in https://github.com/wikimedia/wikipedia-ios/pull/4018 to allow for more frequent polling and looser API parameters.

### Test Steps
1. Launch on freshly installed app. Wait for notifications polling to occur.
2. Inspect database, confirm the records added looks right.
3. Terminate app. Add `let messageLinks = readNotifications.first?.messageLinks` right before the `markAsRead` call to the `apiController` in `RemoteNotificationsMarkAsReadOperation` [here](https://github.com/wikimedia/wikipedia-ios/blob/T287298-2/WMF%20Framework/Remote%20Notifications/Operations/RemoteNotificationsMarkAsReadOperation.swift#L9). Also add a breakpoint here. Launch app. When breakpoint is hit, confirm `messageLinks` value looks right.