### PR TITLE
Address talk page view design feedback for usability test

### DIFF
--- a/Wikipedia/Code/TalkPageCell.swift
+++ b/Wikipedia/Code/TalkPageCell.swift
@@ -90,11 +90,11 @@ final class TalkPageCell: UICollectionViewCell {
         contentView.addSubview(rootContainer)
         rootContainer.addSubview(stackView)
         
-        let rootContainerBottomConstraint = rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16)
+        let rootContainerBottomConstraint = rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8)
         rootContainerBottomConstraint.priority = .defaultHigh
 
         NSLayoutConstraint.activate([
-            rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
+            rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
             rootContainerBottomConstraint,
             rootContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
             rootContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),

--- a/Wikipedia/Code/TalkPageHeaderView.swift
+++ b/Wikipedia/Code/TalkPageHeaderView.swift
@@ -36,7 +36,10 @@ final class TalkPageHeaderView: SetupView {
     lazy var imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.contentMode = .scaleAspectFit
+        imageView.contentMode = .scaleAspectFill
+        imageView.masksToBounds = true
+        imageView.layer.masksToBounds = true
+        imageView.layer.cornerRadius = 4
         return imageView
     }()
 

--- a/Wikipedia/Code/TalkPageView.swift
+++ b/Wikipedia/Code/TalkPageView.swift
@@ -44,7 +44,22 @@ final class TalkPageView: SetupView {
 extension TalkPageView: Themeable {
 
     func apply(theme: Theme) {
-        collectionView.backgroundColor = theme.colors.baseBackground
+        // TODO: Replace these once new theme colors are added/refreshed in the app
+        let baseBackground: UIColor!
+        switch theme {
+        case .light:
+            baseBackground = UIColor.wmf_colorWithHex(0xF8F9FA)
+        case .sepia:
+            baseBackground = UIColor.wmf_colorWithHex(0xF0E6D6)
+        case .dark:
+            baseBackground = UIColor.wmf_colorWithHex(0x202122)
+        case .black:
+            baseBackground = UIColor.wmf_colorWithHex(0x202122)
+        default:
+            baseBackground = UIColor.wmf_colorWithHex(0xF8F9FA)
+        }
+
+        collectionView.backgroundColor = baseBackground
     }
 
 }

--- a/Wikipedia/Code/TalkPageView.swift
+++ b/Wikipedia/Code/TalkPageView.swift
@@ -11,6 +11,7 @@ final class TalkPageView: SetupView {
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),heightDimension: heightDimension)
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,subitems: [item])
         let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0)
         let layout = UICollectionViewCompositionalLayout(section: section)
         return layout
     }()

--- a/Wikipedia/Code/TalkPageViewModel.swift
+++ b/Wikipedia/Code/TalkPageViewModel.swift
@@ -19,7 +19,7 @@ final class TalkPageViewModel {
     private(set) var projectSourceImage: UIImage?
     private(set) var projectLanguage: String?
     
-    static let leadImageSideLength = 98
+    static let leadImageSideLength = 80
     
     var theme: Theme = .light
     private(set) var topics: [TalkPageCellViewModel] = []

--- a/Wikipedia/Code/TalkPageViewModel.swift
+++ b/Wikipedia/Code/TalkPageViewModel.swift
@@ -112,7 +112,7 @@ final class TalkPageViewModel {
         headerTitle = pageTitle.namespaceAndTitleOfWikiResourcePath(with: languageCode).title
         
         headerDescription = articleSummary?.wikidataDescription
-        leadImageURL = articleSummary?.imageURL(forWidth: Self.leadImageSideLength)
+        leadImageURL = articleSummary?.imageURL(forWidth: Self.leadImageSideLength * Int(UIScreen.main.scale))
         
         if let otherContent = items.first?.otherContent,
            !otherContent.isEmpty {


### PR DESCRIPTION
**Phabricator:** N/A (see Figma)

### Notes
- Adds special case background colors for talk page view (added TODO to replace when Theme color refactor is complete)
- Update the inter-cell vertical/horizontal spacing to properly be 16 pts
- Updates the header image constraints to always be 80x80pt
- Changes the header image to be scale aspect fill, cropping as needed to fill the bounds
- Adds 4pt border to header image view
- Bonus: updated header image to take into account the screen scale factor so it's no longer displayed in a low resolution
