### PR TITLE
Talk Pages - Reply Compose Overlay (Part 1)

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -388,6 +388,10 @@
 		67112E3E275E603B007A9850 /* NotificationsCenterInboxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67112E3C275E603B007A9850 /* NotificationsCenterInboxViewModel.swift */; };
 		67112E3F275E603B007A9850 /* NotificationsCenterInboxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67112E3C275E603B007A9850 /* NotificationsCenterInboxViewModel.swift */; };
 		67112E40275E603B007A9850 /* NotificationsCenterInboxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67112E3C275E603B007A9850 /* NotificationsCenterInboxViewModel.swift */; };
+		67134A1728A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67134A1628A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift */; };
+		67134A1828A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67134A1628A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift */; };
+		67134A1928A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67134A1628A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift */; };
+		67134A1A28A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67134A1628A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift */; };
 		6713519D277285B7006C07D9 /* RemoteNotificationsRefreshDeadlineController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6713519C277285B7006C07D9 /* RemoteNotificationsRefreshDeadlineController.swift */; };
 		67146032243B885E008CE885 /* SurveyAnnouncementsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67146031243B885E008CE885 /* SurveyAnnouncementsController.swift */; };
 		67146034243B8B4F008CE885 /* AnnouncementType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67146033243B8B4F008CE885 /* AnnouncementType.swift */; };
@@ -3965,6 +3969,7 @@
 		670AF1CD26CA188B005F76D0 /* RemoteNotificationLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationLinks.swift; sourceTree = "<group>"; };
 		670F765E22B0C10600D87545 /* FakeProgressLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeProgressLoading.swift; sourceTree = "<group>"; };
 		67112E3C275E603B007A9850 /* NotificationsCenterInboxViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCenterInboxViewModel.swift; sourceTree = "<group>"; };
+		67134A1628A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TalkPageReplyComposeController.swift; sourceTree = "<group>"; };
 		6713519C277285B7006C07D9 /* RemoteNotificationsRefreshDeadlineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationsRefreshDeadlineController.swift; sourceTree = "<group>"; };
 		67146031243B885E008CE885 /* SurveyAnnouncementsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyAnnouncementsController.swift; sourceTree = "<group>"; usesTabs = 0; };
 		67146033243B8B4F008CE885 /* AnnouncementType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementType.swift; sourceTree = "<group>"; };
@@ -6081,6 +6086,7 @@
 				00D1F58E28885BA300127169 /* TalkPageViewModel.swift */,
 				00D46DA42889B7F50015DE9B /* TalkPageView.swift */,
 				00D46DA92889B9250015DE9B /* TalkPageCell.swift */,
+				67134A1628A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift */,
 				6730FD0D28998EFD000E5F40 /* TalkPageReplyComposeContentView.swift */,
 			);
 			name = "Talk Pages";
@@ -11409,6 +11415,7 @@
 				B00DDEDD1DB591C400615FA2 /* WMFWelcomeContainerViewController.swift in Sources */,
 				00FCB2BE26D8398700F5A47A /* NotificationsCenterCell.swift in Sources */,
 				83F1097323D0F115003F3E9E /* HelpViewController.swift in Sources */,
+				67134A1728A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift in Sources */,
 				83FBE96F1F6172ED0026C7EB /* ShareAFactActivityTextItemProvider.swift in Sources */,
 				6789FA2E22E7790900E43842 /* TalkPage+Extensions.swift in Sources */,
 				D8A47C8523D7259A002AA823 /* NoIntrinsicContentSizeImageView.swift in Sources */,
@@ -12340,6 +12347,7 @@
 				D87676A221E7B73C00491039 /* ToolbarSeparatorView.swift in Sources */,
 				00FCB2C126D8398700F5A47A /* NotificationsCenterCell.swift in Sources */,
 				D8A42AE61E815A9C00D8E281 /* WMFAccountCreator.swift in Sources */,
+				67134A1A28A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift in Sources */,
 				83F1097623D0F115003F3E9E /* HelpViewController.swift in Sources */,
 				D8A42AE71E815A9C00D8E281 /* UIViewController+WMFHideKeyboard.swift in Sources */,
 				6789FA3122E7790900E43842 /* TalkPage+Extensions.swift in Sources */,
@@ -13148,6 +13156,7 @@
 				D8CE260C1E698E2400DAE2E0 /* MapUtilities.swift in Sources */,
 				D8CE260E1E698E2400DAE2E0 /* WKWebView+ElementLocation.m in Sources */,
 				678D79FD235E59B2006161FF /* DiffListUneditedViewModel.swift in Sources */,
