### PR TITLE
Rename more old Talk Pages classes

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -448,7 +448,7 @@
 		6734116522739CCB005B31DA /* TalkPageLocalHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116322739CA2005B31DA /* TalkPageLocalHandler.swift */; };
 		6734116622739CCB005B31DA /* TalkPageLocalHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116322739CA2005B31DA /* TalkPageLocalHandler.swift */; };
 		6734116722739CCC005B31DA /* TalkPageLocalHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116322739CA2005B31DA /* TalkPageLocalHandler.swift */; };
-		6734117022773122005B31DA /* TalkPageReplyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116F22773122005B31DA /* TalkPageReplyCell.swift */; };
+		6734117022773122005B31DA /* OldTalkPageReplyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116F22773122005B31DA /* OldTalkPageReplyCell.swift */; };
 		6734EE7322976AE300F00B05 /* InfoBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6706A21622925FD2004774E2 /* InfoBannerView.swift */; };
 		6734EE7422976AE300F00B05 /* InfoBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6706A21622925FD2004774E2 /* InfoBannerView.swift */; };
 		6734EE7522976AE400F00B05 /* InfoBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6706A21622925FD2004774E2 /* InfoBannerView.swift */; };
@@ -490,9 +490,9 @@
 		675175DE276D3B9700CD2974 /* DisappearingCallbackNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675175DB276D3B9700CD2974 /* DisappearingCallbackNavigationController.swift */; };
 		675175DF276D3B9700CD2974 /* DisappearingCallbackNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675175DB276D3B9700CD2974 /* DisappearingCallbackNavigationController.swift */; };
 		67540CA924D221E3008B2894 /* LocationManagerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67540CA824D221E3008B2894 /* LocationManagerFactory.swift */; };
-		6754E44922773587005EEAD1 /* TalkPageReplyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116F22773122005B31DA /* TalkPageReplyCell.swift */; };
-		6754E44A22773587005EEAD1 /* TalkPageReplyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116F22773122005B31DA /* TalkPageReplyCell.swift */; };
-		6754E44B22773588005EEAD1 /* TalkPageReplyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116F22773122005B31DA /* TalkPageReplyCell.swift */; };
+		6754E44922773587005EEAD1 /* OldTalkPageReplyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116F22773122005B31DA /* OldTalkPageReplyCell.swift */; };
+		6754E44A22773587005EEAD1 /* OldTalkPageReplyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116F22773122005B31DA /* OldTalkPageReplyCell.swift */; };
+		6754E44B22773588005EEAD1 /* OldTalkPageReplyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116F22773122005B31DA /* OldTalkPageReplyCell.swift */; };
 		675A7CFE227A3F7C0034D9D9 /* OldTalkPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675A7CFD227A3F7C0034D9D9 /* OldTalkPageHeaderView.swift */; };
 		676070A2227CE60800A81F09 /* TalkPageReplyFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676070A1227CE60800A81F09 /* TalkPageReplyFooterView.swift */; };
 		676070A42280987C00A81F09 /* TalkPageTopicNewViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 676070A32280987C00A81F09 /* TalkPageTopicNewViewController.xib */; };
@@ -894,14 +894,14 @@
 		67E5DA5E2761B0AB00CE827D /* NotificationsCenterFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E5DA5B2761B0AB00CE827D /* NotificationsCenterFilterView.swift */; };
 		67E5DA5F2761B0AB00CE827D /* NotificationsCenterFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E5DA5B2761B0AB00CE827D /* NotificationsCenterFilterView.swift */; };
 		67E5DA6B276416A600CE827D /* RemoteNotificationsRefreshCrossWikiOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E5DA6A276416A600CE827D /* RemoteNotificationsRefreshCrossWikiOperation.swift */; };
-		67E8B0742268DA8B00537BC9 /* TalkPageTopicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0732268DA8B00537BC9 /* TalkPageTopicCell.swift */; };
+		67E8B0742268DA8B00537BC9 /* OldTalkPageTopicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0732268DA8B00537BC9 /* OldTalkPageTopicCell.swift */; };
 		67E8B0762268DE4B00537BC9 /* TalkPageContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0752268DE4B00537BC9 /* TalkPageContainerViewController.swift */; };
 		67E8B07B226A57DE00537BC9 /* AccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F73E6C2267B79E0079DEEF /* AccountViewController.swift */; };
 		67E8B07C226A57DE00537BC9 /* AccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F73E6C2267B79E0079DEEF /* AccountViewController.swift */; };
 		67E8B07D226A57DF00537BC9 /* AccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F73E6C2267B79E0079DEEF /* AccountViewController.swift */; };
-		67E8B07F226A57E400537BC9 /* TalkPageTopicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0732268DA8B00537BC9 /* TalkPageTopicCell.swift */; };
-		67E8B082226A57E500537BC9 /* TalkPageTopicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0732268DA8B00537BC9 /* TalkPageTopicCell.swift */; };
-		67E8B083226A57E600537BC9 /* TalkPageTopicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0732268DA8B00537BC9 /* TalkPageTopicCell.swift */; };
+		67E8B07F226A57E400537BC9 /* OldTalkPageTopicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0732268DA8B00537BC9 /* OldTalkPageTopicCell.swift */; };
+		67E8B082226A57E500537BC9 /* OldTalkPageTopicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0732268DA8B00537BC9 /* OldTalkPageTopicCell.swift */; };
+		67E8B083226A57E600537BC9 /* OldTalkPageTopicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0732268DA8B00537BC9 /* OldTalkPageTopicCell.swift */; };
 		67E8B084226A57E900537BC9 /* TalkPageContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0752268DE4B00537BC9 /* TalkPageContainerViewController.swift */; };
 		67E8B085226A57E900537BC9 /* TalkPageTopicListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F73E702267B8020079DEEF /* TalkPageTopicListViewController.swift */; };
 		67E8B086226A57E900537BC9 /* TalkPageTopicNewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F73E782267B9500079DEEF /* TalkPageTopicNewViewController.swift */; };
@@ -3971,7 +3971,7 @@
 		6734115122700C47005B31DA /* TalkPageTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageTestHelpers.swift; sourceTree = "<group>"; };
 		6734116322739CA2005B31DA /* TalkPageLocalHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageLocalHandler.swift; sourceTree = "<group>"; };
 		6734116922739FD6005B31DA /* TalkPageLocalHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageLocalHandlerTests.swift; sourceTree = "<group>"; };
-		6734116F22773122005B31DA /* TalkPageReplyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageReplyCell.swift; sourceTree = "<group>"; };
+		6734116F22773122005B31DA /* OldTalkPageReplyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldTalkPageReplyCell.swift; sourceTree = "<group>"; };
 		6734F051227B634900BDDB94 /* ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
 		673612F124FD7210002A1989 /* ArticleAsLivingDocViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleAsLivingDocViewModelTests.swift; sourceTree = "<group>"; };
 		6739A181273061220063E0E0 /* RemoteNotificationsMarkAllAsReadOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationsMarkAllAsReadOperation.swift; sourceTree = "<group>"; };
@@ -4134,7 +4134,7 @@
 		67E50B2A27EAD3AD00ABA159 /* NotificationsCenterDetailViewModel+ImageExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationsCenterDetailViewModel+ImageExtensions.swift"; sourceTree = "<group>"; };
 		67E5DA5B2761B0AB00CE827D /* NotificationsCenterFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCenterFilterView.swift; sourceTree = "<group>"; };
 		67E5DA6A276416A600CE827D /* RemoteNotificationsRefreshCrossWikiOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationsRefreshCrossWikiOperation.swift; sourceTree = "<group>"; };
-		67E8B0732268DA8B00537BC9 /* TalkPageTopicCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageTopicCell.swift; sourceTree = "<group>"; };
+		67E8B0732268DA8B00537BC9 /* OldTalkPageTopicCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldTalkPageTopicCell.swift; sourceTree = "<group>"; };
 		67E8B0752268DE4B00537BC9 /* TalkPageContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageContainerViewController.swift; sourceTree = "<group>"; };
 		67E8B0A4226A64CB00537BC9 /* OldTalkPagesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldTalkPagesController.swift; sourceTree = "<group>"; };
 		67E8B0A7226A654D00537BC9 /* OldTalkPageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldTalkPageFetcher.swift; sourceTree = "<group>"; };
@@ -7164,8 +7164,8 @@
 		67E8B0782268F8F100537BC9 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				67E8B0732268DA8B00537BC9 /* TalkPageTopicCell.swift */,
