### PR TITLE
TalkPageCell expand / collapse animation

### DIFF
--- a/Wikipedia/Code/TalkPageCell.swift
+++ b/Wikipedia/Code/TalkPageCell.swift
@@ -27,7 +27,6 @@ final class TalkPageCellRootContainerView: SetupView, Themeable {
         
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: Self.padding.top),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Self.padding.bottom),
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.padding.leading),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Self.padding.trailing)
         ])

--- a/Wikipedia/Code/TalkPageCell.swift
+++ b/Wikipedia/Code/TalkPageCell.swift
@@ -20,14 +20,16 @@ final class TalkPageCellRootContainerView: SetupView, Themeable {
     lazy var disclosureRow: TalkPageCellDisclosureRow = TalkPageCellDisclosureRow()
     lazy var commentView = TalkPageCellCommentView()
     
+    static let padding = NSDirectionalEdgeInsets(top: 12, leading: 12, bottom: 12, trailing: 12)
+    
     override func setup() {
         addSubview(stackView)
         
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: topAnchor, constant: 12),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12)
+            stackView.topAnchor.constraint(equalTo: topAnchor, constant: Self.padding.top),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Self.padding.bottom),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.padding.leading),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Self.padding.trailing)
         ])
         
         stackView.addArrangedSubview(disclosureRow)
@@ -74,6 +76,8 @@ final class TalkPageCell: UICollectionViewCell {
 
     weak var viewModel: TalkPageCellViewModel?
     weak var delegate: TalkPageCellDelegate?
+    
+    static let padding = NSDirectionalEdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16)
 
     // MARK: - UI Elements
 
@@ -110,10 +114,10 @@ final class TalkPageCell: UICollectionViewCell {
         contentView.addSubview(rootContainer)
 
         NSLayoutConstraint.activate([
-            rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
-            rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16),
-            rootContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-            rootContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16)
+            rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Self.padding.top),
+            rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -Self.padding.bottom),
+            rootContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Self.padding.leading),
+            rootContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Self.padding.trailing)
         ])
     }
 

--- a/Wikipedia/Code/TalkPageCell.swift
+++ b/Wikipedia/Code/TalkPageCell.swift
@@ -20,15 +20,14 @@ final class TalkPageCellRootContainerView: SetupView, Themeable {
     lazy var disclosureRow: TalkPageCellDisclosureRow = TalkPageCellDisclosureRow()
     lazy var commentView = TalkPageCellCommentView()
     
-    static let padding = NSDirectionalEdgeInsets(top: 12, leading: 12, bottom: 12, trailing: 12)
-    
     override func setup() {
         addSubview(stackView)
         
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: topAnchor, constant: Self.padding.top),
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.padding.leading),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Self.padding.trailing)
+            stackView.topAnchor.constraint(equalTo: topAnchor, constant: 12),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12)
         ])
         
         stackView.addArrangedSubview(disclosureRow)
@@ -114,7 +113,6 @@ final class TalkPageCell: UICollectionViewCell {
 
         NSLayoutConstraint.activate([
             rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Self.padding.top),
-            rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -Self.padding.bottom),
             rootContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Self.padding.leading),
             rootContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Self.padding.trailing)
         ])

--- a/Wikipedia/Code/TalkPageView.swift
+++ b/Wikipedia/Code/TalkPageView.swift
@@ -4,16 +4,12 @@ final class TalkPageView: SetupView {
 
     // MARK: - Private Properties
 
-    private lazy var topicGroupLayout: UICollectionViewLayout = {
-        let heightDimension: NSCollectionLayoutDimension = .estimated(225)
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),heightDimension: heightDimension)
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),heightDimension: heightDimension)
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,subitems: [item])
-        let section = NSCollectionLayoutSection(group: group)
-        let layout = UICollectionViewCompositionalLayout(section: section)
+    private var topicGroupLayout: UICollectionViewLayout {
+        let layout = UICollectionViewFlowLayout()
+        layout.minimumInteritemSpacing = 0
+        layout.minimumLineSpacing = 0
         return layout
-    }()
+    }
 
     // MARK: - UI Elements
 

--- a/Wikipedia/Code/TalkPageView.swift
+++ b/Wikipedia/Code/TalkPageView.swift
@@ -47,7 +47,10 @@ final class TalkPageView: SetupView {
         sizingView.isHidden = true
         self.sizingView = sizingView
     }
-
+    
+    func animateLayoutUpdate() {
+        collectionView.setCollectionViewLayout(topicGroupLayout, animated: true)
+    }
 }
 
 // MARK: - Themeable

--- a/Wikipedia/Code/TalkPageView.swift
+++ b/Wikipedia/Code/TalkPageView.swift
@@ -20,6 +20,8 @@ final class TalkPageView: SetupView {
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         return collectionView
     }()
+    
+    private(set) var sizingView: TalkPageCellRootContainerView?
 
     // MARK: - Lifecycle
 
