### PR TITLE
Add Notifications Center notification detail view

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -217,6 +217,30 @@
 		00E2EA8F26E2A45C00B1A741 /* NotificationsCenterCellDisplayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E2EA8D26E2A45C00B1A741 /* NotificationsCenterCellDisplayState.swift */; };
 		00E2EA9026E2A45C00B1A741 /* NotificationsCenterCellDisplayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E2EA8D26E2A45C00B1A741 /* NotificationsCenterCellDisplayState.swift */; };
 		00E2EA9126E2A45C00B1A741 /* NotificationsCenterCellDisplayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E2EA8D26E2A45C00B1A741 /* NotificationsCenterCellDisplayState.swift */; };
+		00E75B5D27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B5C27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift */; };
+		00E75B5E27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B5C27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift */; };
+		00E75B5F27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B5C27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift */; };
+		00E75B6027EB874A00A45B78 /* NotificationsCenterDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B5C27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift */; };
+		00E75B6227EB87DC00A45B78 /* NotificationsCenterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B6127EB87DC00A45B78 /* NotificationsCenterDetailView.swift */; };
+		00E75B6327EB87DC00A45B78 /* NotificationsCenterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B6127EB87DC00A45B78 /* NotificationsCenterDetailView.swift */; };
+		00E75B6427EB87DC00A45B78 /* NotificationsCenterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B6127EB87DC00A45B78 /* NotificationsCenterDetailView.swift */; };
+		00E75B6527EB87DC00A45B78 /* NotificationsCenterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B6127EB87DC00A45B78 /* NotificationsCenterDetailView.swift */; };
+		00E75B6727EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B6627EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift */; };
+		00E75B6827EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B6627EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift */; };
+		00E75B6927EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B6627EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift */; };
+		00E75B6A27EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B6627EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift */; };
+		00E75B6C27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B6B27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift */; };
+		00E75B6D27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B6B27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift */; };
+		00E75B6E27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B6B27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift */; };
+		00E75B6F27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B6B27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift */; };
+		00E75B7127EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B7027EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift */; };
+		00E75B7227EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B7027EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift */; };
+		00E75B7327EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B7027EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift */; };
+		00E75B7427EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B7027EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift */; };
+		00E75B7627EB946D00A45B78 /* ReusableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B7527EB946D00A45B78 /* ReusableCell.swift */; };
+		00E75B7727EB946D00A45B78 /* ReusableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B7527EB946D00A45B78 /* ReusableCell.swift */; };
+		00E75B7827EB946D00A45B78 /* ReusableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B7527EB946D00A45B78 /* ReusableCell.swift */; };
+		00E75B7927EB946D00A45B78 /* ReusableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E75B7527EB946D00A45B78 /* ReusableCell.swift */; };
 		00EBB7C727D6878E002025AC /* BarButtonImageStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EBB7C627D6878E002025AC /* BarButtonImageStyle.swift */; };
 		00EBB7C827D6878E002025AC /* BarButtonImageStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EBB7C627D6878E002025AC /* BarButtonImageStyle.swift */; };
 		00EBB7C927D6878E002025AC /* BarButtonImageStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EBB7C627D6878E002025AC /* BarButtonImageStyle.swift */; };
@@ -3826,6 +3850,12 @@
 		00D5593424DB152300C78F08 /* WidgetsExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WidgetsExtension.entitlements; sourceTree = "<group>"; };
 		00E2EA8826E28A9700B1A741 /* NotificationsCenterCellStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCenterCellStyle.swift; sourceTree = "<group>"; };
 		00E2EA8D26E2A45C00B1A741 /* NotificationsCenterCellDisplayState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCenterCellDisplayState.swift; sourceTree = "<group>"; };
+		00E75B5C27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCenterDetailViewController.swift; sourceTree = "<group>"; };
+		00E75B6127EB87DC00A45B78 /* NotificationsCenterDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCenterDetailView.swift; sourceTree = "<group>"; };
+		00E75B6627EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCenterDetailActionCell.swift; sourceTree = "<group>"; };
+		00E75B6B27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCenterDetailHeaderCell.swift; sourceTree = "<group>"; };
+		00E75B7027EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCenterDetailContentCell.swift; sourceTree = "<group>"; };
+		00E75B7527EB946D00A45B78 /* ReusableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableCell.swift; sourceTree = "<group>"; };
 		00EBB7C627D6878E002025AC /* BarButtonImageStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarButtonImageStyle.swift; sourceTree = "<group>"; };
 		00EBB7CB27D6A86A002025AC /* SettingsPresentationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPresentationDelegate.swift; sourceTree = "<group>"; };
 		00F5AECF27C6C80C006390A8 /* PushNotificationsSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationsSettingsViewController.swift; sourceTree = "<group>"; };
@@ -6012,7 +6042,13 @@
 				6761AEE52704FD3F00E47BAD /* NotificationsCenterCellViewModel+IconNameExtensions.swift */,
 				678D29AD2729F0580036C5D9 /* NotificationsCenterCellViewModel+LinkExtensions.swift */,
 				678D29B2272AF1DA0036C5D9 /* NotificationsCenterCellViewModel+SheetActionExtensions.swift */,
