### PR TITLE
Add full screen coffee roll text view

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -141,7 +141,19 @@
 		004281C825E6EFC4004945B3 /* LSHTTPRequestDSLRepresentation.m in Sources */ = {isa = PBXBuildFile; fileRef = 004281AC25E6EFC4004945B3 /* LSHTTPRequestDSLRepresentation.m */; };
 		004281C925E6EFC4004945B3 /* LSStubResponseDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 004281AE25E6EFC4004945B3 /* LSStubResponseDSL.m */; };
 		004281CA25E6EFC4004945B3 /* LSStubRequestDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 004281AF25E6EFC4004945B3 /* LSStubRequestDSL.m */; };
+		00474A2A28DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00474A2928DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift */; };
+		00474A2B28DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00474A2928DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift */; };
+		00474A2C28DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00474A2928DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift */; };
+		00474A2D28DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00474A2928DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift */; };
+		00474A2F28DD1B13002E3C09 /* TalkPageCoffeeRollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00474A2E28DD1B13002E3C09 /* TalkPageCoffeeRollView.swift */; };
+		00474A3028DD1B13002E3C09 /* TalkPageCoffeeRollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00474A2E28DD1B13002E3C09 /* TalkPageCoffeeRollView.swift */; };
+		00474A3128DD1B13002E3C09 /* TalkPageCoffeeRollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00474A2E28DD1B13002E3C09 /* TalkPageCoffeeRollView.swift */; };
+		00474A3228DD1B13002E3C09 /* TalkPageCoffeeRollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00474A2E28DD1B13002E3C09 /* TalkPageCoffeeRollView.swift */; };
 		00550D2626B1E7DB0055C496 /* Featured Article Widget Preview Content.json in Resources */ = {isa = PBXBuildFile; fileRef = 00550D2526B1E7DB0055C496 /* Featured Article Widget Preview Content.json */; };
+		005E004128DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005E004028DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift */; };
+		005E004228DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005E004028DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift */; };
+		005E004328DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005E004028DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift */; };
+		005E004428DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005E004028DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift */; };
 		0062597324DE0A2500C95037 /* WidgetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0062597224DE0A2500C95037 /* WidgetController.swift */; };
 		006694FC265D9F2900E23AE4 /* WidgetSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006694FB265D9F2900E23AE4 /* WidgetSettings.swift */; };
 		006694FE265D9F3A00E23AE4 /* WidgetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006694FD265D9F3A00E23AE4 /* WidgetCache.swift */; };
@@ -3897,7 +3909,10 @@
 		004281AF25E6EFC4004945B3 /* LSStubRequestDSL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LSStubRequestDSL.m; sourceTree = "<group>"; };
 		004281B025E6EFC4004945B3 /* LSHTTPRequestDSLRepresentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LSHTTPRequestDSLRepresentation.h; sourceTree = "<group>"; };
 		004281B125E6EFC4004945B3 /* LSStubResponseDSL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LSStubResponseDSL.h; sourceTree = "<group>"; };
+		00474A2928DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageCoffeeRollViewController.swift; sourceTree = "<group>"; };
+		00474A2E28DD1B13002E3C09 /* TalkPageCoffeeRollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageCoffeeRollView.swift; sourceTree = "<group>"; };
 		00550D2526B1E7DB0055C496 /* Featured Article Widget Preview Content.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "Featured Article Widget Preview Content.json"; sourceTree = "<group>"; };
+		005E004028DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageCoffeeRollViewModel.swift; sourceTree = "<group>"; };
 		0062597224DE0A2500C95037 /* WidgetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetController.swift; sourceTree = "<group>"; usesTabs = 0; };
 		006694FB265D9F2900E23AE4 /* WidgetSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSettings.swift; sourceTree = "<group>"; };
 		006694FD265D9F3A00E23AE4 /* WidgetCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetCache.swift; sourceTree = "<group>"; };
@@ -6195,6 +6210,9 @@
 				00DEE61828AD6C9500A60DF9 /* TalkPageCellCommentViewModel.swift */,
 				67C1757528AD4D6000C5ABA4 /* TalkPageDataController.swift */,
 				67BEFFD428AD9DF000606B38 /* TalkPageType.swift */,
+				00474A2928DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift */,
+				005E004028DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift */,
+				00474A2E28DD1B13002E3C09 /* TalkPageCoffeeRollView.swift */,
 			);
 			name = "Talk Pages";
 			sourceTree = "<group>";
@@ -11310,6 +11328,7 @@
 				7A7AC84621B6B89B003B849B /* SectionEditorViewController.swift in Sources */,
 				D87234011E1FF0A500751E83 /* PlacesViewController.swift in Sources */,
 				678D79FC235E59B2006161FF /* DiffListUneditedViewModel.swift in Sources */,