+				67134A1928A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift in Sources */,
 				D8CE26101E698E2400DAE2E0 /* UIViewController+WMFStoryboardUtilities.swift in Sources */,
 				B0016CBA21354D9D00FA1096 /* AutoLayoutSafeMultiLineButton.swift in Sources */,
 				83DB4412244A57590046FABE /* RootNavigationController.swift in Sources */,
@@ -13694,6 +13703,7 @@
 				D8EC3F0B1E9BDA35006712EB /* MapUtilities.swift in Sources */,
 				D8EC3F0D1E9BDA35006712EB /* WKWebView+ElementLocation.m in Sources */,
 				678D79FE235E59B2006161FF /* DiffListUneditedViewModel.swift in Sources */,
+				67134A1828A73C0A00BA0BB9 /* TalkPageReplyComposeController.swift in Sources */,
 				D8EC3F0F1E9BDA35006712EB /* UIViewController+WMFStoryboardUtilities.swift in Sources */,
 				B0016CBB21354D9D00FA1096 /* AutoLayoutSafeMultiLineButton.swift in Sources */,
 				83DB4411244A57590046FABE /* RootNavigationController.swift in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -448,6 +448,10 @@
 		672D69AB273ACAA100B123B3 /* UITabBarAppearance+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672D69A8273ACAA100B123B3 /* UITabBarAppearance+Extensions.swift */; };
 		672D69AC273ACAA200B123B3 /* UITabBarAppearance+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672D69A8273ACAA100B123B3 /* UITabBarAppearance+Extensions.swift */; };
 		672F0558222F24FB00FB1084 /* IconBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672F0557222F24FB00FB1084 /* IconBarButtonItem.swift */; };
+		6730FD0E28998EFD000E5F40 /* TalkPageReplyComposeContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6730FD0D28998EFD000E5F40 /* TalkPageReplyComposeContentView.swift */; };
+		6730FD0F28998EFD000E5F40 /* TalkPageReplyComposeContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6730FD0D28998EFD000E5F40 /* TalkPageReplyComposeContentView.swift */; };
+		6730FD1028998EFD000E5F40 /* TalkPageReplyComposeContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6730FD0D28998EFD000E5F40 /* TalkPageReplyComposeContentView.swift */; };
+		6730FD1128998EFD000E5F40 /* TalkPageReplyComposeContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6730FD0D28998EFD000E5F40 /* TalkPageReplyComposeContentView.swift */; };
 		6734115422735788005B31DA /* OldTalkPageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0A7226A654D00537BC9 /* OldTalkPageFetcher.swift */; };
 		6734115522735789005B31DA /* OldTalkPageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0A7226A654D00537BC9 /* OldTalkPageFetcher.swift */; };
 		673411562273578A005B31DA /* OldTalkPageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8B0A7226A654D00537BC9 /* OldTalkPageFetcher.swift */; };
@@ -3982,6 +3986,7 @@
 		672D69A3273ABD3600B123B3 /* UINavigationBarAppearance+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationBarAppearance+Extensions.swift"; sourceTree = "<group>"; };
 		672D69A8273ACAA100B123B3 /* UITabBarAppearance+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarAppearance+Extensions.swift"; sourceTree = "<group>"; };
 		672F0557222F24FB00FB1084 /* IconBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconBarButtonItem.swift; sourceTree = "<group>"; };
+		6730FD0D28998EFD000E5F40 /* TalkPageReplyComposeContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageReplyComposeContentView.swift; sourceTree = "<group>"; };
 		6734114F22700A95005B31DA /* TalkPageControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageControllerTests.swift; sourceTree = "<group>"; };
 		6734115122700C47005B31DA /* TalkPageTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageTestHelpers.swift; sourceTree = "<group>"; };
 		6734116322739CA2005B31DA /* TalkPageLocalHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageLocalHandler.swift; sourceTree = "<group>"; };
@@ -6076,6 +6081,7 @@
 				00D1F58E28885BA300127169 /* TalkPageViewModel.swift */,
 				00D46DA42889B7F50015DE9B /* TalkPageView.swift */,
 				00D46DA92889B9250015DE9B /* TalkPageCell.swift */,
+				6730FD0D28998EFD000E5F40 /* TalkPageReplyComposeContentView.swift */,
 			);
 			name = "Talk Pages";
 			sourceTree = "<group>";
@@ -11162,6 +11168,7 @@
 				B0CD9DDB1F70997300051843 /* WMFWelcomeLanguagesAnimationView.swift in Sources */,
 				6782DB9D2343B7DB003FA21B /* DiffHeaderTitleView.swift in Sources */,
 				830D71CF1F704DD40080078B /* ArticleFetchedResultsViewController.swift in Sources */,
