### PR TITLE
Do not allow fundraising prompt on donation thank you article

### DIFF
--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -31,6 +31,7 @@ extension ArticleViewController {
         else {
             return
         }
+        
         let dismiss = {
             // re-fetch since time has elapsed
             let contentGroup = self.dataStore.viewContext.contentGroup(for: contentGroupURL)
@@ -42,6 +43,12 @@ extension ArticleViewController {
                 DDLogError("Error saving after marking article announcement as dismissed: \(saveError)")
             }
         }
+        
+        guard !articleURL.isThankYouDonationURL else {
+            dismiss()
+            return
+        }
+        
         let context = FeedFunnelContext(contentGroup)
         FeedFunnel.shared.logFeedImpression(for: context)
         wmf_showAnnouncementPanel(announcement: announcement, primaryButtonTapHandler: { (sender) in
@@ -55,5 +62,11 @@ extension ArticleViewController {
         }, traceableDismissHandler: { _ in
             dismiss()
         }, theme: theme)
+    }
+}
+
+private extension URL {
+    var isThankYouDonationURL: Bool {
+        return self.host == "thankyou.wikipedia.org"
     }
 }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T259312#7547073

### Notes
Users that do not enter the donation flow through the app can still get kicked out to the app on the donation thank you screen. This deep links into the thank you article page, which assumes the user has never been through the donation flow (because they didn't go through the app) and displays the fundraising prompt _over_ the thank you screen.

Here we are checking the if the article host == `thankyou.wikipedia.org`, and if so bailing out of the fundraising prompt display logic. Bailing will also run through the same logic as if they originally dismissed the prompt, preventing them from ever getting the prompt again.

### Test Steps
1. Fresh install. Launch app.
2. On Explore, background and terminate the app.
3. Launch app again so that announcements are fetched (which is only on 2nd+ launch).
4. Go to Safari and type in https://thankyou.wikipedia.org/wiki/Thank_You/en?country=US in browser.
5. If it doesn't automatically redirect you to the app, select Open in App option at the top of Safari.
6. You should land on the thank you screen without the fundraising prompt. Exit the article and visit a different article. You should still not see the fundraising prompt. Terminate and relaunch and go to another article. You should still not see the fundraising prompt.