### PR TITLE
Talk pages - Push to overflow web destinations

### DIFF
--- a/Wikipedia/Code/TalkPageDataController.swift
+++ b/Wikipedia/Code/TalkPageDataController.swift
@@ -10,6 +10,7 @@ class TalkPageDataController {
     private let siteURL: URL
     private let talkPageFetcher = TalkPageFetcher()
     private let articleSummaryController: ArticleSummaryController
+    private let articleRevisionFetcher = WMFArticleRevisionFetcher()
     
     init(pageType: TalkPageType, pageTitle: String, siteURL: URL, articleSummaryController: ArticleSummaryController) {
         self.pageType = pageType
@@ -20,7 +21,7 @@ class TalkPageDataController {
     
     // MARK: Public
     
-    typealias TalkPageResult = Result<(articleSummary: WMFArticle?, items: [TalkPageItem], subscribedTopicNames: [String]), Error>
+    typealias TalkPageResult = Result<(articleSummary: WMFArticle?, items: [TalkPageItem], subscribedTopicNames: [String], latestRevisionID: Int?), Error>
     
     func fetchTalkPage(completion: @escaping (TalkPageResult) -> Void) {
         
@@ -31,6 +32,7 @@ class TalkPageDataController {
         var finalErrors: [Error] = []
         var finalItems: [TalkPageItem] = []
         var finalArticleSummary: WMFArticle?
+        var latestRevisionID: Int?
         var finalSubscribedTopics: [String] = []
         
         fetchTalkPageItems(dispatchGroup: group) { items, errors in
@@ -43,6 +45,9 @@ class TalkPageDataController {
             finalErrors.append(contentsOf: errors)
         }
         
+        fetchLatestRevisionID(dispatchGroup: group) { revisionID in
+            latestRevisionID = revisionID
+        }
         
         group.notify(queue: DispatchQueue.main, execute: {
             
@@ -50,10 +55,11 @@ class TalkPageDataController {
                 completion(.failure(firstError))
                 return
             }
+            
             self.fetchTopicSubscriptions(for: finalItems, dispatchGroup: group) { items, errors in
                 finalSubscribedTopics = items
                 finalErrors.append(contentsOf: errors)
-                completion(.success((finalArticleSummary, finalItems, finalSubscribedTopics)))
+                completion(.success((finalArticleSummary, finalItems, finalSubscribedTopics, latestRevisionID)))
             }
             
         })
@@ -169,6 +175,40 @@ class TalkPageDataController {
                 completion(nil, [])
             }
         }
+    }
+    
+    func fetchLatestRevisionID(dispatchGroup: DispatchGroup, completion: @escaping (Int?) -> Void) {
+        
+        guard let mediaWikiURL = Configuration.current.mediaWikiAPIURLForURL(siteURL, with: nil),
+              let revisionURL = mediaWikiURL.wmf_URL(withTitle: pageTitle) else {
+            completion(nil)
+            return
+        }
+        
+        let failureBlock: (Error) -> Void = { error in
+            dispatchGroup.leave()
+            completion(nil)
+        }
+        
+        let successBlock: (Any) -> Void = { object in
+            
+            defer {
+                dispatchGroup.leave()
+            }
+            
+            let queryResults = (object as? [WMFRevisionQueryResults])?.first ?? (object as? WMFRevisionQueryResults)
+            
+            guard let lastRevisionId = queryResults?.revisions.first?.revisionId.intValue else {
+                completion(nil)
+                return
+            }
+            
+            completion(lastRevisionId)
+        }
+        
+        dispatchGroup.enter()
+        articleRevisionFetcher.fetchLatestRevisions(forArticleURL: revisionURL, resultLimit: 1, startingWithRevision: nil, endingWithRevision: nil, failure: failureBlock, success: successBlock)
+
     }
 }
 

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -91,8 +91,8 @@ class TalkPageViewController: ViewController {
             self?.pushToRevisionHistory()
         })
         
-        let openInWebAction = UIAction(title: TalkPageLocalizedStrings.readInWeb, image: UIImage(systemName: "display"), handler: { _ in
-            
+        let openInWebAction = UIAction(title: TalkPageLocalizedStrings.readInWeb, image: UIImage(systemName: "display"), handler: { [weak self] _ in
+            self?.pushToMobileWeb()
         })
         
         let submenu = UIMenu(title: String(), options: .displayInline, children: overflowSubmenuActions)
@@ -287,6 +287,17 @@ class TalkPageViewController: ViewController {
     fileprivate func pushToRevisionHistory() {
         let historyVC = PageHistoryViewController(pageTitle: viewModel.pageTitle, pageURL: viewModel.siteURL)
         navigationController?.pushViewController(historyVC, animated: true)
+    }
+    
+    // MARK: - Overflow menu navigation
+    
+    fileprivate func pushToMobileWeb() {
+        guard let url = viewModel.siteURL.wmf_URL(withPath: "/wiki/\(viewModel.pageTitle)", isMobile: true) else {
+            return
+        }
+        
+        let webVC = SinglePageWebViewController(url: url, theme: theme)
+        navigationController?.pushViewController(webVC, animated: true)
     }
     
     // MARK: - Alerts

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -87,8 +87,8 @@ class TalkPageViewController: ViewController {
             self.talkPageView.collectionView.reloadData()
         })
         
-        let revisionHistoryAction = UIAction(title: CommonStrings.revisionHistory, image: UIImage(systemName: "clock.arrow.circlepath"), handler: { _ in
-            
+        let revisionHistoryAction = UIAction(title: CommonStrings.revisionHistory, image: UIImage(systemName: "clock.arrow.circlepath"), handler: { [weak self] _ in
+            self?.pushToRevisionHistory()
         })
         
         let openInWebAction = UIAction(title: TalkPageLocalizedStrings.readInWeb, image: UIImage(systemName: "display"), handler: { _ in
@@ -260,7 +260,7 @@ class TalkPageViewController: ViewController {
     }
     
     @objc fileprivate func userDidTapRevisionButton() {
-        
+        pushToRevisionHistory()
     }
     
     @objc fileprivate func userDidTapAddTopicButton() {
@@ -282,6 +282,11 @@ class TalkPageViewController: ViewController {
         findButton.accessibilityLabel = TalkPageLocalizedStrings.findButtonAccesibilityLabel
         revisionButton.accessibilityLabel = CommonStrings.revisionHistory
         addTopicButton.accessibilityLabel = TalkPageLocalizedStrings.addTopicButtonAccesibilityLabel
+    }
+    
+    fileprivate func pushToRevisionHistory() {
+        let historyVC = PageHistoryViewController(pageTitle: viewModel.pageTitle, pageURL: viewModel.siteURL)
+        navigationController?.pushViewController(historyVC, animated: true)
     }
     
     // MARK: - Alerts

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -299,6 +299,7 @@ class TalkPageViewController: ViewController {
     
     fileprivate func pushToMobileWeb() {
         guard let url = viewModel.siteURL.wmf_URL(withPath: "/wiki/\(viewModel.pageTitle)", isMobile: true) else {
+            // TODO: Error banner
             return
         }
         
@@ -310,6 +311,7 @@ class TalkPageViewController: ViewController {
         guard let host = viewModel.siteURL.host,
         let url = Configuration.current.expandedArticleURLForHost(host, languageVariantCode: viewModel.siteURL.wmf_languageVariantCode, queryParameters: ["title": viewModel.pageTitle,
                                                                         "action": "info"]) else {
+            // TODO: Error banner
             return
         }
         
@@ -318,6 +320,7 @@ class TalkPageViewController: ViewController {
     
     fileprivate func pushToWhatLinksHere() {
         guard let url = viewModel.siteURL.wmf_URL(withPath: "/wiki/Special:WhatLinksHere/\(viewModel.pageTitle)", isMobile: true) else {
+            // TODO: Error banner
             return
         }
         
@@ -327,6 +330,7 @@ class TalkPageViewController: ViewController {
     fileprivate func pushToContributions() {
         guard let username = usernameFromPageTitle(),
         let url = viewModel.siteURL.wmf_URL(withPath: "/wiki/Special:Contributions/\(username)", isMobile: true) else {
+            // TODO: Error banner
             return
         }
         
@@ -336,6 +340,7 @@ class TalkPageViewController: ViewController {
     fileprivate func pushToUserGroups() {
         guard let username = usernameFromPageTitle(),
         let url = viewModel.siteURL.wmf_URL(withPath: "/wiki/Special:UserRights/\(username)", isMobile: true) else {
+            // TODO: Error banner
             return
         }
         
@@ -345,6 +350,7 @@ class TalkPageViewController: ViewController {
     fileprivate func pushToLogs() {
         guard let username = usernameFromPageTitle(),
         let url = viewModel.siteURL.wmf_URL(withPath: "/wiki/Special:Log/\(username)", isMobile: true) else {
+            // TODO: Error banner
             return
         }
         
@@ -372,6 +378,7 @@ class TalkPageViewController: ViewController {
               let host = mobileSiteURL.host,
               let url = Configuration.current.expandedArticleURLForHost(host, languageVariantCode: viewModel.siteURL.wmf_languageVariantCode, queryParameters: ["title": viewModel.pageTitle,
                                                                         "oldid": latestRevisionID]) else {
+            // TODO: Error banner
             return
         }
         

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -54,7 +54,8 @@ class TalkPageViewController: ViewController {
         let goToPermalinkAction = UIAction(title: TalkPageLocalizedStrings.permaLink, image: UIImage(systemName: "link"), handler: { _ in
         })
 
-        let relatedLinksAction = UIAction(title: TalkPageLocalizedStrings.relatedLinks, image: UIImage(systemName: "arrowshape.turn.up.forward"), handler: { _ in
+        let relatedLinksAction = UIAction(title: TalkPageLocalizedStrings.relatedLinks, image: UIImage(systemName: "arrowshape.turn.up.forward"), handler: { [weak self] _ in
+            self?.pushToWhatLinksHere()
         })
 
         var actions = [goToArchivesAction, pageInfoAction, goToPermalinkAction, relatedLinksAction]
@@ -305,6 +306,14 @@ class TalkPageViewController: ViewController {
         guard let host = viewModel.siteURL.host,
         let url = Configuration.current.expandedArticleURLForHost(host, languageVariantCode: viewModel.siteURL.wmf_languageVariantCode, queryParameters: ["title": viewModel.pageTitle,
                                                                         "action": "info"]) else {
+            return
+        }
+        
+        navigate(to: url)
+    }
+    
+    fileprivate func pushToWhatLinksHere() {
+        guard let url = viewModel.siteURL.wmf_URL(withPath: "/wiki/Special:WhatLinksHere/\(viewModel.pageTitle)", isMobile: true) else {
             return
         }
         

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -30,7 +30,8 @@ class TalkPageViewController: ViewController {
     // MARK: - Overflow menu properties
     
     fileprivate var userTalkOverflowSubmenuActions: [UIAction] {
-        let contributionsAction = UIAction(title: TalkPageLocalizedStrings.contributions, image: UIImage(named: "user-contributions"), handler: { _ in
+        let contributionsAction = UIAction(title: TalkPageLocalizedStrings.contributions, image: UIImage(named: "user-contributions"), handler: { [weak self] _ in
+            self?.pushToContributions()
         })
 
         let userGroupsAction = UIAction(title: TalkPageLocalizedStrings.userGroups, image: UIImage(systemName: "person.2"), handler: { _ in
@@ -318,6 +319,29 @@ class TalkPageViewController: ViewController {
         }
         
         navigate(to: url)
+    }
+    
+    fileprivate func pushToContributions() {
+        guard let username = usernameFromPageTitle(),
+        let url = viewModel.siteURL.wmf_URL(withPath: "/wiki/Special:Contributions/\(username)", isMobile: true) else {
+            return
+        }
+        
+        navigate(to: url)
+    }
+    
+    fileprivate func usernameFromPageTitle() -> String? {
+        guard let languageCode = viewModel.siteURL.wmf_languageCode else {
+            return nil
+        }
+        
+        let namespaceAndTitle = viewModel.pageTitle.namespaceAndTitleOfWikiResourcePath(with: languageCode)
+        
+        guard namespaceAndTitle.0 == .userTalk else {
+            return nil
+        }
+        
+        return namespaceAndTitle.1
     }
     
     // MARK: - Alerts

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -47,7 +47,8 @@ class TalkPageViewController: ViewController {
         let goToArchivesAction = UIAction(title: TalkPageLocalizedStrings.archives, image: UIImage(systemName: "archivebox"), handler: { _ in
         })
 
-        let pageInfoAction = UIAction(title: TalkPageLocalizedStrings.pageInfo, image: UIImage(systemName: "info.circle"), handler: { _ in
+        let pageInfoAction = UIAction(title: TalkPageLocalizedStrings.pageInfo, image: UIImage(systemName: "info.circle"), handler: { [weak self] _ in
+            self?.pushToPageInfo()
         })
 
         let goToPermalinkAction = UIAction(title: TalkPageLocalizedStrings.permaLink, image: UIImage(systemName: "link"), handler: { _ in
@@ -297,6 +298,17 @@ class TalkPageViewController: ViewController {
         }
         
         navigate(to: url, useSafari: true)
+    }
+    
+    fileprivate func pushToPageInfo() {
+        
+        guard let host = viewModel.siteURL.host,
+        let url = Configuration.current.expandedArticleURLForHost(host, languageVariantCode: viewModel.siteURL.wmf_languageVariantCode, queryParameters: ["title": viewModel.pageTitle,
+                                                                        "action": "info"]) else {
+            return
+        }
+        
+        navigate(to: url)
     }
     
     // MARK: - Alerts

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -54,7 +54,8 @@ class TalkPageViewController: ViewController {
             self?.pushToPageInfo()
         })
 
-        let goToPermalinkAction = UIAction(title: TalkPageLocalizedStrings.permaLink, image: UIImage(systemName: "link"), handler: { _ in
+        let goToPermalinkAction = UIAction(title: TalkPageLocalizedStrings.permaLink, image: UIImage(systemName: "link"), handler: { [weak self] _ in
+            self?.pushToPermanentLink()
         })
 
         let relatedLinksAction = UIAction(title: TalkPageLocalizedStrings.relatedLinks, image: UIImage(systemName: "arrowshape.turn.up.forward"), handler: { [weak self] _ in
@@ -362,6 +363,19 @@ class TalkPageViewController: ViewController {
         }
         
         return namespaceAndTitle.1
+    }
+    
+    fileprivate func pushToPermanentLink() {
+        
+        guard let latestRevisionID = viewModel.latestRevisionID,
+              let mobileSiteURL = viewModel.siteURL.wmf_URL(withPath: "", isMobile: true),
+              let host = mobileSiteURL.host,
+              let url = Configuration.current.expandedArticleURLForHost(host, languageVariantCode: viewModel.siteURL.wmf_languageVariantCode, queryParameters: ["title": viewModel.pageTitle,
+                                                                        "oldid": latestRevisionID]) else {
+            return
+        }
+        
+        navigate(to: url, useSafari: true)
     }
     
     // MARK: - Alerts

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -38,7 +38,8 @@ class TalkPageViewController: ViewController {
             self?.pushToUserGroups()
         })
 
-        let logsAction = UIAction(title: TalkPageLocalizedStrings.logs, image: UIImage(systemName: "list.bullet"), handler: { _ in
+        let logsAction = UIAction(title: TalkPageLocalizedStrings.logs, image: UIImage(systemName: "list.bullet"), handler: { [weak self] _ in
+            self?.pushToLogs()
         })
 
         return [contributionsAction, userGroupsAction, logsAction]
@@ -334,6 +335,15 @@ class TalkPageViewController: ViewController {
     fileprivate func pushToUserGroups() {
         guard let username = usernameFromPageTitle(),
         let url = viewModel.siteURL.wmf_URL(withPath: "/wiki/Special:UserRights/\(username)", isMobile: true) else {
+            return
+        }
+        
+        navigate(to: url)
+    }
+    
+    fileprivate func pushToLogs() {
+        guard let username = usernameFromPageTitle(),
+        let url = viewModel.siteURL.wmf_URL(withPath: "/wiki/Special:Log/\(username)", isMobile: true) else {
             return
         }
         

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -296,8 +296,7 @@ class TalkPageViewController: ViewController {
             return
         }
         
-        let webVC = SinglePageWebViewController(url: url, theme: theme)
-        navigationController?.pushViewController(webVC, animated: true)
+        navigate(to: url, useSafari: true)
     }
     
     // MARK: - Alerts

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -34,7 +34,8 @@ class TalkPageViewController: ViewController {
             self?.pushToContributions()
         })
 
-        let userGroupsAction = UIAction(title: TalkPageLocalizedStrings.userGroups, image: UIImage(systemName: "person.2"), handler: { _ in
+        let userGroupsAction = UIAction(title: TalkPageLocalizedStrings.userGroups, image: UIImage(systemName: "person.2"), handler: { [weak self] _ in
+            self?.pushToUserGroups()
         })
 
         let logsAction = UIAction(title: TalkPageLocalizedStrings.logs, image: UIImage(systemName: "list.bullet"), handler: { _ in
@@ -324,6 +325,15 @@ class TalkPageViewController: ViewController {
     fileprivate func pushToContributions() {
         guard let username = usernameFromPageTitle(),
         let url = viewModel.siteURL.wmf_URL(withPath: "/wiki/Special:Contributions/\(username)", isMobile: true) else {
+            return
+        }
+        
+        navigate(to: url)
+    }
+    
+    fileprivate func pushToUserGroups() {
+        guard let username = usernameFromPageTitle(),
+        let url = viewModel.siteURL.wmf_URL(withPath: "/wiki/Special:UserRights/\(username)", isMobile: true) else {
             return
         }
         

--- a/Wikipedia/Code/TalkPageViewModel.swift
+++ b/Wikipedia/Code/TalkPageViewModel.swift
@@ -12,13 +12,13 @@ final class TalkPageViewModel {
     let authenticationManager: WMFAuthenticationManager
     private let dataController: TalkPageDataController
 
-    // TODO: - Populate from data controller
     private(set) var headerTitle: String
     private(set) var headerDescription: String?
     private(set) var leadImageURL: URL?
     private(set) var coffeeRollText: String?
     private(set) var projectSourceImage: UIImage?
     private(set) var projectLanguage: String?
+    private(set) var latestRevisionID: Int?
     
     static let leadImageSideLength = 80
     
@@ -77,6 +77,7 @@ final class TalkPageViewModel {
                 self.topics.removeAll()
                 self.populateCellData(topics: result.items, oldViewModels: oldViewModels)
                 self.updateSubscriptionForTopic(topicNames: result.subscribedTopicNames)
+                self.latestRevisionID = result.latestRevisionID
                 completion(.success(()))
             case .failure(let error):
                 DDLogError("Failure fetching talk page: \(error)")


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T310294
https://phabricator.wikimedia.org/T315330 (Revision ID fetching portion)

### Notes
This PR pushes to all of the overflow menu external links, as described in https://phabricator.wikimedia.org/T310294. The last remaining web view will be pushing to an "About talk pages / About user talk pages" wiki page.

I tried to push to an in-app web view for most of these, but a couple I decided to switch over to Safari for:

"Read in Web" - It felt a little strange to keep this in the app. In my mind, a user wants to separate entirely from the app when they choose this option.
"Permanent link" - Unfortunately our router automatically pushes this url to the native revision diff screen, which is different than how mobile web handles it. I'm not entirely sure what "Permanent link" is used for, so for now I'm pushing out to where mobile web goes in Safari to avoid the risk of touching our routing code.

### Test Steps
1. Test the various overflow menu items for article and user talk, in two different languages. Confirm they go to the correct url in a web view (either in-app or in Safari), according to the task description.