-				6734116F22773122005B31DA /* TalkPageReplyCell.swift */,
+				67E8B0732268DA8B00537BC9 /* OldTalkPageTopicCell.swift */,
+				6734116F22773122005B31DA /* OldTalkPageReplyCell.swift */,
 				67D3C452228CB54E001D5741 /* TalkPageReplyComposeView.swift */,
 				675A7CFD227A3F7C0034D9D9 /* OldTalkPageHeaderView.swift */,
 				676070A1227CE60800A81F09 /* TalkPageReplyFooterView.swift */,
@@ -11143,7 +11143,7 @@
 				67E2E48F250452E60070F12D /* ArticleAsLivingDocHeaderView.swift in Sources */,
 				B0524B6F214854E900D8FD8D /* DescriptionWelcomeContentsViewController.swift in Sources */,
 				67F73E752267B9070079DEEF /* TalkPageReplyListViewController.swift in Sources */,
-				67E8B0742268DA8B00537BC9 /* TalkPageTopicCell.swift in Sources */,
+				67E8B0742268DA8B00537BC9 /* OldTalkPageTopicCell.swift in Sources */,
 				B0F92C6F1E3C580900B72802 /* WMFCaptchaResetter.swift in Sources */,
 				830D71C31F703C980080078B /* ArticleURLListViewController.swift in Sources */,
 				7A7AC84621B6B89B003B849B /* SectionEditorViewController.swift in Sources */,
@@ -11620,7 +11620,7 @@
 				83F1095F23D09F80003F3E9E /* ArticleViewController+WIconPopover.swift in Sources */,
 				7A25367721B5AA4F00F841A1 /* ContextualHighlightEditToolbarView.swift in Sources */,
 				D8E6FF6C24056AC300686272 /* ArticleViewController+ContextMenu.swift in Sources */,
-				6734117022773122005B31DA /* TalkPageReplyCell.swift in Sources */,
+				6734117022773122005B31DA /* OldTalkPageReplyCell.swift in Sources */,
 				7A2432BE1FCF401900FB4BA5 /* CreateReadingListViewController.swift in Sources */,
 				7A0DE50020CEEC760032AB57 /* ExploreFeedSettingsViewController.swift in Sources */,
 				B0E805611C0CE0DC0065EBC0 /* WKWebView+ElementLocation.m in Sources */,
@@ -12230,7 +12230,7 @@
 				67DAEDA623CE24DA003AA208 /* SavedArticlesFetcher.swift in Sources */,
 				D8A42AB31E815A9C00D8E281 /* MWKSearchRedirectMapping.m in Sources */,
 				D8A42AB41E815A9C00D8E281 /* MWKImageInfoFetcher+PicOfTheDayInfo.m in Sources */,
-				67E8B082226A57E500537BC9 /* TalkPageTopicCell.swift in Sources */,
+				67E8B082226A57E500537BC9 /* OldTalkPageTopicCell.swift in Sources */,
 				D8A42AB61E815A9C00D8E281 /* RoundedCornerView.swift in Sources */,
 				7AE1FE3421B4A9790068BE9F /* TextFormattingButtonView.swift in Sources */,
 				83E52BC21F682E3E0045E776 /* LicenseView.swift in Sources */,
@@ -12548,7 +12548,7 @@
 				B068EDE3206B183500C827D1 /* Progress+ProgressUI.swift in Sources */,
 				83F1096223D09F80003F3E9E /* ArticleViewController+WIconPopover.swift in Sources */,
 				7A25367A21B5AA4F00F841A1 /* ContextualHighlightEditToolbarView.swift in Sources */,
-				6754E44B22773588005EEAD1 /* TalkPageReplyCell.swift in Sources */,
+				6754E44B22773588005EEAD1 /* OldTalkPageReplyCell.swift in Sources */,
 				7A0DE50320CEEC760032AB57 /* ExploreFeedSettingsViewController.swift in Sources */,
 				7A2432C11FCF401900FB4BA5 /* CreateReadingListViewController.swift in Sources */,
 				D8A42B8D1E815A9C00D8E281 /* UIViewController+WMFStoryboardUtilities.swift in Sources */,
@@ -13072,7 +13072,7 @@
 				B0BCF0AC2023AC7700986F72 /* ScrollableEducationPanelViewController.swift in Sources */,
 				B0B423691EF9D6D500D3DC4C /* OnThisDayViewControllerHeader.swift in Sources */,
 				D8CE25FE1E698E2400DAE2E0 /* WMFArticleRevision.m in Sources */,
-				6754E44A22773587005EEAD1 /* TalkPageReplyCell.swift in Sources */,
+				6754E44A22773587005EEAD1 /* OldTalkPageReplyCell.swift in Sources */,
 				83F1096023D09F80003F3E9E /* ArticleViewController+WIconPopover.swift in Sources */,
 				6782DBA42343B7EE003FA21B /* DiffHeaderSummaryView.swift in Sources */,
 				D8CE25FF1E698E2400DAE2E0 /* ArticlePlaceView.swift in Sources */,
@@ -13129,7 +13129,7 @@
 				D8CE26191E698E2400DAE2E0 /* PageHistoryFetcher.swift in Sources */,
 				83F1096F23D0E787003F3E9E /* RandomArticleViewController.swift in Sources */,
 				7ABE17252239BB54006BA309 /* WelcomePanelViewController.swift in Sources */,
-				67E8B07F226A57E400537BC9 /* TalkPageTopicCell.swift in Sources */,
+				67E8B07F226A57E400537BC9 /* OldTalkPageTopicCell.swift in Sources */,
 				678D79F1235E5979006161FF /* DiffListChangeViewModel.swift in Sources */,
 				D8CE261B1E698E2400DAE2E0 /* CreateAccountFunnel.m in Sources */,
 				D8CE261D1E698E2400DAE2E0 /* WMFShareFunnel.m in Sources */,
@@ -13614,7 +13614,7 @@
 				B0BCF0AD2023AC7700986F72 /* ScrollableEducationPanelViewController.swift in Sources */,
 				D8EC3EFE1E9BDA35006712EB /* ArticlePlaceView.swift in Sources */,
 				D8EC3EFF1E9BDA35006712EB /* WMFCaptchaViewController.swift in Sources */,
-				6754E44922773587005EEAD1 /* TalkPageReplyCell.swift in Sources */,
+				6754E44922773587005EEAD1 /* OldTalkPageReplyCell.swift in Sources */,
 				83F1096123D09F80003F3E9E /* ArticleViewController+WIconPopover.swift in Sources */,
 				6782DBA52343B7EE003FA21B /* DiffHeaderSummaryView.swift in Sources */,
 				D8EC3F001E9BDA35006712EB /* DDLog+WMFLogger.m in Sources */,
