### PR TITLE
Add feature flag logic for the article talk page

### DIFF
--- a/WMF Framework/Configuration.swift
+++ b/WMF Framework/Configuration.swift
@@ -50,7 +50,7 @@ public class Configuration: NSObject {
 			.deploymentLabsForEventLogging = labs instance for testing event logging endpoints
 			All other endpoints would point to production */
 		
-        return Configuration.staging(options: [.betaCluster])
+        return Configuration.staging(options: [.deploymentLabsForEventLogging])
         #else
         return .production
         #endif

--- a/WMF Framework/FeatureFlags.swift
+++ b/WMF Framework/FeatureFlags.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-struct FeatureFlags {
+public struct FeatureFlags {
     
-    static var needsNewTalkPage: Bool {
+    public static var needsNewTalkPage: Bool {
         #if WMF_STAGING
             return true
         #else

--- a/WMF Framework/Router.swift
+++ b/WMF Framework/Router.swift
@@ -7,6 +7,7 @@ public class Router: NSObject {
         case articleHistory(_: URL, articleTitle: String)
         case articleDiffCompare(_: URL, fromRevID: Int?, toRevID: Int?)
         case articleDiffSingle(_: URL, fromRevID: Int?, toRevID: Int?)
+        case talk(_: URL)
         case userTalk(_: URL)
         case search(_: URL, term: String?)
         case audio(_: URL)
@@ -56,6 +57,8 @@ public class Router: NSObject {
         let title = namespaceAndTitle.1
         let inAppLinkDestination = Destination.inAppLink(url)
         switch namespace {
+        case .talk:
+            return .talk(url)
         case .userTalk:
             return .userTalk(url)
         case .special:

--- a/WMF Framework/Router.swift
+++ b/WMF Framework/Router.swift
@@ -58,7 +58,11 @@ public class Router: NSObject {
         let inAppLinkDestination = Destination.inAppLink(url)
         switch namespace {
         case .talk:
-            return .talk(url)
+            if FeatureFlags.needsNewTalkPage {
+                return .talk(url)
+            } else {
+                return .inAppLink(url)
+            }
         case .userTalk:
             return .userTalk(url)
         case .special:

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -922,6 +922,7 @@
 		67EA9E16228F035E008D9EFD /* TalkPageReplyFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676070A1227CE60800A81F09 /* TalkPageReplyFooterView.swift */; };
 		67ED8EB124F99FF400DD5D39 /* SignificantEventsFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67ED8EB024F99FF400DD5D39 /* SignificantEventsFetcherTests.swift */; };
 		67F1375E23C986CD00512B61 /* CacheTaskTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F1375D23C986CD00512B61 /* CacheTaskTracking.swift */; };
+		67F1A180286F34A5000D0F74 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836BF56B2869EC2600B98321 /* FeatureFlags.swift */; };
 		67F73383273C163700D7D713 /* TimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F73382273C163700D7D713 /* TimeInterval+Extensions.swift */; };
 		67F73386273C1FBA00D7D713 /* NotificationServiceHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F73385273C1FBA00D7D713 /* NotificationServiceHelperTests.swift */; };
 		67F73388273C26A000D7D713 /* NotificationServiceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F73387273C26A000D7D713 /* NotificationServiceHelper.swift */; };
@@ -1585,10 +1586,6 @@
 		8330533023EF107D00123141 /* MediaListGalleryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8330532D23EF107D00123141 /* MediaListGalleryViewController.swift */; };
 		8330533123EF107D00123141 /* MediaListGalleryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8330532D23EF107D00123141 /* MediaListGalleryViewController.swift */; };
 		8330533323F0388E00123141 /* DataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8330533223F0388E00123141 /* DataStoreTests.swift */; };
