### PR TITLE
Talk pages - link to FAQ page

### DIFF
--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -74,8 +74,8 @@ class TalkPageViewController: ViewController {
             actions.insert(contentsOf: userTalkOverflowSubmenuActions, at: 1)
 
         }
-        let aboutTalkPagesAction = UIAction(title: TalkPageLocalizedStrings.aboutTalkPages, image: UIImage(systemName: "doc.plaintext"), handler: { _ in
-
+        let aboutTalkPagesAction = UIAction(title: TalkPageLocalizedStrings.aboutTalkPages, image: UIImage(systemName: "doc.plaintext"), handler: { [weak self] _ in
+            self?.pushToAboutTalkPages()
         })
         actions.append(aboutTalkPagesAction)
 
@@ -426,6 +426,14 @@ class TalkPageViewController: ViewController {
               let url = Configuration.current.expandedArticleURLForHost(host, languageVariantCode: viewModel.siteURL.wmf_languageVariantCode, queryParameters: ["title": viewModel.pageTitle,
                                                                                                                                                                 "oldid": latestRevisionID]) else {
             // TODO: Error banner
+            return
+        }
+        
+        navigate(to: url, useSafari: true)
+    }
+    
+    fileprivate func pushToAboutTalkPages() {
+        guard let url = URL(string: "https://www.mediawiki.org/wiki/Wikimedia_Apps/iOS_FAQ#Talk_pages") else {
             return
         }
         


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T310294#8300565 (partially)

### Notes
This is the final piece of the overflow menu links task. It links to the talk pages section of our FAQ in Safari. I decided to open the link in Safari to match our FAQ link behavior in the notifications center onboarding modal.

### Test Steps
For user talk and article talk pages, tap "About talk pages" in the overflow menu. Confirm it goes to our FAQ talk pages section in the user's browser of choice.
