### PR TITLE
Replace `willLogOutNotification` with `authenticationManagerWillLogOut` delegate method

### DIFF
--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -582,7 +582,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
     NSURL *legacyDirectory = [[[NSFileManager defaultManager] wmf_containerURL] URLByAppendingPathComponent:@"Permanent Image Cache" isDirectory:YES];
     NSURL *newDirectory = [[[NSFileManager defaultManager] wmf_containerURL] URLByAppendingPathComponent:@"Permanent Cache" isDirectory:YES];
 
-    //move legacy image cache to new non-image path name
+    // move legacy image cache to new non-image path name
     return [[NSFileManager defaultManager] moveItemAtURL:legacyDirectory toURL:newDirectory error:error];
 }
 
@@ -656,7 +656,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
     return [documentsFolder stringByAppendingPathComponent:@"Data"];
 }
 
-+ (NSString *)appSpecificMainDataStorePath { //deprecated, use the group folder from mainDataStorePath
++ (NSString *)appSpecificMainDataStorePath { // deprecated, use the group folder from mainDataStorePath
     NSString *documentsFolder =
         [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
     return [documentsFolder stringByAppendingPathComponent:@"Data"];
@@ -981,6 +981,10 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
 
 - (nullable NSURL *)loginSiteURL {
     return self.primarySiteURL;
+}
+
+- (void)authenticationManagerWillLogOutWithCompletionHandler:(void (^)(void))completionHandler {
+    [self.notificationsController authenticationManagerWillLogOut:completionHandler];
 }
 
 - (void)authenticationManagerDidLogin {

--- a/Wikipedia/Code/WMFAuthenticationManager.swift
+++ b/Wikipedia/Code/WMFAuthenticationManager.swift
@@ -3,6 +3,7 @@ import CocoaLumberjackSwift
 
 @objc protocol WMFAuthenticationManagerDelegate: NSObjectProtocol {
     var loginSiteURL: URL? { get }
+    func authenticationManagerWillLogOut(completionHandler: @escaping ()->Void) // allows interested objects to perform authenticated clean up actions before log out
     func authenticationManagerDidLogin()
     func authenticationManagerDidReset()
 }
@@ -256,28 +257,29 @@ import CocoaLumberjackSwift
      */
     @objc(logoutInitiatedBy:completion:)
     public func logout(initiatedBy logoutInitiator: LogoutInitiator, completion: @escaping () -> Void = {}){
-        NotificationCenter.default.post(name: WMFAuthenticationManager.willLogOutNotification, object: nil)
-        if logoutInitiator == .app || logoutInitiator == .server {
-            isUserUnawareOfLogout = true
-        }
-        let postDidLogOutNotification = {
-            NotificationCenter.default.post(name: WMFAuthenticationManager.didLogOutNotification, object: nil)
-        }
-        performTokenizedMediaWikiAPIPOST(to: loginSiteURL, with: ["action": "logout", "format": "json"], reattemptLoginOn401Response: false) { (result, response, error) in
-            DispatchQueue.main.async {
-                if let error = error {
-                    // ...but if "action=logout" fails we *still* want to clear local login settings, which still effectively logs the user out.
-                    DDLogDebug("Failed to log out, delete login tokens and other browser cookies: \(error)")
+        delegate?.authenticationManagerWillLogOut {
+            if logoutInitiator == .app || logoutInitiator == .server {
+                self.isUserUnawareOfLogout = true
+            }
+            let postDidLogOutNotification = {
+                NotificationCenter.default.post(name: WMFAuthenticationManager.didLogOutNotification, object: nil)
+            }
+            self.performTokenizedMediaWikiAPIPOST(to: self.loginSiteURL, with: ["action": "logout", "format": "json"], reattemptLoginOn401Response: false) { (result, response, error) in
+                DispatchQueue.main.async {
+                    if let error = error {
+                        // ...but if "action=logout" fails we *still* want to clear local login settings, which still effectively logs the user out.
+                        DDLogDebug("Failed to log out, delete login tokens and other browser cookies: \(error)")
+                        self.resetLocalUserLoginSettings()
+                        completion()
+                        postDidLogOutNotification()
+                        return
+                    }
+                    DDLogDebug("Successfully logged out, deleted login tokens and other browser cookies")
+                    // It's best to call "action=logout" API *before* clearing local login settings...
                     self.resetLocalUserLoginSettings()
                     completion()
                     postDidLogOutNotification()
-                    return
                 }
-                DDLogDebug("Successfully logged out, deleted login tokens and other browser cookies")
-                // It's best to call "action=logout" API *before* clearing local login settings...
-                self.resetLocalUserLoginSettings()
-                completion()
-                postDidLogOutNotification()
             }
         }
     }
@@ -317,7 +319,6 @@ extension WMFAuthenticationManager {
         case server
     }
 
-    @objc public static let willLogOutNotification = Notification.Name("WMFAuthenticationManagerWillLogOut")
     @objc public static let didLogOutNotification = Notification.Name("WMFAuthenticationManagerDidLogOut")
     @objc public static let didLogInNotification = Notification.Name("WMFAuthenticationManagerDidLogIn")
 

--- a/Wikipedia/Code/WMFNotificationsController.h
+++ b/Wikipedia/Code/WMFNotificationsController.h
@@ -47,6 +47,8 @@ extern NSString *const WMFNotificationInfoFeedNewsStoryKey;
 
 - (void)setRemoteNotificationRegistrationStatusWithDeviceToken:(nullable NSData *)deviceToken error:(nullable NSError *)error;
 
+- (void)authenticationManagerWillLogOut:(void (^)(void))completionHandler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wikipedia/Code/WMFNotificationsController.m
+++ b/Wikipedia/Code/WMFNotificationsController.m
@@ -37,7 +37,6 @@ NSString *const WMFNotificationInfoFeedNewsStoryKey = @"feedNewsStory";
         self.languageLinkController = languageLinkController;
         self.echoSubscriptionFetcher = [[WMFEchoSubscriptionFetcher alloc] initWithSession:dataStore.session configuration:dataStore.configuration];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleAppLanguageDidChangeNotification:) name:WMFAppLanguageDidChangeNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(authenticationManagerWillLogOut) name:WMFAuthenticationManager.willLogOutNotification object:nil];
         [self silentlyOptInToBadgePermissionsIfNecessary];
     }
     return self;
@@ -47,8 +46,14 @@ NSString *const WMFNotificationInfoFeedNewsStoryKey = @"feedNewsStory";
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)authenticationManagerWillLogOut {
-    [self unsubscribeFromEchoNotificationsWithCompletionHandler:nil];
+- (void)authenticationManagerWillLogOut:(void (^)(void))completionHandler {
+    if (NSUserDefaults.standardUserDefaults.wmf_isSubscribedToEchoNotifications) {
+        [self unsubscribeFromEchoNotificationsWithCompletionHandler:^(NSError *error) {
+            completionHandler();
+        }];
+    } else {
+        completionHandler();
+    }
 }
 
 - (void)silentlyOptInToBadgePermissionsIfNecessary {


### PR DESCRIPTION
**Phabricator**: https://phabricator.wikimedia.org/T288688 (in part)

### Notes

This branch is a cherry-picked clone of https://github.com/wikimedia/wikipedia-ios/pull/4149.

This PR addresses issues when unsubscribing the user's device from echo subscriptions when logging out. The previous willLogOutNotification approach was not sufficient to always unsubscribe the user from Echo. The echo unsubscription call requires an authenticated account (with a valid CSRF token), and the old notification approach would sometimes fail trying to unsubscribe them after their device was no longer authenticated, leaving the user as subscribed to echo as far as the app was concerned. This became evident when following the test steps below, but seeing during step 3 that the Push switch was still enabled on a fresh log in, which should not happen.

This approach allows the Authentication Manager's delegate to perform any authenticated actions (like unsubscribing the device from Echo notifications) before it performs log out related actions.

We should wait to merge it until after https://github.com/wikimedia/wikipedia-ios/pull/4138 is merged.

### Test Steps

1. Log in to an account on device
2. Enroll in Push notifications (Settings > Push notifications)
3. Log out, then log back in and confirm the Push notifications switch (Settings > Push notifications) is off