@@ -13671,7 +13671,7 @@
 				D87B13A71F276B1000B27227 /* ShareActivityController.swift in Sources */,
 				83F1097023D0E787003F3E9E /* RandomArticleViewController.swift in Sources */,
 				7ABE17262239BB54006BA309 /* WelcomePanelViewController.swift in Sources */,
-				67E8B083226A57E600537BC9 /* TalkPageTopicCell.swift in Sources */,
+				67E8B083226A57E600537BC9 /* OldTalkPageTopicCell.swift in Sources */,
 				678D79F2235E5979006161FF /* DiffListChangeViewModel.swift in Sources */,
 				D8EC3F1A1E9BDA35006712EB /* CreateAccountFunnel.m in Sources */,
 				D8EC3F1C1E9BDA35006712EB /* WMFShareFunnel.m in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -812,10 +812,10 @@
 		67CEF2702351113000D5CA6C /* DiffController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CEF26E2351113000D5CA6C /* DiffController.swift */; };
 		67CEF2712351113000D5CA6C /* DiffController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CEF26E2351113000D5CA6C /* DiffController.swift */; };
 		67CEF2722351113000D5CA6C /* DiffController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CEF26E2351113000D5CA6C /* DiffController.swift */; };
-		67D3C453228CB54E001D5741 /* TalkPageReplyComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D3C452228CB54E001D5741 /* TalkPageReplyComposeView.swift */; };
-		67D3C454228CB54E001D5741 /* TalkPageReplyComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D3C452228CB54E001D5741 /* TalkPageReplyComposeView.swift */; };
-		67D3C455228CB54E001D5741 /* TalkPageReplyComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D3C452228CB54E001D5741 /* TalkPageReplyComposeView.swift */; };
-		67D3C456228CB54E001D5741 /* TalkPageReplyComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D3C452228CB54E001D5741 /* TalkPageReplyComposeView.swift */; };
+		67D3C453228CB54E001D5741 /* OldTalkPageReplyComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D3C452228CB54E001D5741 /* OldTalkPageReplyComposeView.swift */; };
+		67D3C454228CB54E001D5741 /* OldTalkPageReplyComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D3C452228CB54E001D5741 /* OldTalkPageReplyComposeView.swift */; };
+		67D3C455228CB54E001D5741 /* OldTalkPageReplyComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D3C452228CB54E001D5741 /* OldTalkPageReplyComposeView.swift */; };
+		67D3C456228CB54E001D5741 /* OldTalkPageReplyComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D3C452228CB54E001D5741 /* OldTalkPageReplyComposeView.swift */; };
 		67D6C00A240581ED005709B1 /* CacheItemMigrationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D6C009240581ED005709B1 /* CacheItemMigrationPolicy.swift */; };
 		67D6C00C24058714005709B1 /* CacheItemMappingModel.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 67D6C00B24058714005709B1 /* CacheItemMappingModel.xcmappingmodel */; };
 		67D6C01C2405A4FB005709B1 /* CacheItem+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D6C01A2405A4FB005709B1 /* CacheItem+CoreDataClass.swift */; };
@@ -4096,7 +4096,7 @@
 		67CEF2602350C29D00D5CA6C /* DiffListUneditedCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DiffListUneditedCell.xib; sourceTree = "<group>"; };
 		67CEF262235110F700D5CA6C /* DiffNetworkModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffNetworkModels.swift; sourceTree = "<group>"; };
 		67CEF26E2351113000D5CA6C /* DiffController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffController.swift; sourceTree = "<group>"; };
-		67D3C452228CB54E001D5741 /* TalkPageReplyComposeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TalkPageReplyComposeView.swift; sourceTree = "<group>"; };
+		67D3C452228CB54E001D5741 /* OldTalkPageReplyComposeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldTalkPageReplyComposeView.swift; sourceTree = "<group>"; };
 		67D6C008240581B2005709B1 /* Cache 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Cache 2.xcdatamodel"; sourceTree = "<group>"; };
 		67D6C009240581ED005709B1 /* CacheItemMigrationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheItemMigrationPolicy.swift; sourceTree = "<group>"; };
 		67D6C00B24058714005709B1 /* CacheItemMappingModel.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = CacheItemMappingModel.xcmappingmodel; sourceTree = "<group>"; };
@@ -7166,7 +7166,7 @@
 			children = (
 				67E8B0732268DA8B00537BC9 /* OldTalkPageTopicCell.swift */,
 				6734116F22773122005B31DA /* OldTalkPageReplyCell.swift */,
-				67D3C452228CB54E001D5741 /* TalkPageReplyComposeView.swift */,
+				67D3C452228CB54E001D5741 /* OldTalkPageReplyComposeView.swift */,
 				675A7CFD227A3F7C0034D9D9 /* OldTalkPageHeaderView.swift */,
 				676070A1227CE60800A81F09 /* TalkPageReplyFooterView.swift */,
 				6706A21622925FD2004774E2 /* InfoBannerView.swift */,
@@ -11590,7 +11590,7 @@
 				6761AEE62704FD3F00E47BAD /* NotificationsCenterCellViewModel+IconNameExtensions.swift in Sources */,
 				671DF9C125F2AE4E0011799E /* ArticleDescriptionControlling.swift in Sources */,
 				67CEF26F2351113000D5CA6C /* DiffController.swift in Sources */,
-				67D3C453228CB54E001D5741 /* TalkPageReplyComposeView.swift in Sources */,
+				67D3C453228CB54E001D5741 /* OldTalkPageReplyComposeView.swift in Sources */,
 				7A6F560521AF527A0076D184 /* TextFormattingInputViewController.swift in Sources */,
 				7AC809C521DD1FE100E8B6E1 /* SectionEditorInputViewsController.swift in Sources */,
 				B083371E1DADB251002860D2 /* WMFWelcomePageViewController.swift in Sources */,
@@ -12126,7 +12126,7 @@
 				7A49A20421231510005C574C /* CollectionViewFooter.swift in Sources */,
 				67CEF26C2351111D00D5CA6C /* DiffNetworkModels.swift in Sources */,
 				83B4CDC220E3DCD6007D5A6E /* SearchViewController.swift in Sources */,
-				67D3C456228CB54E001D5741 /* TalkPageReplyComposeView.swift in Sources */,
+				67D3C456228CB54E001D5741 /* OldTalkPageReplyComposeView.swift in Sources */,
 				7AC19E352301EF7D00E25B83 /* PageHistoryFilterCountsViewController.swift in Sources */,
 				41CCB67721CC1F9700206B47 /* SavedArticlesCollectionViewController.swift in Sources */,
 				6780D5BD237AF8A10087A5D1 /* DiffToolbarView.swift in Sources */,
@@ -12611,7 +12611,7 @@
 				007CCF0326D5A10200D5EA7C /* NotificationsCenterViewController.swift in Sources */,
 				B0524B76214856A400D8FD8D /* UIViewController+DescriptionWelcomeStoryboard.swift in Sources */,
 				B0D3E70D214AF776007578BA /* DescriptionEditViewController.swift in Sources */,
-				67D3C454228CB54E001D5741 /* TalkPageReplyComposeView.swift in Sources */,
+				67D3C454228CB54E001D5741 /* OldTalkPageReplyComposeView.swift in Sources */,
 				B0F4761C21F921D300C4E254 /* EditSummaryViewController.swift in Sources */,
 				00AA5AA9276BF29E005295B0 /* StatusTextBarButtonItem.swift in Sources */,
 				0042812F25E6E841004945B3 /* NYTPhotoCaptionView.m in Sources */,
