### PR TITLE
Notifications - fix bugs with special character url fragments

### DIFF
--- a/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataClass.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotification+CoreDataClass.swift
@@ -162,8 +162,20 @@ public class RemoteNotification: NSManagedObject {
         }
     }
 
-    public var primaryLinkHost: String? {
-        return messageLinks?.primary?.url?.host
+    public var linkHost: String? {
+        if let primaryLinkHost = messageLinks?.primary?.url?.host {
+            return primaryLinkHost
+        }
+        
+        if let secondaryLinks = messageLinks?.secondary {
+            for secondaryLink in secondaryLinks {
+                if let secondaryHost = secondaryLink.url?.host {
+                    return secondaryHost
+                }
+            }
+        }
+        
+        return nil
     }
 
     public var primaryLinkFragment: String? {

--- a/WMF Framework/Remote Notifications/Model/RemoteNotificationLinks.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotificationLinks.swift
@@ -31,7 +31,7 @@ public class RemoteNotificationLinks: NSObject, NSSecureCoding, Codable {
 }
 
 @objc(RemoteNotificationLink)
-public class RemoteNotificationLink: NSObject, NSSecureCoding, Codable {
+public final class RemoteNotificationLink: NSObject, NSSecureCoding, Codable {
     public static var supportsSecureCoding: Bool = true
     
     let type: String?
@@ -42,6 +42,20 @@ public class RemoteNotificationLink: NSObject, NSSecureCoding, Codable {
         self.type = type as String?
         self.url = url
         self.label = label as String?
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        type = try? values.decode(String.self, forKey: .type)
+        
+        let urlString = try? values.decode(String.self, forKey: .url)
+        if let urlString = urlString {
+            url = URL(string: urlString)
+        } else {
+            url = nil
+        }
+        
+        label = try? values.decode(String.self, forKey: .label)
     }
 
     public required convenience init(coder decoder: NSCoder) {

--- a/Wikipedia/Code/NotificationsCenterCommonViewModel+LinkExtensions.swift
+++ b/Wikipedia/Code/NotificationsCenterCommonViewModel+LinkExtensions.swift
@@ -21,7 +21,7 @@ extension NotificationsCenterCommonViewModel {
 
     var linkData: LinkData? {
 
-        guard let host = notification.primaryLinkHost ?? configuration.defaultSiteURL.host,
+        guard let host = notification.linkHost,
               let wiki = notification.wiki else {
             return nil
         }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T307529

### Notes
This fixes the worst of the bugs caused by special character fragments in notifications. I was halfway towards fixing by seeking out the fragment manually and url encoding it as we were processing them from the API call, but ultimately felt like it was papering over a server-side bug too much. So instead of adding any additional encoding on our side, this PR is just a little more forgiving when doing the initial `Decodable` call for `RemoteNotificationLink` to allow for nil `urls`. We are also no longer resorting to a default site domain when building up our links, which caused the random EN diff revision screen and empty talk page bugs.

The only remaining bug that this PR doesn't fix is seeking out the nested talk page reply thread and pushing directly to that, because we're dropping the url entirely and do not have a section title to to seek out. I can spin off a followup bug (which isn't a must-fix for 6.9.0, in my opinion) to track this.

### Test Steps

[special-char-fragments.txt](https://github.com/wikimedia/wikipedia-ios/files/8621162/special-char-fragments.txt)

This is a custom notifications response of some of my problem notifications, with special characters in the url fragments. You can use this to map the notifications response locally via a proxy if you'd like. 

1. Test the detail screen links on a user talk page notification that has special characters in its urls (i.e. from a user talk page message with a topic title that has special characters).
2. Confirm the notification body content is now populating in the notifications cell and detail screen.
3. Confirm the routing to "your talk page" goes to the correct talk page (note it will not go to the nested reply thread as explained above).
4. Confirm the routing of "diff" goes to the correct revision of the diff on that language Wikipedia instead of a random one on EN Wikipedia.