### PR TITLE
Talk fetcher tests

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -1522,6 +1522,7 @@
 		83023C2020E6584F00EC7592 /* SearchTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83023C1E20E6584F00EC7592 /* SearchTransition.swift */; };
 		83023C2120E6584F00EC7592 /* SearchTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83023C1E20E6584F00EC7592 /* SearchTransition.swift */; };
 		83023C2220E6584F00EC7592 /* SearchTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83023C1E20E6584F00EC7592 /* SearchTransition.swift */; };
+		8307C6582888A5D5002E98CF /* TalkPageFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8307C6572888A5D5002E98CF /* TalkPageFetcherTests.swift */; };
 		830AD2B924D1D615003EEFE6 /* WebPageUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830AD2B824D1D615003EEFE6 /* WebPageUserScript.swift */; };
 		830AD2BA24D1D615003EEFE6 /* WebPageUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830AD2B824D1D615003EEFE6 /* WebPageUserScript.swift */; };
 		830AD2BB24D1D615003EEFE6 /* WebPageUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830AD2B824D1D615003EEFE6 /* WebPageUserScript.swift */; };
@@ -4328,6 +4329,7 @@
 		83023C0520E51DDF00EC7592 /* SearchLanguagesBarViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchLanguagesBarViewController.xib; sourceTree = "<group>"; };
 		83023C1020E6561900EC7592 /* ViewControllerTransitionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerTransitionsController.swift; sourceTree = "<group>"; usesTabs = 0; };
 		83023C1E20E6584F00EC7592 /* SearchTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTransition.swift; sourceTree = "<group>"; };
+		8307C6572888A5D5002E98CF /* TalkPageFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageFetcherTests.swift; sourceTree = "<group>"; };
 		830AD2B824D1D615003EEFE6 /* WebPageUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageUserScript.swift; sourceTree = "<group>"; };
 		830C0DD423D9AFBE006471C4 /* UIViewController+Push.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Push.swift"; sourceTree = "<group>"; };
 		830C0DD923D9C218006471C4 /* Properties.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = Properties.js; sourceTree = "<group>"; };
@@ -7596,6 +7598,14 @@
 			name = Transitions;
 			sourceTree = "<group>";
 		};
+		8307C6562888A5BA002E98CF /* TalkPageTests */ = {
+			isa = PBXGroup;
+			children = (
+				8307C6572888A5D5002E98CF /* TalkPageFetcherTests.swift */,
+			);
+			path = TalkPageTests;
+			sourceTree = "<group>";
+		};
 		83ACAA9F24E6DC8E003B3035 /* Command Line Tools */ = {
 			isa = PBXGroup;
 			children = (
@@ -8573,6 +8583,7 @@
 		BCD67E7D1C1F12F2005179E1 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				8307C6562888A5BA002E98CF /* TalkPageTests */,
 				67F73384273C1FA200D7D713 /* Notifications Tests */,
 				671DF9D625F2B57B0011799E /* Article Description Tests */,
 				67ED8EAF24F99F1900DD5D39 /* Significant Events Tests */,
@@ -11080,6 +11091,7 @@
 				D8396D1B22CF7052005625D8 /* WMFArticleTests.swift in Sources */,
 				B0E8090D1C0D18E70065EBC0 /* WMFImageURLParsingTests.m in Sources */,
 				6790AAF722D6861500D442D6 /* OldTalkPageLocalHandlerTests.swift in Sources */,
+				8307C6582888A5D5002E98CF /* TalkPageFetcherTests.swift in Sources */,
 				67C6F77827E2E78800B9C864 /* NotificationsCenterCellViewModelThanksTests.swift in Sources */,
 				004281B525E6EFC4004945B3 /* LSHTTPRequestDiff.m in Sources */,
 				A452F9F924081A5500D8ED09 /* MockCLHeading.swift in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -705,11 +705,11 @@
 		678F512A23A7EE5100CE5357 /* ArticleCacheDBWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 678F511823A4B92000CE5357 /* ArticleCacheDBWriter.swift */; };
 		678F512B23A7EE6600CE5357 /* ArticleFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676A8A8223A4013D0084B967 /* ArticleFetcher.swift */; };
 		67901E232550E45D0018B218 /* ArticleAsLivingDocFunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67FF8E2C2550BB6F0048E741 /* ArticleAsLivingDocFunnel.swift */; };
