### PR TITLE
Add translation test for nonbreaking space

### DIFF
--- a/WikipediaUnitTests/Code/TWNStringsTests.m
+++ b/WikipediaUnitTests/Code/TWNStringsTests.m
@@ -169,6 +169,22 @@
     }
 }
 
+- (void)assertLprojFiles:(NSArray *)lprojFiles withTranslationStringsInDirectory:(NSString *)directory doesNotContain:(NSString *)banned {
+    XCTAssertNotNil(banned);
+    NSString * bannedUpper = [banned uppercaseString];
+    for (NSString *lprojFileName in lprojFiles) {
+        if (![TWNStringsTests localeForLprojFilenameIsAvailableOniOS:lprojFileName]) {
+            continue;
+        }
+        NSDictionary *stringsDict = [self getTranslationStringsDictFromLprogAtPath:[directory stringByAppendingPathComponent:lprojFileName]];
+        for (NSString *key in stringsDict) {
+            NSString *localizedString = stringsDict[key];
+            BOOL doesContainBannedString = [[localizedString uppercaseString] containsString:bannedUpper];
+            XCTAssertFalse(doesContainBannedString, @"Invalid substring %@ found in: %@ for key: %@ in locale: %@", banned, localizedString, key, lprojFileName);
+        }
+    }
+}
+
 - (void)testiOSTranslationStringForTWNSubstitutionShortcuts {
     [self assertLprojFiles:TWNStringsTests.iOSLprojFiles withTranslationStringsInDirectory:TWNStringsTests.bundleRoot haveNoMatchesWithRegex:TWNStringsTests.twnTokenRegex];
 }
@@ -196,6 +212,10 @@
 
 - (void)testIncomingTranslationStringForHTML {
     [self assertLprojFiles:TWNStringsTests.twnLprojFiles withTranslationStringsInDirectory:TWNStringsTests.bundleRoot haveNoMatchesWithRegex:TWNStringsTests.htmlTagRegex];
+}
+
+- (void)testIncomingTranslationStringForNBSP {
+    [self assertLprojFiles:TWNStringsTests.twnLprojFiles withTranslationStringsInDirectory:TWNStringsTests.bundleRoot doesNotContain:@"&nbsp;"];
 }
 
 - (void)testIncomingTranslationStringForBracketSubstitutions {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T227915

### Notes
* Adds translation test.

### Test Steps
1. Add a `&nbsp` to a string in any (non-processed) TWN file. 
2. Run the new test. Ensure it catches it.

Alternatively, look at log output below instead of running your own tests.

### Screenshots/Videos
Log output:
```
Test Case '-[TWNStringsTests testIncomingTranslationStringForNBSP]' started.
/Users/mattcl/wikipedia-ios/WikipediaUnitTests/Code/TWNStringsTests.m:183: error: -[TWNStringsTests testIncomingTranslationStringForNBSP] : ((doesContainBannedString) is false) failed - Invalid substring &nbsp; found in: &nbsp;การแก้ไขโดยผู้ใช้นิรนาม for key: aaald-revision-by-anonymous in locale: th.lproj
/Users/mattcl/wikipedia-ios/WikipediaUnitTests/Code/TWNStringsTests.m:183: error: -[TWNStringsTests testIncomingTranslationStringForNBSP] : ((doesContainBannedString) is false) failed - Invalid substring &nbsp; found in: สัญญาอนุ&nBsp;ญาตเนื้อหา for key: about-content-license in locale: th.lproj
Test Case '-[TWNStringsTests testIncomingTranslationStringForNBSP]' failed (0.452 seconds).
Test Suite 'TWNStringsTests' failed at 2022-01-26 17:22:43.060.
	 Executed 1 test, with 2 failures (0 unexpected) in 0.452 (0.452) seconds
Test Suite 'WikipediaUnitTests.xctest' failed at 2022-01-26 17:22:43.060.
	 Executed 1 test, with 2 failures (0 unexpected) in 0.452 (0.453) seconds
```