### PR TITLE
Talk pages - Remove archive option

### DIFF
--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -68,7 +68,9 @@ class TalkPageViewController: ViewController {
             self?.pushToWhatLinksHere()
         })
 
-        var actions = [goToArchivesAction, pageInfoAction, goToPermalinkAction, relatedLinksAction]
+        // goToArchivesAction
+        // TODO: Restore archives option with T321853
+        var actions = [pageInfoAction, goToPermalinkAction, relatedLinksAction]
         
         if viewModel.project.languageCode != nil {
             actions.insert(changeLanguageAction, at: 3)


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T310294
https://phabricator.wikimedia.org/T321853

### Notes
We're going to remove the Archive option from the overflow menu. It will be added back in and tackled separately in https://phabricator.wikimedia.org/T321853.

### Test Steps
1. Confirm Archive option no longer displays in overflow menu on article talk and user talk pages.