+				6730FD0E28998EFD000E5F40 /* TalkPageReplyComposeContentView.swift in Sources */,
 				6747117E250703BB00287951 /* ArticleAsLivingDocReferenceCollectionViewCell.swift in Sources */,
 				B0EFCD6D1EBF12E5008F36E5 /* LibrariesUsed.swift in Sources */,
 				67DC5BE923A03FE700B03A84 /* ArticleToolbarController.swift in Sources */,
@@ -12092,6 +12099,7 @@
 				B0CD9DF01F70997500051843 /* WMFWelcomeLanguagesAnimationView.swift in Sources */,
 				67B64D5A2507DE3E00FA27F3 /* ArticleAsLivingDocSectionHeaderView.swift in Sources */,
 				6782DBA02343B7DB003FA21B /* DiffHeaderTitleView.swift in Sources */,
+				6730FD1128998EFD000E5F40 /* TalkPageReplyComposeContentView.swift in Sources */,
 				830D71D21F704DD40080078B /* ArticleFetchedResultsViewController.swift in Sources */,
 				83AE1C831F34BB5A004B62E0 /* ImageDimmingExampleViewController.swift in Sources */,
 				67DC5BEC23A03FE700B03A84 /* ArticleToolbarController.swift in Sources */,
@@ -12844,6 +12852,7 @@
 				B0524B70214854E900D8FD8D /* DescriptionWelcomeContentsViewController.swift in Sources */,
 				7A2FE55D20517BAE00F92F8F /* EraseSavedArticlesView.swift in Sources */,
 				7A6F560621AF527A0076D184 /* TextFormattingInputViewController.swift in Sources */,
+				6730FD1028998EFD000E5F40 /* TalkPageReplyComposeContentView.swift in Sources */,
 				D8CE256D1E698E2400DAE2E0 /* UIViewController+WMFHideKeyboard.swift in Sources */,
 				BA4524191F324C3100439C42 /* FontSizeSliderViewController.swift in Sources */,
 				FF921887252F7EA500C39A8F /* ThanksGiving.swift in Sources */,
@@ -13389,6 +13398,7 @@
 				7A393283236CBDD500A89C2F /* PageHistoryComparisonSelectionViewController.swift in Sources */,
 				7A9524CD22665E6400C55CDC /* InsertMediaSettingsImageView.swift in Sources */,
 				B0524B71214854E900D8FD8D /* DescriptionWelcomeContentsViewController.swift in Sources */,
+				6730FD0F28998EFD000E5F40 /* TalkPageReplyComposeContentView.swift in Sources */,
 				D8EC3E5D1E9BDA35006712EB /* AboutViewController.m in Sources */,
 				7A6F560721AF527A0076D184 /* TextFormattingInputViewController.swift in Sources */,
 				D818D38D1ED765470076110D /* ArticleLocationCollectionViewController.swift in Sources */,

--- a/Wikipedia/Code/TalkPageReplyComposeContentView.swift
+++ b/Wikipedia/Code/TalkPageReplyComposeContentView.swift
@@ -1,0 +1,29 @@
+import UIKit
+import WMF
+
+class TalkPageReplyComposeContentView: SetupView {
+    private lazy var replyTextView: UITextView = {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        return textView
+    }()
+    
+    override func setup() {
+        addSubview(replyTextView)
+        
+        NSLayoutConstraint.activate([
+            safeAreaLayoutGuide.topAnchor.constraint(equalTo: replyTextView.topAnchor),
+            safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: replyTextView.trailingAnchor),
+            safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: replyTextView.bottomAnchor),
+            safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: replyTextView.leadingAnchor)
+        ])
+    }
+}
+
+extension TalkPageReplyComposeContentView: Themeable {
+    func apply(theme: Theme) {
+        backgroundColor = theme.colors.paperBackground
+        replyTextView.backgroundColor = theme.colors.paperBackground
+        replyTextView.textColor = theme.colors.primaryText
+    }
+}