+				00E75B5C27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift */,
+				00E75B6127EB87DC00A45B78 /* NotificationsCenterDetailView.swift */,
 				67C6F7AA27E8D22400B9C864 /* NotificationsCenterDetailViewModel.swift */,
+				00E75B6B27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift */,
+				00E75B7027EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift */,
+				00E75B6627EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift */,
+				67C6F79127E8C03900B9C864 /* NotificationsCenterAction.swift */,
 				67DAEDD827E8DCBF005CF9B6 /* NotificationsCenterDetailViewModel+TextExtensions.swift */,
 				67E50B2A27EAD3AD00ABA159 /* NotificationsCenterDetailViewModel+ImageExtensions.swift */,
 				6741244F27E97DBC0071177D /* NotificationsCenterDetailViewModel+ActionExtensions.swift */,
@@ -6026,7 +6062,6 @@
 				675175DB276D3B9700CD2974 /* DisappearingCallbackNavigationController.swift */,
 				67C6F77D27E3BAC700B9C864 /* NotificationsCenterFlowHostingController.swift */,
 				67C6F78227E8BC2E00B9C864 /* NotificationsCenterIconType.swift */,
-				67C6F79127E8C03900B9C864 /* NotificationsCenterAction.swift */,
 			);
 			name = "Notifications Center";
 			sourceTree = "<group>";
@@ -7481,6 +7516,7 @@
 				FF921856252E8F4F00C39A8F /* ThanksGiving.swift */,
 				FF59DF4C2555E0CB0048E66C /* InternalLinkPreviewing.swift */,
 				FF5555632771388F00925099 /* CollectionViewContextMenuShowing.swift */,
+				00E75B7527EB946D00A45B78 /* ReusableCell.swift */,
 			);
 			name = Protocols;
 			sourceTree = "<group>";
@@ -11091,6 +11127,7 @@
 				7A1C498F227254EC00230ED2 /* InsertMediaSearchViewController.swift in Sources */,
 				672D69A4273ABD3600B123B3 /* UINavigationBarAppearance+Extensions.swift in Sources */,
 				D8A6BAED1E4C9BF400A981C8 /* UserLocationAnnotationView.swift in Sources */,
+				00E75B5D27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift in Sources */,
 				6798331A22C174ED0073CE6F /* LinkOnlyTextView.swift in Sources */,
 				B0E8059A1C0CE2E40065EBC0 /* WMFSearchFunnel.m in Sources */,
 				00A7946B245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */,
@@ -11118,11 +11155,13 @@
 				7A7AC84621B6B89B003B849B /* SectionEditorViewController.swift in Sources */,
 				D87234011E1FF0A500751E83 /* PlacesViewController.swift in Sources */,
 				678D79FC235E59B2006161FF /* DiffListUneditedViewModel.swift in Sources */,
+				00E75B7627EB946D00A45B78 /* ReusableCell.swift in Sources */,
 				00E2EA8E26E2A45C00B1A741 /* NotificationsCenterCellDisplayState.swift in Sources */,
 				B01E54AF206479CC00374FEE /* ProgressContainer.swift in Sources */,
 				00AA5AAC276BF2AE005295B0 /* TextBarButtonItem.swift in Sources */,
 				67C6F79227E8C03A00B9C864 /* NotificationsCenterAction.swift in Sources */,
 				B0CD9DDC1F70997300051843 /* WMFWelcomeAnalyticsAnimationView.swift in Sources */,
+				00E75B6227EB87DC00A45B78 /* NotificationsCenterDetailView.swift in Sources */,
 				83987AD020E4FB2C00C92C60 /* UISearchBar+Theme.swift in Sources */,
 				7A420DB422A029780005689B /* EditFunnel.swift in Sources */,
 				B027FD281E678F5C005644A9 /* WMFAuthButton.swift in Sources */,
@@ -11131,6 +11170,7 @@
 				B0ACB13321265B930078C136 /* WMFImageGalleryDescriptionTextView.swift in Sources */,
 				53A575FA2602C845009835E6 /* WMFAppViewController+Extensions.swift in Sources */,
 				B0C7A0801F710E94008415E7 /* WMFWelcomeLanguagesAnimationBackgroundView.swift in Sources */,
+				00E75B6C27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift in Sources */,
 				8382F8D320D928BF00AE5250 /* ColumnarCollectionViewControllerLayoutCache.swift in Sources */,
 				D88FCADF1E4B74D300505A9F /* WikidataFetcher+Places.swift in Sources */,
 				B0432344210680A900A9A6B6 /* WMFContentGroupKind+FeedCustomization.swift in Sources */,
@@ -11232,6 +11272,7 @@
 				B389CFCE1E6F238300483C06 /* WMFMapsActivity.swift in Sources */,
 				7A2BB1D421F27AC5004C0FDF /* WKWebView+OffsetHack.swift in Sources */,
 				B01E3AF921F986750015B715 /* PreviewWebViewContainer.swift in Sources */,
+				00E75B7127EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift in Sources */,
 				7A9524D722669A8B00C55CDC /* InsertMediaSettingsButtonView.swift in Sources */,
 				83B01F7223DA5327001185F4 /* ArticleViewController+ArticleWebMessageHandling.swift in Sources */,
 				7A6ED52120ADBF950001849F /* LoginFunnel.swift in Sources */,