-		6790AAF322D6861500D442D6 /* TalkPageNetworkDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0AB226A6DCA00537BC9 /* TalkPageNetworkDataTests.swift */; };
+		6790AAF322D6861500D442D6 /* OldTalkPageNetworkDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0AB226A6DCA00537BC9 /* OldTalkPageNetworkDataTests.swift */; };
 		6790AAF422D6861500D442D6 /* OldTalkPageFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0AD226A74C200537BC9 /* OldTalkPageFetcherTests.swift */; };
-		6790AAF522D6861500D442D6 /* TalkPageControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734114F22700A95005B31DA /* TalkPageControllerTests.swift */; };
-		6790AAF622D6861500D442D6 /* TalkPageTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734115122700C47005B31DA /* TalkPageTestHelpers.swift */; };
-		6790AAF722D6861500D442D6 /* TalkPageLocalHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116922739FD6005B31DA /* TalkPageLocalHandlerTests.swift */; };
+		6790AAF522D6861500D442D6 /* OldTalkPageControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734114F22700A95005B31DA /* OldTalkPageControllerTests.swift */; };
+		6790AAF622D6861500D442D6 /* OldTalkPageTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734115122700C47005B31DA /* OldTalkPageTestHelpers.swift */; };
+		6790AAF722D6861500D442D6 /* OldTalkPageLocalHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734116922739FD6005B31DA /* OldTalkPageLocalHandlerTests.swift */; };
 		679471DB275F245000621071 /* NotificationsCenterInboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679471DA275F245000621071 /* NotificationsCenterInboxView.swift */; };
 		679471DC275F245000621071 /* NotificationsCenterInboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679471DA275F245000621071 /* NotificationsCenterInboxView.swift */; };
 		679471DD275F245000621071 /* NotificationsCenterInboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679471DA275F245000621071 /* NotificationsCenterInboxView.swift */; };
