### PR TITLE
Fix double back button on iOS16 Vanish view

### DIFF
--- a/Wikipedia/Code/AccountViewController.swift
+++ b/Wikipedia/Code/AccountViewController.swift
@@ -145,8 +145,8 @@ class AccountViewController: SubSettingsViewController {
                 return
             }
 
-            let hostingController = VanishAccountCustomUIHostingController(title: CommonStrings.vanishAccount.localizedCapitalized, theme: theme, username: username)
-            self.navigationController?.pushViewController(hostingController, animated: true)
+            let viewController = VanishAccountContainerViewController(title: CommonStrings.vanishAccount.localizedCapitalized, theme: theme, username: username)
+            self.navigationController?.pushViewController(viewController, animated: true)
         default:
             break
         }

--- a/Wikipedia/Code/VanishAccountCustomUIHostingController.swift
+++ b/Wikipedia/Code/VanishAccountCustomUIHostingController.swift
@@ -5,7 +5,7 @@ class UserInput: ObservableObject {
     @Published var text: String = ""
 }
 
-class VanishAccountCustomUIHostingController: UIHostingController<VanishAccountContentView> {
+class VanishAccountContainerViewController: UIViewController {
     
     enum LocalizedStrings {
         static let backConfirmationTitle = WMFLocalizedString("vanish-account-back-confirm-title", value: "Are you sure you want to discard this vanish request?", comment: "Title of confirmation alert on vanishing request screen, if user taps Back after filling out information.")
@@ -13,15 +13,34 @@ class VanishAccountCustomUIHostingController: UIHostingController<VanishAccountC
         static let backConfirmationKeepEditing = WMFLocalizedString("vanish-account-back-confirm-keep-editing", value: "Keep Editing", comment: "Text of confirmation alert keep editing option on vanishing request screen, if user taps Back after filling out information. This option keeps them on the screen to continue editing.")
     }
     
+    private let hostingController: UIHostingController<VanishAccountContentView>
     let userInput = UserInput()
     
     init(title: String, theme: Theme, username: String) {
-        super.init(rootView: VanishAccountContentView(userInput: userInput, theme: theme, username: username))
+        hostingController = VanishAccountCustomUIHostingController(title: title, theme: theme, username: username, userInput: userInput)
+        super.init(nibName: nil, bundle: nil)
         self.title = title
     }
     
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        addChild(hostingController)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hostingController.view)
+        
+        NSLayoutConstraint.activate([
+            hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        
+        hostingController.didMove(toParent: self)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -55,5 +74,16 @@ class VanishAccountCustomUIHostingController: UIHostingController<VanishAccountC
         } else {
             navigationController?.popViewController(animated: true)
         }
+    }
+}
+
+class VanishAccountCustomUIHostingController: UIHostingController<VanishAccountContentView> {
+    
+    init(title: String, theme: Theme, username: String, userInput: UserInput) {
+        super.init(rootView: VanishAccountContentView(userInput: userInput, theme: theme, username: username))
+    }
+    
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T318625

### Notes
iOS16 shows a double back navigation bar button in our Vanishing flow. This seemed unique to UIHostingControllers that are a UINavigationController's root view controller for iOS16. Embedding it in it's own container view controller seems to fix it.

### Test Steps
1. Load the Vanishing screen in iOS16.
2. Confirm you only see a single arrow back button.
3. Tap back button, confirm it goes back.
4. Go back to Vanishing screen. Fill out additional information.
5. Tap back button, confirm you see a confirmation action sheet for discarding a request before it navigates you back.
6. Confirm tapping Send Request still sends you to email client as before.
7. Repeat steps 1-6 with iOS 15, 14, and 13 (note you will not be navigated to email client on simulator in step 6 - this is expected).