### PR TITLE
Address vanishing view design feedback

### DIFF
--- a/Wikipedia/Code/VanishAccountContentView.swift
+++ b/Wikipedia/Code/VanishAccountContentView.swift
@@ -82,7 +82,7 @@ struct VanishAccountContentView: View {
                                 .padding([.top], 5)
                             TextView(placeholder: LocalizedStrings.additionalInformationFieldPlaceholder, theme: theme, text: $userInput.text)
                                 .padding([.leading, .trailing], 20)
-                                .frame(maxWidth: .infinity, minHeight: 100)
+                                .frame(maxWidth: .infinity, maxHeight: 50)
                             Spacer()
                                 .frame(height: 12)
                         }

--- a/Wikipedia/Code/VanishAccountContentView.swift
+++ b/Wikipedia/Code/VanishAccountContentView.swift
@@ -23,7 +23,7 @@ struct VanishAccountContentView: View {
     private let titleFont = UIFont.wmf_scaledSystemFont(forTextStyle: .headline, weight: .medium, size: 18)
     private let buttonFont = UIFont.wmf_scaledSystemFont(forTextStyle: .headline, weight: .medium, size: 16)
     private let bodyFont = UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .regular, size: 13)
-    private let fieldTitleFont = UIFont.wmf_scaledSystemFont(forTextStyle: .subheadline, weight: .regular, size: 15)
+    private let fieldTitleFont = UIFont.wmf_scaledSystemFont(forTextStyle: .subheadline, weight: .regular, size: 16)
     
     private var extraBottomPaddingiOS13: CGFloat {
         // iOS 13 doesn't add a bottom scroll view content inset with the keyboard like 14 & 15

--- a/Wikipedia/Code/VanishAccountContentView.swift
+++ b/Wikipedia/Code/VanishAccountContentView.swift
@@ -37,7 +37,7 @@ struct VanishAccountContentView: View {
     var body: some View {
         ZStack {
             ScrollView(.vertical, showsIndicators: false) {
-                VStack {
+                VStack(spacing: 0) {
                     VStack(spacing: 0) {
                         Text(LocalizedStrings.title)
                             .foregroundColor(Color(theme.colors.primaryText))

--- a/Wikipedia/Code/VanishAccountContentView.swift
+++ b/Wikipedia/Code/VanishAccountContentView.swift
@@ -24,114 +24,78 @@ struct VanishAccountContentView: View {
     private let buttonFont = UIFont.wmf_scaledSystemFont(forTextStyle: .headline, weight: .medium, size: 16)
     private let bodyFont = UIFont.wmf_scaledSystemFont(forTextStyle: .body, weight: .regular, size: 13)
     private let fieldTitleFont = UIFont.wmf_scaledSystemFont(forTextStyle: .subheadline, weight: .regular, size: 16)
-    
-    private var extraBottomPaddingiOS13: CGFloat {
-        // iOS 13 doesn't add a bottom scroll view content inset with the keyboard like 14 & 15
-        // Adding some extra padding here so it's easier to scroll and see the text view on smaller iOS13 devices
-        if #available(iOS 14, *) {
-            return 0
-        } else {
+
+    private var extraBottomPadding: CGFloat {
+        // Extra padding to accommodate the one or two (depending on OS version) floating bottom buttons
+        if #available(iOS 15, *) {
             return 100
+        } else {
+            return 200
         }
     }
-    
+
     var body: some View {
         ZStack {
-            GeometryReader { proxy in
-                ScrollView(.vertical, showsIndicators: false) {
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack {
                     VStack {
-                        VStack {
-                            Text(LocalizedStrings.title)
-                                .foregroundColor(Color(theme.colors.primaryText))
-                                .fixedSize(horizontal: false, vertical: true)
-                                .font(Font(titleFont))
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding([.bottom], 10)
-                            Text(LocalizedStrings.description)
-                                .foregroundColor(Color(theme.colors.secondaryText))
-                                .fixedSize(horizontal: false, vertical: true)
-                                .font(Font(bodyFont))
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                        .background(Color(theme.colors.baseBackground).edgesIgnoringSafeArea(.all))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(20)
-                        VStack {
-                            Text(LocalizedStrings.usernameFieldTitle)
-                                .foregroundColor(Color(theme.colors.secondaryText))
-                                .fixedSize(horizontal: false, vertical: true)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .font(Font(fieldTitleFont))
-                                .padding([.top], 10)
-                                .padding([.leading, .trailing], 20)
-                            Text(username)
-                                .foregroundColor(Color(theme.colors.secondaryText))
-                                .fixedSize(horizontal: false, vertical: true)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .font(Font(fieldTitleFont))
-                                .padding([.bottom], 5)
-                                .padding([.top], 2)
-                                .padding([.leading, .trailing], 20)
-                            Divider().padding([.leading], 20)
-                            Text(LocalizedStrings.additionalInformationFieldTitle)
-                                .foregroundColor(Color(theme.colors.link))
-                                .fixedSize(horizontal: false, vertical: true)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .font(Font(fieldTitleFont))
-                                .padding([.leading, .trailing], 20)
-                                .padding([.top], 5)
-                            TextView(placeholder: LocalizedStrings.additionalInformationFieldPlaceholder, theme: theme, text: $userInput.text)
-                                .padding([.leading, .trailing], 20)
-                                .frame(maxWidth: .infinity, maxHeight: 50)
-                            Spacer()
-                                .frame(height: 12)
-                        }
-                        .background(Color(theme.colors.paperBackground))
-                        .frame(maxWidth: .infinity, minHeight: 300)
-                        VStack {
-                            VanishAccountFooterView()
-                                .foregroundColor(Color(theme.colors.secondaryText))
-                                .fixedSize(horizontal: false, vertical: true)
-                                .font(Font(bodyFont))
-                                .padding(20)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                            Spacer()
-                            VStack {
-                                Button(action: {
-                                    openMailClient()
-                                }, label: {
-                                    Text(LocalizedStrings.buttonText)
-                                        .font(Font(buttonFont))
-                                        .foregroundColor(Color(theme.colors.link))
-                                        .frame(minWidth: 335)
-                                        .frame(height: 46)
-                                        .background(Color(theme.colors.paperBackground))
-                                        .cornerRadius(8)
-                                })
-                                if #unavailable(iOS 15) {
-                                    Button(action: {
-                                        goToVanishPage()
-                                    }, label: {
-                                        Text(LocalizedStrings.learnMoreButtonText)
-                                            .font(Font(buttonFont))
-                                            .foregroundColor(Color(theme.colors.link))
-                                            .frame(minWidth: 335)
-                                            .frame(height: 46)
-                                            .background(Color(theme.colors.baseBackground))
-                                        
-                                    })
-                                }
-                            }
-                            .padding(0)
-                            Spacer()
-                        }
+                        Text(LocalizedStrings.title)
+                            .foregroundColor(Color(theme.colors.primaryText))
+                            .fixedSize(horizontal: false, vertical: true)
+                            .font(Font(titleFont))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding([.bottom], 16)
+                        Text(LocalizedStrings.description)
+                            .foregroundColor(Color(theme.colors.secondaryText))
+                            .fixedSize(horizontal: false, vertical: true)
+                            .font(Font(bodyFont))
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                    .padding([.bottom], extraBottomPaddingiOS13)
-                    .frame(minHeight: proxy.size.height)
-                    .frame(maxWidth: .infinity)
+                    .padding(16)
+                    VStack {
+                        Text(LocalizedStrings.usernameFieldTitle)
+                            .foregroundColor(Color(theme.colors.secondaryText))
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .font(Font(fieldTitleFont))
+                            .padding([.top], 16)
+                            .padding([.leading, .trailing], 16)
+                        Text(username)
+                            .foregroundColor(Color(theme.colors.secondaryText))
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .font(Font(fieldTitleFont))
+                            .padding([.bottom], 5)
+                            .padding([.top], 2)
+                            .padding([.leading, .trailing], 16)
+                        Divider().padding([.leading], 16)
+                        Text(LocalizedStrings.additionalInformationFieldTitle)
+                            .foregroundColor(Color(theme.colors.link))
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .font(Font(fieldTitleFont))
+                            .padding([.leading, .trailing], 16)
+                            .padding([.top], 10)
+                        TextView(placeholder: LocalizedStrings.additionalInformationFieldPlaceholder, theme: theme, text: $userInput.text)
+                            .padding([.leading, .trailing], 16)
+                            .frame(maxWidth: .infinity, minHeight: 50)
+                        Spacer()
+                            .frame(height: 12)
+                    }
+                    .background(Color(theme.colors.paperBackground))
+                    VStack {
+                        VanishAccountFooterView()
+                            .foregroundColor(Color(theme.colors.secondaryText))
+                            .fixedSize(horizontal: false, vertical: true)
+                            .font(Font(bodyFont))
+                            .padding(16)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Spacer()
+                    }
                 }
-                .background(Color(theme.colors.baseBackground).edgesIgnoringSafeArea(.all))
+                .padding([.bottom], extraBottomPadding)
             }
+            .background(Color(theme.colors.baseBackground).edgesIgnoringSafeArea(.all))
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
                 if shouldShowModalOnForeground {
                     withAnimation(.linear(duration: 0.3)) {
@@ -140,6 +104,35 @@ struct VanishAccountContentView: View {
                     }
                 }
             }
+            VStack {
+                Spacer()
+                Button(action: {
+                    openMailClient()
+                }, label: {
+                    Text(LocalizedStrings.buttonText)
+                        .font(Font(buttonFont))
+                        .foregroundColor(Color(theme.colors.link))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 46)
+                        .background(Color(theme.colors.paperBackground))
+                        .cornerRadius(8)
+                })
+                .padding(16)
+                if #unavailable(iOS 15) {
+                    Button(action: {
+                        goToVanishPage()
+                    }, label: {
+                        Text(LocalizedStrings.learnMoreButtonText)
+                            .font(Font(buttonFont))
+                            .foregroundColor(Color(theme.colors.link))
+                            .frame(minWidth: 335)
+                            .frame(height: 46)
+                            .background(Color(theme.colors.baseBackground))
+                    })
+                }
+            }
+            .padding(0)
+            Spacer()
             VanishAccountPopUpAlertView(theme:theme, isVisible: $isModalVisible, userInput: $userInput.text)
         }
         

--- a/Wikipedia/Code/VanishAccountContentView.swift
+++ b/Wikipedia/Code/VanishAccountContentView.swift
@@ -38,13 +38,14 @@ struct VanishAccountContentView: View {
         ZStack {
             ScrollView(.vertical, showsIndicators: false) {
                 VStack {
-                    VStack {
+                    VStack(spacing: 0) {
                         Text(LocalizedStrings.title)
                             .foregroundColor(Color(theme.colors.primaryText))
                             .fixedSize(horizontal: false, vertical: true)
                             .font(Font(titleFont))
                             .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding([.bottom], 16)
+                        Spacer()
+                            .frame(height: 16)
                         Text(LocalizedStrings.description)
                             .foregroundColor(Color(theme.colors.secondaryText))
                             .fixedSize(horizontal: false, vertical: true)
@@ -75,7 +76,7 @@ struct VanishAccountContentView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .font(Font(fieldTitleFont))
                             .padding([.leading, .trailing], 16)
-                            .padding([.top], 10)
+                            .padding([.top], 8)
                         TextView(placeholder: LocalizedStrings.additionalInformationFieldPlaceholder, theme: theme, text: $userInput.text)
                             .padding([.leading, .trailing], 16)
                             .frame(maxWidth: .infinity, minHeight: 50)
@@ -83,15 +84,14 @@ struct VanishAccountContentView: View {
                             .frame(height: 12)
                     }
                     .background(Color(theme.colors.paperBackground))
-                    VStack {
+                    VStack(spacing: 0) {
                         VanishAccountFooterView()
                             .foregroundColor(Color(theme.colors.secondaryText))
                             .fixedSize(horizontal: false, vertical: true)
                             .font(Font(bodyFont))
-                            .padding(16)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                        Spacer()
                     }
+                    .padding(16)
                 }
                 .padding([.bottom], extraBottomPadding)
             }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T320758#8357720

### Notes
* Updates element spacing to be 16 pts
* Adjusts leading/trailing padding to be 16 pts
* Updates font size for form elements to 16 pt
* Reduces height of additional information text view
* Updates `Send request` button stack to be pinned at bottom of screen (I confirmed with design that this change is ok)

I removed the `GeometryReader` as it didn't seem necessary anymore, but I didn't originally create this view so please let me know if it's actually still necessary for some reason. Also, GitHub's diff isn't particularly helpful here, so may be work using Xcode's code review feature to more precisely see the differences.

### Test Steps
1. Open vanish account view, confirm spacing/sizing changes
2. Change theme, confirm vanish account view still renders as expected

### Screenshots
![vanishing_view_updates](https://user-images.githubusercontent.com/5652327/199116774-3909f27b-d993-4697-b4ce-491d90afa94b.jpg)

