### PR TITLE
Save identifiers of Notifications to display to `userInfo`

### DIFF
--- a/NotificationServiceExtension/NotificationService.swift
+++ b/NotificationServiceExtension/NotificationService.swift
@@ -27,7 +27,7 @@ class NotificationService: UNNotificationServiceExtension {
         
         self.bestAttemptContent = bestAttemptContent
         
-        guard bestAttemptContent.body == "checkEchoV1" else {
+        guard bestAttemptContent.body == EchoModelVersion.current else {
             bestAttemptContent.body = fallbackPushContent
             contentHandler(bestAttemptContent)
             return
@@ -83,6 +83,9 @@ class NotificationService: UNNotificationServiceExtension {
                         }
                     }
                 }
+
+                let displayContentIdentifiers = finalNotificationsToDisplay.compactMap { PushNotificationContentIdentifier(key: $0.key, date: $0.date) }
+                PushNotificationContentIdentifier.save(displayContentIdentifiers, to: &bestAttemptContent.userInfo)
 
                 bestAttemptContent.badge = NSNumber(value: newCache.currentUnreadCount + finalNotificationsToDisplay.count)
                 

--- a/WMF Framework/Remote Notifications/Model/EchoModelVersion.swift
+++ b/WMF Framework/Remote Notifications/Model/EchoModelVersion.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Represents the identifier received in a remote push notification sent by the Echo push notifier service. Note this is a class with a static property instead of an enum to simplify the interoperability with Objective-C.
+@objc class EchoModelVersion: NSObject {
+    @objc static let current = "checkEchoV1"
+}

--- a/WMF Framework/Remote Notifications/Model/PushNotificationContentIdentifier.swift
+++ b/WMF Framework/Remote Notifications/Model/PushNotificationContentIdentifier.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// A lightweight model to uniquely identify incoming push notifications
+@objc public class PushNotificationContentIdentifier: NSObject, Codable {
+
+    // MARK: - Properties
+
+    fileprivate static let dictionaryKey = "WMFPushNotificationContentIdentifier"
+
+    public let key: String
+    public let date: Date?
+
+    // MARK: - Lifecycle
+
+    public init(key: String, date: Date?) {
+        self.key = key
+        self.date = date
+    }
+
+    // MARK: - Public Utilities
+
+    public static func save(_ identifiers: [PushNotificationContentIdentifier], to userInfo: inout [AnyHashable: Any]) {
+        let encoded = try? JSONEncoder().encode(identifiers)
+        if let encoded = encoded {
+            userInfo[dictionaryKey] = encoded
+        }
+    }
+
+    @objc public static func load(from userInfo: Dictionary<AnyHashable, Any>) -> [PushNotificationContentIdentifier] {
+        guard let data = userInfo[dictionaryKey] as? Data, let decoded = try? JSONDecoder().decode([PushNotificationContentIdentifier].self, from: data) else {
+            return []
+        }
+
+        return decoded
+    }
+
+}

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -179,6 +179,8 @@
 		00A7946E245CA4E60063BA18 /* ArticleSurveyTimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A7946A245CA4E60063BA18 /* ArticleSurveyTimerController.swift */; };
 		00A8F58626BDD5E700175B8E /* WidgetSampleContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A8F58526BDD5E700175B8E /* WidgetSampleContentTests.swift */; };
 		00A8F58826BDD88700175B8E /* Featured Article Widget Preview Content.json in Resources */ = {isa = PBXBuildFile; fileRef = 00550D2526B1E7DB0055C496 /* Featured Article Widget Preview Content.json */; };
+		00A988082829D92B006D800B /* PushNotificationContentIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A988072829D92B006D800B /* PushNotificationContentIdentifier.swift */; };
+		00A988092829D92B006D800B /* PushNotificationContentIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A988072829D92B006D800B /* PushNotificationContentIdentifier.swift */; };
 		00AA5AA7276BF29E005295B0 /* StatusTextBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00AA5AA6276BF29E005295B0 /* StatusTextBarButtonItem.swift */; };
 		00AA5AA8276BF29E005295B0 /* StatusTextBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00AA5AA6276BF29E005295B0 /* StatusTextBarButtonItem.swift */; };
 		00AA5AA9276BF29E005295B0 /* StatusTextBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00AA5AA6276BF29E005295B0 /* StatusTextBarButtonItem.swift */; };
@@ -209,6 +211,8 @@
 		00D280F9247EFFFE006BEE23 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D280F6247EFFFE006BEE23 /* Date+Extensions.swift */; };
 		00D280FA247EFFFE006BEE23 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D280F6247EFFFE006BEE23 /* Date+Extensions.swift */; };
 		00D280FC247F019C006BEE23 /* Date+ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D280FB247F019C006BEE23 /* Date+ExtensionTests.swift */; };
+		00D4B1B4282996A2008C705C /* EchoModelVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D4B1B3282996A2008C705C /* EchoModelVersion.swift */; };
+		00D4B1B5282996A2008C705C /* EchoModelVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D4B1B3282996A2008C705C /* EchoModelVersion.swift */; };
 		00E2EA8926E28A9700B1A741 /* NotificationsCenterCellStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E2EA8826E28A9700B1A741 /* NotificationsCenterCellStyle.swift */; };
 		00E2EA8A26E28A9700B1A741 /* NotificationsCenterCellStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E2EA8826E28A9700B1A741 /* NotificationsCenterCellStyle.swift */; };
 		00E2EA8B26E28A9700B1A741 /* NotificationsCenterCellStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E2EA8826E28A9700B1A741 /* NotificationsCenterCellStyle.swift */; };