@@ -13154,7 +13154,7 @@
 				B04AE84E21C6475C00CE51D8 /* WKWebViewWithSettableInputViews.swift in Sources */,
 				FFD7B85A24B3CA9F005C2471 /* ReferenceShowing.swift in Sources */,
 				B0524B77214856A400D8FD8D /* UIViewController+DescriptionWelcomeStoryboard.swift in Sources */,
-				67D3C455228CB54E001D5741 /* TalkPageReplyComposeView.swift in Sources */,
+				67D3C455228CB54E001D5741 /* OldTalkPageReplyComposeView.swift in Sources */,
 				00AA5AA8276BF29E005295B0 /* StatusTextBarButtonItem.swift in Sources */,
 				0042812E25E6E841004945B3 /* NYTPhotoCaptionView.m in Sources */,
 				B0D3E70E214AF776007578BA /* DescriptionEditViewController.swift in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -360,9 +360,9 @@
 		6707C039237F0A6E0017E7B6 /* UIFont+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707C037237F0A6E0017E7B6 /* UIFont+Extensions.swift */; };
 		6707C03A237F0A6E0017E7B6 /* UIFont+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707C037237F0A6E0017E7B6 /* UIFont+Extensions.swift */; };
 		6707C03B237F0A6E0017E7B6 /* UIFont+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707C037237F0A6E0017E7B6 /* UIFont+Extensions.swift */; };
-		670AF18D26BDE645005F76D0 /* TalkPageHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 672B127722A450F000CC85A5 /* TalkPageHeaderView.xib */; };
-		670AF18E26BDE646005F76D0 /* TalkPageHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 672B127722A450F000CC85A5 /* TalkPageHeaderView.xib */; };
-		670AF18F26BDE647005F76D0 /* TalkPageHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 672B127722A450F000CC85A5 /* TalkPageHeaderView.xib */; };
+		670AF18D26BDE645005F76D0 /* OldTalkPageHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 672B127722A450F000CC85A5 /* OldTalkPageHeaderView.xib */; };
+		670AF18E26BDE646005F76D0 /* OldTalkPageHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 672B127722A450F000CC85A5 /* OldTalkPageHeaderView.xib */; };
+		670AF18F26BDE647005F76D0 /* OldTalkPageHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 672B127722A450F000CC85A5 /* OldTalkPageHeaderView.xib */; };
 		670AF19026BDE6E7005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
 		670AF19126BDE6E8005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
 		670AF19226BDE6E9005F76D0 /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671F5E0A236B8CAF00111116 /* EmptyViewController.xib */; };
@@ -422,7 +422,7 @@
 		67282FBE24855B7B00B73E20 /* ArticleContextMenuPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67282FBC24855B7B00B73E20 /* ArticleContextMenuPresenting.swift */; };
 		67282FBF24855B7B00B73E20 /* ArticleContextMenuPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67282FBC24855B7B00B73E20 /* ArticleContextMenuPresenting.swift */; };
 		67282FC024855B7B00B73E20 /* ArticleContextMenuPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67282FBC24855B7B00B73E20 /* ArticleContextMenuPresenting.swift */; };
-		672B127822A450F000CC85A5 /* TalkPageHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 672B127722A450F000CC85A5 /* TalkPageHeaderView.xib */; };
+		672B127822A450F000CC85A5 /* OldTalkPageHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 672B127722A450F000CC85A5 /* OldTalkPageHeaderView.xib */; };
 		672C35EB22D8E7CA007B8D46 /* EmptyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672C35EA22D8E7C9007B8D46 /* EmptyViewController.swift */; };
 		672C35EC22D8E7D2007B8D46 /* EmptyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672C35EA22D8E7C9007B8D46 /* EmptyViewController.swift */; };
 		672C35ED22D8E7D2007B8D46 /* EmptyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672C35EA22D8E7C9007B8D46 /* EmptyViewController.swift */; };
@@ -493,7 +493,7 @@
 		6754E44922773587005EEAD1 /* TalkPageReplyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116F22773122005B31DA /* TalkPageReplyCell.swift */; };
 		6754E44A22773587005EEAD1 /* TalkPageReplyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116F22773122005B31DA /* TalkPageReplyCell.swift */; };
 		6754E44B22773588005EEAD1 /* TalkPageReplyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116F22773122005B31DA /* TalkPageReplyCell.swift */; };
-		675A7CFE227A3F7C0034D9D9 /* TalkPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675A7CFD227A3F7C0034D9D9 /* TalkPageHeaderView.swift */; };
+		675A7CFE227A3F7C0034D9D9 /* OldTalkPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675A7CFD227A3F7C0034D9D9 /* OldTalkPageHeaderView.swift */; };
 		676070A2227CE60800A81F09 /* TalkPageReplyFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676070A1227CE60800A81F09 /* TalkPageReplyFooterView.swift */; };
 		676070A42280987C00A81F09 /* TalkPageTopicNewViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 676070A32280987C00A81F09 /* TalkPageTopicNewViewController.xib */; };
 		676070A52280D72400A81F09 /* TalkPageTopicNewViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 676070A32280987C00A81F09 /* TalkPageTopicNewViewController.xib */; };
@@ -915,9 +915,9 @@
 		67E8B094226A57EA00537BC9 /* TalkPageTopicNewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F73E782267B9500079DEEF /* TalkPageTopicNewViewController.swift */; };
 		67E8B096226A57EA00537BC9 /* TalkPageReplyListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F73E742267B9070079DEEF /* TalkPageReplyListViewController.swift */; };
 		67E9A11C25536B6F00C5ED31 /* ABTestsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E9A11B25536B6F00C5ED31 /* ABTestsController.swift */; };
-		67EA9E10228F0358008D9EFD /* TalkPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675A7CFD227A3F7C0034D9D9 /* TalkPageHeaderView.swift */; };
-		67EA9E11228F0359008D9EFD /* TalkPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675A7CFD227A3F7C0034D9D9 /* TalkPageHeaderView.swift */; };
-		67EA9E12228F0359008D9EFD /* TalkPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675A7CFD227A3F7C0034D9D9 /* TalkPageHeaderView.swift */; };
+		67EA9E10228F0358008D9EFD /* OldTalkPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675A7CFD227A3F7C0034D9D9 /* OldTalkPageHeaderView.swift */; };
+		67EA9E11228F0359008D9EFD /* OldTalkPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675A7CFD227A3F7C0034D9D9 /* OldTalkPageHeaderView.swift */; };
+		67EA9E12228F0359008D9EFD /* OldTalkPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675A7CFD227A3F7C0034D9D9 /* OldTalkPageHeaderView.swift */; };
 		67EA9E14228F035D008D9EFD /* TalkPageReplyFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676070A1227CE60800A81F09 /* TalkPageReplyFooterView.swift */; };
 		67EA9E15228F035E008D9EFD /* TalkPageReplyFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676070A1227CE60800A81F09 /* TalkPageReplyFooterView.swift */; };
 		67EA9E16228F035E008D9EFD /* TalkPageReplyFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676070A1227CE60800A81F09 /* TalkPageReplyFooterView.swift */; };
