### PR TITLE
Talk Pages - Cell performance improvements

### DIFF
--- a/Wikipedia/Code/TalkPageCell.swift
+++ b/Wikipedia/Code/TalkPageCell.swift
@@ -152,13 +152,9 @@ final class TalkPageCell: UICollectionViewCell {
 
     func setup() {
         contentView.addSubview(rootContainer)
-        
-        let rootContainerBottomConstraint = rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -Self.padding.bottom)
-        rootContainerBottomConstraint.priority = .defaultHigh
 
         NSLayoutConstraint.activate([
             rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Self.padding.top),
-            rootContainerBottomConstraint,
             rootContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Self.padding.leading),
             rootContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Self.padding.trailing)
         ])

--- a/Wikipedia/Code/TalkPageCell.swift
+++ b/Wikipedia/Code/TalkPageCell.swift
@@ -62,7 +62,7 @@ final class TalkPageCellRootContainerView: SetupView, Themeable {
         stackView.addArrangedSubview(leadReplyButton)
     }
     
-    func configure(viewModel: TalkPageCellViewModel, linkDelegate: TalkPageTextViewLinkHandling, replyDelegate: TalkPageCellReplyDelegate) {
+    func configure(viewModel: TalkPageCellViewModel, linkDelegate: TalkPageTextViewLinkHandling, replyDelegate: TalkPageCellReplyDelegate, theme: Theme) {
         disclosureRow.configure(viewModel: viewModel)
         topicView.configure(viewModel: viewModel)
         topicView.linkDelegate = linkDelegate
@@ -93,6 +93,8 @@ final class TalkPageCellRootContainerView: SetupView, Themeable {
             stackView.addArrangedSubview(separator)
             stackView.addArrangedSubview(commentView)
         }
+        
+        apply(theme: theme)
     }
     
     func apply(theme: Theme) {
@@ -162,11 +164,11 @@ final class TalkPageCell: UICollectionViewCell {
 
     // MARK: - Configure
 
-    func configure(viewModel: TalkPageCellViewModel, linkDelegate: TalkPageTextViewLinkHandling, replyDelegate: TalkPageCellReplyDelegate) {
+    func configure(viewModel: TalkPageCellViewModel, linkDelegate: TalkPageTextViewLinkHandling, replyDelegate: TalkPageCellReplyDelegate, theme: Theme) {
         self.viewModel = viewModel
         self.replyDelegate = replyDelegate
 
-        rootContainer.configure(viewModel: viewModel, linkDelegate: linkDelegate, replyDelegate: replyDelegate)
+        rootContainer.configure(viewModel: viewModel, linkDelegate: linkDelegate, replyDelegate: replyDelegate, theme: theme)
 
         rootContainer.disclosureRow.disclosureButton.addTarget(self, action: #selector(userDidTapDisclosureButton), for: .primaryActionTriggered)
         rootContainer.disclosureRow.subscribeButton.addTarget(self, action: #selector(userDidTapSubscribeButton), for: .primaryActionTriggered)

--- a/Wikipedia/Code/TalkPageCell.swift
+++ b/Wikipedia/Code/TalkPageCell.swift
@@ -115,6 +115,8 @@ final class TalkPageCell: UICollectionViewCell {
     weak var viewModel: TalkPageCellViewModel?
     weak var delegate: TalkPageCellDelegate?
     weak var replyDelegate: TalkPageCellReplyDelegate?
+    
+    static let padding = NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16)
 
     // MARK: - UI Elements
 
@@ -151,14 +153,14 @@ final class TalkPageCell: UICollectionViewCell {
     func setup() {
         contentView.addSubview(rootContainer)
         
-        let rootContainerBottomConstraint = rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8)
+        let rootContainerBottomConstraint = rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -Self.padding.bottom)
         rootContainerBottomConstraint.priority = .defaultHigh
 
         NSLayoutConstraint.activate([
-            rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+            rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Self.padding.top),
             rootContainerBottomConstraint,
-            rootContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-            rootContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16)
+            rootContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Self.padding.leading),
+            rootContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Self.padding.trailing)
         ])
     }
 

--- a/Wikipedia/Code/TalkPageCellCommentView.swift
+++ b/Wikipedia/Code/TalkPageCellCommentView.swift
@@ -5,25 +5,6 @@ final class TalkPageCellCommentView: SetupView {
 
     // MARK: - UI Elements
 
-    lazy var verticalStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        stackView.distribution = .fill
-        stackView.alignment = .top
-        return stackView
-    }()
-
-    lazy var horizontalStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.alignment = .leading
-        stackView.distribution = .fillProportionally
-        stackView.spacing = 4
-        return stackView
-    }()
-
     lazy var commentTextView: UITextView = {
         let textView = UITextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
@@ -39,6 +20,7 @@ final class TalkPageCellCommentView: SetupView {
 
     lazy var replyButton: UIButton = {
         let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(CommonStrings.talkPageReply, for: .normal)
         button.setTitleColor(.black, for: .normal)
         button.setImage(UIImage(systemName: "arrowshape.turn.up.left"), for: .normal)
@@ -55,11 +37,20 @@ final class TalkPageCellCommentView: SetupView {
         button.titleLabel?.font = UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .semibold, size: 15)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         
+        button.titleLabel?.setContentHuggingPriority(.required, for: .vertical)
+        button.titleLabel?.setContentCompressionResistancePriority(.required, for: .vertical)
+        
         button.addTarget(self, action: #selector(tappedReply), for: .touchUpInside)
         return button
     }()
 
-    lazy var replyDepthView = TalkPageCellReplyDepthIndicator(depth: 0)
+    lazy var replyDepthView: TalkPageCellReplyDepthIndicator = {
+        let depthIndicator = TalkPageCellReplyDepthIndicator(depth: 0)
+        depthIndicator.translatesAutoresizingMaskIntoConstraints = false
+        depthIndicator.setContentCompressionResistancePriority(UILayoutPriority(999), for: .horizontal)
+        depthIndicator.setContentHuggingPriority(.required, for: .horizontal)
+        return depthIndicator
+    }()
     
     weak var viewModel: TalkPageCellCommentViewModel?
     weak var replyDelegate: TalkPageCellReplyDelegate?
@@ -68,28 +59,34 @@ final class TalkPageCellCommentView: SetupView {
     // MARK: - Lifecycle
 
     override func setup() {
-        addSubview(horizontalStackView)
+        addSubview(replyDepthView)
+        addSubview(commentTextView)
+        addSubview(replyButton)
 
-        horizontalStackView.addArrangedSubview(replyDepthView)
-        horizontalStackView.addArrangedSubview(verticalStackView)
-        verticalStackView.addArrangedSubview(commentTextView)
-        verticalStackView.addArrangedSubview(replyButton)
+        NSLayoutConstraint.activate([
+            replyDepthView.topAnchor.constraint(equalTo: commentTextView.topAnchor),
+            replyDepthView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            replyDepthView.bottomAnchor.constraint(equalTo: replyButton.bottomAnchor),
 
-        let replyDepthWidthConstraint = replyDepthView.widthAnchor.constraint(lessThanOrEqualTo: horizontalStackView.widthAnchor, multiplier: 1/2)
+            commentTextView.leadingAnchor.constraint(equalTo: replyDepthView.trailingAnchor, constant: 4),
+            commentTextView.topAnchor.constraint(equalTo: topAnchor),
+            commentTextView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            commentTextView.bottomAnchor.constraint(equalTo: replyButton.topAnchor),
+
+            replyButton.leadingAnchor.constraint(equalTo: commentTextView.leadingAnchor),
+            replyButton.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+
+        let replyDepthWidthConstraint = replyDepthView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor, multiplier: 1/2)
         replyDepthWidthConstraint.priority = .required
 
-        let replyDepthHeightConstraint = replyDepthView.heightAnchor.constraint(equalTo: horizontalStackView.heightAnchor)
+        let replyDepthHeightConstraint = replyDepthView.heightAnchor.constraint(equalTo: heightAnchor)
         replyDepthHeightConstraint.priority = .required
 
-        let commentTextWidthConstraint = commentTextView.widthAnchor.constraint(greaterThanOrEqualTo: horizontalStackView.widthAnchor, multiplier: 1/2)
+        let commentTextWidthConstraint = commentTextView.widthAnchor.constraint(greaterThanOrEqualTo: widthAnchor, multiplier: 1/2)
         commentTextWidthConstraint.priority = .required
 
         NSLayoutConstraint.activate([
-            horizontalStackView.topAnchor.constraint(equalTo: topAnchor),
-            horizontalStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            horizontalStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            horizontalStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-
             replyDepthWidthConstraint,
             replyDepthHeightConstraint,
             commentTextWidthConstraint

--- a/Wikipedia/Code/TalkPageCellViewModel.swift
+++ b/Wikipedia/Code/TalkPageCellViewModel.swift
@@ -38,8 +38,4 @@ final class TalkPageCellViewModel {
         self.replies = replies
         self.activeUsersCount = activeUsersCount
     }
-    
-    func resetCachedSize() {
-        cachedCellSizes.removeAll()
-    }
 }

--- a/Wikipedia/Code/TalkPageCellViewModel.swift
+++ b/Wikipedia/Code/TalkPageCellViewModel.swift
@@ -20,6 +20,16 @@ final class TalkPageCellViewModel {
         return "\(replies.count + 1)"
     }
     
+    struct CachedCellSize {
+        var collapsedHeight: CGFloat?
+        var expandedHeight: CGFloat?
+        var width: CGFloat
+    }
+    
+    typealias CollectionViewWidth = CGFloat
+
+    var cachedCellSizes: [CollectionViewWidth: CachedCellSize] = [:]
+    
     init(id: String, topicTitle: String, timestamp: Date?, leadComment: TalkPageCellCommentViewModel, replies: [TalkPageCellCommentViewModel], activeUsersCount: String) {
         self.id = id
         self.topicTitle = topicTitle
@@ -27,5 +37,9 @@ final class TalkPageCellViewModel {
         self.leadComment = leadComment
         self.replies = replies
         self.activeUsersCount = activeUsersCount
+    }
+    
+    func resetCachedSize() {
+        cachedCellSizes.removeAll()
     }
 }

--- a/Wikipedia/Code/TalkPageView.swift
+++ b/Wikipedia/Code/TalkPageView.swift
@@ -3,18 +3,14 @@ import UIKit
 final class TalkPageView: SetupView {
 
     // MARK: - Private Properties
-
-    private lazy var topicGroupLayout: UICollectionViewLayout = {
-        let heightDimension: NSCollectionLayoutDimension = .estimated(225)
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),heightDimension: heightDimension)
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),heightDimension: heightDimension)
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,subitems: [item])
-        let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0)
-        let layout = UICollectionViewCompositionalLayout(section: section)
+    
+    private var topicGroupLayout: UICollectionViewLayout {
+        let layout = UICollectionViewFlowLayout()
+        layout.minimumInteritemSpacing = 0
+        layout.minimumLineSpacing = 0
+        layout.sectionInset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
         return layout
-    }()
+    }
 
     // MARK: - UI Elements
 

--- a/Wikipedia/Code/TalkPageView.swift
+++ b/Wikipedia/Code/TalkPageView.swift
@@ -21,6 +21,8 @@ final class TalkPageView: SetupView {
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         return collectionView
     }()
+    
+    private(set) var sizingView: TalkPageCellRootContainerView?
 
     // MARK: - Lifecycle
 
@@ -32,6 +34,20 @@ final class TalkPageView: SetupView {
             collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
+        
+        // Add Sizing View for cell height calculations
+        let sizingView = TalkPageCellRootContainerView(frame: .zero)
+        sizingView.translatesAutoresizingMaskIntoConstraints = false
+        insertSubview(sizingView, at: 0)
+
+        NSLayoutConstraint.activate([
+            sizingView.topAnchor.constraint(equalTo: topAnchor),
+            sizingView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: TalkPageCell.padding.leading),
+            sizingView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -TalkPageCell.padding.trailing)
+        ])
+        
+        sizingView.isHidden = false
+        self.sizingView = sizingView
     }
 
 }

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -425,6 +425,19 @@ extension TalkPageViewController: TalkPageReplyComposeDelegate {
     }
     
     func tappedPublish(text: String, commentViewModel: TalkPageCellCommentViewModel) {
+        
+        // TODO: Better pulling of old topic
+        let oldTopic = viewModel.topics.first { topic in
+            let allReplies = topic.replies + [topic.leadComment]
+            for reply in allReplies {
+                if commentViewModel.commentId == reply.commentId {
+                    return true
+                }
+            }
+
+            return false
+        }
+        
         viewModel.postReply(commentId: commentViewModel.commentId, comment: text) { [weak self] result in
 
             switch result {
@@ -432,7 +445,7 @@ extension TalkPageViewController: TalkPageReplyComposeDelegate {
                 self?.replyComposeController.reset()
                 
                 // Try to refresh page
-                self?.viewModel.fetchTalkPage { [weak self] result in
+                self?.viewModel.fetchTalkPage(replyingToTopic: oldTopic) { [weak self] result in
                     switch result {
                     case .success:
                         self?.talkPageView.collectionView.reloadData()

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -349,7 +349,8 @@ extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewData
               let sizingView = talkPageView.sizingView else {
             return .zero
         }
-
+        
+        sizingView.prepareForReuse()
         sizingView.configure(viewModel: viewModel, linkDelegate: self, replyDelegate: self, theme: theme)
         sizingView.setNeedsLayout()
         sizingView.layoutIfNeeded()
@@ -380,6 +381,7 @@ extension TalkPageViewController: TalkPageCellDelegate {
         let configuredCellViewModel = viewModel.topics[indexOfConfiguredCell]
         configuredCellViewModel.isThreadExpanded.toggle()
         
+        cell.prepareForReuse()
         cell.configure(viewModel: configuredCellViewModel, linkDelegate: self, replyDelegate: self, theme: theme)
         talkPageView.collectionView.collectionViewLayout.invalidateLayout()
     }
@@ -391,6 +393,7 @@ extension TalkPageViewController: TalkPageCellDelegate {
         
         let configuredCellViewModel = viewModel.topics[indexOfConfiguredCell]
         configuredCellViewModel.isSubscribed.toggle()
+        cell.prepareForReuse()
         cell.configure(viewModel: configuredCellViewModel, linkDelegate: self, replyDelegate: self, theme: theme)
         self.handleSubscriptionAlert(isSubscribedToTopic: configuredCellViewModel.isSubscribed)
     }

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -26,8 +26,6 @@ class TalkPageViewController: ViewController {
         progressController.delay = 0.0
         return progressController
     }()
-
-    var isReloadingAfterReply = false
     
     // MARK: - Overflow menu properties
     
@@ -333,16 +331,6 @@ extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewData
         userDidTapDisclosureButton(cellViewModel: cell.viewModel, cell: cell)
     }
     
-    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        if isReloadingAfterReply && cell.frame.size.height == 225 {
-            DispatchQueue.main.async {
-                collectionView.collectionViewLayout.invalidateLayout()
-                collectionView.layoutIfNeeded()
-                self.isReloadingAfterReply = false
-            }
-        }
-    }
-    
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
         guard let viewModel = viewModel.topics[safeIndex: indexPath.item],
@@ -421,7 +409,6 @@ extension TalkPageViewController: TalkPageReplyComposeDelegate {
                 self?.viewModel.fetchTalkPage { [weak self] result in
                     switch result {
                     case .success:
-                        self?.isReloadingAfterReply = true
                         self?.talkPageView.collectionView.reloadData()
                         self?.handleNewTopicOrCommentAlert(isNewTopic: false)
                     case .failure:

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -318,8 +318,7 @@ extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewData
         let viewModel = viewModel.topics[indexPath.row]
 
         cell.delegate = self
-        cell.replyDelegate = self
-        cell.configure(viewModel: viewModel, linkDelegate: self)
+        cell.configure(viewModel: viewModel, linkDelegate: self, replyDelegate: self)
         cell.apply(theme: theme)
 
         return cell
@@ -357,7 +356,7 @@ extension TalkPageViewController: TalkPageCellDelegate {
         let configuredCellViewModel = viewModel.topics[indexOfConfiguredCell]
         configuredCellViewModel.isThreadExpanded.toggle()
         
-        cell.configure(viewModel: configuredCellViewModel, linkDelegate: self)
+        cell.configure(viewModel: configuredCellViewModel, linkDelegate: self, replyDelegate: self)
         cell.apply(theme: theme)
         talkPageView.collectionView.collectionViewLayout.invalidateLayout()
     }
@@ -369,7 +368,7 @@ extension TalkPageViewController: TalkPageCellDelegate {
         
         let configuredCellViewModel = viewModel.topics[indexOfConfiguredCell]
         configuredCellViewModel.isSubscribed.toggle()
-        cell.configure(viewModel: configuredCellViewModel, linkDelegate: self)
+        cell.configure(viewModel: configuredCellViewModel, linkDelegate: self, replyDelegate: self)
         self.handleSubscriptionAlert(isSubscribedToTopic: configuredCellViewModel.isSubscribed)
     }
 }

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -304,7 +304,7 @@ class TalkPageViewController: ViewController {
 
 // MARK: - UICollectionViewDelegate, UICollectionViewDataSource
 
-extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return viewModel.topics.count
@@ -342,6 +342,9 @@ extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewData
         }
     }
     
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: collectionView.frame.width, height: 225)
+    }
 }
 
 // MARK: - TalkPageCellDelegate

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -338,22 +338,48 @@ extension TalkPageViewController: UICollectionViewDelegate, UICollectionViewData
             return .zero
         }
         
+        let collectionViewWidth = talkPageView.collectionView.frame.width
+ 
+        if let cachedSize = cachedSize(viewModel: viewModel, collectionViewWidth: collectionViewWidth) {
+            return cachedSize
+        }
+        
         sizingView.prepareForReuse()
         sizingView.configure(viewModel: viewModel, linkDelegate: self, replyDelegate: self, theme: theme)
         sizingView.setNeedsLayout()
         sizingView.layoutIfNeeded()
-
+        
         let horizontalPadding = TalkPageCell.padding.leading + TalkPageCell.padding
-            .trailing
-        let verticalPadding = TalkPageCell.padding.top +
-                                TalkPageCell.padding.bottom
-
+                    .trailing
+        let verticalPadding = TalkPageCell.padding.top + TalkPageCell.padding.bottom
+        
         let newWidth = sizingView.frame.width + horizontalPadding
         let newHeight = sizingView.frame.height + verticalPadding
 
-        let newSize = CGSize(width: newWidth, height: newHeight)
+        setCachedSize(viewModel: viewModel, newWidth: newWidth, newHeight: newHeight, collectionViewWidth: collectionViewWidth)
 
-        return newSize
+        return CGSize(width: newWidth, height: newHeight)
+    }
+    
+    private func cachedSize(viewModel: TalkPageCellViewModel, collectionViewWidth: CGFloat) -> CGSize? {
+        if let cachedSize = viewModel.cachedCellSizes[collectionViewWidth],
+           let height = viewModel.isThreadExpanded ? cachedSize.expandedHeight : cachedSize.collapsedHeight {
+            return CGSize(width: cachedSize.width, height: height)
+        }
+        
+        return nil
+    }
+    
+    private func setCachedSize(viewModel: TalkPageCellViewModel, newWidth: CGFloat, newHeight: CGFloat, collectionViewWidth: CGFloat) {
+        var sizeToCache = viewModel.cachedCellSizes[collectionViewWidth] ?? TalkPageCellViewModel.CachedCellSize(width: newWidth)
+        
+        if viewModel.isThreadExpanded {
+            sizeToCache.expandedHeight = newHeight
+        } else {
+            sizeToCache.collapsedHeight = newHeight
+        }
+        
+        viewModel.cachedCellSizes[collectionViewWidth] = sizeToCache
     }
 }
 


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T311637

### Notes
This is an attempt at improving the performance and layout quirks of the talk page cells that we've been seeing. The goal is to get this to an acceptable place without having to rework too much of what we already have.

I could not figure out how to get smooth layout and smooth reloading of cells with the dynamic cell layout heights. Even without expanded cells, the layout appeared jumpy when scrolling quickly, because it defaults to the estimated size very often. Once I switched to precalculated heights using a sizing view, everything worked smoothly. I am heavily caching these sizes to try and reduce the additional layout burden this precalculation causes. To help with testing, also implemented the "Open all threads" functionality.

There's additional precalculation and caching I could do up front for other orientations, but I wanted to go ahead and get this up before too long for feedback. I think if this still doesn't work for us, we may want to consider reworking the view model comments into their own cells, or dipping into manually sized frames everywhere. I would like to avoid that if we can though.

### Test Steps
1. Load a large talk page (Queen Elizabeth II is a good one). Confirm scrolling is much smoother than it was in `main`.
2. Confirm cells expand and collapse correctly.
3. Confirm rotation works correctly (it should be faster after the first rotation, once the new sizes are cached).
4. Confirm open all threads works correctly. I added a spinner here since this could take a while to lay out.