### PR TITLE
Address Notifications Center action sheet navigation crash

### DIFF
--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1223,12 +1223,20 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
             [self showSettingsWithSubViewController:appearanceSettingsVC animated:animated];
         } break;
         case WMFUserActivityTypeNotificationSettings: {
-            [self dismissPresentedViewControllers];
-            [self setSelectedIndex:WMFAppTabTypeMain];
-            [self.navigationController popToRootViewControllerAnimated:YES];
             WMFNotificationSettingsViewController *notificationSettingsVC = [[WMFNotificationSettingsViewController alloc] initWithAuthManager:self.dataStore.authenticationManager notificationsController:self.notificationsController];
             [notificationSettingsVC applyTheme:self.theme];
-            [self showSettingsWithSubViewController:notificationSettingsVC animated:animated];
+            [self dismissPresentedViewControllers];
+            switch ([NSUserDefaults standardUserDefaults].defaultTabType) {
+                case WMFAppDefaultTabTypeExplore: {
+                    [self setSelectedIndex:WMFAppTabTypeMain];
+                    [self.navigationController popToRootViewControllerAnimated:YES];
+                    [self showSettingsWithSubViewController:notificationSettingsVC animated:animated];
+                } break;
+                case WMFAppDefaultTabTypeSettings: {
+                    [self.navigationController popToRootViewControllerAnimated:YES];
+                    [self.navigationController pushViewController:notificationSettingsVC animated:YES];
+                } break;
+            }
         } break;
         default: {
             NSURL *linkURL = [activity wmf_linkURL];


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T300926

### Notes
Adds some conditional logic to the notifications setting user activity to prevent a crash that was previously occurring post-routing the user to the Notifications Settings view controller. I don't particularly love my approach here, but I haven't been able to reproduce the crash with this fix.

### Test Steps
1. Turn off the Explore feed
2. Be sure you're logged into the app, and tap the Notifications Center bell button
3. Swipe a cell, open the More action sheet
4. Tap the Notifications settings action
5. Dismiss the Notifications setting view and tap between the app tabs at the bottom of the screen, confirming the app doesn't crash
6. Turn the Explore feed back on, and confirm steps 2-5
