### PR TITLE
Address lead reply button and participant metadata design feedback for usability testing

### DIFF
--- a/Wikipedia/Code/TalkPageCell.swift
+++ b/Wikipedia/Code/TalkPageCell.swift
@@ -37,8 +37,29 @@ final class TalkPageCell: UICollectionViewCell {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
+        stackView.alignment = .leading
         stackView.distribution = .fill
         return stackView
+    }()
+
+    lazy var leadReplySpacer = VerticalSpacerView.spacerWith(space: 16)
+
+    lazy var leadReplyButton: UIButton = {
+        let button = UIButton()
+        button.layer.cornerRadius = 8
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
+        button.titleLabel?.font = UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .semibold, size: 15)
+        button.setTitle(CommonStrings.talkPageReply, for: .normal)
+        button.setTitleColor(.black, for: .normal)
+        button.setImage(UIImage(systemName: "arrowshape.turn.up.left"), for: .normal)
+
+        button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
+        button.imageEdgeInsets = UIEdgeInsets(top: 0, left: -2, bottom: 0, right: 2)
+        button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 2, bottom: 0, right: -2)
+
+        button.setContentHuggingPriority(.required, for: .horizontal)        
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
+        return button
     }()
 
     lazy var topicView: TalkPageCellTopicView = TalkPageCellTopicView()
@@ -82,6 +103,8 @@ final class TalkPageCell: UICollectionViewCell {
 
         stackView.addArrangedSubview(disclosureRow)
         stackView.addArrangedSubview(topicView)
+        stackView.addArrangedSubview(leadReplySpacer)
+        stackView.addArrangedSubview(leadReplyButton)
     }
 
     // MARK: - Configure