--- a/Wikipedia/Code/TalkPageReplyComposeController.swift
+++ b/Wikipedia/Code/TalkPageReplyComposeController.swift
@@ -1,0 +1,115 @@
+import Foundation
+import UIKit
+import WMF
+
+/// Class for coordinating talk page reply compose views
+class TalkPageReplyComposeController {
+    
+    private(set) var containerView: UIView?
+    private var containerViewTopConstraint: NSLayoutConstraint?
+    private var containerViewBottomConstraint: NSLayoutConstraint?
+    private var containerViewHeightConstraint: NSLayoutConstraint?
+    
+    private var contentView: TalkPageReplyComposeContentView?
+    
+    private let containerPinnedTopSpacing = CGFloat(10)
+    private let contentTopSpacing = CGFloat(15)
+
+    // MARK: Public
+    
+    func setupAndDisplay(in viewController: TalkPageViewController, theme: Theme) {
+        
+        guard containerView == nil && contentView == nil else {
+            return
+        }
+        
+        setupViews(in: viewController)
+        calculateLayout(in: viewController)
+        apply(theme: theme)
+    }
+    
+    func calculateLayout(in viewController: ViewController, newViewSize: CGSize? = nil, newKeyboardFrame: CGRect? = nil) {
+        
+        containerViewBottomConstraint?.constant = newKeyboardFrame?.height ?? 0
+        
+        let viewHeight = newViewSize?.height ?? viewController.view.frame.height
+        let oneFifthViewHeight = viewHeight / 5
+        
+        containerViewHeightConstraint?.constant = oneFifthViewHeight
+        
+        // always pin compact vertical size classes
+        guard viewController.traitCollection.verticalSizeClass != .compact else {
+            toggleConstraints(shouldPinToTop: true)
+            return
+        }
+
+        toggleConstraints(shouldPinToTop: false)
+    }
+    
+    // MARK: Private
+    
+    private func setupViews(in viewController: ViewController) {
+        let containerView = UIView(frame: .zero)
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        
+        addShadow(to: containerView)
+        viewController.view.addSubview(containerView)
+        
+        // always active constraints
+        let trailingConstraint = viewController.view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
+        let bottomConstraint = viewController.view.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
+        let leadingConstraint = viewController.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor)
+        NSLayoutConstraint.activate([trailingConstraint, bottomConstraint, leadingConstraint])
+        
+        self.containerViewBottomConstraint = bottomConstraint
+        
+        // sometimes inactive constraints
+        self.containerViewTopConstraint = containerView.topAnchor.constraint(equalTo: viewController.view.safeAreaLayoutGuide.topAnchor, constant: containerPinnedTopSpacing)
+        self.containerViewHeightConstraint = containerView.heightAnchor.constraint(equalToConstant: 0)
+
+        self.containerView = containerView
+        
+        addContentView(to: containerView)
+    }
+    
+    private func addShadow(to containerView: UIView) {
+        containerView.layer.masksToBounds = false
+        containerView.layer.shadowOffset = CGSize(width: 0, height: -2)
+        containerView.layer.shadowOpacity = 1.0
+        containerView.layer.shadowRadius = 5
+        containerView.layer.cornerRadius = 8
+    }
+    
+    private func addContentView(to containerView: UIView) {
+        let contentView = TalkPageReplyComposeContentView(frame: .zero)
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(contentView)
+        
+        NSLayoutConstraint.activate([
+            contentView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: contentTopSpacing),
+            contentView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+            contentView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor)
+        ])
+        
+        self.contentView = contentView
+    }
+    
+    private func toggleConstraints(shouldPinToTop: Bool) {
+        if shouldPinToTop {
+            containerViewHeightConstraint?.isActive = false
+            containerViewTopConstraint?.isActive = true
+        } else {
+            containerViewTopConstraint?.isActive = false
+            containerViewHeightConstraint?.isActive = true
+        }
+    }
+}
+
+extension TalkPageReplyComposeController: Themeable {
+    func apply(theme: Theme) {
+        containerView?.backgroundColor = theme.colors.paperBackground
+        containerView?.layer.shadowColor = theme.colors.shadow.cgColor
+        contentView?.apply(theme: theme)
+    }
+}