+				00474A2F28DD1B13002E3C09 /* TalkPageCoffeeRollView.swift in Sources */,
 				00E75B7627EB946D00A45B78 /* ReusableCell.swift in Sources */,
 				00E2EA8E26E2A45C00B1A741 /* NotificationsCenterCellDisplayState.swift in Sources */,
 				B01E54AF206479CC00374FEE /* ProgressContainer.swift in Sources */,
@@ -11405,6 +11424,7 @@
 				B0E803441C0CD7980065EBC0 /* WMFSearchFetcher.m in Sources */,
 				83B01F7C23DB0BA2001185F4 /* ArticleViewController+Editing.swift in Sources */,
 				BCA15AE51C0E213300D0A3EA /* LoggingDefaults.swift in Sources */,
+				005E004128DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift in Sources */,
 				67B5334128416C0D00C33E13 /* UserDataExportCache.swift in Sources */,
 				7A741DCA207FB9CC00CBAAE2 /* SearchBarExtendedViewController.swift in Sources */,
 				7A0CD24021DFA34100066F68 /* TextFormattingToolbarView.swift in Sources */,
@@ -11419,6 +11439,7 @@
 				83E776A320FFA4D700E26A47 /* DetailTransition.swift in Sources */,
 				832BD3BC28996B68002623CA /* VanishAccountContentView.swift in Sources */,
 				671DF9C925F2AE4F0011799E /* WikidataDescriptionController.swift in Sources */,
+				00474A2A28DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift in Sources */,
 				B0E803E61C0CDD450065EBC0 /* UIViewController+WMFStoryboardUtilities.m in Sources */,
 				7A4D227D21B1CD8600D889BD /* TextFormattingTableViewCell.swift in Sources */,
 				B0524B75214856A400D8FD8D /* UIViewController+DescriptionWelcomeStoryboard.swift in Sources */,
@@ -12261,6 +12282,7 @@
 				D8A42A5E1E815A9C00D8E281 /* WMFCaptchaResetter.swift in Sources */,
 				67146039243BCE51008CE885 /* ArticleViewController+SurveyAnnouncements.swift in Sources */,
 				678D79FF235E59B2006161FF /* DiffListUneditedViewModel.swift in Sources */,
+				00474A3228DD1B13002E3C09 /* TalkPageCoffeeRollView.swift in Sources */,
 				00E75B7927EB946D00A45B78 /* ReusableCell.swift in Sources */,
 				00E2EA9126E2A45C00B1A741 /* NotificationsCenterCellDisplayState.swift in Sources */,
 				B0CD9DF11F70997500051843 /* WMFWelcomeAnalyticsAnimationView.swift in Sources */,
@@ -12356,6 +12378,7 @@
 				8351CE7B20D4424100E32FC1 /* CollectionViewHeader.swift in Sources */,
 				6734EE7922976AED00F00B05 /* ActionButton.swift in Sources */,
 				7A0CD24321DFA34100066F68 /* TextFormattingToolbarView.swift in Sources */,
+				005E004428DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift in Sources */,
 				67B5334428416C0F00C33E13 /* UserDataExportCache.swift in Sources */,
 				83B01F7F23DB0BA2001185F4 /* ArticleViewController+Editing.swift in Sources */,
 				D8A42A901E815A9C00D8E281 /* WMFSearchFetcher.m in Sources */,
@@ -12370,6 +12393,7 @@
 				6747118B25072D1500287951 /* IconTitleBadge.swift in Sources */,
 				832BD3BF28996B68002623CA /* VanishAccountContentView.swift in Sources */,
 				671DF9CC25F2AE4F0011799E /* WikidataDescriptionController.swift in Sources */,
+				00474A2D28DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift in Sources */,
 				7A4D228021B1CD8600D889BD /* TextFormattingTableViewCell.swift in Sources */,
 				B0524B78214856A400D8FD8D /* UIViewController+DescriptionWelcomeStoryboard.swift in Sources */,
 				D8A42A9A1E815A9C00D8E281 /* UIViewController+WMFStoryboardUtilities.m in Sources */,
@@ -12838,6 +12862,7 @@
 				83F26B2B220B62EC002D87A4 /* SectionEditorButton.swift in Sources */,
 				D8CE24EC1E698E2400DAE2E0 /* PlacesViewController.swift in Sources */,
 				67C78F7828B7407000AC207A /* VanishAccountFooterView.swift in Sources */,
+				00474A2C28DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift in Sources */,
 				67146037243BCE51008CE885 /* ArticleViewController+SurveyAnnouncements.swift in Sources */,
 				B0C7A07D1F710E75008415E7 /* WMFWelcomeExplorationAnimationBackgroundView.swift in Sources */,
 				D8CE24EE1E698E2400DAE2E0 /* WMFReferencePanelViewController.swift in Sources */,
