### PR TITLE
Add Ukrainian  to 'on this day' lang whitelist.

### DIFF
--- a/WMF Framework/WMFOnThisDayEventsFetcher.m
+++ b/WMF Framework/WMFOnThisDayEventsFetcher.m
@@ -9,7 +9,7 @@
     static dispatch_once_t onceToken;
     static NSSet<NSString *> *supportedLanguages;
     dispatch_once(&onceToken, ^{
-        supportedLanguages = [NSSet setWithObjects:@"en", @"de", @"sv", @"fr", @"es", @"ru", @"pt", @"ar", nil];
+        supportedLanguages = [NSSet setWithObjects:@"en", @"de", @"sv", @"fr", @"es", @"ru", @"pt", @"ar", @"uk", nil];
     });
     return supportedLanguages;
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T285846

### Notes
* This PR includes whitelisting Ukrainian language for onThisDay features. Previously, onthisday support was added for ukrainian wikifeeds api (https://phabricator.wikimedia.org/T279243).

### Test Steps
Test that onthisday features (widget, primarily) are working properly with Ukrainian device language.