@@ -11241,6 +11282,7 @@
 				D818FEBB21E39EE2001A7A00 /* CodemirrorSetupUserScript.swift in Sources */,
 				0042812925E6E841004945B3 /* NYTPhotoViewController.m in Sources */,
 				BC23E4DD1C223DCB00B5AFDE /* WMFArticleRevisionFetcher.m in Sources */,
+				00E75B6727EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift in Sources */,
 				B0B4CF0A1CC0500E0051DF7A /* WMFArticleLanguagesSectionHeader.m in Sources */,
 				7ABE17352239DCF6006BA309 /* WelcomeAnimationViewController.swift in Sources */,
 				D837CC37231FE9CC00BA6130 /* ThemeableViewController.swift in Sources */,
@@ -12011,6 +12053,7 @@
 				D8A42A571E815A9C00D8E281 /* UserLocationAnnotationView.swift in Sources */,
 				672D69A7273ABD3600B123B3 /* UINavigationBarAppearance+Extensions.swift in Sources */,
 				6798331D22C174F00073CE6F /* LinkOnlyTextView.swift in Sources */,
+				00E75B6027EB874A00A45B78 /* NotificationsCenterDetailViewController.swift in Sources */,
 				D8A42A581E815A9C00D8E281 /* WMFSearchFunnel.m in Sources */,
 				8368BB8724129F3D00BC88BA /* ViewController+ArticleErrorHandling.swift in Sources */,
 				00A7946E245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */,
@@ -12038,11 +12081,13 @@
 				D8A42A5E1E815A9C00D8E281 /* WMFCaptchaResetter.swift in Sources */,
 				67146039243BCE51008CE885 /* ArticleViewController+SurveyAnnouncements.swift in Sources */,
 				678D79FF235E59B2006161FF /* DiffListUneditedViewModel.swift in Sources */,
+				00E75B7927EB946D00A45B78 /* ReusableCell.swift in Sources */,
 				00E2EA9126E2A45C00B1A741 /* NotificationsCenterCellDisplayState.swift in Sources */,
 				B0CD9DF11F70997500051843 /* WMFWelcomeAnalyticsAnimationView.swift in Sources */,
 				00AA5AAF276BF2AE005295B0 /* TextBarButtonItem.swift in Sources */,
 				67C6F79527E8C03A00B9C864 /* NotificationsCenterAction.swift in Sources */,
 				7A420DB722A029780005689B /* EditFunnel.swift in Sources */,
+				00E75B6527EB87DC00A45B78 /* NotificationsCenterDetailView.swift in Sources */,
 				B0B4236B1EF9D6D500D3DC4C /* OnThisDayViewControllerHeader.swift in Sources */,
 				D8A42A621E815A9C00D8E281 /* PlacesViewController.swift in Sources */,
 				B0ACB13621265B9D0078C136 /* WMFImageGalleryDescriptionTextView.swift in Sources */,
@@ -12051,6 +12096,7 @@
 				67DDD18A250C1A28006C0F93 /* ThreeLineHeaderView.swift in Sources */,
 				53A575FD2602C845009835E6 /* WMFAppViewController+Extensions.swift in Sources */,
 				678D79ED235E595A006161FF /* DiffListChangeItemViewModel.swift in Sources */,
+				00E75B6F27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift in Sources */,
 				D8A42A641E815A9C00D8E281 /* WMFAuthButton.swift in Sources */,
 				B0432347210680A900A9A6B6 /* WMFContentGroupKind+FeedCustomization.swift in Sources */,
 				7A20AE0B2057F39C005FB5DF /* UIView+Identifier.swift in Sources */,
@@ -12152,6 +12198,7 @@
 				B0421AA5206991F500C22630 /* SavedTabBarItemProgressBadgeManager.swift in Sources */,
 				7A2BB1D721F27AC5004C0FDF /* WKWebView+OffsetHack.swift in Sources */,
 				B01E3AFC21F986750015B715 /* PreviewWebViewContainer.swift in Sources */,
+				00E75B7427EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift in Sources */,
 				7A9524DA22669A8B00C55CDC /* InsertMediaSettingsButtonView.swift in Sources */,
 				67861A1A223C13940044F69D /* FocusNavigationView.swift in Sources */,
 				D8A42A9E1E815A9C00D8E281 /* WMFChangePasswordViewController.swift in Sources */,
@@ -12161,6 +12208,7 @@
 				83DB4413244A57590046FABE /* RootNavigationController.swift in Sources */,
 				0042812C25E6E841004945B3 /* NYTPhotoViewController.m in Sources */,
 				67E0690A22399D1C008550AC /* ReadingThemesControlsViewController.swift in Sources */,
+				00E75B6A27EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift in Sources */,
 				670F766222B0C49000D87545 /* FakeProgressLoading.swift in Sources */,
 				B0016CC621362DB300FA1096 /* SetupGradientView.swift in Sources */,
 				67B64D5F2507E9FD00FA27F3 /* ArticleAsLivingDocSmallEventCollectionViewCell.swift in Sources */,
@@ -12646,6 +12694,7 @@
 				7AE1FE3221B4A9790068BE9F /* TextFormattingButtonView.swift in Sources */,
 				D8CE25151E698E2400DAE2E0 /* WMFSettingsTableViewCell.m in Sources */,
 				7A35CB881FD82B6300AAF3B7 /* ReadingListDetailViewController.swift in Sources */,