@@ -93,6 +116,9 @@ final class TalkPageCell: UICollectionViewCell {
         topicView.configure(viewModel: viewModel)
         topicView.linkDelegate = linkDelegate
 
+        leadReplySpacer.isHidden = !viewModel.isThreadExpanded
+        leadReplyButton.isHidden = !viewModel.isThreadExpanded
+
         let comments: [UIView] = stackView.arrangedSubviews.filter { view in view is TalkPageCellCommentView || view is TalkPageCellCommentSeparator }
         stackView.arrangedSubviews.forEach { view in
             if comments.contains(view) {
@@ -102,6 +128,9 @@ final class TalkPageCell: UICollectionViewCell {
 
         for commentViewModel in viewModel.replies {
             let separator = TalkPageCellCommentSeparator()
+            separator.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            separator.setContentCompressionResistancePriority(.required, for: .horizontal)
+
             let commentView = TalkPageCellCommentView()
             commentView.replyDelegate = replyDelegate
             commentView.configure(viewModel: commentViewModel)
@@ -116,7 +145,7 @@ final class TalkPageCell: UICollectionViewCell {
 
         disclosureRow.disclosureButton.addTarget(self, action: #selector(userDidTapDisclosureButton), for: .primaryActionTriggered)
         disclosureRow.subscribeButton.addTarget(self, action: #selector(userDidTapSubscribeButton), for: .primaryActionTriggered)
-        topicView.replyButton.addTarget(self, action: #selector(userDidTapLeadReply), for: .touchUpInside)
+        leadReplyButton.addTarget(self, action: #selector(userDidTapLeadReply), for: .touchUpInside)
     }
 
     // MARK: - Actions
@@ -148,6 +177,10 @@ extension TalkPageCell: Themeable {
         rootContainer.layer.borderColor = theme.colors.border.cgColor
 
         stackView.arrangedSubviews.forEach { ($0 as? Themeable)?.apply(theme: theme) }
+
+        leadReplyButton.setTitleColor(theme.colors.paperBackground, for: .normal)
+        leadReplyButton.backgroundColor = theme.colors.link
+        leadReplyButton.tintColor = theme.colors.paperBackground
     }
 
 }

--- a/Wikipedia/Code/TalkPageCellCommentSeparator.swift
+++ b/Wikipedia/Code/TalkPageCellCommentSeparator.swift
@@ -19,6 +19,10 @@ final class TalkPageCellCommentSeparator: SetupView {
         return view
     }()
 
+    override var intrinsicContentSize: CGSize {
+        return UIView.layoutFittingExpandedSize
+    }
+
     // MARK: - Lifecycle
 
     override func setup() {

--- a/Wikipedia/Code/TalkPageCellTopicView.swift
+++ b/Wikipedia/Code/TalkPageCellTopicView.swift
@@ -126,7 +126,7 @@ final class TalkPageCellTopicView: SetupView {
         return button
     }()
 
-    lazy var trailingSpacer: UIView = {
+    lazy var centerSpacer: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         let widthConstraint = view.widthAnchor.constraint(equalToConstant: 99999)
@@ -140,9 +140,8 @@ final class TalkPageCellTopicView: SetupView {
     override func setup() {
         addSubview(stackView)
         stackView.addArrangedSubview(topicTitleTextView)
-        stackView.addArrangedSubview(timestampLabel)
-        stackView.addArrangedSubview(topicCommentTextView)
         stackView.addArrangedSubview(horizontalStack)
+        stackView.addArrangedSubview(topicCommentTextView)
         stackView.addArrangedSubview(replyButton)
 
         activeUsersStack.addArrangedSubview(activeUsersImageView)
@@ -150,10 +149,11 @@ final class TalkPageCellTopicView: SetupView {
         repliesStack.addArrangedSubview(repliesImageView)
         repliesStack.addArrangedSubview(repliesCountLabel)
 
+        horizontalStack.addArrangedSubview(timestampLabel)
+        horizontalStack.addArrangedSubview(centerSpacer)
         horizontalStack.addArrangedSubview(activeUsersStack)
         horizontalStack.addArrangedSubview(metadataSpacer)
         horizontalStack.addArrangedSubview(repliesStack)
-        horizontalStack.addArrangedSubview(trailingSpacer)
 
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: 8),

--- a/Wikipedia/Code/TalkPageCellTopicView.swift
+++ b/Wikipedia/Code/TalkPageCellTopicView.swift
@@ -108,24 +108,6 @@ final class TalkPageCellTopicView: SetupView {
         return label
     }()
 
-    lazy var replyButton: UIButton = {
-        let button = UIButton()
-        button.layer.cornerRadius = 8
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.titleLabel?.font = UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .semibold, size: 15)
-        button.setTitle(CommonStrings.talkPageReply, for: .normal)
-        button.setTitleColor(.black, for: .normal)
-        button.setImage(UIImage(systemName: "arrowshape.turn.up.left"), for: .normal)
-
-        button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
-        button.imageEdgeInsets = UIEdgeInsets(top: 0, left: -2, bottom: 0, right: 2)
-        button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 2, bottom: 0, right: -2)
-
-        button.setContentHuggingPriority(.required, for: .horizontal)
-        button.setContentCompressionResistancePriority(.required, for: .horizontal)
-        return button
-    }()
-
     lazy var centerSpacer: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -142,7 +124,6 @@ final class TalkPageCellTopicView: SetupView {
         stackView.addArrangedSubview(topicTitleTextView)
         stackView.addArrangedSubview(horizontalStack)
         stackView.addArrangedSubview(topicCommentTextView)
-        stackView.addArrangedSubview(replyButton)
 
         activeUsersStack.addArrangedSubview(activeUsersImageView)
         activeUsersStack.addArrangedSubview(activeUsersLabel)
@@ -206,10 +187,6 @@ extension TalkPageCellTopicView: Themeable {
         activeUsersLabel.textColor = theme.colors.secondaryText
         repliesImageView.tintColor = theme.colors.secondaryText
         repliesCountLabel.textColor = theme.colors.secondaryText
-
-        replyButton.setTitleColor(theme.colors.paperBackground, for: .normal)
-        replyButton.backgroundColor = theme.colors.link
-        replyButton.tintColor = theme.colors.paperBackground
     }
     
 }


### PR DESCRIPTION
**Phabricator:** N/A (see Figma)

### Notes
- Moves the lead reply button below the fold, only displayed when the cell's thread is expanded.
- Moves the participant metadata higher up in the stack view next to the lead timestamp.

### Test Steps
1. Confirm the lead reply button now only displays when the cell is expanded
2. Confirm the participant metadata container renders to the right of the lead timestamp
