### PR TITLE
Add ProMotion support to Core Animation on iPhone 13 Pro/Pro Max

### DIFF
--- a/Wikipedia/Experimental-Info.plist
+++ b/Wikipedia/Experimental-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.wikimedia.wikipedia.appRefresh</string>

--- a/Wikipedia/Local-Info.plist
+++ b/Wikipedia/Local-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>mailto</string>

--- a/Wikipedia/Staging-Info.plist
+++ b/Wikipedia/Staging-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.wikimedia.wikipedia.appRefresh</string>

--- a/Wikipedia/User Testing-Info.plist
+++ b/Wikipedia/User Testing-Info.plist
@@ -104,6 +104,8 @@
 	<array>
 		<string>mailto</string>
 	</array>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>

--- a/Wikipedia/Wikipedia-Info.plist
+++ b/Wikipedia/Wikipedia-Info.plist
@@ -104,6 +104,8 @@
 	<array>
 		<string>mailto</string>
 	</array>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T301586

### Notes

Adds ProMotion support to Core Animation use on iPhone 13 Pro and Pro Max. The iPad Pro apparently automatically opts in to this usage, but the iPhone 13 Pro and Pro Max require explicitly setting this flag: https://developer.apple.com/documentation/quartzcore/optimizing_promotion_refresh_rates_for_iphone_13_pro_and_ipad_pro.

Currently, the iOS 15.4 adds ProMotion support to `UIView` block animator methods (which we have fair usage of): https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-15_4-release-notes. With the combination of this PR and that release, I believe we'll have covered most of the "for free" benefits of ProMotion in app.

### Test Steps
I don't have great objective test steps here other than to load an article with an animated GIF (like https://en.wikipedia.org/wiki/GIF) and confirm it still animates as expected.
