### PR TITLE
Long-press back button fix for iPad

### DIFF
--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -105,6 +105,12 @@ class ArticleViewController: ViewController, HintPresenting {
         super.init(theme: theme)
         
         self.surveyTimerController = ArticleSurveyTimerController(delegate: self)
+
+        // `viewDidLoad` isn't called when re-creating the navigation stack on an iPad, and hence a cold launch on iPad doesn't properly show article names when long-pressing the back button if this code is in `viewDidLoad`
+        if #available(iOS 14.0, *) {
+            self.navigationItem.backButtonTitle = articleURL.wmf_title
+            self.navigationItem.backButtonDisplayMode = .generic
+        }
     }
     
     deinit {
@@ -321,10 +327,6 @@ class ArticleViewController: ViewController, HintPresenting {
             }
             
             self.showSurveyAnnouncementPanel(surveyAnnouncementResult: result, linkState: self.articleAsLivingDocController.surveyLinkState)
-        }
-        if #available(iOS 14.0, *) {
-            self.navigationItem.backButtonTitle = articleURL.wmf_title
-            self.navigationItem.backButtonDisplayMode = .generic
         }
     }
     

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1339,6 +1339,11 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
 }
 
 - (BOOL)shouldShowExploreScreenOnLaunch {
+    BOOL shouldOpenAppOnSearchTab = [NSUserDefaults standardUserDefaults].wmf_openAppOnSearchTab;
+    if (shouldOpenAppOnSearchTab) {
+        return NO;
+    }
+
     NSDate *resignActiveDate = [[NSUserDefaults standardUserDefaults] wmf_appResignActiveDate];
     if (!resignActiveDate) {
         return NO;


### PR DESCRIPTION
**Phabricator:** No phab task, sorry.

### Notes
* Since iOS 14, long-pressing a back button has given a list of all prior VCs in the stack, and you can jump to any of them.
* There was [a PR](https://github.com/wikimedia/wikipedia-ios/pull/3640/) to make this work with our navigation code, as well as a [follow-up PR](https://github.com/wikimedia/wikipedia-ios/pull/3954) with a couple bug fixes.
* This PR fixes one last bug I discovered - a cold launch on iPad constitutes the article stack appropriately, but instead of getting the titles when long-pressing the back button, instead each string just says "Back".
* From some investigation, it looks like `viewDidLoad` isn't being called when reconstituting the nav stack on iPad. I moved this code elsewhere, it now works.

### Test Steps
1. On iPad, open a few articles in a row. Long press the back button, ensure you see all article names.
2. Hard quit the app, re-open it.
3. Ensure you're on the last article, and when you long-press the back button, you again see the article names.

### Screenshots/Videos
Broken: 
<img width="200" alt="Screenshot" src="https://user-images.githubusercontent.com/9295855/176966768-7f6d4d21-f68e-4e71-bb02-9bcc2adaf0e3.jpeg">

Working:
<img width="200" alt="Screenshot" src="https://user-images.githubusercontent.com/9295855/176966787-ff047a5b-1a73-470d-8fac-209a63d1ed0b.png">

