### PR TITLE
Check and remove new line characters from coffee roll text

### DIFF
--- a/Wikipedia/Code/TalkPageHeaderView.swift
+++ b/Wikipedia/Code/TalkPageHeaderView.swift
@@ -335,7 +335,21 @@ final class TalkPageHeaderView: SetupView {
         
         let theme = viewModel.theme
         
-        coffeeRollLabel.attributedText = coffeeRollText.byAttributingHTML(with: .callout, boldWeight: .semibold, matching: traitCollection, color: theme.colors.primaryText, linkColor: theme.colors.link, handlingLists: true, handlingSuperSubscripts: true, tagMapping: ["a": "b"])
+        var attributedText: NSMutableAttributedString = coffeeRollText.byAttributingHTML(with: .callout, boldWeight: .semibold, matching: traitCollection, color: theme.colors.primaryText, linkColor: theme.colors.link, handlingLists: true, handlingSuperSubscripts: true, tagMapping: ["a": "b"])
+        if attributedText.string.first == "\n" {
+            attributedText = removeInitialCharactersFrom(&attributedText)
+        }
+        coffeeRollLabel.attributedText = attributedText
+    }
+    
+    // Coffee roll attributed strigs were sometimes created with extra escape characters (\n) as the initial characters, so we remove them to properly render the text
+    func removeInitialCharactersFrom(_ attributedString: inout NSMutableAttributedString) -> NSMutableAttributedString {
+        while attributedString.string.first == "\n" {
+            let range = (attributedString.string as NSString).range(of: "\n")
+            attributedString.deleteCharacters(in: range)
+        }
+        
+        return attributedString
     }
 
 }

--- a/Wikipedia/Code/TalkPageHeaderView.swift
+++ b/Wikipedia/Code/TalkPageHeaderView.swift
@@ -342,7 +342,7 @@ final class TalkPageHeaderView: SetupView {
         coffeeRollLabel.attributedText = attributedText
     }
     
-    // Coffee roll attributed strigs were sometimes created with extra escape characters (\n) as the initial characters, so we remove them to properly render the text
+    // Coffee roll attributed strigs were sometimes created with extra new line characters (\n) as the initial characters, so we remove them to properly render the text
     func removeInitialCharactersFrom(_ attributedString: inout NSMutableAttributedString) -> NSMutableAttributedString {
         while attributedString.string.first == "\n" {
             let range = (attributedString.string as NSString).range(of: "\n")


### PR DESCRIPTION
**Phabricator:** N/A (see figma)

### Notes
* This PR verifies the existence of undesired new line characters `\n` at the beginning of coffee roll text to remove it, so the text aligns with the layout according to the design

### Test Steps
1. Go to a talk page that has a coffee roll (a yellow-ish table)
2. Verify that the text aligns according to the design