@@ -3806,6 +3810,7 @@
 		007F5C6C275AA74200E4B02C /* StackedImageLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackedImageLabelView.swift; sourceTree = "<group>"; usesTabs = 0; };
 		00A7946A245CA4E60063BA18 /* ArticleSurveyTimerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleSurveyTimerController.swift; sourceTree = "<group>"; usesTabs = 0; };
 		00A8F58526BDD5E700175B8E /* WidgetSampleContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSampleContentTests.swift; sourceTree = "<group>"; };
+		00A988072829D92B006D800B /* PushNotificationContentIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationContentIdentifier.swift; sourceTree = "<group>"; };
 		00AA5AA6276BF29E005295B0 /* StatusTextBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusTextBarButtonItem.swift; sourceTree = "<group>"; };
 		00AA5AAB276BF2AE005295B0 /* TextBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBarButtonItem.swift; sourceTree = "<group>"; };
 		00BCB71726DEE04D002C3F72 /* InsetLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetLabelView.swift; sourceTree = "<group>"; };
@@ -3814,6 +3819,7 @@
 		00CF2E9F27DABCA8006EFDDC /* NotificationsCenterOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCenterOnboardingView.swift; sourceTree = "<group>"; };
 		00D280F6247EFFFE006BEE23 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; usesTabs = 0; };
 		00D280FB247F019C006BEE23 /* Date+ExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+ExtensionTests.swift"; sourceTree = "<group>"; usesTabs = 0; };
+		00D4B1B3282996A2008C705C /* EchoModelVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EchoModelVersion.swift; sourceTree = "<group>"; };
 		00D5593424DB152300C78F08 /* WidgetsExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WidgetsExtension.entitlements; sourceTree = "<group>"; };
 		00E2EA8826E28A9700B1A741 /* NotificationsCenterCellStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCenterCellStyle.swift; sourceTree = "<group>"; };
 		00E2EA8D26E2A45C00B1A741 /* NotificationsCenterCellDisplayState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCenterCellDisplayState.swift; sourceTree = "<group>"; };
@@ -7278,6 +7284,8 @@
 				6761AEDE2704CF0000E47BAD /* RemoteNotificationsProject.swift */,
 				6761AEEC2706247800E47BAD /* PushNotificationsSettings.swift */,
 				6761AEEE2706249300E47BAD /* PushNotificationsCache.swift */,
+				00D4B1B3282996A2008C705C /* EchoModelVersion.swift */,
+				00A988072829D92B006D800B /* PushNotificationContentIdentifier.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -10853,6 +10861,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				676C864726D40AEB00A704C1 /* NotificationService.swift in Sources */,
+				00D4B1B5282996A2008C705C /* EchoModelVersion.swift in Sources */,
+				00A988092829D92B006D800B /* PushNotificationContentIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11624,6 +11634,8 @@
 				67D6C0202405B3D2005709B1 /* CacheGroup+CoreDataClass.swift in Sources */,
 				7A5357AB215552E7007998DC /* RemoteNotificationsOperation.swift in Sources */,
 				D84C361E1F32404700895FA1 /* NewsCollectionViewCell.swift in Sources */,
+				00D4B1B4282996A2008C705C /* EchoModelVersion.swift in Sources */,
+				00A988082829D92B006D800B /* PushNotificationContentIdentifier.swift in Sources */,
 				D844D9F61D6CC0440042D692 /* Cancellable.swift in Sources */,
 				7A3AD05B20ADB1DF00C92E04 /* WMFCurrentlyLoggedInUserFetcher.swift in Sources */,
 				D89D44031D74D40100F7862E /* MWKSearchResult.m in Sources */,

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1679,7 +1679,9 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
     NSDictionary *info = response.notification.request.content.userInfo;
 
-    [self showNotificationCenterForNotificationInfo:info];
+    if ([response.notification.request.content.threadIdentifier isEqualToString:EchoModelVersion.current]) {
+        [self showNotificationCenterForNotificationInfo:info];
+    }
 
     completionHandler();
 }


### PR DESCRIPTION
**Phabricator:** 
- https://phabricator.wikimedia.org/T301127 (partially) 
- https://phabricator.wikimedia.org/T291019 (partially)

### Notes
This PR adds some architectural/clean up work to help support upcoming notifications refresh work and upcoming work related to identifying and clearing out the OS's Notification Center.

- Adds a "model" to represent the Echo notifier's `checkEchoV1` message
- Adds a lightweight model to persist notification keys and dates of notifications about to be displayed for later use in the app's Notifications Center 
- Only pushes a tapped notification to the Notifications Center if it meets the criteria of being a `threadIdentifier` identified Echo message

The strangeness about type choice (class vs. enum) for `EchoModelVersion` is purely for simplicity with Objective-C interoperability. I'm happy to explore some alternates if you can think of a less gross approach. I just wanted to safely namespace the identifier because it's being used more than one place now, but didn't want to over-engineer a solution for something that will likely not change in the near future.

### Test Steps
I typically disable the relevance score work in `NotificationService` in order for quickly trigger displayed notifications with our Push utility.

1. Lightly regression test push notifications to confirm you can a. still receive them and b. tapping them opens the Notifications Center in app. Our Push utility serves as a good tool to trigger cases of no notifications, 1 notification, and multiple notifications of multiple types to help confirm the service extension does not crash.
2. Confirm the received push notifications on device don't display "checkEchoV1" text or anything else out of the ordinary in the body.
