### PR TITLE
Fix bug where keyboard popped up when opening app

### DIFF
--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1339,6 +1339,11 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
 }
 
 - (BOOL)shouldShowExploreScreenOnLaunch {
+    BOOL shouldOpenAppOnSearchTab = [NSUserDefaults standardUserDefaults].wmf_openAppOnSearchTab;
+    if (shouldOpenAppOnSearchTab) {
+        return NO;
+    }
+
     NSDate *resignActiveDate = [[NSUserDefaults standardUserDefaults] wmf_appResignActiveDate];
     if (!resignActiveDate) {
         return NO;


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T310798

### Notes
* `shouldShowExploreScreenOnLaunch` didn't consider whether the user wanted to always launch into the search tab - so it was opening to Search, then switching to Settings and causing the bug

### Test Steps
1. set `WMFTimeBeforeShowingExploreScreenOnLaunch` to 10 seconds.
2. Turn off Explore feed (so first tab is Settings), and set option to always open on Search screen.
3. Close app, wait 10 seconds, re-open app, ensure bug no longer exists.

(Run steps 1-3 on main branch to see bug in action.)

