### PR TITLE
Present push opt-in panel in Notifications Center when user re-authenticates

### DIFF
--- a/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
+++ b/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
@@ -31,6 +31,7 @@ let WMFAppInstallId = "WMFAppInstallId"
 let WMFSendUsageReports = "WMFSendUsageReports"
 let WMFShowNotificationsExploreFeedCard = "WMFShowNotificationsExploreFeedCard"
 let WMFUserHasOnboardedToNotificationsCenter = "WMFUserHasOnboardedToNotificationsCenter"
+let WMFDidShowNotificationsCenterPushOptInPanel = "WMFDidShowNotificationsCenterPushOptInPanel"
 let WMFSubscribedToEchoNotifications = "WMFSubscribedToEchoNotifications"
 
 @objc public enum WMFAppDefaultTabType: Int {
@@ -447,6 +448,15 @@ let WMFSubscribedToEchoNotifications = "WMFSubscribedToEchoNotifications"
         }
         set {
             set(newValue, forKey: WMFUserHasOnboardedToNotificationsCenter)
+        }
+    }
+
+    @objc var wmf_didShowNotificationsCenterPushOptInPanel: Bool {
+        get {
+            return bool(forKey: WMFDidShowNotificationsCenterPushOptInPanel)
+        }
+        set {
+            set(newValue, forKey: WMFDidShowNotificationsCenterPushOptInPanel)
         }
     }
 

--- a/Wikipedia/Code/NotificationsCenterViewController.swift
+++ b/Wikipedia/Code/NotificationsCenterViewController.swift
@@ -461,6 +461,7 @@ extension NotificationsCenterViewController: NotificationsCenterOnboardingDelega
 
     func presentOnboardingEducationModalIfNecessary() {
         guard !UserDefaults.standard.wmf_userHasOnboardedToNotificationsCenter else {
+            presentOnboardingPushOptInIfNecessary()
             return
         }
 
@@ -472,12 +473,13 @@ extension NotificationsCenterViewController: NotificationsCenterOnboardingDelega
     }
 
     func presentOnboardingPushOptInIfNecessary() {
-        guard !UserDefaults.standard.wmf_userHasOnboardedToNotificationsCenter else {
+        guard !UserDefaults.standard.wmf_didShowNotificationsCenterPushOptInPanel else {
             return
         }
 
         guard !UserDefaults.standard.wmf_isSubscribedToEchoNotifications else {
             UserDefaults.standard.wmf_userHasOnboardedToNotificationsCenter = true
+            UserDefaults.standard.wmf_didShowNotificationsCenterPushOptInPanel = true
             return
         }
 
@@ -486,6 +488,7 @@ extension NotificationsCenterViewController: NotificationsCenterOnboardingDelega
 
             guard status != .denied else {
                 UserDefaults.standard.wmf_userHasOnboardedToNotificationsCenter = true
+                UserDefaults.standard.wmf_didShowNotificationsCenterPushOptInPanel = true
                 return
             }
 
@@ -502,6 +505,7 @@ extension NotificationsCenterViewController: NotificationsCenterOnboardingDelega
 
                 let dismissHandler: ScrollableEducationPanelDismissHandler = {
                     UserDefaults.standard.wmf_userHasOnboardedToNotificationsCenter = true
+                    UserDefaults.standard.wmf_didShowNotificationsCenterPushOptInPanel = true
                 }
 
                 let panel = NotificationsCenterOnboardingPushPanelViewController(showCloseButton: false, primaryButtonTapHandler: primaryTapHandler, secondaryButtonTapHandler: secondaryTapHandler, dismissHandler: dismissHandler, theme: self.theme)

--- a/Wikipedia/Code/WMFNotificationsController.m
+++ b/Wikipedia/Code/WMFNotificationsController.m
@@ -47,6 +47,7 @@ NSString *const WMFNotificationInfoFeedNewsStoryKey = @"feedNewsStory";
 }
 
 - (void)authenticationManagerWillLogOut:(void (^)(void))completionHandler {
+    NSUserDefaults.standardUserDefaults.wmf_didShowNotificationsCenterPushOptInPanel = NO;
     if (NSUserDefaults.standardUserDefaults.wmf_isSubscribedToEchoNotifications) {
         [self unsubscribeFromEchoNotificationsWithCompletionHandler:^(NSError *error) {
             completionHandler();


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T287768 (partially, [bullet point #3](https://phabricator.wikimedia.org/T287768#7802012))

### Notes
This PR separates the presentation logic of the Notifications Center onboarding educational modal from the Notifications Center push opt-in panel. The first run experience of a user who first taps the Notifications Center will be to see the onboarding education modal and then the push opt-in panel. They will not see the onboarding education modal again for this app install, but they will see the push opt-in panel again if they choose to log out of their account and re-authenticate again.

Ready for review, **but hold on merging until https://github.com/wikimedia/wikipedia-ios/pull/4174 is merged.**

### Test Steps
1. Fresh install the app, log in to an account, then tap the Notifications Center bell.
2. Confirm you see the onboarding education modal and the push opt-in panel.
3. Leave the Notifications Center, and tap it again to confirm you see neither the modal nor the panel.
4. Log out of your account and log back in.
5. Tap the Notifications Center bell again, and confirm you do not see the education modal, but do see the push opt-in panel.
