### PR TITLE
Reorder messages about talk pages

### DIFF
--- a/Wikipedia/Localizations/en.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/en.lproj/Localizable.strings
@@ -581,13 +581,13 @@
 "notifications-center-filters-types-item-title-all" = "All types";
 "notifications-center-filters-types-section-title" = "Types of notifications";
 "notifications-center-go-to-article" = "Go to article";
-"notifications-center-go-to-article-collaboration-format" = "Go to $1 collaboration page";
-"notifications-center-go-to-article-discussion-format" = "Go to $1 discussion page";
 "notifications-center-go-to-article-talk-format" = "Go to $1 talk page";
-"notifications-center-go-to-collaboration-page" = "Go to collaboration page";
+"notifications-center-go-to-article-discussion-format" = "Go to $1 discussion page";
+"notifications-center-go-to-article-collaboration-format" = "Go to $1 collaboration page";
 "notifications-center-go-to-diff" = "Go to diff";
-"notifications-center-go-to-discussion-page" = "Go to discussion page";
 "notifications-center-go-to-talk-page" = "Go to talk page";
+"notifications-center-go-to-discussion-page" = "Go to discussion page";
+"notifications-center-go-to-collaboration-page" = "Go to collaboration page";
 "notifications-center-go-to-title-format" = "Go to $1";
 "notifications-center-go-to-user-page" = "Go to $1's user page";
 "notifications-center-go-to-user-page-format" = "Go to $1's user page";


### PR DESCRIPTION
"Talk page" is the most common name, so it should
appear first to help translators be in the right
context.

**Phabricator:** 

### Notes
* 

### Test Steps
1. 

### Screenshots/Videos