--- a/Wikipedia/Code/TalkPageReplyComposeController.swift
+++ b/Wikipedia/Code/TalkPageReplyComposeController.swift
@@ -5,7 +5,7 @@ import WMF
 /// Class for coordinating talk page reply compose views
 class TalkPageReplyComposeController {
     
-    private(set) var containerView: UIView?
+    private var containerView: UIView?
     private var containerViewTopConstraint: NSLayoutConstraint?
     private var containerViewBottomConstraint: NSLayoutConstraint?
     private var containerViewHeightConstraint: NSLayoutConstraint?
@@ -44,6 +44,10 @@ class TalkPageReplyComposeController {
         }
 
         toggleConstraints(shouldPinToTop: false)
+    }
+    
+    var additionalBottomContentInset: CGFloat {
+        return containerViewHeightConstraint?.constant ?? 0
     }
     
     // MARK: Private

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -61,6 +61,10 @@ class TalkPageViewController: ViewController {
     
     let replyComposeController = TalkPageReplyComposeController()
     
+    override var additionalBottomContentInset: CGFloat {
+        return replyComposeController.additionalBottomContentInset
+    }
+    
     override func keyboardDidChangeFrame(from oldKeyboardFrame: CGRect?, newKeyboardFrame: CGRect?) {
         super.keyboardDidChangeFrame(from: oldKeyboardFrame, newKeyboardFrame: newKeyboardFrame)
         

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -38,6 +38,10 @@ class TalkPageViewController: ViewController {
 
         talkPageView.collectionView.dataSource = self
         talkPageView.collectionView.delegate = self
+        
+        // Needed for reply compose views to display on top of navigation bar.
+        navigationController?.setNavigationBarHidden(true, animated: false)
+        navigationMode = .forceBar
     }
 
     // MARK: - Public

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -63,7 +63,7 @@ class TalkPageViewController: ViewController {
 extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewDataSource {
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 1
+        return 25
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -74,6 +74,10 @@ extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewData
         cell.apply(theme: theme)
 
         return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        print("tapped cell")
     }
 
 }

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -54,6 +54,34 @@ class TalkPageViewController: ViewController {
 
         talkPageView.apply(theme: theme)
         talkPageView.collectionView.reloadData()
+        replyComposeController.apply(theme: theme)
+    }
+    
+    // MARK: Reply Compose Management
+    
+    let replyComposeController = TalkPageReplyComposeController()
+    
+    override func keyboardDidChangeFrame(from oldKeyboardFrame: CGRect?, newKeyboardFrame: CGRect?) {
+        super.keyboardDidChangeFrame(from: oldKeyboardFrame, newKeyboardFrame: newKeyboardFrame)
+        
+        replyComposeController.calculateLayout(in: self, newKeyboardFrame: newKeyboardFrame)
+        
+        view.setNeedsLayout()
+        UIView.animate(withDuration: 0.2) {
+            self.view.layoutIfNeeded()
+        }
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
+        replyComposeController.calculateLayout(in: self)
+    }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        
+        replyComposeController.calculateLayout(in: self, newViewSize: size)
     }
 
 }
@@ -77,7 +105,7 @@ extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewData
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        print("tapped cell")
+        replyComposeController.setupAndDisplay(in: self, theme: theme)
     }
 
 }

--- a/Wikipedia/Code/ViewController.swift
+++ b/Wikipedia/Code/ViewController.swift
@@ -294,6 +294,8 @@ class ViewController: ThemeableViewController, NavigationBarHiderDelegate {
             bottom += toolbar.frame.height
         }
         
+        bottom += additionalBottomContentInset
+        
         let scrollIndicatorInsets: UIEdgeInsets = UIEdgeInsets(top: top, left: safeInsets.left, bottom: bottom, right: safeInsets.right)
         
         if let rc = scrollView.refreshControl, rc.isRefreshing {
@@ -303,6 +305,11 @@ class ViewController: ThemeableViewController, NavigationBarHiderDelegate {
         if scrollView.setContentInset(contentInset, verticalScrollIndicatorInsets: scrollIndicatorInsets, preserveContentOffset: navigationBar.isAdjustingHidingFromContentInsetChangesEnabled, preserveAnimation: shouldAnimateWhileUpdatingScrollViewInsets) {
             scrollViewInsetsDidChange()
         }
+    }
+    
+    /// Override to add any additional bottom insets during content inset calculations
+    var additionalBottomContentInset: CGFloat {
+        return 0
     }
 
     open func scrollViewInsetsDidChange() {


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T310291

### Notes
This is the beginning of the talk page reply compose overlay. It presents an empty view over the keyboard, set to 1/5 height of the parent view, and expands to nearly full screen in vertical compact trait collections.

I tried to keep as much as I could out of the view controller just so we can try to keep that class size small, so most of this is managed in a separate controller class. I'm fine moving the logic back into the view controller or into the view model if it doesn't make sense here, though.

### Test Steps
1. Load a talk page and tap a cell.
2. Confirm you see an empty reply compose view appear at the bottom in 1/5 the parent view height.
3. Tap empty reply compose view, keyboard should appear. Confirm reply compose view moves up with the keyboard.
4. Confirm you can still scroll the cells behind it per requirements. Confirm you can scroll all the way to the bottom and fully see the last cell.
5. Rotate to iPhone landscape, confirm it expands to full screen, over the navigation bar per mocks.
6. Confirm rotating back goes back to 1/5 height.
7. Test on iPad, confirm rotating works as expected, they should all keep the 1/5 height.
8. Confirm no autolayout complaints appear in the console.

Draggable handle and the rest of the reply compose content view will come in a follow up PR.