@@ -13262,6 +13287,7 @@
 				D8E6FF6824054FA100686272 /* ArticleViewController+LinkPreviewing.swift in Sources */,
 				830D71D01F704DD40080078B /* ArticleFetchedResultsViewController.swift in Sources */,
 				B0845E1220618DA400CDD98E /* SavedProgressViewController.swift in Sources */,
+				00474A3128DD1B13002E3C09 /* TalkPageCoffeeRollView.swift in Sources */,
 				D8CE25EC1E698E2400DAE2E0 /* WMFImageGalleryViewController.m in Sources */,
 				7AF0265722985CB9000E0A06 /* BeKindInputAccessoryView.swift in Sources */,
 				00E75B6927EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift in Sources */,
@@ -13304,6 +13330,7 @@
 				6782DBA42343B7EE003FA21B /* DiffHeaderSummaryView.swift in Sources */,
 				D8CE25FF1E698E2400DAE2E0 /* ArticlePlaceView.swift in Sources */,
 				7A70797E223AB69000A2BDFC /* WelcomePanelLabelContentViewController.swift in Sources */,
+				005E004328DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift in Sources */,
 				D8CE26001E698E2400DAE2E0 /* WMFCaptchaViewController.swift in Sources */,
 				7A23CED2211A24FE00441A79 /* FeedFunnel.swift in Sources */,
 				D8CE26011E698E2400DAE2E0 /* DDLog+WMFLogger.m in Sources */,
@@ -13402,6 +13429,7 @@
 				D8EC3DE31E9BDA35006712EB /* PlacesViewController.swift in Sources */,
 				67146038243BCE51008CE885 /* ArticleViewController+SurveyAnnouncements.swift in Sources */,
 				67C78F7728B7407000AC207A /* VanishAccountFooterView.swift in Sources */,
+				00474A2B28DD1AE2002E3C09 /* TalkPageCoffeeRollViewController.swift in Sources */,
 				83987AD220E4FB2C00C92C60 /* UISearchBar+Theme.swift in Sources */,
 				B0C7A0791F710E75008415E7 /* WMFWelcomeExplorationAnimationBackgroundView.swift in Sources */,
 				7AC19E342301EF7D00E25B83 /* PageHistoryFilterCountsViewController.swift in Sources */,
@@ -13826,6 +13854,7 @@
 				D8E6FF6924054FA100686272 /* ArticleViewController+LinkPreviewing.swift in Sources */,
 				B0CD9DE41F70997400051843 /* WMFWelcomeAnimationView.swift in Sources */,
 				B0845E1320618DA400CDD98E /* SavedProgressViewController.swift in Sources */,
+				00474A3028DD1B13002E3C09 /* TalkPageCoffeeRollView.swift in Sources */,
 				B0F9299C1F84789D002A0788 /* WMFWelcomeInitialViewController.swift in Sources */,
 				6747118925072D1500287951 /* IconTitleBadge.swift in Sources */,
 				00E75B6827EB927B00A45B78 /* NotificationsCenterDetailActionCell.swift in Sources */,
@@ -13868,6 +13897,7 @@
 				6782DBA52343B7EE003FA21B /* DiffHeaderSummaryView.swift in Sources */,
 				D8EC3F001E9BDA35006712EB /* DDLog+WMFLogger.m in Sources */,
 				7A70797F223AB69000A2BDFC /* WelcomePanelLabelContentViewController.swift in Sources */,
+				005E004228DE1F2800721584 /* TalkPageCoffeeRollViewModel.swift in Sources */,
 				D818D3881ED750E40076110D /* ArticleCollectionViewController.swift in Sources */,
 				7A23CED1211A24FD00441A79 /* FeedFunnel.swift in Sources */,
 				D80ED25E1EE18D0900CE8C50 /* PlacesSearchSuggestionTableViewCell.swift in Sources */,

