### PR TITLE
Fix crash when deiniting articles

### DIFF
--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -108,11 +108,10 @@ class ArticleViewController: ViewController, HintPresenting {
     }
     
     deinit {
-        // Need following line to prevent memory leak.
-        articleLoadWaitGroup?.leave()
         NotificationCenter.default.removeObserver(self)
         contentSizeObservation?.invalidate()
         messagingController.removeScriptMessageHandler()
+        articleLoadWaitGroup = nil
     }
     
     // MARK: WebView


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T307222

### Notes
This code was introduced in #4094. Per Apple's [documentation](https://developer.apple.com/documentation/dispatch/dispatchgroup/1452872-leave):

> A call to this function must balance a call to enter(). It is invalid to call it more times than enter(), which would result in a negative count.

If you search `articleLoadWaitGroup` in the project, you will notice there are two`enter()` calls, and this one bumps it up to 3 `leave()` calls. I'm not certain this `leave()` call fixes memory leaks here, and it's not worth the crash.

Setting the dispatch group property to nil here was just an attempt to fix the original memory leaks, although I'm still seeing some. It may be unnecessary, but I figure it couldn't hurt. I'm open to removing this new line though.

### Test Steps
1. Fresh install app. Open Explore feed. Rapidly tap in and out of various articles. Also rapidly hold to peek into article and tap "Read Now".

 On `main` you might eventually get a crash by doing this for a while. In this PR you shouldn't. I was able to get a crash eventually on `main` with these steps on my slowest device. I seemed to be able to reach the crash faster on TestFlight, so maybe the release mode optimizations surface it more. 

**Note:** If you do decide to run the Leaks instrument, there are a number of them on the notifications operations that might muddy your view. I will look into these next. To reduce these, comment out [these lines of code](https://github.com/wikimedia/wikipedia-ios/blob/main/WMF%20Framework/Remote%20Notifications/RemoteNotificationsOperationsController.swift#L209-L242).