### PR TITLE
Fix "Find in Page" bug introduced by iOS 15 accessibility

### DIFF
--- a/Wikipedia/Code/FindAndReplaceKeyboardBar.swift
+++ b/Wikipedia/Code/FindAndReplaceKeyboardBar.swift
@@ -116,6 +116,10 @@ final class FindAndReplaceKeyboardBar: UIInputView {
         updateShowingReplaceState()
         updateReplaceLabelState()
         updateReplaceButtonsState()
+
+        // See comment on findTextFieldTextChanged for why we use these.
+        findTextField.addTarget(self, action: #selector(findTextFieldTextChanged), for: .editingChanged)
+        replaceTextField.addTarget(self, action: #selector(replaceTextFieldTextChanged), for: .editingChanged)
     }
     
     override var intrinsicContentSize: CGSize {
@@ -192,21 +196,20 @@ final class FindAndReplaceKeyboardBar: UIInputView {
     @IBAction func tappedReplaceSwitch() {
         displayDelegate?.keyboardBarDidTapReplaceSwitch(self)
     }
-    
-    @IBAction func textFieldDidChange(_ sender: UITextField) {
-        let count = sender.text?.count ?? 0
-        
-        switch sender {
-        case findTextField:
-            delegate?.keyboardBar(self, didChangeSearchTerm: findTextField.text)
-            findClearButton.isHidden = count == 0
-            updateReplaceButtonsState()
-        case replaceTextField:
-            updateReplaceButtonsState()
-            updateReplaceLabelState()
-        default:
-            break
-        }
+
+    // We are using manually added targets rather than an IBAction because iOS 15 introduced a bug: If `Full Keyboard Access` in enabled within Accessibility
+    // settings, the IBAction `Editing Changed` for a UITextField is not called. This is a workaround for the bug.
+    @objc func findTextFieldTextChanged() {
+        let count = findTextField.text?.count ?? 0
+        delegate?.keyboardBar(self, didChangeSearchTerm: findTextField.text)
+        findClearButton.isHidden = count == 0
+        updateReplaceButtonsState()
+    }
+
+    // See comment above on findTextFieldTextChanged.
+    @objc func replaceTextFieldTextChanged() {
+        updateReplaceButtonsState()
+        updateReplaceLabelState()
     }
 }
 

--- a/Wikipedia/Code/FindAndReplaceKeyboardBar.swift
+++ b/Wikipedia/Code/FindAndReplaceKeyboardBar.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WMF
 
 @objc (WMFFindAndReplaceKeyboardBarDelegate)
 protocol FindAndReplaceKeyboardBarDelegate: AnyObject {
@@ -390,12 +391,12 @@ private extension FindAndReplaceKeyboardBar {
 extension FindAndReplaceKeyboardBar {
     func setFindTextForTesting(_ text: String) {
         findTextField.text = text
-        textFieldDidChange(findTextField)
+        findTextFieldTextChanged()
     }
     
     func setReplaceTextForTesting(_ text: String) {
         replaceTextField.text = text
-        textFieldDidChange(replaceTextField)
+        replaceTextFieldTextChanged()
     }
     
     func tapNextForTesting() {

--- a/Wikipedia/Code/WMFFindAndReplaceKeyboardBar.xib
+++ b/Wikipedia/Code/WMFFindAndReplaceKeyboardBar.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -59,11 +57,10 @@
                                                     <rect key="frame" x="10" y="8.5" width="13" height="13"/>
                                                 </imageView>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="SWF-dB-rso">
-                                                    <rect key="frame" x="33" y="6.5" width="223" height="17"/>
+                                                    <rect key="frame" x="33" y="6" width="223" height="18.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="search" enablesReturnKeyAutomatically="YES" smartQuotesType="no"/>
                                                     <connections>
-                                                        <action selector="textFieldDidChange:" destination="-2" eventType="editingChanged" id="AbV-ee-dAL"/>
                                                         <outlet property="delegate" destination="iN0-l3-epB" id="LDX-LI-4nu"/>
                                                     </connections>
                                                 </textField>
@@ -128,11 +125,10 @@
                                                     <rect key="frame" x="10" y="8.5" width="13" height="13"/>
                                                 </imageView>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Dce-vp-s0R">
-                                                    <rect key="frame" x="33" y="6.5" width="267" height="17"/>
+                                                    <rect key="frame" x="33" y="6" width="267" height="18.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="go" enablesReturnKeyAutomatically="YES" smartQuotesType="no"/>
                                                     <connections>
-                                                        <action selector="textFieldDidChange:" destination="-2" eventType="editingChanged" id="dWX-yg-1uq"/>
                                                         <outlet property="delegate" destination="iN0-l3-epB" id="XLZ-Yt-8tI"/>
                                                     </connections>
                                                 </textField>
@@ -224,6 +220,7 @@
                     </constraints>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="nUH-ZK-lDf"/>
             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="mcZ-4f-6ui" firstAttribute="leading" secondItem="nUH-ZK-lDf" secondAttribute="leading" id="Hb3-fq-BHR"/>
@@ -235,7 +232,6 @@
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="nUH-ZK-lDf"/>
             <connections>
                 <outlet property="closeButton" destination="cVz-34-psT" id="ugE-BQ-Wie"/>
                 <outlet property="currentMatchLabel" destination="6cQ-Pa-aFx" id="K9Y-CS-Rke"/>
@@ -271,6 +267,6 @@
         <image name="dots" width="18" height="4"/>
         <image name="find-replace-search" width="13" height="13"/>
         <image name="pencil" width="13" height="13"/>
-        <image name="replace" width="19" height="18"/>
+        <image name="replace" width="19" height="19"/>
     </resources>
 </document>


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T292471

### Notes
* Confirmed that this bug is an Apple-side one. For some reason, if `Full Keyboard Access` in enabled within Accessibility settings, the IBAction `Editing Changed` for a UITextField is not called. We're using a simple workaround of manually setting an `editingChanged` target in code, and this is not affected by the bug. (The bug is not present in iOS 14.)
* Sample code that I'll be submitting to Apple: [SampleInputView.zip](https://github.com/wikimedia/wikipedia-ios/files/7975464/SampleInputView.zip)
* Further testing seems to show that this bug only exists for `UITextField`s within `inputAccessoryView`, so this is the only place this bug reveals itself in our app. Other `inputAccessoryView`s and other `UITextField`s do not have this issue.

### Test Steps
1. Turn on `Full Keyboard Access` accessibility setting on a device. (It isn't available on Simulator.)
2. Run app on a device. 
3. Ensure Find in Page works.
4. Ensure find/replace in editing works.


