### PR TITLE
Fix vanishing text view placeholder position in RTL

### DIFF
--- a/Wikipedia/Code/SwiftUITextView.swift
+++ b/Wikipedia/Code/SwiftUITextView.swift
@@ -9,6 +9,7 @@ class SwiftUITextView: UITextView {
     lazy var placeholderLabel: UILabel = {
         let label = UILabel(frame: .zero)
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .natural
         return label
     }()
     
@@ -33,9 +34,11 @@ class SwiftUITextView: UITextView {
         placeholderLabel.text = placeholder
         
         addSubview(placeholderLabel)
+        
         NSLayoutConstraint.activate([
-            placeholderLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
-            placeholderLabel.topAnchor.constraint(equalTo: topAnchor)
+            placeholderLabel.leftAnchor.constraint(equalTo: leftAnchor),
+            placeholderLabel.topAnchor.constraint(equalTo: topAnchor),
+            placeholderLabel.widthAnchor.constraint(equalTo: widthAnchor)
         ])
         
         setDoneOnKeyboard()


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T300080

### Notes
This should fix the "Optional" placeholder position in the Vanishing text view. 

### Test Steps
1. Go to the Vanishing screen in the RTL scheme. Confirm you can now see the "Optional" label.
