### PR TITLE
Fix link in article has wrong prefix "app://"

### DIFF
--- a/Wikipedia/Code/AboutViewController.plist
+++ b/Wikipedia/Code/AboutViewController.plist
@@ -73,6 +73,7 @@
 		<string>Kaity Hammerstein</string>
 		<string>Kelly Roach</string>
 		<string>Kenan Wang</string>
+		<string>Koji Nakashima</string>
 		<string>Kotaro Fujita</string>
 		<string>Kunal Mehta</string>
 		<string>Logan Keller</string>

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -35,7 +35,6 @@ class ArticleViewController: ViewController, HintPresenting {
     /// Called when initial JS setup is complete
     @objc public var initialSetupCompletion: (() -> Void)?
     
-    internal let schemeHandler: SchemeHandler
     internal let dataStore: MWKDataStore
     
     private let cacheController: ArticleCacheController
@@ -100,7 +99,6 @@ class ArticleViewController: ViewController, HintPresenting {
         self.article = article
         
         self.dataStore = dataStore
-        self.schemeHandler = schemeHandler ?? SchemeHandler(scheme: "app", session: dataStore.session)
         self.cacheController = cacheController
         
         super.init(theme: theme)
@@ -123,7 +121,6 @@ class ArticleViewController: ViewController, HintPresenting {
     lazy var webViewConfiguration: WKWebViewConfiguration = {
         let configuration = WKWebViewConfiguration()
         configuration.processPool = ArticleViewController.webProcessPool
-        configuration.setURLSchemeHandler(schemeHandler, forURLScheme: schemeHandler.scheme)
         return configuration
     }()
     
@@ -455,7 +452,7 @@ class ArticleViewController: ViewController, HintPresenting {
             callLoadCompletionIfNecessary()
         }
         
-        guard let request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, revisionID: revisionID, scheme: schemeHandler.scheme, cachePolicy: cachePolicy, isPageView: true) else {
+        guard let request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, revisionID: revisionID, scheme: nil, cachePolicy: cachePolicy, isPageView: true) else {
             showGenericError()
             state = .error
             return


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T291298

### Notes
* Currently, link in article has a custom url scheme `app://`, so when it's copied & pasted into other App, the link doesn't work. So I changed `app://` to `https://` to fix this

### Test Steps
1. Go to any article
2. Copy a sentence with a link in it
3. Open up Apple's Notes app
4. Paste copied text