@@ -3962,7 +3962,7 @@
 		672034E427A2600C007DC24F /* RemoteNotificationsProjectOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationsProjectOperation.swift; sourceTree = "<group>"; };
 		672428962362113400490629 /* DiffFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffFetcher.swift; sourceTree = "<group>"; };
 		67282FBC24855B7B00B73E20 /* ArticleContextMenuPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleContextMenuPresenting.swift; sourceTree = "<group>"; };
-		672B127722A450F000CC85A5 /* TalkPageHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TalkPageHeaderView.xib; sourceTree = "<group>"; };
+		672B127722A450F000CC85A5 /* OldTalkPageHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OldTalkPageHeaderView.xib; sourceTree = "<group>"; };
 		672C35EA22D8E7C9007B8D46 /* EmptyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyViewController.swift; sourceTree = "<group>"; };
 		672D69A3273ABD3600B123B3 /* UINavigationBarAppearance+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationBarAppearance+Extensions.swift"; sourceTree = "<group>"; };
 		672D69A8273ACAA100B123B3 /* UITabBarAppearance+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarAppearance+Extensions.swift"; sourceTree = "<group>"; };
@@ -3983,7 +3983,7 @@
 		674E8AB82382DEFF0053D206 /* DiffTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffTransformer.swift; sourceTree = "<group>"; };
 		675175DB276D3B9700CD2974 /* DisappearingCallbackNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisappearingCallbackNavigationController.swift; sourceTree = "<group>"; };
 		67540CA824D221E3008B2894 /* LocationManagerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManagerFactory.swift; sourceTree = "<group>"; };
-		675A7CFD227A3F7C0034D9D9 /* TalkPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageHeaderView.swift; sourceTree = "<group>"; };
+		675A7CFD227A3F7C0034D9D9 /* OldTalkPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldTalkPageHeaderView.swift; sourceTree = "<group>"; };
 		676070A1227CE60800A81F09 /* TalkPageReplyFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageReplyFooterView.swift; sourceTree = "<group>"; };
 		676070A32280987C00A81F09 /* TalkPageTopicNewViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TalkPageTopicNewViewController.xib; sourceTree = "<group>"; };
 		6761AED82704BA3800E47BAD /* RemoteNotification+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteNotification+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -7167,10 +7167,10 @@
 				67E8B0732268DA8B00537BC9 /* TalkPageTopicCell.swift */,
 				6734116F22773122005B31DA /* TalkPageReplyCell.swift */,
 				67D3C452228CB54E001D5741 /* TalkPageReplyComposeView.swift */,
-				675A7CFD227A3F7C0034D9D9 /* TalkPageHeaderView.swift */,
+				675A7CFD227A3F7C0034D9D9 /* OldTalkPageHeaderView.swift */,
 				676070A1227CE60800A81F09 /* TalkPageReplyFooterView.swift */,
 				6706A21622925FD2004774E2 /* InfoBannerView.swift */,
-				672B127722A450F000CC85A5 /* TalkPageHeaderView.xib */,
+				672B127722A450F000CC85A5 /* OldTalkPageHeaderView.xib */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -10350,7 +10350,7 @@
 				B0267CE91E316A79006B6D8D /* WMFForgotPasswordViewController.storyboard in Resources */,
 				B0845E1C2061B44A00CDD98E /* SavedProgressViewController.storyboard in Resources */,
 				6782DBF023453799003FA21B /* DiffHeaderCompareView.xib in Resources */,
-				672B127822A450F000CC85A5 /* TalkPageHeaderView.xib in Resources */,
+				672B127822A450F000CC85A5 /* OldTalkPageHeaderView.xib in Resources */,
 				00A8F58826BDD88700175B8E /* Featured Article Widget Preview Content.json in Resources */,
 				671F5E0B236B8CAF00111116 /* EmptyViewController.xib in Resources */,
 				83836ED11F615E5B007D1A05 /* ShareViewController.xib in Resources */,
@@ -10436,7 +10436,7 @@
 				D8A42BD81E815A9C00D8E281 /* NotificationBackgroundMessage@2x.png in Resources */,
 				7A393289236CBDD500A89C2F /* PageHistoryComparisonSelectionViewController.xib in Resources */,
 				BA4524201F324C3100439C42 /* FontSizeSliderViewController.xib in Resources */,
-				670AF18F26BDE647005F76D0 /* TalkPageHeaderView.xib in Resources */,
+				670AF18F26BDE647005F76D0 /* OldTalkPageHeaderView.xib in Resources */,
 				BA45242C1F32500C00439C42 /* TextSizeChangeExampleViewController.xib in Resources */,
 				6782DBF323453799003FA21B /* DiffHeaderCompareView.xib in Resources */,
 				7ADF498321B45CEE009EA338 /* TextFormattingPlainToolbarView.xib in Resources */,
@@ -10562,7 +10562,7 @@
 				D8CE265F1E698E2400DAE2E0 /* NotificationBackgroundMessage@2x.png in Resources */,
 				7A393287236CBDD500A89C2F /* PageHistoryComparisonSelectionViewController.xib in Resources */,
 				BA45241E1F324C3100439C42 /* FontSizeSliderViewController.xib in Resources */,
-				670AF18E26BDE646005F76D0 /* TalkPageHeaderView.xib in Resources */,
+				670AF18E26BDE646005F76D0 /* OldTalkPageHeaderView.xib in Resources */,
 				BA45242A1F32500C00439C42 /* TextSizeChangeExampleViewController.xib in Resources */,
 				6782DBF123453799003FA21B /* DiffHeaderCompareView.xib in Resources */,
 				7ADF498121B45CEE009EA338 /* TextFormattingPlainToolbarView.xib in Resources */,
@@ -10688,7 +10688,7 @@
 				D8EC3F5F1E9BDA35006712EB /* NotificationBackgroundMessage@2x.png in Resources */,
 				7A393288236CBDD500A89C2F /* PageHistoryComparisonSelectionViewController.xib in Resources */,
 				BA45241F1F324C3100439C42 /* FontSizeSliderViewController.xib in Resources */,
-				670AF18D26BDE645005F76D0 /* TalkPageHeaderView.xib in Resources */,
+				670AF18D26BDE645005F76D0 /* OldTalkPageHeaderView.xib in Resources */,
 				BA45242B1F32500C00439C42 /* TextSizeChangeExampleViewController.xib in Resources */,
 				6782DBF223453799003FA21B /* DiffHeaderCompareView.xib in Resources */,
 				7ADF498221B45CEE009EA338 /* TextFormattingPlainToolbarView.xib in Resources */,
@@ -11405,7 +11405,7 @@
 				0EC0447B1C796FEF0033D773 /* WMFImageTextActivitySource.swift in Sources */,
 				83EE476A20D019A100A21F34 /* ExploreViewController.swift in Sources */,
 				B0E805951C0CE2C60065EBC0 /* ToCInteractionFunnel.m in Sources */,
-				675A7CFE227A3F7C0034D9D9 /* TalkPageHeaderView.swift in Sources */,
+				675A7CFE227A3F7C0034D9D9 /* OldTalkPageHeaderView.swift in Sources */,
 				7A8422532268DA2C0074648E /* InsertMediaSearchResultPreviewingViewController.swift in Sources */,
 				B0BCF0B9202537D800986F72 /* Panels.swift in Sources */,
 				67C6F7A127E8C7C500B9C864 /* NotificationsCenterCommonViewModel+ActionExtensions.swift in Sources */,
@@ -12259,7 +12259,7 @@
 				D8A42AC61E815A9C00D8E281 /* ProtectedEditAttemptFunnel.m in Sources */,
 				6780D7702832908F00265F10 /* Notification+NotificationsCenter.swift in Sources */,
 				B0C7A07B1F710E75008415E7 /* WMFWelcomeExplorationAnimationBackgroundView.swift in Sources */,
