### PR TITLE
Talk pages - Prevent disclosure button from horizontally compressing

### DIFF
--- a/Wikipedia/Code/TalkPageCellTopicView.swift
+++ b/Wikipedia/Code/TalkPageCellTopicView.swift
@@ -50,6 +50,7 @@ final class TalkPageCellTopicView: SetupView {
         button.setImage(UIImage(systemName: "chevron.down"), for: .normal)
         button.tintColor = .black
         button.setContentCompressionResistancePriority(.required, for: .vertical)
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
         return button
     }()
 


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
This fixes a bug I noticed where a long title would sometimes make the disclosure button compress horizontally when the user was viewing a talk page without being logged in.

### Test Steps
1. Replace the `TopicTitleTextView` text at line 265 in `TalkPageCellTopicView` to something long, like "This is a title that is long enough to make the disclosure button shrink when the text is at two lines"
2. Log out, and go to any text page.
3. Confirm you don't see any horizontally compressed disclosure buttons like in the before screenshot below. In `main`, it should be easy to see the bug.

### Screenshot

![ba](https://user-images.githubusercontent.com/5652327/195163718-bdc2d63d-d109-4cdf-85f6-3d289c8eda04.png)