+				00E75B6E27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift in Sources */,
 				D8CE25161E698E2400DAE2E0 /* UIView+WMFSubviews.swift in Sources */,
 				830C0DD623D9AFBE006471C4 /* UIViewController+Push.swift in Sources */,
 				67E8B085226A57E900537BC9 /* TalkPageTopicListViewController.swift in Sources */,
@@ -12667,6 +12716,7 @@
 				B0524AF22144D7BE00D8FD8D /* DescriptionHelpViewController.swift in Sources */,
 				7A715668226974D10066FEC4 /* InsertMediaImageSizeSettingsViewController.swift in Sources */,
 				D8CE25231E698E2400DAE2E0 /* UIVIewController+WMFCommonRotationSupport.swift in Sources */,
+				00E75B6427EB87DC00A45B78 /* NotificationsCenterDetailView.swift in Sources */,
 				7ADF498821B45E42009EA338 /* TextFormattingGroupedToolbarView.swift in Sources */,
 				D8CE25241E698E2400DAE2E0 /* (null) in Sources */,
 				D818D3821ED7254D0076110D /* ColumnarCollectionViewController.swift in Sources */,
@@ -12690,6 +12740,7 @@
 				6798332A22C3F2940073CE6F /* UITextView+Extensions.swift in Sources */,
 				7A5A0544225FBE0500BBEAC1 /* InsertMediaSearchResultCollectionViewCell.swift in Sources */,
 				D8CE252E1E698E2400DAE2E0 /* WMFArticleRevisionFetcher.m in Sources */,
+				00E75B5F27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift in Sources */,
 				D8CE252F1E698E2400DAE2E0 /* WMFArticleLanguagesSectionHeader.m in Sources */,
 				83C0656C23D23220001821BC /* TableOfContentsItem.swift in Sources */,
 				7A0CD24121DFA34100066F68 /* TextFormattingToolbarView.swift in Sources */,
@@ -12773,6 +12824,7 @@
 				D8CE256F1E698E2400DAE2E0 /* WeakScriptMessageDelegate.swift in Sources */,
 				6782DBF9234537D0003FA21B /* DiffHeaderExtendedView.swift in Sources */,
 				83B01F9623DB41D7001185F4 /* ArticleViewController+FindInPage.swift in Sources */,
+				00E75B7827EB946D00A45B78 /* ReusableCell.swift in Sources */,
 				834C269F240D49F400245BE7 /* ReferenceViewController.swift in Sources */,
 				7AB809DD22679F9300BFAB7C /* InsertMediaAdvancedSettingsViewController.swift in Sources */,
 				7AC19E462301F79700E25B83 /* PageHistoryFilterCountCollectionViewCell.swift in Sources */,
@@ -12852,6 +12904,7 @@
 				B0FFFB2B21C9BED1001E787E /* TextFormattingButton.swift in Sources */,
 				7A420DB522A029780005689B /* EditFunnel.swift in Sources */,
 				0042811F25E6E841004945B3 /* NYTPhotoTransitionAnimator.m in Sources */,
+				00E75B7327EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift in Sources */,
 				6761AEE82704FD3F00E47BAD /* NotificationsCenterCellViewModel+IconNameExtensions.swift in Sources */,
 				D8CE259F1E698E2400DAE2E0 /* UIViewController+WMFScrollToTop.swift in Sources */,
 				B0524B52214854E900D8FD8D /* DescriptionWelcomeContainerViewController.swift in Sources */,
@@ -12983,6 +13036,7 @@
 				B0845E1220618DA400CDD98E /* SavedProgressViewController.swift in Sources */,
 				D8CE25EC1E698E2400DAE2E0 /* WMFImageGalleryViewController.m in Sources */,
 				7AF0265722985CB9000E0A06 /* BeKindInputAccessoryView.swift in Sources */,
+				00E75B6927EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift in Sources */,
 				67DAEDA423CE24DA003AA208 /* SavedArticlesFetcher.swift in Sources */,
 				7AB7DEC9227203A600DD61A2 /* InsertMediaViewController.swift in Sources */,
 				B0CD9DDD1F70997400051843 /* WMFWelcomeAnimationView.swift in Sources */,
@@ -13178,6 +13232,7 @@
 				7AE1FE3321B4A9790068BE9F /* TextFormattingButtonView.swift in Sources */,
 				D8EC3E001E9BDA35006712EB /* PlaceSearchSuggestionController.swift in Sources */,
 				B0B423631EF9D6A300D3DC4C /* OnThisDayViewController.swift in Sources */,
+				00E75B6D27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift in Sources */,
 				D8EC3E021E9BDA35006712EB /* WMFPageHistoryRevision.m in Sources */,
 				830C0DD723D9AFBE006471C4 /* UIViewController+Push.swift in Sources */,
 				67E8B08C226A57E900537BC9 /* TalkPageTopicListViewController.swift in Sources */,
@@ -13199,6 +13254,7 @@
 				B0524AF32144D7BE00D8FD8D /* DescriptionHelpViewController.swift in Sources */,
 				7A715669226974D10066FEC4 /* InsertMediaImageSizeSettingsViewController.swift in Sources */,
 				D8EC3E121E9BDA35006712EB /* LoggingDefaults.swift in Sources */,