@@ -3967,10 +3967,10 @@
 		672D69A3273ABD3600B123B3 /* UINavigationBarAppearance+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationBarAppearance+Extensions.swift"; sourceTree = "<group>"; };
 		672D69A8273ACAA100B123B3 /* UITabBarAppearance+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarAppearance+Extensions.swift"; sourceTree = "<group>"; };
 		672F0557222F24FB00FB1084 /* IconBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconBarButtonItem.swift; sourceTree = "<group>"; };
-		6734114F22700A95005B31DA /* TalkPageControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageControllerTests.swift; sourceTree = "<group>"; };
-		6734115122700C47005B31DA /* TalkPageTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageTestHelpers.swift; sourceTree = "<group>"; };
+		6734114F22700A95005B31DA /* OldTalkPageControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldTalkPageControllerTests.swift; sourceTree = "<group>"; };
+		6734115122700C47005B31DA /* OldTalkPageTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldTalkPageTestHelpers.swift; sourceTree = "<group>"; };
 		6734116322739CA2005B31DA /* TalkPageLocalHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageLocalHandler.swift; sourceTree = "<group>"; };
-		6734116922739FD6005B31DA /* TalkPageLocalHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageLocalHandlerTests.swift; sourceTree = "<group>"; };
+		6734116922739FD6005B31DA /* OldTalkPageLocalHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldTalkPageLocalHandlerTests.swift; sourceTree = "<group>"; };
 		6734116F22773122005B31DA /* OldTalkPageReplyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldTalkPageReplyCell.swift; sourceTree = "<group>"; };
 		6734F051227B634900BDDB94 /* ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
 		673612F124FD7210002A1989 /* ArticleAsLivingDocViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleAsLivingDocViewModelTests.swift; sourceTree = "<group>"; };
@@ -4138,7 +4138,7 @@
 		67E8B0752268DE4B00537BC9 /* TalkPageContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageContainerViewController.swift; sourceTree = "<group>"; };
 		67E8B0A4226A64CB00537BC9 /* OldTalkPagesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldTalkPagesController.swift; sourceTree = "<group>"; };
 		67E8B0A7226A654D00537BC9 /* OldTalkPageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldTalkPageFetcher.swift; sourceTree = "<group>"; };
-		67E8B0AB226A6DCA00537BC9 /* TalkPageNetworkDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageNetworkDataTests.swift; sourceTree = "<group>"; };
+		67E8B0AB226A6DCA00537BC9 /* OldTalkPageNetworkDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldTalkPageNetworkDataTests.swift; sourceTree = "<group>"; };
 		67E8B0AD226A74C200537BC9 /* OldTalkPageFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldTalkPageFetcherTests.swift; sourceTree = "<group>"; };
 		67E8B0B6226F5E3800537BC9 /* Wikipedia 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Wikipedia 2.xcdatamodel"; sourceTree = "<group>"; };
 		67E9A11B25536B6F00C5ED31 /* ABTestsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestsController.swift; sourceTree = "<group>"; };
@@ -7175,16 +7175,16 @@
 			name = Views;
 			sourceTree = "<group>";
 		};
-		67E8B0AA226A6DB000537BC9 /* TalkPageTests */ = {
+		67E8B0AA226A6DB000537BC9 /* OldTalkPageTests */ = {
 			isa = PBXGroup;
 			children = (
-				67E8B0AB226A6DCA00537BC9 /* TalkPageNetworkDataTests.swift */,
+				67E8B0AB226A6DCA00537BC9 /* OldTalkPageNetworkDataTests.swift */,
 				67E8B0AD226A74C200537BC9 /* OldTalkPageFetcherTests.swift */,
-				6734114F22700A95005B31DA /* TalkPageControllerTests.swift */,
-				6734115122700C47005B31DA /* TalkPageTestHelpers.swift */,
-				6734116922739FD6005B31DA /* TalkPageLocalHandlerTests.swift */,
+				6734114F22700A95005B31DA /* OldTalkPageControllerTests.swift */,
+				6734115122700C47005B31DA /* OldTalkPageTestHelpers.swift */,
+				6734116922739FD6005B31DA /* OldTalkPageLocalHandlerTests.swift */,
 			);
-			name = TalkPageTests;
+			name = OldTalkPageTests;
 			sourceTree = "<group>";
 		};
 		67ED8EAF24F99F1900DD5D39 /* Significant Events Tests */ = {
@@ -8577,7 +8577,7 @@
 				671DF9D625F2B57B0011799E /* Article Description Tests */,
 				67ED8EAF24F99F1900DD5D39 /* Significant Events Tests */,
 				679FA102242E64FC0095F3C6 /* Article Tests */,
-				67E8B0AA226A6DB000537BC9 /* TalkPageTests */,
+				67E8B0AA226A6DB000537BC9 /* OldTalkPageTests */,
 				8330533223F0388E00123141 /* DataStoreTests.swift */,
 				D8BDA8C01E71C0760031F4BF /* WMFBlocksKitTests.m */,
 				B39427411E71F79700D3146D /* NSDictionaryBlocksKitTest.m */,
@@ -11024,7 +11024,7 @@
 				B0E8092F1C0D1A0B0065EBC0 /* NSURL+WMFExtrasTests.m in Sources */,
 				B39427441E71F79700D3146D /* NSDictionaryBlocksKitTest.m in Sources */,
 				67DAEDF027E8FB63005CF9B6 /* NotificationsCenterDetailViewModelMentionTests.swift in Sources */,
-				6790AAF522D6861500D442D6 /* TalkPageControllerTests.swift in Sources */,
+				6790AAF522D6861500D442D6 /* OldTalkPageControllerTests.swift in Sources */,
 				B0E808771C0D155A0065EBC0 /* XCTestCase+WMFBundleConvenience.m in Sources */,
 				004281BC25E6EFC4004945B3 /* LSASIHTTPRequestHook.m in Sources */,
 				67C6F77C27E2E78800B9C864 /* NotificationsCenterCellViewModelWelcomeTests.swift in Sources */,
@@ -11079,12 +11079,12 @@
 				B0E8090B1C0D18D90065EBC0 /* NSString+FormattedAttributedStringTests.m in Sources */,
 				D8396D1B22CF7052005625D8 /* WMFArticleTests.swift in Sources */,
 				B0E8090D1C0D18E70065EBC0 /* WMFImageURLParsingTests.m in Sources */,
-				6790AAF722D6861500D442D6 /* TalkPageLocalHandlerTests.swift in Sources */,
+				6790AAF722D6861500D442D6 /* OldTalkPageLocalHandlerTests.swift in Sources */,
 				67C6F77827E2E78800B9C864 /* NotificationsCenterCellViewModelThanksTests.swift in Sources */,
 				004281B525E6EFC4004945B3 /* LSHTTPRequestDiff.m in Sources */,
 				A452F9F924081A5500D8ED09 /* MockCLHeading.swift in Sources */,
 				00A8F58626BDD5E700175B8E /* WidgetSampleContentTests.swift in Sources */,
-				6790AAF322D6861500D442D6 /* TalkPageNetworkDataTests.swift in Sources */,
+				6790AAF322D6861500D442D6 /* OldTalkPageNetworkDataTests.swift in Sources */,
 				B0E8089C1C0D165B0065EBC0 /* XCTestCase+SwiftDefaults.swift in Sources */,
 				BCD3200A1C6EC6BC00317D08 /* NSTimeZone+WMFTestingUtils.m in Sources */,
 				B0E808831C0D15A20065EBC0 /* MWKDataStore+TemporaryDataStore.m in Sources */,
@@ -11104,7 +11104,7 @@
 				67DAEDF127E8FB63005CF9B6 /* NotificationsCenterDetailViewModelEditMilestoneTests.swift in Sources */,
 				004281C925E6EFC4004945B3 /* LSStubResponseDSL.m in Sources */,
 				004281B225E6EFC4004945B3 /* LSStubRequest.m in Sources */,
-				6790AAF622D6861500D442D6 /* TalkPageTestHelpers.swift in Sources */,
+				6790AAF622D6861500D442D6 /* OldTalkPageTestHelpers.swift in Sources */,
 				004281C025E6EFC4004945B3 /* NSString+Matcheable.m in Sources */,
 				004281C425E6EFC4004945B3 /* LSRegexMatcher.m in Sources */,
 				004281C225E6EFC4004945B3 /* LSDataMatcher.m in Sources */,

--- a/Wikipedia/Code/TalkPageFetcher.swift
+++ b/Wikipedia/Code/TalkPageFetcher.swift
@@ -58,7 +58,6 @@ class TalkPageFetcher: Fetcher {
             switch result {
             case let .success(talk):
                 completion(.success(talk.threads.threadItems))
-                
             case let .failure(error):
                 completion(.failure(error))
             }

--- a/WikipediaUnitTests/Code/OldTalkPageControllerTests.swift
+++ b/WikipediaUnitTests/Code/OldTalkPageControllerTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Wikipedia
 @testable import WMF
 
-fileprivate class MockTalkPageFetcher: OldTalkPageFetcher {
+fileprivate class OldMockTalkPageFetcher: OldTalkPageFetcher {
     
     static var name = "Username1"
     static var domain = "en.wikipedia.org"
@@ -22,7 +22,7 @@ fileprivate class MockTalkPageFetcher: OldTalkPageFetcher {
         
         fetchCalled = true
         
-        if let networkTalkPage = TalkPageTestHelpers.networkTalkPage(for: "https://\(MockTalkPageFetcher.domain)/api/rest_v1/page/talk/\(urlTitle)", data: data, revisionId: MockArticleRevisionFetcher.revisionId) {
+        if let networkTalkPage = OldTalkPageTestHelpers.networkTalkPage(for: "https://\(OldMockTalkPageFetcher.domain)/api/rest_v1/page/talk/\(urlTitle)", data: data, revisionId: MockArticleRevisionFetcher.revisionId) {
             completion(.success(networkTalkPage))
         } else {
             XCTFail("Expected network talk page from helper")
@@ -66,19 +66,19 @@ fileprivate class MockArticleRevisionFetcher: WMFArticleRevisionFetcher {
     }
 }
 
-class TalkPageControllerTests: XCTestCase {
+class oldTalkPageControllerTests: XCTestCase {
 
     var tempDataStore: MWKDataStore!
     var talkPageController: OldTalkPageController!
-    fileprivate var talkPageFetcher: MockTalkPageFetcher!
+    fileprivate var talkPageFetcher: OldMockTalkPageFetcher!
     fileprivate var articleRevisionFetcher: MockArticleRevisionFetcher!
 
     override func setUp() {
         super.setUp()
         tempDataStore = MWKDataStore.temporary()
         
-        if let data = wmf_bundle().wmf_data(fromContentsOfFile: TalkPageTestHelpers.TalkPageJSONType.original.fileName, ofType: "json") {
-            talkPageFetcher = MockTalkPageFetcher(session: tempDataStore.session, configuration: tempDataStore.configuration, data: data)
+        if let data = wmf_bundle().wmf_data(fromContentsOfFile: OldTalkPageTestHelpers.TalkPageJSONType.original.fileName, ofType: "json") {
+            talkPageFetcher = OldMockTalkPageFetcher(session: tempDataStore.session, configuration: tempDataStore.configuration, data: data)
         } else {
             XCTFail("Failure setting up MockTalkPageFetcher")
         }
@@ -246,7 +246,7 @@ class TalkPageControllerTests: XCTestCase {
         wait(for: [initialFetchCallback], timeout: 5)
         
         // fetch again for ES language
-        MockTalkPageFetcher.domain = "es.wikipedia.org"
+        OldMockTalkPageFetcher.domain = "es.wikipedia.org"
         talkPageController = OldTalkPageController(fetcher: talkPageFetcher, articleRevisionFetcher: articleRevisionFetcher, moc: tempDataStore.viewContext, title: "User talk:Username1", siteURL: URL(string: "https://es.wikipedia.org")!, type: .user)
         
         let nextFetchCallback = expectation(description: "Waiting for next fetch callback")
@@ -298,7 +298,7 @@ class TalkPageControllerTests: XCTestCase {
         
         wait(for: [initialFetchCallback], timeout: 5)
         
-        MockTalkPageFetcher.name = "Username2"
+        OldMockTalkPageFetcher.name = "Username2"
         talkPageController = OldTalkPageController(fetcher: talkPageFetcher, articleRevisionFetcher: articleRevisionFetcher, moc: tempDataStore.viewContext, title: "User talk:Username2", siteURL: URL(string: "https://en.wikipedia.org")!, type: .user)
         
         let nextFetchCallback = expectation(description: "Waiting for next fetch callback")

--- a/WikipediaUnitTests/Code/OldTalkPageFetcherTests.swift
+++ b/WikipediaUnitTests/Code/OldTalkPageFetcherTests.swift
@@ -35,7 +35,7 @@ class OldTalkPageFetcherTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        if let data = wmf_bundle().wmf_data(fromContentsOfFile: TalkPageTestHelpers.TalkPageJSONType.original.fileName, ofType: "json") {
+        if let data = wmf_bundle().wmf_data(fromContentsOfFile: OldTalkPageTestHelpers.TalkPageJSONType.original.fileName, ofType: "json") {
             mockSession = MockSession(configuration: Configuration.current, data: data)
         } else {
             XCTFail("Failure setting up MockTalkPageFetcher")

--- a/WikipediaUnitTests/Code/OldTalkPageLocalHandlerTests.swift
+++ b/WikipediaUnitTests/Code/OldTalkPageLocalHandlerTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import CoreData
 @testable import Wikipedia
 
-class TalkPageLocalHandlerTests: XCTestCase {
+class OldTalkPageLocalHandlerTests: XCTestCase {
     
     let urlString1 = "https://en.wikipedia.org/api/rest_v1/page/talk/Username1"
     let urlString2 = "https://en.wikipedia.org/api/rest_v1/page/talk/Username2"
@@ -36,8 +36,8 @@ class TalkPageLocalHandlerTests: XCTestCase {
         XCTAssertEqual(firstResults.count, 0, "Expected zero existing talk pages at first")
         
         // add network talk page
-        guard let json = wmf_bundle().wmf_data(fromContentsOfFile: TalkPageTestHelpers.TalkPageJSONType.original.fileName, ofType: "json"),
-            let talkPage = TalkPageTestHelpers.networkTalkPage(for: urlString1, data: json, revisionId: 1) else {
+        guard let json = wmf_bundle().wmf_data(fromContentsOfFile: OldTalkPageTestHelpers.TalkPageJSONType.original.fileName, ofType: "json"),
+            let talkPage = OldTalkPageTestHelpers.networkTalkPage(for: urlString1, data: json, revisionId: 1) else {
             XCTFail("Failure stubbing out network talk page")
             return
         }
@@ -143,8 +143,8 @@ class TalkPageLocalHandlerTests: XCTestCase {
         XCTAssertEqual(firstResults.count, 0, "Expected zero existing talk pages at first")
         
         // add network talk page
-        guard let json = wmf_bundle().wmf_data(fromContentsOfFile: TalkPageTestHelpers.TalkPageJSONType.original.fileName, ofType: "json"),
-            let talkPage = TalkPageTestHelpers.networkTalkPage(for: urlString1, data: json, revisionId: 1) else {
+        guard let json = wmf_bundle().wmf_data(fromContentsOfFile: OldTalkPageTestHelpers.TalkPageJSONType.original.fileName, ofType: "json"),
+            let talkPage = OldTalkPageTestHelpers.networkTalkPage(for: urlString1, data: json, revisionId: 1) else {
             XCTFail("Failure stubbing out network talk page")
             return
         }
@@ -184,8 +184,8 @@ class TalkPageLocalHandlerTests: XCTestCase {
         XCTAssertEqual(firstResults.count, 0, "Expected zero existing talk pages at first")
         
         // add network talk page
-        guard let originalJson = wmf_bundle().wmf_data(fromContentsOfFile: TalkPageTestHelpers.TalkPageJSONType.original.fileName, ofType: "json"),
-            let talkPage = TalkPageTestHelpers.networkTalkPage(for: urlString1, data: originalJson, revisionId: 1) else {
+        guard let originalJson = wmf_bundle().wmf_data(fromContentsOfFile: OldTalkPageTestHelpers.TalkPageJSONType.original.fileName, ofType: "json"),
+            let talkPage = OldTalkPageTestHelpers.networkTalkPage(for: urlString1, data: originalJson, revisionId: 1) else {
             XCTFail("Failure stubbing out network talk page")
             return
         }
@@ -208,8 +208,8 @@ class TalkPageLocalHandlerTests: XCTestCase {
         }
         
         // get updated talk page payload
-        guard let updatedJson = wmf_bundle().wmf_data(fromContentsOfFile: TalkPageTestHelpers.TalkPageJSONType.updated.fileName, ofType: "json"),
-            let updatedTalkPage = TalkPageTestHelpers.networkTalkPage(for: urlString1, data: updatedJson, revisionId: 1) else {
+        guard let updatedJson = wmf_bundle().wmf_data(fromContentsOfFile: OldTalkPageTestHelpers.TalkPageJSONType.updated.fileName, ofType: "json"),
+            let updatedTalkPage = OldTalkPageTestHelpers.networkTalkPage(for: urlString1, data: updatedJson, revisionId: 1) else {
             XCTFail("Failure stubbing out network talk page")
             return
         }

--- a/WikipediaUnitTests/Code/OldTalkPageNetworkDataTests.swift
+++ b/WikipediaUnitTests/Code/OldTalkPageNetworkDataTests.swift
@@ -2,13 +2,13 @@ import XCTest
 @testable import Wikipedia
 @testable import WMF
 
-class TalkPageNetworkDataTests: XCTestCase {
+class OldTalkPageNetworkDataTests: XCTestCase {
     
     let session = MWKDataStore.temporary().session
 
     func testLocalJsonDecodesToTalkPage() {
         
-        guard let json = wmf_bundle().wmf_data(fromContentsOfFile: TalkPageTestHelpers.TalkPageJSONType.original.fileName, ofType: "json") else {
+        guard let json = wmf_bundle().wmf_data(fromContentsOfFile: OldTalkPageTestHelpers.TalkPageJSONType.original.fileName, ofType: "json") else {
             XCTFail("Failure pulling local talk page json")
             return
         }

--- a/WikipediaUnitTests/Code/OldTalkPageTestHelpers.swift
+++ b/WikipediaUnitTests/Code/OldTalkPageTestHelpers.swift
@@ -3,7 +3,7 @@ import Foundation
 @testable import WMF
 import XCTest
 
-class TalkPageTestHelpers {
+class OldTalkPageTestHelpers {
     
     enum TalkPageJSONType {
         case original

--- a/WikipediaUnitTests/Code/TalkPageTests/TalkPageFetcherTests.swift
+++ b/WikipediaUnitTests/Code/TalkPageTests/TalkPageFetcherTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+@testable import Wikipedia
+@testable import WMF
+
+
+final class TalkPageFetcherTests: XCTestCase {
+    
+}

--- a/WikipediaUnitTests/Code/TalkPageTests/TalkPageFetcherTests.swift
+++ b/WikipediaUnitTests/Code/TalkPageTests/TalkPageFetcherTests.swift
@@ -6,4 +6,25 @@ import XCTest
 
 final class TalkPageFetcherTests: XCTestCase {
     
+    func testFetchTalkPage() {
+        
+        let fetcher = TalkPageFetcher()
+        let siteURL = URL(string: "https://en.wikipedia.org")!
+        let expectation = expectation(description: "Waiting for completion")
+        
+        fetcher.fetchTalkPageContent(talkPageTitle: "Talk:Archaeoindris", siteURL: siteURL) { result in
+            
+            expectation.fulfill()
+            
+            switch result {
+            case let .success(talk):
+                XCTAssertNotNil(talk)
+            case .failure:
+                XCTFail("Expected Success")
+            }
+            
+        }
+        wait(for: [expectation], timeout: 5)
+    }
+    
 }

--- a/WikipediaUnitTests/Code/TalkPageTests/TalkPageFetcherTests.swift
+++ b/WikipediaUnitTests/Code/TalkPageTests/TalkPageFetcherTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Wikipedia
 @testable import WMF
+import SwiftUI
 
 
 final class TalkPageFetcherTests: XCTestCase {
@@ -13,7 +14,6 @@ final class TalkPageFetcherTests: XCTestCase {
         let expectation = expectation(description: "Waiting for completion")
         
         fetcher.fetchTalkPageContent(talkPageTitle: "Talk:Archaeoindris", siteURL: siteURL) { result in
-            
             expectation.fulfill()
             
             switch result {
@@ -22,9 +22,40 @@ final class TalkPageFetcherTests: XCTestCase {
             case .failure:
                 XCTFail("Expected Success")
             }
-            
         }
         wait(for: [expectation], timeout: 5)
+    }
+    
+    func testPostReply() {
+        
+        let fetcher = MockTalkPageFetcher()
+        let siteURL = URL(string: "https://en.wikipedia.org")!
+        
+        fetcher.postReply(talkPageTitle: "User_talk:Username", siteURL: siteURL, commentId: "commentid", comment: "comment") { _ in }
+        XCTAssertTrue(fetcher.postReplyWasCalled)
+    }
+    
+    func testPostTopic() {
+        let fetcher = MockTalkPageFetcher()
+        let siteURL = URL(string: "https://en.wikipedia.org")!
+        
+        fetcher.postTopic(talkPageTitle: "User_talk:Username", siteURL: siteURL, topicTitle: "Title", topicBody: "body") { _ in }
+        XCTAssertTrue(fetcher.postTopicWasCalled)
+    }
+}
+
+class MockTalkPageFetcher: TalkPageFetcher {
+    
+    var postReplyWasCalled = false
+    var postTopicWasCalled = false
+    
+    override func postReply(talkPageTitle: String, siteURL: URL, commentId: String, comment: String, completion: @escaping(Result<[AnyHashable: Any], Error>) -> Void) {
+        
+        postReplyWasCalled = true
+    }
+    
+    override func postTopic(talkPageTitle: String, siteURL: URL, topicTitle: String, topicBody: String, completion: @escaping(Result<[AnyHashable: Any], Error>) -> Void) {
+        postTopicWasCalled = true
     }
     
 }

--- a/WikipediaUnitTests/Manual Tests/TalkPageManualPerformanceTests.swift
+++ b/WikipediaUnitTests/Manual Tests/TalkPageManualPerformanceTests.swift
@@ -34,10 +34,10 @@ class TalkPageManualPerformanceTests: XCTestCase {
         
         XCTAssertEqual(firstResults.count, 0, "Expected zero existing talk pages at first")
         
-        guard let largeJson = wmf_bundle().wmf_data(fromContentsOfFile: TalkPageTestHelpers.TalkPageJSONType.largeForPerformance.fileName, ofType: "json"),
-            let largeUpdatedJson = wmf_bundle().wmf_data(fromContentsOfFile: TalkPageTestHelpers.TalkPageJSONType.largeUpdatedForPerformance.fileName, ofType: "json"),
-            let networkTalkPage = TalkPageTestHelpers.networkTalkPage(for: urlString1, data: largeJson, revisionId: 1),
-            let updatedNetworkTalkPage = TalkPageTestHelpers.networkTalkPage(for: urlString1, data: largeUpdatedJson, revisionId: 1) else {
+        guard let largeJson = wmf_bundle().wmf_data(fromContentsOfFile: OldTalkPageTestHelpers.TalkPageJSONType.largeForPerformance.fileName, ofType: "json"),
+            let largeUpdatedJson = wmf_bundle().wmf_data(fromContentsOfFile: OldTalkPageTestHelpers.TalkPageJSONType.largeUpdatedForPerformance.fileName, ofType: "json"),
+            let networkTalkPage = OldTalkPageTestHelpers.networkTalkPage(for: urlString1, data: largeJson, revisionId: 1),
+            let updatedNetworkTalkPage = OldTalkPageTestHelpers.networkTalkPage(for: urlString1, data: largeUpdatedJson, revisionId: 1) else {
             XCTFail("Failure stubbing out network talk pages")
             return
         }
@@ -72,10 +72,10 @@ class TalkPageManualPerformanceTests: XCTestCase {
         
         XCTAssertEqual(firstResults.count, 0, "Expected zero existing talk pages at first")
         
-        guard let smallJson = wmf_bundle().wmf_data(fromContentsOfFile: TalkPageTestHelpers.TalkPageJSONType.smallForPerformance.fileName, ofType: "json"),
-            let largeUpdatedJson = wmf_bundle().wmf_data(fromContentsOfFile: TalkPageTestHelpers.TalkPageJSONType.largeUpdatedForPerformance.fileName, ofType: "json"),
-            let networkTalkPage = TalkPageTestHelpers.networkTalkPage(for: urlString1, data: smallJson, revisionId: 1),
-            let updatedNetworkTalkPage = TalkPageTestHelpers.networkTalkPage(for: urlString1, data: largeUpdatedJson, revisionId: 1) else {
+        guard let smallJson = wmf_bundle().wmf_data(fromContentsOfFile: OldTalkPageTestHelpers.TalkPageJSONType.smallForPerformance.fileName, ofType: "json"),
+            let largeUpdatedJson = wmf_bundle().wmf_data(fromContentsOfFile: OldTalkPageTestHelpers.TalkPageJSONType.largeUpdatedForPerformance.fileName, ofType: "json"),
+            let networkTalkPage = OldTalkPageTestHelpers.networkTalkPage(for: urlString1, data: smallJson, revisionId: 1),
+            let updatedNetworkTalkPage = OldTalkPageTestHelpers.networkTalkPage(for: urlString1, data: largeUpdatedJson, revisionId: 1) else {
                 XCTFail("Failure stubbing out network talk pages")
                 return
         }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T311071

### Notes
* Adds unit tests to new methods created (still waiting for other PRs to be merged)
* Renames existing Talk Page tests with the prefix `Old`

### Test Steps
1. Check if CI tests pass