-				67EA9E12228F0359008D9EFD /* TalkPageHeaderView.swift in Sources */,
+				67EA9E12228F0359008D9EFD /* OldTalkPageHeaderView.swift in Sources */,
 				7A9F2779225E3462002119B3 /* InsertMediaSearchResultsCollectionViewController.swift in Sources */,
 				D8A42AC71E815A9C00D8E281 /* WKWebView+WMFWebViewControllerJavascript.m in Sources */,
 				D8A42ACB1E815A9C00D8E281 /* WMFArticleTextActivitySource.m in Sources */,
@@ -12784,7 +12784,7 @@
 				67C6F78527E8BC2F00B9C864 /* NotificationsCenterIconType.swift in Sources */,
 				D8CE25571E698E2400DAE2E0 /* WMFPasswordResetter.swift in Sources */,
 				D8CE255A1E698E2400DAE2E0 /* UIBarButtonItem+WMFButtonConvenience.m in Sources */,
-				67EA9E10228F0358008D9EFD /* TalkPageHeaderView.swift in Sources */,
+				67EA9E10228F0358008D9EFD /* OldTalkPageHeaderView.swift in Sources */,
 				D8CE255B1E698E2400DAE2E0 /* UIViewController+WMFEmptyView.m in Sources */,
 				B0408C562127F2C100AC76CE /* WMFImageGalleryGradientViews.swift in Sources */,
 				BA69725B1F2BA2D800E35F78 /* SettingsTableViewSection.swift in Sources */,
@@ -13327,7 +13327,7 @@
 				8321FCCE2387231E0079F3C7 /* ViewControllerRouter.swift in Sources */,
 				D8EC3E441E9BDA35006712EB /* ProtectedEditAttemptFunnel.m in Sources */,
 				D8EC3E451E9BDA35006712EB /* WKWebView+WMFWebViewControllerJavascript.m in Sources */,
-				67EA9E11228F0359008D9EFD /* TalkPageHeaderView.swift in Sources */,
+				67EA9E11228F0359008D9EFD /* OldTalkPageHeaderView.swift in Sources */,
 				B0408C572127F2C100AC76CE /* WMFImageGalleryGradientViews.swift in Sources */,
 				D8EC3E491E9BDA35006712EB /* WMFArticleTextActivitySource.m in Sources */,
 				6782DBDB2344EC86003FA21B /* DiffHeaderViewModels.swift in Sources */,

--- a/Wikipedia/Code/OldTalkPageHeaderView.swift
+++ b/Wikipedia/Code/OldTalkPageHeaderView.swift
@@ -1,13 +1,13 @@
 import UIKit
 