+				00E75B6327EB87DC00A45B78 /* NotificationsCenterDetailView.swift in Sources */,
 				7ADF498921B45E42009EA338 /* TextFormattingGroupedToolbarView.swift in Sources */,
 				D8EC3E171E9BDA35006712EB /* MWKTitleLanguageController.m in Sources */,
 				B0016CC521362DB300FA1096 /* SetupGradientView.swift in Sources */,
@@ -13222,6 +13278,7 @@
 				6798332B22C3F2950073CE6F /* UITextView+Extensions.swift in Sources */,
 				7A5A0545225FBE0500BBEAC1 /* InsertMediaSearchResultCollectionViewCell.swift in Sources */,
 				D8EC3E1E1E9BDA35006712EB /* WMFChangePasswordViewController.swift in Sources */,
+				00E75B5E27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift in Sources */,
 				D8B166871FD97A0500097D8B /* ViewController.swift in Sources */,
 				83C0656D23D23220001821BC /* TableOfContentsItem.swift in Sources */,
 				B0421AA4206991F500C22630 /* SavedTabBarItemProgressBadgeManager.swift in Sources */,
@@ -13305,6 +13362,7 @@
 				7A6ED51920ADBF950001849F /* SettingsFunnel.swift in Sources */,
 				6782DBFC234537D0003FA21B /* DiffHeaderExtendedView.swift in Sources */,
 				834C26A0240D49F400245BE7 /* ReferenceViewController.swift in Sources */,
+				00E75B7727EB946D00A45B78 /* ReusableCell.swift in Sources */,
 				83B01F9723DB41D7001185F4 /* ArticleViewController+FindInPage.swift in Sources */,
 				7AB809DE22679F9300BFAB7C /* InsertMediaAdvancedSettingsViewController.swift in Sources */,
 				7AC19E472301F79700E25B83 /* PageHistoryFilterCountCollectionViewCell.swift in Sources */,
@@ -13384,6 +13442,7 @@
 				7A420DB622A029780005689B /* EditFunnel.swift in Sources */,
 				D8EC3E9C1E9BDA35006712EB /* WMFAuthButton.swift in Sources */,
 				0042811E25E6E841004945B3 /* NYTPhotoTransitionAnimator.m in Sources */,
+				00E75B7227EB92F600A45B78 /* NotificationsCenterDetailContentCell.swift in Sources */,
 				6761AEE72704FD3F00E47BAD /* NotificationsCenterCellViewModel+IconNameExtensions.swift in Sources */,
 				B0524B53214854E900D8FD8D /* DescriptionWelcomeContainerViewController.swift in Sources */,
 				BA69725A1F2BA2D800E35F78 /* SettingsTableViewSection.swift in Sources */,
@@ -13515,6 +13574,7 @@
 				B0845E1320618DA400CDD98E /* SavedProgressViewController.swift in Sources */,
 				B0F9299C1F84789D002A0788 /* WMFWelcomeInitialViewController.swift in Sources */,
 				6747118925072D1500287951 /* IconTitleBadge.swift in Sources */,
+				00E75B6827EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift in Sources */,
 				7AF0265822985CB9000E0A06 /* BeKindInputAccessoryView.swift in Sources */,
 				67DAEDA523CE24DA003AA208 /* SavedArticlesFetcher.swift in Sources */,
 				7AB7DECA227203A600DD61A2 /* InsertMediaViewController.swift in Sources */,

--- a/Wikipedia/Code/NotificationsCenterAction.swift
+++ b/Wikipedia/Code/NotificationsCenterAction.swift
@@ -4,6 +4,13 @@ enum NotificationsCenterAction: Equatable {
     case markAsReadOrUnread(NotificationsCenterActionData)
     case custom(NotificationsCenterActionData)
     case notificationSubscriptionSettings(NotificationsCenterActionData)
+
+    var actionData: NotificationsCenterActionData? {
+        switch self {
+        case .notificationSubscriptionSettings(let data), .markAsReadOrUnread(let data), .custom(let data):
+            return data
+        }
+    }
 }
 
 struct NotificationsCenterActionData: Equatable {

--- a/Wikipedia/Code/NotificationsCenterDetailActionCell.swift
+++ b/Wikipedia/Code/NotificationsCenterDetailActionCell.swift
@@ -1,0 +1,62 @@
+import UIKit
+
+class NotificationsCenterDetailActionCell: UITableViewCell, ReusableCell {
+
+    // MARK: - Properties
+
+    var action: NotificationsCenterAction?
+    var theme: Theme = .light
+
+    // MARK: - Lifecycle
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .value1, reuseIdentifier: reuseIdentifier)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        action = nil
+    }
+
+    func setup() {
+        detailTextLabel?.font = UIFont.wmf_scaledSystemFont(forTextStyle: .footnote, weight: .regular, size: 13, maximumPointSize: 64)
+    }
+
+    // MARK: - Configuration
+
+    func configure(action: NotificationsCenterAction?, theme: Theme) {
+        self.theme = theme
+
+        backgroundColor = theme.colors.paperBackground
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = theme.colors.midBackground
+
+        imageView?.tintColor = theme.colors.link
+        textLabel?.textColor = theme.colors.link
+        detailTextLabel?.textColor = theme.colors.secondaryText
+
+        guard let action = action else { return }
+
+        self.action = action
+
+        if let actionData = action.actionData {
+            let imageType = actionData.iconType
+            textLabel?.text = actionData.text
+            detailTextLabel?.text = actionData.destinationText
+            switch imageType {
+            case .custom(let name):
+                imageView?.image = UIImage(named: name)
+            case .system(let name):
+                imageView?.image = UIImage(systemName: name)
+            case .none:
+                break
+            }
+        }
+    }
+
+}

