### PR TITLE
Talk pages - header design review

### DIFF
--- a/Wikipedia/Code/TalkPageHeaderView.swift
+++ b/Wikipedia/Code/TalkPageHeaderView.swift
@@ -49,6 +49,7 @@ final class TalkPageHeaderView: SetupView {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.distribution = .fill
         stackView.alignment = .top
+        stackView.spacing = 12
         return stackView
     }()
 


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T310273#8340053

### Notes
This increases the spacing between the image and labels in the header view.

### Test Steps
1. Visit a user talk and article talk page. Confirm there are no layout regression issues in the header.

### Screenshots/Videos

Before:
![Screen Shot 2022-10-31 at 8 40 54 AM](https://user-images.githubusercontent.com/3620196/199023785-fc0c17d2-bbf6-4b1d-8204-dbf0305797f7.png)

After:
![Screen Shot 2022-10-31 at 8 42 08 AM](https://user-images.githubusercontent.com/3620196/199023814-6acd1d77-12a5-420f-9c85-8410475656ba.png)
