### PR TITLE
[HOLD] Notifications performance fix - improve performance of bell icon state

### DIFF
--- a/Wikipedia/Code/WMFSettingsViewController.h
+++ b/Wikipedia/Code/WMFSettingsViewController.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)settingsViewControllerWithDataStore:(MWKDataStore *)store;
 
 - (void)loadSections;
-- (void)configureBarButtonItems;
+- (void)configureBarButtonItemsWithNumUnreadNotifications: (NSInteger)numUnreadNotifications andNeedsUpdate: (BOOL)needsUpdate;
 
 @property (nonatomic, strong, readonly) MWKDataStore *dataStore;
 @property (nonatomic, weak, nullable) id<NotificationsCenterPresentationDelegate> notificationsCenterPresentationDelegate;


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T301837 (Part 3 of 3)

### Notes
When performance testing notifications, I noticed sometimes the Explore feed navigation bar buttons would not respond to my tap (when either tapping the bell icon or the settings gear) during a large import. I suspect it's because the update badge NSNotification is firing `notificationsCenterBadgeNeedsUpdate` really often and causing the navigation bar to reconfigure it's buttons. This PR is an attempt to only go through the update logic if the current number of unread notifications will cause a state change (that is, from 0 to 1+, or from 1+ to 0).

This PR is more of an open question, because the fix ended up feeling a bit messy, and I'm not sure if the performance bug is bad enough to warrant it. Happy to discuss further if we don't feel comfortable with this.

**Note:** You can use the `notifications-performance-testing` branch to generate mock notifications if you'd like. See https://github.com/wikimedia/wikipedia-ios/pull/4124 for notes about this.

### Test Steps
1. Pull the notifications-performance-testing branch down and cherry-pick this commit into it (do not push up this change though).
2. Launch the app and log in. You will start to see lots of debug text printed out while 10,000 notifications import.
3. While it's importing, tap the bell icon and settings gear often from the Explore feed. Confirm it's responsive every time.
4. Log out via Settings. Turn off the Explore feed via Settings > Explore tab toggle. Also go to Settings > Search > Open app on Search tab. Terminate app. Re-run via Xcode. Log back in on Settings tab. Again you will see lots of debug text printed out while 10,000 notifications import again.
3. While it's importing, tap the bell icon often on the Settings tab. Confirm it's responsive every time.
