### PR TITLE
Fix notification operation memory leaks

### DIFF
--- a/WMF Framework/Remote Notifications/RemoteNotificationsOperationsController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsOperationsController.swift
@@ -209,28 +209,28 @@ class RemoteNotificationsOperationsController: NSObject {
         //BEGIN: chained cross wiki operations
         //this generates additional API calls to fetch extra unread messages by inspecting the app language operation's cross wiki summary notification object in its response
         let crossWikiGroupOperation = RemoteNotificationsRefreshCrossWikiGroupOperation(appLanguageProject: appLanguageProject, secondaryProjects: secondaryProjects, languageLinkController: languageLinkController, apiController: apiController, modelController: modelController)
-        let crossWikiAdapterOperation = BlockOperation {
-            crossWikiGroupOperation.crossWikiSummaryNotification = appLanguageOperation.crossWikiSummaryNotification
+        let crossWikiAdapterOperation = BlockOperation { [weak crossWikiGroupOperation] in
+            crossWikiGroupOperation?.crossWikiSummaryNotification = appLanguageOperation.crossWikiSummaryNotification
         }
         crossWikiAdapterOperation.addDependency(appLanguageOperation)
         crossWikiGroupOperation.addDependency(crossWikiAdapterOperation)
         //END: chained cross wiki operations
-        
+
         //BEGIN: chained reauthentication operations
         //these will ask the authManager to reauthenticate if the app language operation has an unauthenticaated error code in it's response
         //then it will cancel existing operations running and recursively call kickoffPagingOperations again
         let reauthenticateOperation = RemoteNotificationsReauthenticateOperation(authManager: authManager)
-        let reauthenticateAdapterOperation = BlockOperation {
-            reauthenticateOperation.appLanguageOperationError = appLanguageOperation.error
+        let reauthenticateAdapterOperation = BlockOperation { [weak reauthenticateOperation] in
+            reauthenticateOperation?.appLanguageOperationError = appLanguageOperation.error
         }
         reauthenticateAdapterOperation.addDependency(appLanguageOperation)
         reauthenticateOperation.addDependency(reauthenticateAdapterOperation)
         let recursiveKickoffOperation = BlockOperation { [weak self] in
-            
+
             guard let self = self else {
                 return
             }
-            
+
             if reauthenticateOperation.didReauthenticate {
                 DispatchQueue.main.async {
                     self.operationQueue.cancelAllOperations()


### PR DESCRIPTION
**Phabricator:** 
N/A

### Notes
I noticed a lot of new memory leaks coming from the notifications operations when digging into #4203. This fixes them.

### Test Steps
1. Run leaks instrument on device. Log in via Settings (if you aren't already) so that notifications begin importing.
2. At this point in `main` you would start to see many leaks of foundation objects and RemoteNotification operations. This clears most of those out (I only see 2 now and they seem unrelated to notifications).

**Confirm cross wiki and reauth operations still work after changes:**
1. Fresh install app, log into an account that has an unread notification on a Wiki that is **not** an app language, wikidata or commons. You should still see that notification imported and displaying in notifications center.
2. While app is logged in on app, log into your same account on Desktop. Then log out on Desktop. Revisit Notifications Center on app. If you watch at this point via a Proxy, you will see that the initial notification refresh calls return a logged out error, but then it should automatically refresh the token and reattempt the notifications calls.