### PR TITLE
Enable Search Swipe to Save or Share

### DIFF
--- a/Wikipedia/Code/AboutViewController.plist
+++ b/Wikipedia/Code/AboutViewController.plist
@@ -47,6 +47,7 @@
 		<string>Brion Vibber</string>
 		<string>Carolyn Li-Madeo</string>
 		<string>Chelsy Xie</string>
+		<string>Cole Roberts</string>
 		<string>Corey Floyd</string>
 		<string>cromulentlabs</string>
 		<string>Daisy Chen</string>

--- a/Wikipedia/Code/SearchResultsViewController.swift
+++ b/Wikipedia/Code/SearchResultsViewController.swift
@@ -102,11 +102,11 @@ class SearchResultsViewController: ArticleCollectionViewController {
         }
         cell.configureForCompactList(at: indexPath.item)
         cell.setTitleHTML(result.displayTitleHTML, boldedString: resultsInfo?.searchTerm)
-       
         cell.articleSemanticContentAttribute = MWKLanguageLinkController.semanticContentAttribute(forContentLanguageCode: contentLanguageCode)
         cell.titleLabel.accessibilityLanguage = languageCode
         cell.descriptionLabel.text = descriptionForSearchResult(result)
         cell.descriptionLabel.accessibilityLanguage = languageCode
+        cell.actions = availableActions(at: indexPath)
         if layoutOnly {
             cell.isImageViewHidden = result.thumbnailURL != nil
         } else {

--- a/Wikipedia/Code/SearchResultsViewController.swift
+++ b/Wikipedia/Code/SearchResultsViewController.swift
@@ -106,7 +106,7 @@ class SearchResultsViewController: ArticleCollectionViewController {
         cell.titleLabel.accessibilityLanguage = languageCode
         cell.descriptionLabel.text = descriptionForSearchResult(result)
         cell.descriptionLabel.accessibilityLanguage = languageCode
-        cell.actions = availableActions(at: indexPath)
+        editController.configureSwipeableCell(cell, forItemAt: indexPath, layoutOnly: layoutOnly)
         if layoutOnly {
             cell.isImageViewHidden = result.thumbnailURL != nil
         } else {

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -530,11 +530,20 @@ class SearchViewController: ArticleCollectionViewController, UISearchBarDelegate
     }
     
     override func articleURL(at indexPath: IndexPath) -> URL? {
-        return nil
+        // This guard checks prevents an out of bounds exception, this is due to
+        // `resultsViewController.results` property being empty until performing a search.
+        // The indexPath.row must also be greater than `countOfRecentSearches`, this
+        // ensures that recent search cells remains unchanged and only the delete option
+        // is available.
+        guard
+            !resultsViewController.results.isEmpty,
+            indexPath.row > countOfRecentSearches
+            else { return nil }
+        return resultsViewController.results[indexPath.row].articleURL(forSiteURL: siteURL)
     }
     
     override func article(at indexPath: IndexPath) -> WMFArticle? {
-        return nil
+        return resultsViewController.article(at: indexPath)
     }
     
     override func canDelete(at indexPath: IndexPath) -> Bool {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T208892

### Notes
* Enables Save / Share actions when swiping a search result

### Test Steps
1. Perform a search
2. Swipe left on the cell to reveal the two new Save and Share actions.

### Screenshots/Videos

https://user-images.githubusercontent.com/53830238/133188945-d953afcb-87b8-4a1e-a148-e0e6f6bb6012.mp4


https://user-images.githubusercontent.com/53830238/133188956-98d14f39-5af7-484e-b95e-41cfd7c8108d.mp4