-		8334EC482869FCAA00929DF2 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836BF56B2869EC2600B98321 /* FeatureFlags.swift */; };
-		8334EC492869FCAB00929DF2 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836BF56B2869EC2600B98321 /* FeatureFlags.swift */; };
-		8334EC4A2869FCAB00929DF2 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836BF56B2869EC2600B98321 /* FeatureFlags.swift */; };
-		8334EC4B2869FCAC00929DF2 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836BF56B2869EC2600B98321 /* FeatureFlags.swift */; };
 		8336F1432119BD6E000CDE02 /* MediaWikiAcceptLanguageMapping.json in Resources */ = {isa = PBXBuildFile; fileRef = 8336F1422119BD6E000CDE02 /* MediaWikiAcceptLanguageMapping.json */; };
 		8338AF8D21F7B33E000C4055 /* WMFLegacyFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 8338AF8B21F7B33E000C4055 /* WMFLegacyFetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8338AF8E21F7B33E000C4055 /* WMFLegacyFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 8338AF8C21F7B33E000C4055 /* WMFLegacyFetcher.m */; };
@@ -8376,7 +8373,6 @@
 		BC7C3A371C0FF94A0057F023 /* Code */ = {
 			isa = PBXGroup;
 			children = (
-				836BF56B2869EC2600B98321 /* FeatureFlags.swift */,
 				D84C36461F32485E00895FA1 /* Model */,
 				D818D37F1ED725240076110D /* View Controllers */,
 				D83F5C051F0E5111006130FF /* Views */,
@@ -8955,6 +8951,7 @@
 				70416BF62565D6C000D5BC33 /* Event Platform */,
 				D81A28BD231E8F4C001CC77D /* ExtensionViewController.swift */,
 				83E9A2111F56FE5E006EB091 /* FakeProgressController.swift */,
+				836BF56B2869EC2600B98321 /* FeatureFlags.swift */,
 				0E728D271DAEE3200074EB4B /* Feed */,
 				D80ED2581EE178A800CE8C50 /* Gradient.swift */,
 				D8733C931ECA16940011E379 /* HasText.swift */,
@@ -11158,7 +11155,6 @@
 				B0ACB13321265B930078C136 /* WMFImageGalleryDescriptionTextView.swift in Sources */,
 				53A575FA2602C845009835E6 /* WMFAppViewController+Extensions.swift in Sources */,
 				B0C7A0801F710E94008415E7 /* WMFWelcomeLanguagesAnimationBackgroundView.swift in Sources */,
-				8334EC482869FCAA00929DF2 /* FeatureFlags.swift in Sources */,
 				00E75B6C27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift in Sources */,
 				8382F8D320D928BF00AE5250 /* ColumnarCollectionViewControllerLayoutCache.swift in Sources */,
 				D88FCADF1E4B74D300505A9F /* WikidataFetcher+Places.swift in Sources */,
@@ -12008,6 +12004,7 @@
 				D844D9B81D6CB7980042D692 /* MWKRecentSearchEntry.m in Sources */,
 				D8FA18AF1E1BD891009675C3 /* NSNumberFormatter+WMFExtras.swift in Sources */,
 				D844DA091D6CC4D40042D692 /* MWKLanguageFilter.m in Sources */,
+				67F1A180286F34A5000D0F74 /* FeatureFlags.swift in Sources */,
 				0042807225E6E395004945B3 /* NSError+MTLModelException.m in Sources */,
 				7A03130321542F5C0095C953 /* RemoteNotificationsOperationsController.swift in Sources */,
 				0E728D371DAEEAD60074EB4B /* MWKLocationSearchResult.m in Sources */,
@@ -12083,7 +12080,6 @@
 				67DDD18A250C1A28006C0F93 /* ThreeLineHeaderView.swift in Sources */,
 				53A575FD2602C845009835E6 /* WMFAppViewController+Extensions.swift in Sources */,
 				678D79ED235E595A006161FF /* DiffListChangeItemViewModel.swift in Sources */,
-				8334EC4B2869FCAC00929DF2 /* FeatureFlags.swift in Sources */,
 				00E75B6F27EB92DE00A45B78 /* NotificationsCenterDetailHeaderCell.swift in Sources */,
 				D8A42A641E815A9C00D8E281 /* WMFAuthButton.swift in Sources */,
 				B0432347210680A900A9A6B6 /* WMFContentGroupKind+FeedCustomization.swift in Sources */,
@@ -13039,7 +13035,6 @@
 				D8CE25F01E698E2400DAE2E0 /* WMFAccountCreationViewController.swift in Sources */,
 				674711852507253500287951 /* ArticleAsLivingDocSnippetCollectionViewCell.swift in Sources */,
 				D8CE25F31E698E2400DAE2E0 /* NSAttributedString+WMFModify.m in Sources */,
-				8334EC4A2869FCAB00929DF2 /* FeatureFlags.swift in Sources */,
 				D8CE25F41E698E2400DAE2E0 /* WMFSettingsViewController.m in Sources */,
 				83B01F9B23DB62CD001185F4 /* ArticleViewController+ArticleInformation.swift in Sources */,
 				D8A47C8623D7259A002AA823 /* NoIntrinsicContentSizeImageView.swift in Sources */,
@@ -13581,7 +13576,6 @@
 				B09705B6236B29D7006FDB5C /* DiffThanker.swift in Sources */,
 				D8EC3EEF1E9BDA35006712EB /* WMFAccountCreationViewController.swift in Sources */,
 				83FBE9771F6181E00026C7EB /* ShareAFactActivityImageItemProvider.swift in Sources */,
-				8334EC492869FCAB00929DF2 /* FeatureFlags.swift in Sources */,
 				83836ECE1F615E5B007D1A05 /* ShareViewController.swift in Sources */,
 				83B01F9C23DB62CD001185F4 /* ArticleViewController+ArticleInformation.swift in Sources */,
 				D8A47C8723D7259A002AA823 /* NoIntrinsicContentSizeImageView.swift in Sources */,

--- a/Wikipedia/Code/ViewControllerRouter.swift
+++ b/Wikipedia/Code/ViewControllerRouter.swift
@@ -89,6 +89,19 @@ class ViewControllerRouter: NSObject {
             let player = AVPlayer(url: audioURL)
             vc.player = player
             return presentOrPush(vc, with: completion)
+        case .talk(let linkURL):
+            
+            if FeatureFlags.needsNewTalkPage {
+                guard let newTalkPage = TalkPageViewController(url: linkURL, theme: theme) else {
+                    completion()
+                    return false
+                }
+                return presentOrPush(newTalkPage, with: completion)
+            } else {
+                let singlePageVC = SinglePageWebViewController(url: linkURL, theme: theme)
+                return presentOrPush(singlePageVC, with: completion)
+            }
+            
         case .userTalk(let linkURL):
             
             if FeatureFlags.needsNewTalkPage {

--- a/Wikipedia/Code/ViewControllerRouter.swift
+++ b/Wikipedia/Code/ViewControllerRouter.swift
@@ -91,16 +91,11 @@ class ViewControllerRouter: NSObject {
             return presentOrPush(vc, with: completion)
         case .talk(let linkURL):
             
-            if FeatureFlags.needsNewTalkPage {
-                guard let newTalkPage = TalkPageViewController(url: linkURL, theme: theme) else {
-                    completion()
-                    return false
-                }
-                return presentOrPush(newTalkPage, with: completion)
-            } else {
-                let singlePageVC = SinglePageWebViewController(url: linkURL, theme: theme)
-                return presentOrPush(singlePageVC, with: completion)
+            guard let newTalkPage = TalkPageViewController(url: linkURL, theme: theme) else {
+                completion()
+                return false
             }
+            return presentOrPush(newTalkPage, with: completion)
             
         case .userTalk(let linkURL):
             


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T311313

### Notes
I forgot about the article talk page portion of this! This adds a new check in our routing logic for article talk pages, which we didn't have before. 

I also adjusted what endpoints our Staging scheme points to, so that it mostly hits production. I think this will make development go more smoothly, because the production articles and talk pages will have more robust data to work with. `.deploymentLabsForEventLogging` just means for our legacy events in the app will post to development endpoints, everything else looks at production. This was just the lightest weight staging configuration I could set up - it won't hurt anything setting it to this just for the Staging app. Now you can use your usual main app credentials to log in for the Staging scheme.

### Test Steps
1. Switch to Staging scheme
2. Go to an article and scroll down and tap "View talk page"
3. App should navigate to our new talk page view controller.
4. Run the app in the Main scheme
5. Go to an article and scroll down and tap "View talk page"
6. App should navigate to an in-app web view, showing the mobile view talk page.