--- a/Wikipedia/Code/NotificationsCenterDetailContentCell.swift
+++ b/Wikipedia/Code/NotificationsCenterDetailContentCell.swift
@@ -43,7 +43,7 @@ class NotificationsCenterDetailContentCell: UITableViewCell, ReusableCell {
 
         let bodyContent = viewModel.contentBody != nil ? "\n\n\(viewModel.contentBody!)" : ""
 
-        let boldAttribute = [NSAttributedString.Key.font: UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .semibold, size: 15, maximumPointSize: 64)]
+        let boldAttribute = [NSAttributedString.Key.font: UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .bold, size: 17, maximumPointSize: 64)]
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = 1.7
         let bodyTextAttributes = [

--- a/Wikipedia/Code/NotificationsCenterDetailContentCell.swift
+++ b/Wikipedia/Code/NotificationsCenterDetailContentCell.swift
@@ -1,0 +1,65 @@
+import UIKit
+
+class NotificationsCenterDetailContentCell: UITableViewCell, ReusableCell {
+
+    // MARK: - Properties
+
+    lazy var contentLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        return label
+    }()
+
+    // MARK: - Lifecycle
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .default, reuseIdentifier: reuseIdentifier)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setup() {
+        selectionStyle = .none
+        
+        contentView.addSubview(contentLabel)
+
+        NSLayoutConstraint.activate([
+            contentLabel.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            contentLabel.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            contentLabel.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            contentLabel.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
+        ])
+    }
+
+    // MARK: - Configuration
+
+    func configure(viewModel: NotificationsCenterDetailViewModel, theme: Theme) {
+        backgroundColor = theme.colors.paperBackground
+
+        let bodyContent = viewModel.contentBody != nil ? "\n\n\(viewModel.contentBody!)" : ""
+
+        let boldAttribute = [NSAttributedString.Key.font: UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .semibold, size: 15, maximumPointSize: 64)]
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 1.7
+        let bodyTextAttributes = [
+            NSAttributedString.Key.font: UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .regular, size: 15, maximumPointSize: 64),
+            NSAttributedString.Key.paragraphStyle: paragraphStyle
+        ]
+
+        let attributedTitle = NSMutableAttributedString(string: viewModel.contentTitle, attributes: boldAttribute)
+        let attributedBody = NSMutableAttributedString(string: bodyContent, attributes: bodyTextAttributes)
+
+        let attributedContentText = NSMutableAttributedString()
+        attributedContentText.append(attributedTitle)
+        attributedContentText.append(attributedBody)
+
+        contentLabel.attributedText = attributedContentText
+        contentLabel.textColor = theme.colors.primaryText
+    }
+
+}

--- a/Wikipedia/Code/NotificationsCenterDetailHeaderCell.swift
+++ b/Wikipedia/Code/NotificationsCenterDetailHeaderCell.swift
@@ -1,0 +1,152 @@
+import UIKit
+
+class NotificationsCenterDetailHeaderCell: UITableViewCell, ReusableCell {
+
+    // MARK: - Properties
+
+    lazy var mainStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.distribution = .fill
+        return stackView
+    }()
+
+    lazy var labelStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.spacing = 6
+        stackView.axis = .vertical
+        return stackView
+    }()
+
+    lazy var detailLabelStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.spacing = 6
+        stackView.axis = .horizontal
+        return stackView
+    }()
+
+    lazy var leadingImageView: RoundedImageView = {
+        let view = RoundedImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.imageView.contentMode = .scaleAspectFit
+        view.layer.borderWidth = 2
+        view.layer.borderColor = UIColor.clear.cgColor
+        return view
+    }()
+
+    lazy var leadingImageContainer: UIView = {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        return container
+    }()
+
+    lazy var headerLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        label.font = UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .bold, size: 15, maximumPointSize: 64)
+        return label
+    }()
+
+    lazy var subheaderLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        label.font = UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .regular, size: 13, maximumPointSize: 64)
+        label.textAlignment = effectiveUserInterfaceLayoutDirection == .rightToLeft ? .right : .left
+        return label
+    }()
+
+    lazy var dateLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        label.font = UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .regular, size: 13, maximumPointSize: 64)
+        label.textAlignment = effectiveUserInterfaceLayoutDirection == .rightToLeft ? .left : .right
+        return label
+    }()
+
+    // MARK: - Lifecycle
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .default, reuseIdentifier: reuseIdentifier)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setup() {
+        selectionStyle = .none
+
+        contentView.addSubview(mainStackView)
+
+        mainStackView.addArrangedSubview(leadingImageContainer)
+        mainStackView.addArrangedSubview(labelStackView)
+
+        labelStackView.addArrangedSubview(headerLabel)
+        labelStackView.addArrangedSubview(detailLabelStackView)
+
+        detailLabelStackView.addArrangedSubview(subheaderLabel)
+        detailLabelStackView.addArrangedSubview(dateLabel)
+
+        leadingImageContainer.addSubview(leadingImageView)
+
+        NSLayoutConstraint.activate([
+            leadingImageView.heightAnchor.constraint(equalToConstant: 37),
+            leadingImageView.widthAnchor.constraint(equalToConstant: 37),
+            leadingImageView.centerYAnchor.constraint(equalTo: leadingImageContainer.centerYAnchor),
+            leadingImageView.leadingAnchor.constraint(equalTo: leadingImageContainer.leadingAnchor),
+
+            leadingImageContainer.widthAnchor.constraint(equalToConstant: 45),
+            leadingImageContainer.leadingAnchor.constraint(equalTo: mainStackView.leadingAnchor),
+            leadingImageContainer.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            leadingImageContainer.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
+
+            mainStackView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            mainStackView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            mainStackView.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            mainStackView.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
+        ])
+    }
+
+    // MARK: - Configuration
+
+    func configure(viewModel: NotificationsCenterDetailViewModel, theme: Theme) {
+        backgroundColor = theme.colors.paperBackground
+
+        headerLabel.text = viewModel.headerTitle
+        subheaderLabel.text = viewModel.headerSubtitle
+        dateLabel.text = viewModel.headerDate
+
+        headerLabel.textColor = theme.colors.primaryText
+        subheaderLabel.textColor = theme.colors.secondaryText
+        dateLabel.textColor = theme.colors.secondaryText
+
+        leadingImageView.imageView.image = UIImage(named: viewModel.commonViewModel.notification.type.imageName)
+        leadingImageView.tintColor = theme.colors.paperBackground
+        leadingImageView.backgroundColor = viewModel.headerImageBackgroundColorWithTheme(theme)
+
+        configureDetailLabelStackFor(sizeCategory: traitCollection.preferredContentSizeCategory)
+    }
+
+    // MARK: - Private
+
+    fileprivate func configureDetailLabelStackFor(sizeCategory: UIContentSizeCategory) {
+        if sizeCategory < .accessibilityMedium {
+            detailLabelStackView.axis = .horizontal
+            dateLabel.textAlignment = effectiveUserInterfaceLayoutDirection == .rightToLeft ? .left : .right
+        } else {
+            detailLabelStackView.axis = .vertical
+            dateLabel.textAlignment = effectiveUserInterfaceLayoutDirection == .rightToLeft ? .right : .left
+        }
+    }
+
+}