@@ -31,6 +33,19 @@ final class TalkPageView: SetupView {
             collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
+        
+        // Add Sizing View for cell height calculations
+        let sizingView = TalkPageCellRootContainerView(frame: .zero)
+        sizingView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.insertSubview(sizingView, at: 0)
+        let horizontalPadding = TalkPageCell.padding.leading + TalkPageCell.padding.trailing
+        NSLayoutConstraint.activate([
+            sizingView.topAnchor.constraint(equalTo: collectionView.topAnchor),
+            sizingView.leadingAnchor.constraint(equalTo: collectionView.safeAreaLayoutGuide.leadingAnchor),
+            sizingView.widthAnchor.constraint(equalTo: safeAreaLayoutGuide.widthAnchor, constant: -horizontalPadding)
+        ])
+        sizingView.isHidden = true
+        self.sizingView = sizingView
     }
 
 }

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -160,6 +160,10 @@ extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewData
         
         return newSize
     }
+    
+    func collectionView(_ collectionView: UICollectionView, targetContentOffsetForProposedContentOffset proposedContentOffset: CGPoint) -> CGPoint {
+        return collectionView.contentOffset
+    }
 }
 
 // MARK: - TalkPageCellDelegate
@@ -176,7 +180,7 @@ extension TalkPageViewController: TalkPageCellDelegate {
         configuredCellViewModel.isThreadExpanded.toggle()
         
         cell.configure(viewModel: configuredCellViewModel)
-        talkPageView.collectionView.collectionViewLayout.invalidateLayout()
+        talkPageView.animateLayoutUpdate()
     }
 
     func userDidTapSubscribeButton(cellViewModel: TalkPageCellViewModel?, cell: TalkPageCell) {

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -136,7 +136,29 @@ extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewData
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: collectionView.frame.width, height: 225)
+        
+        guard let viewModel = viewModel.topics[safeIndex: indexPath.item],
+              let sizingView = talkPageView.sizingView else {
+            return .zero
+        }
+        
+        sizingView.configure(viewModel: viewModel)
+        sizingView.setNeedsLayout()
+        sizingView.layoutIfNeeded()
+        
+        let horizontalPadding = TalkPageCell.padding.leading + TalkPageCell.padding
+            .trailing
+        let verticalPadding = TalkPageCell.padding.top +
+                                TalkPageCell.padding.bottom +
+                                TalkPageCellRootContainerView.padding.top +
+                                TalkPageCellRootContainerView.padding.bottom
+        
+        let newWidth = sizingView.frame.width + horizontalPadding
+        let newHeight = sizingView.stackView.frame.height + verticalPadding
+        
+        let newSize = CGSize(width: newWidth, height: newHeight)
+        
+        return newSize
     }
 }
 

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -148,13 +148,10 @@ extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewData
         
         let horizontalPadding = TalkPageCell.padding.leading + TalkPageCell.padding
             .trailing
-        let verticalPadding = TalkPageCell.padding.top +
-                                TalkPageCell.padding.bottom +
-                                TalkPageCellRootContainerView.padding.top +
-                                TalkPageCellRootContainerView.padding.bottom
+        let verticalPadding = TalkPageCell.padding.top + TalkPageCell.padding.bottom
         
         let newWidth = sizingView.frame.width + horizontalPadding
-        let newHeight = sizingView.stackView.frame.height + verticalPadding
+        let newHeight = sizingView.frame.height + verticalPadding
         
         let newSize = CGSize(width: newWidth, height: newHeight)
         

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -115,7 +115,7 @@ class TalkPageViewController: ViewController {
 
 // MARK: - UICollectionViewDelegate, UICollectionViewDataSource
 
-extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return viewModel.topics.count
@@ -133,6 +133,10 @@ extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewData
         cell.delegate = self
 
         return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: collectionView.frame.width, height: 225)
     }
 }
 


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T310663

### Notes
This is an approach to consider for a smooth expand and collapse animation for our talk page cells. I tried a few different things before resorting to this, but I think the hitches came down to these issues:
1. The cell content stack view being pinned to the cell's content view bottom. It seemed like during animation, the stack view elements would exist, pinned to the bottom, but the cell size would not yet be the full height. This caused the stack view to squish its elements during animation and look bad. 
2. Dynamically sized cells. I noticed that the height would always seem to briefly resort back to the layout's estimated height, before the new proper height was calculated. On my smaller iPhone 7 device upon expand, the cell would briefly _shrink_ to be even smaller, then expand to its full height.

I did manage to account for 1 & 2 to smooth over the those quirks while keeping the dynamically sized heights (this work is in the `talk-pages/cell-design-animations-2` branch if interested) , but it was still jerky during the animation itself, and sizing still sometimes goes haywire. I'm not sure the reasons for that, but figuring out the cell heights up front seemed to fix it. This approach may come at a performance cost when expanding all the cells from the overflow menu, or rotating. We may be able to improve some of that with some simple caching of the heights.

This approach is similar to how we built the revision diff cells that expand, FYI. On that screen we are calculating the cell heights up front, but doing more manually by traversing each string in the view model and determining it's height via the string [boundingRect]((https://developer.apple.com/documentation/foundation/nsattributedstring/1529154-boundingrect) methods 😱. This approach with a sizing view at least lets us mostly lean on the autolayout setup of the root container view.

There are a couple of bugs here that I still need to look into - there are layout console complaints upon rotation (I'm probably missing an inset consideration in the cell size calculations), and iPad seems to have more of a margin that gets lost upon expand due to the width I set for the cell heights. Both seem fixable though.
