### PR TITLE
Fix console error when enabling logging

### DIFF
--- a/Wikipedia/Code/UserHistoryFunnel.swift
+++ b/Wikipedia/Code/UserHistoryFunnel.swift
@@ -57,8 +57,8 @@ private typealias ContentGroupKindAndLoggingCode = (kind: WMFContentGroupKind, l
             event["device_level_enabled"] = getDeviceNotificationStatus(status)
         }
         
-        let inboxCount = dataStore.remoteNotificationsController.numberOfAllNotifications
-        event["inbox_count"] = inboxCount
+        let inboxCount = try? dataStore.remoteNotificationsController.numberOfAllNotifications()
+        event["inbox_count"] = inboxCount ?? 0
 
         return wholeEvent(with: event)
     }


### PR DESCRIPTION
**Phabricator:**
https://phabricator.wikimedia.org/T305558

### Notes
This is the source of the malformed JSON that caused [this crash](https://github.com/wikimedia/wikipedia-ios/pull/4154).

### Test Steps
1. Fresh install app.
2. Skip past onboarding, then go to Settings > Enable logging toggle.
3. Watch the console. Be sure no Core Data errors appear.
4. Watch network traffic. Be sure the "MobileWikiAppiOSUserHistory" schema successfully POSTs to the legacy logging system.
