### PR TITLE
Notifications performance fix - cell heights

### DIFF
--- a/Wikipedia/Code/NotificationsCenterView.swift
+++ b/Wikipedia/Code/NotificationsCenterView.swift
@@ -13,22 +13,11 @@ final class NotificationsCenterView: SetupView {
     // MARK: - Properties
 
 	lazy var collectionView: UICollectionView = {
-		let collectionView = UICollectionView(frame: .zero, collectionViewLayout: tableStyleLayout)
+		let collectionView = UICollectionView(frame: .zero, collectionViewLayout: tableStyleLayout())
 		collectionView.register(NotificationsCenterCell.self, forCellWithReuseIdentifier: NotificationsCenterCell.reuseIdentifier)
 		collectionView.alwaysBounceVertical = true
 		collectionView.translatesAutoresizingMaskIntoConstraints = false
 		return collectionView
-	}()
-
-	private lazy var tableStyleLayout: UICollectionViewLayout = {
-        let estimatedHeightDimension = NSCollectionLayoutDimension.estimated(150)
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),heightDimension: estimatedHeightDimension)
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),heightDimension: estimatedHeightDimension)
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,subitems: [item])
-        let section = NSCollectionLayoutSection(group: group)
-        let layout = UICollectionViewCompositionalLayout(section: section)
-        return layout
 	}()
 
     private lazy var emptyScrollView: UIScrollView = {
@@ -88,6 +77,7 @@ final class NotificationsCenterView: SetupView {
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
             emptyOverlayHeaderLabel.font = UIFont.wmf_font(.mediumBody, compatibleWithTraitCollection: traitCollection)
             emptyOverlaySubheaderLabel.font = UIFont.wmf_font(.subheadline, compatibleWithTraitCollection: traitCollection)
+            calculatedCellHeight = nil
         }
     }
 
@@ -156,7 +146,46 @@ final class NotificationsCenterView: SetupView {
             subheaderTapGR?.isEnabled = false
         }
     }
+    
+    func updateCalculatedCellHeightIfNeeded() {
 
+        guard let firstCell = collectionView.visibleCells.first else {
+            return
+        }
+
+        if self.calculatedCellHeight == nil {
+            let calculatedCellHeight = firstCell.frame.size.height
+            self.calculatedCellHeight = calculatedCellHeight
+        }
+    }
+    
+//MARK: Private
+    
+    private var calculatedCellHeight: CGFloat? {
+        didSet {
+            if oldValue != calculatedCellHeight {
+                collectionView.setCollectionViewLayout(tableStyleLayout(calculatedCellHeight: calculatedCellHeight), animated: false)
+            }
+        }
+    }
+
+    private func tableStyleLayout(calculatedCellHeight: CGFloat? = nil) -> UICollectionViewLayout {
+        let heightDimension: NSCollectionLayoutDimension
+
+        if let calculatedCellHeight = calculatedCellHeight {
+            heightDimension = NSCollectionLayoutDimension.absolute(calculatedCellHeight)
+        } else {
+            heightDimension = NSCollectionLayoutDimension.estimated(150)
+        }
+
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),heightDimension: heightDimension)
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),heightDimension: heightDimension)
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,subitems: [item])
+        let section = NSCollectionLayoutSection(group: group)
+        let layout = UICollectionViewCompositionalLayout(section: section)
+        return layout
+    }
 }
 
 extension NotificationsCenterView: Themeable {

--- a/Wikipedia/Code/NotificationsCenterViewController.swift
+++ b/Wikipedia/Code/NotificationsCenterViewController.swift
@@ -196,7 +196,10 @@ private extension NotificationsCenterViewController {
             var snapshot = Snapshot()
             snapshot.appendSections([.main])
             snapshot.appendItems(cellViewModels)
-            dataSource.apply(snapshot, animatingDifferences: animatingDifferences)
+            dataSource.apply(snapshot, animatingDifferences: animatingDifferences) {
+                //Note: API docs indicate this completion block is already called on the main thread
+                self.notificationsView.updateCalculatedCellHeightIfNeeded()
+            }
         }
     }
     


### PR DESCRIPTION
**Phabricator:**
https://phabricator.wikimedia.org/T301837 (Part 1 of 3)

### Notes
When performance testing, I noticed the scroll view would start to lag when I reached around 3,000 notifications. I was testing on an iPhone 7, iOS 15.2.1. Leaning on any previously calculated heights in-memory seemed to fix it.

**Note:** The `notifications-performance-testing` branch is based off of `main` as it is now, plus one small loading tweak that's coming in a future PR. It is also set up to import around 10,000 mock notifications if you add 7+ app languages. Try that and scroll until 3,000 notifications have loaded in Notifications Center. It might be helpful to print out the index path in `willDisplayCell` on `NotifiationsCenterViewController` so you can see how many have loaded. You can also try tweaking the default `fetchLimit` parameter in `RemoteNotificationsController` to immediately fetch a lot of notifications without having to page.

### Test Steps
0. Pull the `notifications-performance-testing` branch down and cherry-pick this commit into it (do not push up this change though).
1. Open Notifications Center and scroll until 3,000 notifications have loaded. Confirm it still scrolls smoothly.
2. Background the app and change the user's dynamic type setting. Go back to Notifications Center. Confirm the cells resize properly to the new font size and it still scrolls smoothly.
