### PR TITLE
Attempt to fix performBatchUpdates() crashes

### DIFF
--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -40,6 +40,12 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         }
 #endif
     }
+    
+    @objc var isGranularUpdatingEnabled: Bool = true {
+        didSet {
+            collectionViewUpdater?.isGranularUpdatingEnabled = isGranularUpdatingEnabled
+        }
+    }
 
     deinit {
         NotificationCenter.default.removeObserver(self)
@@ -63,7 +69,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        collectionViewUpdater?.isGranularUpdatingEnabled = true
+        isGranularUpdatingEnabled = true
         restoreScrollPositionIfNeeded()
 
         /// Terrible hack to make back button text appropriate for iOS 14 - need to set the title on `WMFAppViewController`. For all app tabs, this is set in `viewWillAppear`.
@@ -88,7 +94,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         super.viewDidDisappear(animated)
         dataStore.feedContentController.dismissCollapsedContentGroups()
         stopMonitoringReachability()
-        collectionViewUpdater?.isGranularUpdatingEnabled = false
+        isGranularUpdatingEnabled = false
     }
 
     @objc func updateNotificationsCenterButton() {

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -382,6 +382,10 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
     if (![self uiIsLoaded]) {
         return;
     }
+    
+    if ([self visibleViewController] == self.exploreViewController) {
+        self.exploreViewController.isGranularUpdatingEnabled = YES;
+    }
 
     if (self.isResumeComplete) {
         [self performTasksThatShouldOccurAfterBecomeActiveAndResume];
@@ -393,6 +397,9 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
     if (![self uiIsLoaded]) {
         return;
     }
+    
+    self.exploreViewController.isGranularUpdatingEnabled = NO;
+    
     [self.navigationStateController saveNavigationStateFor:self.navigationController
                                                         in:self.dataStore.viewContext];
     NSError *saveError = nil;


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T253762

### Notes
This PR attempts to reduce the potential number of invalid collection view updates happening within CollectionViewUpdater by adding a little extra logic to force a `reloadData()` call. It tries to do this with two approaches:

d5d8857c5071aaf78d384878af719fd477c81b70 - I noticed `CollectionViewUpdater` [already](https://github.com/wikimedia/wikipedia-ios/blob/fd697a4b762c5d3a7b37c2893539d3bac8565b55/Wikipedia/Code/CollectionViewUpdater.swift#L126) tries to fall back to `reloadData` if the number of sections pulled from the fetchResultsController match the number of sections from the previous update, plus or minus the new section delta value. Here I thought I would also check against `collectionView.numberOfSections`, in case it's somehow changing when we don't expect.
61b7f6804994c49917095f811610020eabddd859 - I also noticed `ExploreViewController` sets `isGranularPushEnabled` flag within it's  `viewDidDisappear` and `viewDidAppear` methods, which also forces a `reloadData()` in `CollectionViewUpdater()` when it's disabled. To match this functionality I thought I would also set this flag when the app is backgrounded. There's no need for us to have insertion/deletion animations here if the app is backgrounded. 

### Test Steps
I couldn't reproduce this, so most of this testing will just be regression testing.
1. Load the Explore feed on a fresh install. Page back several days and be sure older dates animate in.
2. Background the app, change the device date to the next day, then foreground. Pull to refresh Explore. Be sure new date data animates in at the top. 
3. Try hiding some cards, be sure those animate out well.
4. Terminate the app. Change the device date to 1 week later. Relaunch the app. Be sure new data animates in at the top.
