### PR TITLE
Update coffee roll background colors to be legible

### DIFF
--- a/Wikipedia/Code/TalkPageHeaderView.swift
+++ b/Wikipedia/Code/TalkPageHeaderView.swift
@@ -351,8 +351,21 @@ extension TalkPageHeaderView: Themeable {
         projectLanguageLabel.textColor = theme.colors.secondaryText
         projectLanguageLabelContainer.layer.borderColor = theme.colors.secondaryText.cgColor
 
-        // TODO: Use new Sepia `beige` for background color
-        coffeeRollContainer.backgroundColor = .sepiaBase100
+        // TODO: Replace these once new theme colors are added/refreshed in the app
+        let coffeeRollContainerBackground: UIColor!
+        switch theme {
+        case .light:
+            coffeeRollContainerBackground = UIColor.wmf_colorWithHex(0xF8F1E3)
+        case .sepia:
+            coffeeRollContainerBackground = UIColor.wmf_colorWithHex(0xE1DAD1)
+        case .dark:
+            coffeeRollContainerBackground = UIColor.wmf_colorWithHex(0x101418)
+        case .black:
+            coffeeRollContainerBackground = UIColor.wmf_colorWithHex(0x101418)
+        default:
+            coffeeRollContainerBackground = UIColor.wmf_colorWithHex(0xF8F1E3)
+        }
+        coffeeRollContainer.backgroundColor = coffeeRollContainerBackground
 
         coffeeRollSeparator.backgroundColor = theme.colors.tertiaryText
         coffeeRollReadMoreButton.setTitleColor(theme.colors.link, for: .normal)


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T310275#8234596

### Notes
Previously, the coffee roll was not legible in themes other than light. This adds theme specific colors for it. Like the page background color, we'll need to update these values once the color theme updates are implemented. I made a note of that [here](https://phabricator.wikimedia.org/T299793#8236964).

### Test Steps
1. Confirm talk pages coffee roll is legible using each theme.