--- a/Wikipedia/Code/TalkPageCoffeeRollView.swift
+++ b/Wikipedia/Code/TalkPageCoffeeRollView.swift
@@ -1,0 +1,76 @@
+import UIKit
+
+final class TalkPageCoffeeRollView: SetupView {
+
+    // MARK: - Properties
+
+    var theme: Theme!
+    var viewModel: TalkPageCoffeeRollViewModel!
+    
+    weak var linkDelegate: TalkPageTextViewLinkHandling?
+
+    // MARK: - UI Elements
+
+    lazy var textView: UITextView = {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.isScrollEnabled = true
+        textView.isEditable = false
+        textView.textContainerInset = UIEdgeInsets(top: 16, left: 0, bottom: 16, right: 16)
+        textView.delegate = self
+        return textView
+    }()
+
+    // MARK: - Lifecycle
+
+    required init(theme: Theme, viewModel: TalkPageCoffeeRollViewModel, frame: CGRect) {
+        self.theme = theme
+        self.viewModel = viewModel
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func setup() {
+        addSubview(textView)
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: topAnchor),
+            textView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            textView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
+            textView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor)
+        ])
+    }
+
+    // MARK: - Configure
+
+    func configure(viewModel: TalkPageCoffeeRollViewModel) {
+        self.viewModel = viewModel
+        textView.attributedText = viewModel.coffeeRollText?.byAttributingHTML(with: .callout, boldWeight: .semibold, matching: traitCollection, color: theme.colors.primaryText, linkColor: theme.colors.link, handlingLists: true, handlingSuperSubscripts: true)
+    }
+
+}
+
+extension TalkPageCoffeeRollView: Themeable {
+
+    func apply(theme: Theme) {
+        self.theme = theme
+
+        backgroundColor = theme.colors.paperBackground
+
+        textView.backgroundColor = theme.colors.paperBackground
+        configure(viewModel: viewModel)
+    }
+
+}
+
+extension TalkPageCoffeeRollView: UITextViewDelegate {
+
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        linkDelegate?.tappedLink(URL, sourceTextView: textView)
+        return false
+    }
+
+}

--- a/Wikipedia/Code/TalkPageCoffeeRollViewController.swift
+++ b/Wikipedia/Code/TalkPageCoffeeRollViewController.swift
@@ -1,0 +1,58 @@
+import UIKit
+import WMF
+import CocoaLumberjackSwift
+
+final class TalkPageCoffeeRollViewController: ViewController {
+
+    // MARK: - Properties
+
+    fileprivate let viewModel: TalkPageCoffeeRollViewModel
+
+    var coffeeRollView: TalkPageCoffeeRollView {
+        return view as! TalkPageCoffeeRollView
+    }
+
+    // MARK: - Lifecycle
+
+    override func loadView() {
+        let coffeeRollView = TalkPageCoffeeRollView(theme: theme, viewModel: viewModel, frame: UIScreen.main.bounds)
+        view = coffeeRollView
+        coffeeRollView.configure(viewModel: viewModel)
+        scrollView = coffeeRollView.textView        
+    }
+
+    init(theme: Theme, viewModel: TalkPageCoffeeRollViewModel) {
+        self.viewModel = viewModel
+        super.init(theme: theme)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        coffeeRollView.linkDelegate = self
+
+        navigationItem.title = TalkPageViewController.TalkPageLocalizedStrings.title
+    }
+
+    // MARK: - Themeable
+
+    override func apply(theme: Theme) {
+        super.apply(theme: theme)
+        coffeeRollView.apply(theme: theme)
+    }
+
+}
+
+extension TalkPageCoffeeRollViewController: TalkPageTextViewLinkHandling {
+
+    func tappedLink(_ url: URL, sourceTextView: UITextView) {
+        guard let url = URL(string: url.absoluteString, relativeTo: viewModel.talkPageURL) else {
+            return
+        }
+        navigate(to: url.absoluteURL)
+    }
+    
+}

--- a/Wikipedia/Code/TalkPageCoffeeRollViewModel.swift
+++ b/Wikipedia/Code/TalkPageCoffeeRollViewModel.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+final class TalkPageCoffeeRollViewModel {
+
+    let coffeeRollText: String?
+    let talkPageURL: URL?
+
+    init(coffeeRollText: String?, talkPageURL: URL?) {
+        self.coffeeRollText = coffeeRollText
+        self.talkPageURL = talkPageURL
+    }
+
+}

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -177,6 +177,16 @@ class TalkPageViewController: ViewController {
         updateScrollViewInsets()
         
         headerView.apply(theme: theme)
+
+        headerView.coffeeRollReadMoreButton.addTarget(self, action: #selector(userDidTapCoffeeRollReadMoreButton), for: .primaryActionTriggered)
+    }
+
+    // MARK: - Coffee Roll
+
+    @objc private func userDidTapCoffeeRollReadMoreButton() {
+        let coffeeRollViewModel = TalkPageCoffeeRollViewModel(coffeeRollText: viewModel.coffeeRollText, talkPageURL: talkPageURL)
+        let coffeeViewController = TalkPageCoffeeRollViewController(theme: theme, viewModel: coffeeRollViewModel)
+        push(coffeeViewController, animated: true)
     }
 
     // MARK: - Public


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T310275 (partially)

### Notes
Adds full screen coffee roll view. I reused the text attribution and link handling logic and pattern from the talk page comment view – please let me know if this is unexpected.

### Test Steps
1. Open a talk page with a coffee roll
2. Confirm tapping read more in coffee roll opens new full screen view controller
3. Confirm it renders as expected regardless of the theme

