### PR TITLE
Update/fix RemoteConfig URL.

### DIFF
--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -859,7 +859,7 @@ NSString *MWKCreateImageURLWithPath(NSString *path) {
                              });
                          }];
     // Remote config
-    NSURL *remoteConfigURL = [NSURL URLWithString:@"https://meta.wikimedia.org/static/current/extensions/MobileApp/config/ios.json"];
+    NSURL *remoteConfigURL = [NSURL URLWithString:@"https://meta.wikimedia.org/w/extensions/MobileApp/config/ios.json"];
     [taskGroup enter];
     [self.session getJSONDictionaryFromURL:remoteConfigURL
                                ignoreCache:YES


### PR DESCRIPTION
The URL for fetching our RemoteConfig parameters has been updated recently (or a long time ago, and we hadn't noticed?) and is now returning 404.
This is the new URL.