### PR TITLE
Fix iPad layout bug fix on search results

### DIFF
--- a/Wikipedia/Code/SearchResultsViewController.swift
+++ b/Wikipedia/Code/SearchResultsViewController.swift
@@ -93,6 +93,10 @@ class SearchResultsViewController: ArticleCollectionViewController {
     }
     
     override func configure(cell: ArticleRightAlignedImageCollectionViewCell, forItemAt indexPath: IndexPath, layoutOnly: Bool) {
+        configure(cell: cell, forItemAt: indexPath, layoutOnly: layoutOnly, configureForCompact: true)
+    }
+    
+    private func configure(cell: ArticleRightAlignedImageCollectionViewCell, forItemAt indexPath: IndexPath, layoutOnly: Bool, configureForCompact: Bool) {
         guard indexPath.item < results.count else {
             return
         }
@@ -101,7 +105,11 @@ class SearchResultsViewController: ArticleCollectionViewController {
               let contentLanguageCode = searchSiteURL?.wmf_contentLanguageCode else {
             return
         }
-        cell.configureForCompactList(at: indexPath.item)
+        
+        if configureForCompact {
+            cell.configureForCompactList(at: indexPath.item)
+        }
+        
         cell.setTitleHTML(result.displayTitleHTML, boldedString: resultsInfo?.searchTerm)
         cell.articleSemanticContentAttribute = MWKLanguageLinkController.semanticContentAttribute(forContentLanguageCode: contentLanguageCode)
         cell.titleLabel.accessibilityLanguage = languageCode
@@ -112,7 +120,7 @@ class SearchResultsViewController: ArticleCollectionViewController {
             cell.isImageViewHidden = result.thumbnailURL != nil
         } else {
             cell.imageURL = result.thumbnailURL
-        } 
+        }
         cell.apply(theme: theme)
     }
     
@@ -137,7 +145,7 @@ class SearchResultsViewController: ArticleCollectionViewController {
                 continue
             }
 
-            configure(cell: cell, forItemAt: indexPath, layoutOnly: false)
+            configure(cell: cell, forItemAt: indexPath, layoutOnly: false, configureForCompact: false)
         }
     }
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T208892#7550319

### Notes
This fixes a regression from work done in https://github.com/wikimedia/wikipedia-ios/pull/4036. The `cell.configureForCompactList(at: indexPath.item)` call caused the layout margins to reset to the compact measurements when the configuration came through our new `updateArticleCell(_ notification: NSNotification)` method.

I'm not sure what benefit `configureForCompactList` gives us at all, but to keep the risk low I adjusted the methods so that only when configuring the cell through the `updateArticleCell` method, it no longer tries to reset the layout margins.

### Test Steps
1. Run on iPad
2. Search for an article
3. On the search results list, swipe right on a cell and select the save icon.
4. When cell drawer closes, confirm cell layout margins are retained (before margins would shrink down to compact sizes).
5. Perform same steps on iPhone. Confirm cell layout margins are retained.
