### PR TITLE
Use readable width for cell layout in `NotificationsCenterDetailView`

### DIFF
--- a/Wikipedia/Code/NotificationsCenterDetailView.swift
+++ b/Wikipedia/Code/NotificationsCenterDetailView.swift
@@ -10,6 +10,7 @@ final class NotificationsCenterDetailView: SetupView {
         tableView.register(NotificationsCenterDetailContentCell.self, forCellReuseIdentifier: NotificationsCenterDetailContentCell.reuseIdentifier)
         tableView.register(NotificationsCenterDetailActionCell.self, forCellReuseIdentifier: NotificationsCenterDetailActionCell.reuseIdentifier)
 
+        tableView.cellLayoutMarginsFollowReadableWidth = true
         tableView.estimatedRowHeight = 44
         tableView.rowHeight = UITableView.automaticDimension
         


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T286607 (partially)

### Notes
Lays out detail view table view to mimic Notifications Center's readable content margins.

### Test Steps
1. Open Notifications Center on iPad and tap a notification. Confirm that, similar to the Notifications Center itself, the Notification detail view cells are layout to respect the readable content margins (has leading and trailing margin space to those device edges).