--- a/Wikipedia/Code/NotificationsCenterDetailHeaderCell.swift
+++ b/Wikipedia/Code/NotificationsCenterDetailHeaderCell.swift
@@ -15,7 +15,7 @@ class NotificationsCenterDetailHeaderCell: UITableViewCell, ReusableCell {
     lazy var labelStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.spacing = 6
+        stackView.spacing = 3
         stackView.axis = .vertical
         return stackView
     }()
@@ -48,7 +48,7 @@ class NotificationsCenterDetailHeaderCell: UITableViewCell, ReusableCell {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
-        label.font = UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .bold, size: 15, maximumPointSize: 64)
+        label.font = UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .bold, size: 17, maximumPointSize: 64)
         return label
     }()
 

--- a/Wikipedia/Code/NotificationsCenterDetailView.swift
+++ b/Wikipedia/Code/NotificationsCenterDetailView.swift
@@ -39,6 +39,8 @@ extension NotificationsCenterDetailView: Themeable {
     func apply(theme: Theme) {
         backgroundColor = theme.colors.baseBackground
         tableView.backgroundColor = theme.colors.baseBackground
+
+        tableView.reloadData()
     }
 
 }

--- a/Wikipedia/Code/NotificationsCenterDetailView.swift
+++ b/Wikipedia/Code/NotificationsCenterDetailView.swift
@@ -1,0 +1,44 @@
+import UIKit
+
+final class NotificationsCenterDetailView: SetupView {
+
+    // MARK: - Properties
+
+    lazy var tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .insetGrouped)
+        tableView.register(NotificationsCenterDetailHeaderCell.self, forCellReuseIdentifier: NotificationsCenterDetailHeaderCell.reuseIdentifier)
+        tableView.register(NotificationsCenterDetailContentCell.self, forCellReuseIdentifier: NotificationsCenterDetailContentCell.reuseIdentifier)
+        tableView.register(NotificationsCenterDetailActionCell.self, forCellReuseIdentifier: NotificationsCenterDetailActionCell.reuseIdentifier)
+
+        tableView.estimatedRowHeight = 44
+        tableView.rowHeight = UITableView.automaticDimension
+        
+        return tableView
+    }()
+
+    // MARK: - SetupView
+
+    override func setup() {
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            tableView.topAnchor.constraint(equalTo: topAnchor),
+            tableView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+}
+
+// MARK: - Themeable
+
+extension NotificationsCenterDetailView: Themeable {
+
+    func apply(theme: Theme) {
+        backgroundColor = theme.colors.baseBackground
+        tableView.backgroundColor = theme.colors.baseBackground
+    }
+
+}

