### PR TITLE
Prevent primary notification action from displaying in secondary actions list

### DIFF
--- a/Wikipedia/Code/NotificationsCenterDetailViewController.swift
+++ b/Wikipedia/Code/NotificationsCenterDetailViewController.swift
@@ -65,7 +65,7 @@ extension NotificationsCenterDetailViewController: UITableViewDelegate, UITableV
             }
         default:
             let cell = tableView.dequeueReusableCell(withIdentifier: NotificationsCenterDetailActionCell.reuseIdentifier) as? NotificationsCenterDetailActionCell ?? NotificationsCenterDetailActionCell()
-            cell.configure(action: viewModel.secondaryActions[indexPath.row], theme: theme)
+            cell.configure(action: viewModel.uniqueSecondaryActions[indexPath.row], theme: theme)
             return cell
         }
     }
@@ -83,7 +83,7 @@ extension NotificationsCenterDetailViewController: UITableViewDelegate, UITableV
 
             return 2
         default:
-            return viewModel.secondaryActions.count
+            return viewModel.uniqueSecondaryActions.count
         }
     }
 

--- a/Wikipedia/Code/NotificationsCenterDetailViewModel+ActionExtensions.swift
+++ b/Wikipedia/Code/NotificationsCenterDetailViewModel+ActionExtensions.swift
@@ -124,6 +124,18 @@ extension NotificationsCenterDetailViewModel {
         }
         return secondaryActions
     }
+
+    /// Do not include secondary action if its destination is the same as the primary action
+    var uniqueSecondaryActions: [NotificationsCenterAction] {
+        guard let primaryActionURL = primaryAction?.actionData?.url else {
+            return secondaryActions
+        }
+
+        return secondaryActions.filter({ action in
+            action.actionData?.url != primaryActionURL
+        })
+    }
+
 }
 
 //MARK: Private Helpers - Aggregate Swipe Action methods


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T302453 (partially)

### Notes
Adds a shallow URL check of the primary action and secondary actions to prevent the secondary actions from displaying any action that has the same destination as the primary action.

### Test Steps
Perform a light regression test of the notifications detail view to confirm nothing unexpected happens when displaying or tapping secondary actions. I don't have a particular type where I've personally noticed the duplication to begin with, so perhaps we should rely on QA to test through the available remote notification types.