-protocol TalkPageHeaderViewDelegate: AnyObject {
-    func tappedLink(_ url: URL, headerView: TalkPageHeaderView, sourceView: UIView, sourceRect: CGRect?)
-    func tappedIntro(headerView: TalkPageHeaderView)
+protocol OldTalkPageHeaderViewDelegate: AnyObject {
+    func tappedLink(_ url: URL, headerView: OldTalkPageHeaderView, sourceView: UIView, sourceRect: CGRect?)
+    func tappedIntro(headerView: OldTalkPageHeaderView)
 }
 
-class TalkPageHeaderView: UIView {
+class OldTalkPageHeaderView: UIView {
     
-    weak var delegate: TalkPageHeaderViewDelegate?
+    weak var delegate: OldTalkPageHeaderViewDelegate?
     
     struct ViewModel {
         let header: String
@@ -183,7 +183,7 @@ class TalkPageHeaderView: UIView {
     }
 }
 
-extension TalkPageHeaderView: Themeable {
+extension OldTalkPageHeaderView: Themeable {
     func apply(theme: Theme) {
         self.theme = theme
         titleTextView.backgroundColor = theme.colors.paperBackground
@@ -198,7 +198,7 @@ extension TalkPageHeaderView: Themeable {
 
 // MARK: UITextViewDelegate
 
-extension TalkPageHeaderView: UITextViewDelegate {
+extension OldTalkPageHeaderView: UITextViewDelegate {
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         delegate?.tappedLink(URL, headerView: self, sourceView: textView, sourceRect: textView.frame(of: characterRange))
         return false

--- a/Wikipedia/Code/OldTalkPageHeaderView.xib
+++ b/Wikipedia/Code/OldTalkPageHeaderView.xib
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="TalkPageHeaderView" customModule="Wikipedia" customModuleProvider="target">
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="OldTalkPageHeaderView" customModule="Wikipedia" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="355" height="382"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
@@ -53,6 +51,7 @@
                     </subviews>
                 </stackView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="TTg-py-ooM" secondAttribute="bottom" constant="20" symbolic="YES" id="IUN-Ba-U8A"/>
@@ -63,7 +62,6 @@
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <connections>
                 <outlet property="headerLabel" destination="NmN-pX-JVw" id="T18-M3-XYe"/>
                 <outlet property="infoLabel" destination="q8P-bX-Ouc" id="r7n-5h-c7q"/>

--- a/Wikipedia/Code/OldTalkPageReplyCell.swift
+++ b/Wikipedia/Code/OldTalkPageReplyCell.swift
@@ -1,12 +1,12 @@
 import UIKit
 
-protocol TalkPageReplyCellDelegate: AnyObject {
-    func tappedLink(_ url: URL, cell: TalkPageReplyCell, sourceView: UIView, sourceRect: CGRect?)
+protocol OldTalkPageReplyCellDelegate: AnyObject {
+    func tappedLink(_ url: URL, cell: OldTalkPageReplyCell, sourceView: UIView, sourceRect: CGRect?)
 }
 
-class TalkPageReplyCell: CollectionViewCell {
+class OldTalkPageReplyCell: CollectionViewCell {
     
-    weak var delegate: TalkPageReplyCellDelegate?
+    weak var delegate: OldTalkPageReplyCellDelegate?
     
     private let titleTextView = UITextView()
     private let depthMarker = UIView()
@@ -122,7 +122,7 @@ class TalkPageReplyCell: CollectionViewCell {
 
 // MARK: Themeable
 
-extension TalkPageReplyCell: Themeable {
+extension OldTalkPageReplyCell: Themeable {
     func apply(theme: Theme) {
         self.theme = theme
         titleTextView.textColor = theme.colors.primaryText
@@ -134,7 +134,7 @@ extension TalkPageReplyCell: Themeable {
 
 // MARK: UITextViewDelegate
 
-extension TalkPageReplyCell: UITextViewDelegate {
+extension OldTalkPageReplyCell: UITextViewDelegate {
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         delegate?.tappedLink(URL, cell: self, sourceView: textView, sourceRect: textView.frame(of: characterRange))
         return false

--- a/Wikipedia/Code/OldTalkPageReplyComposeView.swift
+++ b/Wikipedia/Code/OldTalkPageReplyComposeView.swift
@@ -1,16 +1,16 @@
 import UIKit
 
-protocol TalkPageReplyComposeViewDelegate: AnyObject {
+protocol OldTalkPageReplyComposeViewDelegate: AnyObject {
     func composeTextDidChange(text: String?)
      var collectionViewFrame: CGRect { get }
 }
 
-class TalkPageReplyComposeView: SizeThatFitsView {
+class OldTalkPageReplyComposeView: SizeThatFitsView {
     
     lazy private(set) var composeTextView: ThemeableTextView = ThemeableTextView()
     lazy private var finePrintTextView: UITextView = UITextView()
     
-    weak var delegate: TalkPageReplyComposeViewDelegate?
+    weak var delegate: OldTalkPageReplyComposeViewDelegate?
     
     private var theme: Theme?
     
@@ -110,7 +110,7 @@ class TalkPageReplyComposeView: SizeThatFitsView {
 
 // MARK: Private
 
-private extension TalkPageReplyComposeView {
+private extension OldTalkPageReplyComposeView {
     func setupView() {
         preservesSuperviewLayoutMargins = false
         insetsLayoutMarginsFromSafeArea = false
@@ -132,7 +132,7 @@ private extension TalkPageReplyComposeView {
 
 // MARK: Themeable
 
-extension TalkPageReplyComposeView: Themeable {
+extension OldTalkPageReplyComposeView: Themeable {
     func apply(theme: Theme) {
         self.theme = theme
         composeTextView.apply(theme: theme)
@@ -144,7 +144,7 @@ extension TalkPageReplyComposeView: Themeable {
 
 // MARK: ThemeableTextViewPlaceholderDelegate
 
-extension TalkPageReplyComposeView: UITextViewDelegate {
+extension OldTalkPageReplyComposeView: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         delegate?.composeTextDidChange(text: textView.text)
     }

--- a/Wikipedia/Code/OldTalkPageTopicCell.swift
+++ b/Wikipedia/Code/OldTalkPageTopicCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class TalkPageTopicCell: CollectionViewCell {
+class OldTalkPageTopicCell: CollectionViewCell {
     
     private let titleLabel = UILabel()
     private let unreadView = UIView()
@@ -100,7 +100,7 @@ class TalkPageTopicCell: CollectionViewCell {
     }
 }
 
-extension TalkPageTopicCell: Themeable {
+extension OldTalkPageTopicCell: Themeable {
     func apply(theme: Theme) {
         titleLabel.textColor = theme.colors.primaryText
         setBackgroundColors(theme.colors.paperBackground, selected: theme.colors.baseBackground)

--- a/Wikipedia/Code/TalkPageContainerViewController.swift
+++ b/Wikipedia/Code/TalkPageContainerViewController.swift
@@ -77,7 +77,7 @@ class TalkPageContainerViewController: ViewController, HintPresenting {
     private var topicListViewController: TalkPageTopicListViewController?
     private var replyListViewController: TalkPageReplyListViewController?
     private var emptyView: WMFEmptyView?
-    private var headerView: TalkPageHeaderView?
+    private var headerView: OldTalkPageHeaderView?
     private var addButton: UIBarButtonItem?
     
     private var shareIcon: IconBarButtonItem?
@@ -514,7 +514,7 @@ private extension TalkPageContainerViewController {
         
         setupAddBarButton()
         
-        if let headerView = TalkPageHeaderView.wmf_viewFromClassNib() {
+        if let headerView = OldTalkPageHeaderView.wmf_viewFromClassNib() {
             self.headerView = headerView
             configure(header: headerView, introTopic: nil)
             headerView.delegate = self
@@ -530,7 +530,7 @@ private extension TalkPageContainerViewController {
         }
     }
     
-    func configure(header: TalkPageHeaderView, introTopic: TalkPageTopic?) {
+    func configure(header: OldTalkPageHeaderView, introTopic: TalkPageTopic?) {
         
         var headerText: String
         switch type {
@@ -553,7 +553,7 @@ private extension TalkPageContainerViewController {
             introText = replyTexts.joined(separator: "<br />")
         }
         
-        let viewModel = TalkPageHeaderView.ViewModel(header: headerText, title: controller.displayTitle, info: infoText, intro: introText)
+        let viewModel = OldTalkPageHeaderView.ViewModel(header: headerText, title: controller.displayTitle, info: infoText, intro: introText)
         
         header.configure(viewModel: viewModel)
         header.delegate = self
@@ -820,12 +820,12 @@ extension TalkPageContainerViewController: TalkPageReplyListViewControllerDelega
 
 // MARK: TalkPageHeaderViewDelegate
 
-extension TalkPageContainerViewController: TalkPageHeaderViewDelegate {
-    func tappedLink(_ url: URL, headerView: TalkPageHeaderView, sourceView: UIView, sourceRect: CGRect?) {
+extension TalkPageContainerViewController: OldTalkPageHeaderViewDelegate {
+    func tappedLink(_ url: URL, headerView: OldTalkPageHeaderView, sourceView: UIView, sourceRect: CGRect?) {
         tappedLink(url, loadingViewController: self, sourceView: sourceView, sourceRect: sourceRect)
     }
     
-    func tappedIntro(headerView: TalkPageHeaderView) {
+    func tappedIntro(headerView: OldTalkPageHeaderView) {
         if let introTopic = self.introTopic {
             pushToReplyThread(topic: introTopic)
         }

--- a/Wikipedia/Code/TalkPageReplyFooterView.swift
+++ b/Wikipedia/Code/TalkPageReplyFooterView.swift
@@ -7,7 +7,7 @@ protocol ReplyButtonFooterViewDelegate: AnyObject {
 }
 
 class TalkPageReplyFooterView: SizeThatFitsReusableView {
-    let composeView = TalkPageReplyComposeView(frame: .zero)
+    let composeView = OldTalkPageReplyComposeView(frame: .zero)
     weak var delegate: ReplyButtonFooterViewDelegate?
     private let replyButton = ActionButton(frame: .zero)
     let dividerView = UIView(frame: .zero)
@@ -116,7 +116,7 @@ extension TalkPageReplyFooterView: Themeable {
 
 // MARK: TalkPageReplyComposeViewDelegate
 
-extension TalkPageReplyFooterView: TalkPageReplyComposeViewDelegate {
+extension TalkPageReplyFooterView: OldTalkPageReplyComposeViewDelegate {
     func composeTextDidChange(text: String?) {
         delegate?.composeTextDidChange(text: text)
     }

--- a/Wikipedia/Code/TalkPageReplyListViewController.swift
+++ b/Wikipedia/Code/TalkPageReplyListViewController.swift
@@ -205,7 +205,7 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
     
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as? TalkPageReplyCell else {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as? OldTalkPageReplyCell else {
                 return UICollectionViewCell()
         }
         
@@ -215,7 +215,7 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
     
     override func collectionView(_ collectionView: UICollectionView, estimatedHeightForItemAt indexPath: IndexPath, forColumnWidth columnWidth: CGFloat) -> ColumnarCollectionViewLayoutHeightEstimate {
         var estimate = ColumnarCollectionViewLayoutHeightEstimate(precalculated: false, height: 54)
-        guard let placeholderCell = layoutManager.placeholder(forCellWithReuseIdentifier: reuseIdentifier) as? TalkPageReplyCell else {
+        guard let placeholderCell = layoutManager.placeholder(forCellWithReuseIdentifier: reuseIdentifier) as? OldTalkPageReplyCell else {
             return estimate
         }
         configure(cell: placeholderCell, at: indexPath)
@@ -283,7 +283,7 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
 extension TalkPageReplyListViewController: CollectionViewUpdaterDelegate {
     func collectionViewUpdater<T>(_ updater: CollectionViewUpdater<T>, didUpdate collectionView: UICollectionView) where T : NSFetchRequestResult {
         for indexPath in collectionView.indexPathsForVisibleItems {
-            guard let cell = collectionView.cellForItem(at: indexPath) as? TalkPageTopicCell,
+            guard let cell = collectionView.cellForItem(at: indexPath) as? OldTalkPageTopicCell,
                 let title = fetchedResultsController.object(at: indexPath).text else {
                     continue
             }
@@ -302,7 +302,7 @@ extension TalkPageReplyListViewController: CollectionViewUpdaterDelegate {
 private extension TalkPageReplyListViewController {
     
     func registerCells() {
-        layoutManager.register(TalkPageReplyCell.self, forCellWithReuseIdentifier: reuseIdentifier, addPlaceholder: true)
+        layoutManager.register(OldTalkPageReplyCell.self, forCellWithReuseIdentifier: reuseIdentifier, addPlaceholder: true)
         layoutManager.register(TalkPageReplyFooterView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: TalkPageReplyFooterView.identifier, addPlaceholder: true)
     }
     
@@ -392,7 +392,7 @@ private extension TalkPageReplyListViewController {
         footer.composeButtonIsDisabled = repliesAreDisabled
     }
     
-    func configure(cell: TalkPageReplyCell, at indexPath: IndexPath) {
+    func configure(cell: OldTalkPageReplyCell, at indexPath: IndexPath) {
         let item = fetchedResultsController.object(at: indexPath)
         guard let title = item.text,
         item.depth >= 0 else {
@@ -415,8 +415,8 @@ private extension TalkPageReplyListViewController {
 
 // MARK: TalkPageReplyCellDelegate
 
-extension TalkPageReplyListViewController: TalkPageReplyCellDelegate {
-    func tappedLink(_ url: URL, cell: TalkPageReplyCell, sourceView: UIView, sourceRect: CGRect?) {
+extension TalkPageReplyListViewController: OldTalkPageReplyCellDelegate {
+    func tappedLink(_ url: URL, cell: OldTalkPageReplyCell, sourceView: UIView, sourceRect: CGRect?) {
         
         delegate?.tappedLink(url, viewController: self, sourceView: sourceView, sourceRect: sourceRect)
     }

--- a/Wikipedia/Code/TalkPageReplyListViewController.swift
+++ b/Wikipedia/Code/TalkPageReplyListViewController.swift
@@ -35,7 +35,7 @@ class TalkPageReplyListViewController: ColumnarCollectionViewController {
     private var replyBarButtonItem: UIBarButtonItem?
     
     private var shouldFocusVoiceOver = false
-    private var headerView: TalkPageHeaderView?
+    private var headerView: OldTalkPageHeaderView?
     
     var repliesAreDisabled = true {
         didSet {
@@ -322,7 +322,7 @@ private extension TalkPageReplyListViewController {
         replyBarButtonItem?.isEnabled = !repliesAreDisabled
         navigationBar.updateNavigationItems()
         
-        if let headerView = TalkPageHeaderView.wmf_viewFromClassNib(),
+        if let headerView = OldTalkPageHeaderView.wmf_viewFromClassNib(),
             let title = topic.title {
             configure(headerView: headerView)
             navigationBar.isBarHidingEnabled = false
@@ -366,7 +366,7 @@ private extension TalkPageReplyListViewController {
         view.endEditing(true)
     }
     
-    func configure(headerView: TalkPageHeaderView) {
+    func configure(headerView: OldTalkPageHeaderView) {
         
         guard let title = topic.title else {
                 return
@@ -374,7 +374,7 @@ private extension TalkPageReplyListViewController {
         
         let headerText = WMFLocalizedString("talk-page-topic-title", value: "Discussion", comment: "This header label is displayed at the top of a talk page topic thread.").localizedUppercase
         
-        let viewModel = TalkPageHeaderView.ViewModel(header: headerText, title: title, info: nil, intro: nil)
+        let viewModel = OldTalkPageHeaderView.ViewModel(header: headerText, title: title, info: nil, intro: nil)
         
         headerView.delegate = self
         headerView.configure(viewModel: viewModel)
@@ -443,12 +443,12 @@ extension TalkPageReplyListViewController: ReplyButtonFooterViewDelegate {
 
 // MARK: TalkPageHeaderViewDelegate
 
-extension TalkPageReplyListViewController: TalkPageHeaderViewDelegate {
-    func tappedLink(_ url: URL, headerView: TalkPageHeaderView, sourceView: UIView, sourceRect: CGRect?) {
+extension TalkPageReplyListViewController: OldTalkPageHeaderViewDelegate {
+    func tappedLink(_ url: URL, headerView: OldTalkPageHeaderView, sourceView: UIView, sourceRect: CGRect?) {
         delegate?.tappedLink(url, viewController: self, sourceView: sourceView, sourceRect: sourceRect)
     }
     
-    func tappedIntro(headerView: TalkPageHeaderView) {
+    func tappedIntro(headerView: OldTalkPageHeaderView) {
         assertionFailure("Should not be able to tap intro text view from replies screen")
     }
 }

--- a/Wikipedia/Code/TalkPageTopicListViewController.swift
+++ b/Wikipedia/Code/TalkPageTopicListViewController.swift
@@ -111,7 +111,7 @@ class TalkPageTopicListViewController: ColumnarCollectionViewController {
     
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as? TalkPageTopicCell else {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as? OldTalkPageTopicCell else {
                 return UICollectionViewCell()
         }
         
@@ -127,7 +127,7 @@ class TalkPageTopicListViewController: ColumnarCollectionViewController {
             return estimate
         }
         var estimate = ColumnarCollectionViewLayoutHeightEstimate(precalculated: false, height: 54)
-        guard let placeholderCell = layoutManager.placeholder(forCellWithReuseIdentifier: reuseIdentifier) as? TalkPageTopicCell else {
+        guard let placeholderCell = layoutManager.placeholder(forCellWithReuseIdentifier: reuseIdentifier) as? OldTalkPageTopicCell else {
             return estimate
         }
         configure(cell: placeholderCell, at: indexPath)
@@ -162,7 +162,7 @@ class TalkPageTopicListViewController: ColumnarCollectionViewController {
 private extension TalkPageTopicListViewController {
     
     func registerCells() {
-        layoutManager.register(TalkPageTopicCell.self, forCellWithReuseIdentifier: reuseIdentifier, addPlaceholder: true)
+        layoutManager.register(OldTalkPageTopicCell.self, forCellWithReuseIdentifier: reuseIdentifier, addPlaceholder: true)
     }
     
     func setupCollectionViewUpdater() {
@@ -171,7 +171,7 @@ private extension TalkPageTopicListViewController {
         collectionViewUpdater?.performFetch()
     }
 
-    func configure(cell: TalkPageTopicCell, at indexPath: IndexPath) {
+    func configure(cell: OldTalkPageTopicCell, at indexPath: IndexPath) {
         let topic = fetchedResultsController.object(at: indexPath)
         guard let title = topic.title else {
             return
@@ -190,7 +190,7 @@ private extension TalkPageTopicListViewController {
 extension TalkPageTopicListViewController: CollectionViewUpdaterDelegate {
     func collectionViewUpdater<T>(_ updater: CollectionViewUpdater<T>, didUpdate collectionView: UICollectionView) where T : NSFetchRequestResult {
         for indexPath in collectionView.indexPathsForVisibleItems {
-            guard let cell = collectionView.cellForItem(at: indexPath) as? TalkPageTopicCell else {
+            guard let cell = collectionView.cellForItem(at: indexPath) as? OldTalkPageTopicCell else {
                 continue
             }
             


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
In order to prevent namespace clashes with new incoming Talk Pages work, rename more old Talk Pages classes and delegates appending the `Old` prefix already established.

### Test Steps
1. Confirm Talk Pages still load
2. Confirm topics/sections are tappable and load when tapped
3. Confirm tapping reply shows the reply cell