--- a/Wikipedia/Code/NotificationsCenterDetailViewController.swift
+++ b/Wikipedia/Code/NotificationsCenterDetailViewController.swift
@@ -1,0 +1,102 @@
+import UIKit
+import WMF
+import SwiftUI
+
+final class NotificationsCenterDetailViewController: ViewController {
+
+    // MARK: - Properties
+
+    var detailView: NotificationsCenterDetailView {
+        return view as! NotificationsCenterDetailView
+    }
+
+    let viewModel: NotificationsCenterDetailViewModel
+
+    // MARK: - Lifecycle
+
+    init(theme: Theme, viewModel: NotificationsCenterDetailViewModel) {
+        self.viewModel = viewModel
+        super.init(theme: theme)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        let detailView = NotificationsCenterDetailView(frame: UIScreen.main.bounds)
+        view = detailView
+        scrollView = detailView.tableView
+
+        detailView.tableView.dataSource = self
+        detailView.tableView.delegate = self
+    }
+
+    // MARK: - Themeable
+
+    override func apply(theme: Theme) {
+        super.apply(theme: theme)
+
+        detailView.apply(theme: theme)
+    }
+
+}
+
+// MARK: - UITableView
+
+extension NotificationsCenterDetailViewController: UITableViewDelegate, UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch indexPath.section {
+        case 0:
+            switch indexPath.row {
+            case 0:
+                let cell = tableView.dequeueReusableCell(withIdentifier: NotificationsCenterDetailHeaderCell.reuseIdentifier) as? NotificationsCenterDetailHeaderCell ?? NotificationsCenterDetailHeaderCell()
+                cell.configure(viewModel: viewModel, theme: theme)
+                return cell
+            case 1:
+                let cell = tableView.dequeueReusableCell(withIdentifier: NotificationsCenterDetailContentCell.reuseIdentifier) as? NotificationsCenterDetailContentCell ?? NotificationsCenterDetailContentCell()
+                cell.configure(viewModel: viewModel, theme: theme)
+                return cell
+            default:
+                let cell = tableView.dequeueReusableCell(withIdentifier: NotificationsCenterDetailActionCell.reuseIdentifier) as? NotificationsCenterDetailActionCell ?? NotificationsCenterDetailActionCell()
+                cell.configure(action: viewModel.primaryAction, theme: theme)
+                return cell
+            }
+        default:
+            let cell = tableView.dequeueReusableCell(withIdentifier: NotificationsCenterDetailActionCell.reuseIdentifier) as? NotificationsCenterDetailActionCell ?? NotificationsCenterDetailActionCell()
+            cell.configure(action: viewModel.secondaryActions[indexPath.row], theme: theme)
+            return cell
+        }
+    }
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 2
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch section {
+        case 0:
+            if viewModel.primaryAction != nil {
+                return 3
+            }
+
+            return 2
+        default:
+            return viewModel.secondaryActions.count
+        }
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let actionCell = tableView.cellForRow(at: indexPath) as? NotificationsCenterDetailActionCell else {
+            return
+        }
+
+        if let actionData = actionCell.action?.actionData, let url = actionData.url {
+            navigate(to: url)
+        }
+
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+
+}

--- a/Wikipedia/Code/NotificationsCenterIconType.swift
+++ b/Wikipedia/Code/NotificationsCenterIconType.swift
@@ -42,7 +42,11 @@ enum NotificationsCenterIconType: Equatable {
     }
     
     static var diff: NotificationsCenterIconType {
-        return .custom("notifications-icon-diff") //TODO: Need to add icon to project
+        if #available(iOS 15, *) {
+            return .system("chevron.left.forwardslash.chevron.right")
+        } else {
+            return .system("chevron.left.slash.chevron.right")
+        }
     }
     
     static var wikidata: NotificationsCenterIconType {

--- a/Wikipedia/Code/NotificationsCenterViewController.swift
+++ b/Wikipedia/Code/NotificationsCenterViewController.swift
@@ -412,7 +412,7 @@ private extension NotificationsCenterViewController {
         let filterView = NotificationsCenterFilterView(viewModel: filtersViewModel, doneAction: { [weak self] in
             self?.dismiss(animated: true)
         })
-        
+
         presentView(view: filterView)
     }
     
@@ -576,15 +576,15 @@ extension NotificationsCenterViewController: UICollectionViewDelegate {
         }
 
         if !viewModel.isEditing {
-            
             collectionView.deselectItem(at: indexPath, animated: true)
 
-            if let primaryURL = cellViewModel.primaryURL {
-                navigate(to: primaryURL)
-                if !cellViewModel.isRead {
-                    viewModel.markAsReadOrUnread(viewModels: [cellViewModel], shouldMarkRead: true)
-                }
+            if !cellViewModel.isRead {
+                viewModel.markAsReadOrUnread(viewModels: [cellViewModel], shouldMarkRead: true)
             }
+
+            let detailViewModel = NotificationsCenterDetailViewModel(commonViewModel: cellViewModel.commonViewModel)
+            let detailViewController = NotificationsCenterDetailViewController(theme: theme, viewModel: detailViewModel)
+            push(detailViewController)
         } else {
             viewModel.updateCellDisplayStates(cellViewModels: [cellViewModel], isSelected: true)
             let selectedCellViewModels = self.selectedCellViewModels

--- a/Wikipedia/Code/ReusableCell.swift
+++ b/Wikipedia/Code/ReusableCell.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+protocol ReusableCell {
+    static var reuseIdentifier: String { get }
+}
+
+extension ReusableCell {
+    static var reuseIdentifier: String {
+        return String(describing: self)
+    }
+}


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T302453

### Notes
This PR adds the notification detail view UI. Previous PRs address the data layers.

### Test Steps
To access the detail view, tap a notification in your Notifications Center.

1. Change theme, device, and accessibility size to confirm view renders as expected.