### PR TITLE
Add gesture recognizer for Notifications Center cell swipe actions

### DIFF
--- a/Wikipedia/Code/NotificationsCenterViewController.swift
+++ b/Wikipedia/Code/NotificationsCenterViewController.swift
@@ -38,17 +38,17 @@ final class NotificationsCenterViewController: ViewController {
 
         notificationsView.apply(theme: theme)
 
-		title = CommonStrings.notificationsCenterTitle
-		setupBarButtons()
+        title = CommonStrings.notificationsCenterTitle
+        setupBarButtons()
 
-		notificationsView.collectionView.delegate = self
-		notificationsView.collectionView.dataSource = self
+        notificationsView.collectionView.delegate = self
+        notificationsView.collectionView.dataSource = self
 
         notificationsView.collectionView.addGestureRecognizer(cellPanGestureRecognizer)
         cellPanGestureRecognizer.addTarget(self, action: #selector(userDidPanCell(_:)))
         cellPanGestureRecognizer.delegate = self
 
-		viewModel.fetchNotifications(collectionView: notificationsView.collectionView)
+        viewModel.fetchNotifications(collectionView: notificationsView.collectionView)
 	}
     
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T288687 (in part)

### Notes
Adds pan gesture recognizer to Notifications Center collection view in preparation for cells with swipe actions and proactively unblocks action sheet/notification destination work. 

### Test Steps
1. Uncomment the code in `userDidSwipeCell(...)`.
2. Test scrolling and swiping the Notifications Center collection view. A deliberate horizontal swipe on a cell should reveal the action sheet for that cell. Normal vertical scrolling should scroll the collection view as expected. This behavior mimics the Saved view controller.