### PR TITLE
Update email address for vanishing requests

### DIFF
--- a/ContinueReadingWidget/Info.plist
+++ b/ContinueReadingWidget/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/FeaturedArticleWidget/Info.plist
+++ b/FeaturedArticleWidget/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/NotificationServiceExtension/Info.plist
+++ b/NotificationServiceExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>

--- a/TopReadWidget/Info.plist
+++ b/TopReadWidget/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/WMF Framework/Info.plist
+++ b/WMF Framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSPrincipalClass</key>

--- a/Widgets/Info.plist
+++ b/Widgets/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>

--- a/Wikipedia Stickers/Info.plist
+++ b/Wikipedia Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/Wikipedia/Code/VanishAccountContentView.swift
+++ b/Wikipedia/Code/VanishAccountContentView.swift
@@ -154,7 +154,7 @@ struct VanishAccountContentView: View {
     }
     
     func openMailClient() {
-        let address = "ios-support@wikimedia.org"
+        let address = "privacy@wikimedia.org"
         let subject = WMFLocalizedString("vanishing-request-email-title", value: "Request for courtesy vanishing", comment: "Title for vanishing request email")
         let body = getMailBody()
         let mailto = "mailto:\(address)?subject=\(subject)&body=\(body)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)

--- a/Wikipedia/Experimental-Info.plist
+++ b/Wikipedia/Experimental-Info.plist
@@ -24,7 +24,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Wikipedia/Local-Info.plist
+++ b/Wikipedia/Local-Info.plist
@@ -28,7 +28,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Wikipedia/Staging-Info.plist
+++ b/Wikipedia/Staging-Info.plist
@@ -24,7 +24,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Wikipedia/User Testing-Info.plist
+++ b/Wikipedia/User Testing-Info.plist
@@ -22,7 +22,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Wikipedia/Wikipedia-Info.plist
+++ b/Wikipedia/Wikipedia-Info.plist
@@ -22,7 +22,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/WikipediaUITests/Info.plist
+++ b/WikipediaUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/WikipediaUnitTests/Info.plist
+++ b/WikipediaUnitTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.3</string>
+	<string>6.9.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T300080 (partially)

### Notes
Updates vanish request email address to use legal requested T&S address.

### Test Steps
1. With a logged in account, confirm Settings > Account > Vanish account > "Send request" opens an email client with the `to` field pointing to the new email address.

