### PR TITLE
Talk pages - banner design review feedback

### DIFF
--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -490,7 +490,7 @@ class TalkPageViewController: ViewController {
         if UIAccessibility.isVoiceOverRunning {
             UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: title)
         } else {
-            WMFAlertManager.sharedInstance.showBottomAlertWithMessage(title, subtitle: nil, image: UIImage(systemName: "exclamationmark.circle"), type: .custom, customTypeName: "subscription", dismissPreviousAlerts: true)
+            WMFAlertManager.sharedInstance.showBottomAlertWithMessage(title, subtitle: nil, image: UIImage(systemName: "exclamationmark.circle"), type: .custom, customTypeName: "subscription-error", dismissPreviousAlerts: true)
         }
     }
     

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -480,7 +480,7 @@ class TalkPageViewController: ViewController {
         if UIAccessibility.isVoiceOverRunning {
             UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: title)
         } else {
-            WMFAlertManager.sharedInstance.showBottomAlertWithMessage(title, subtitle: subtitle, image: image, type: .normal, customTypeName: nil, dismissPreviousAlerts: true)
+            WMFAlertManager.sharedInstance.showBottomAlertWithMessage(title, subtitle: subtitle, image: image, type: .custom, customTypeName: "subscription-success", dismissPreviousAlerts: true)
         }
     }
 

--- a/Wikipedia/Code/WMFAlertManager.swift
+++ b/Wikipedia/Code/WMFAlertManager.swift
@@ -136,6 +136,8 @@ open class WMFAlertManager: NSObject, RMessageProtocol, Themeable {
         default:
             messageView.titleTextColor = theme.colors.link
         }
+        
+        messageView.layer.shadowColor = theme.colors.shadow.cgColor
     }
 
 }

--- a/Wikipedia/Code/WMFAlertManager.swift
+++ b/Wikipedia/Code/WMFAlertManager.swift
@@ -130,7 +130,7 @@ open class WMFAlertManager: NSObject, RMessageProtocol, Themeable {
             if messageView.customTypeName == "connection" {
                 messageView.imageViewTintColor = theme.colors.error
                 messageView.buttonFont = UIFont.systemFont(ofSize: 14, weight: .semibold)
-            } else if messageView.customTypeName == "subscription" {
+            } else if messageView.customTypeName == "subscription-error" {
                 messageView.imageViewTintColor = theme.colors.warning
             }
         default:

--- a/Wikipedia/Third Party Code/RMessage/RMessageDefaultDesign.json
+++ b/Wikipedia/Third Party Code/RMessage/RMessageDefaultDesign.json
@@ -44,7 +44,7 @@
     "subTitleTextColor": "#222222",
     "blurBackground": 0
   },
-  "subscription": {
+  "subscription-error": {
     "backgroundColor": "#F8F9FA",
     "backgroundColorAlpha": 1.0,
     "titleTextColor": "#222222",

--- a/Wikipedia/Third Party Code/RMessage/RMessageDefaultDesign.json
+++ b/Wikipedia/Third Party Code/RMessage/RMessageDefaultDesign.json
@@ -44,6 +44,15 @@
     "subTitleTextColor": "#222222",
     "blurBackground": 0
   },
+  "subscription-success": {
+    "backgroundColor": "#F8F9FA",
+    "backgroundColorAlpha": 1.0,
+    "titleTextColor": "#222222",
+    "titleFontSize": 14,
+    "subTitleFontSize": 12,
+    "subTitleTextColor": "#222222",
+    "blurBackground": 0
+  },
   "subscription-error": {
     "backgroundColor": "#F8F9FA",
     "backgroundColorAlpha": 1.0,

--- a/Wikipedia/Third Party Code/RMessage/RMessageView.m
+++ b/Wikipedia/Third Party Code/RMessage/RMessageView.m
@@ -437,6 +437,16 @@ static NSMutableDictionary *globalDesignDictionary;
   [self setupTitleLabel];
   [self setupSubTitleLabel];
   [self setupButton];
+
+  if (self.messagePosition != RMessagePositionBottom) {
+    self.layer.shadowOffset = CGSizeMake(0, 2);
+  } else {
+    self.layer.shadowOffset = CGSizeMake(0, -2);
+  }
+    self.layer.shadowRadius = 5;
+    self.layer.shadowOpacity = 1.0;
+
+    self.clipsToBounds = NO;
 }
 
 - (void)setupLayout

--- a/Wikipedia/Third Party Code/RMessage/RMessageView.m
+++ b/Wikipedia/Third Party Code/RMessage/RMessageView.m
@@ -30,7 +30,6 @@ static NSMutableDictionary *globalDesignDictionary;
 @property (nonatomic, weak) IBOutlet UIButton *button;
 @property (nonatomic, weak) IBOutlet UIStackView *stackView;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *titleSubtitleContainerViewLeadingConstraint;
-@property (nonatomic, weak) IBOutlet NSLayoutConstraint *titleSubtitleContainerViewCenterYConstraint;
 @property (weak, nonatomic) IBOutlet UIImageView *closeImageView;
 
 @property (nonatomic, strong) UIImageView *iconImageView;
@@ -53,18 +52,15 @@ static NSMutableDictionary *globalDesignDictionary;
 /** The view controller this message is displayed in */
 @property (nonatomic, strong) UIViewController *viewController;
 
-/** The vertical space between the message view top to its view controller top */
-@property (nonatomic, strong) NSLayoutConstraint *topToVCLayoutConstraint;
+/** Activated for top banners only, this is the constraint that pins a banner to the top safe area */
+@property (nonatomic, strong) NSLayoutConstraint *topToVCTopLayoutConstraint;
+
+/** Activated for bottom banners only, this is the constraint that pins a banner to the bottom safe area */
+@property (nonatomic, strong) NSLayoutConstraint *bottomToVCBottomLayoutConstraint;
 
 @property (nonatomic, copy) void (^callback)(void);
 
 @property (nonatomic, copy) void (^buttonCallback)(void);
-
-/** The starting constant value that should be set for the topToVCTopLayoutConstraint when animating */
-@property (nonatomic, assign) CGFloat topToVCStartConstant;
-
-/** The final constant value that should be set for the topToVCTopLayoutConstraint when animating */
-@property (nonatomic, assign) CGFloat topToVCFinalConstant;
 
 @property (nonatomic, assign) CGFloat iconRelativeCornerRadius;
 @property (nonatomic, assign) RMessageType messageType;
@@ -139,7 +135,6 @@ static NSMutableDictionary *globalDesignDictionary;
     }
     UIViewController *presentedViewController = nil;
     do {
-        
         if (![viewController.presentedViewController conformsToProtocol:@protocol(RMessageSuppressProtocol)]) {
             presentedViewController = viewController.presentedViewController;
         } else {
@@ -153,7 +148,12 @@ static NSMutableDictionary *globalDesignDictionary;
             viewController = presentedViewController;
         }
     } while (presentedViewController != nil);
-    return viewController;
+    
+    if ([viewController isKindOfClass:[UINavigationController class]]) {
+        return ((UINavigationController *)viewController).viewControllers.lastObject;
+    } else {
+        return viewController;
+    }
 }
 
 /**
@@ -443,39 +443,28 @@ static NSMutableDictionary *globalDesignDictionary;
 {
   self.translatesAutoresizingMaskIntoConstraints = NO;
 
-  // Add RMessage to superview and prepare the ending y position constants
-  [self layoutMessageForPresentation];
-  [self setupLabelPreferredMaxLayoutWidth];
+  // Add RMessage to superview
+  [self addToSuperviewForPresentation];
 
-  // Prepare the starting y position constants
   if (self.messagePosition != RMessagePositionBottom) {
     [self layoutIfNeeded];
-    self.topToVCStartConstant = -self.bounds.size.height;
-    self.topToVCLayoutConstraint = [NSLayoutConstraint constraintWithItem:self
+    self.topToVCTopLayoutConstraint = [NSLayoutConstraint constraintWithItem:self.superview
                                                                 attribute:NSLayoutAttributeTop
                                                                 relatedBy:NSLayoutRelationEqual
-                                                                   toItem:self.superview
+                                                                   toItem:self
                                                                 attribute:NSLayoutAttributeTop
                                                                multiplier:1.f
-                                                                 constant:self.topToVCStartConstant];
+                                                                 constant:0.f];
   } else {
-    self.topToVCStartConstant = 0;
-    self.topToVCLayoutConstraint = [NSLayoutConstraint constraintWithItem:self
-                                                                attribute:NSLayoutAttributeTop
+    self.bottomToVCBottomLayoutConstraint = [NSLayoutConstraint constraintWithItem:self
+                                                                attribute:NSLayoutAttributeBottom
                                                                 relatedBy:NSLayoutRelationEqual
-                                                                   toItem:self.superview.safeAreaLayoutGuide
+                                                                   toItem:self.superview
                                                                 attribute:NSLayoutAttributeBottom
                                                                multiplier:1.f
                                                                  constant:0.f];
   }
 
-  NSLayoutConstraint *centerXConstraint = [NSLayoutConstraint constraintWithItem:self
-                                                                       attribute:NSLayoutAttributeCenterX
-                                                                       relatedBy:NSLayoutRelationEqual
-                                                                          toItem:self.superview
-                                                                       attribute:NSLayoutAttributeCenterX
-                                                                      multiplier:1.f
-                                                                        constant:0.f];
   NSLayoutConstraint *leadingConstraint = [NSLayoutConstraint constraintWithItem:self
                                                                        attribute:NSLayoutAttributeLeading
                                                                        relatedBy:NSLayoutRelationEqual
@@ -489,11 +478,20 @@ static NSMutableDictionary *globalDesignDictionary;
                                                                            toItem:self.superview
                                                                         attribute:NSLayoutAttributeTrailing
                                                                        multiplier:1.f
+    
                                                                          constant:0.f];
-  [[self class]
-    activateConstraints:@[centerXConstraint, leadingConstraint, trailingConstraint, self.topToVCLayoutConstraint]
-            inSuperview:self.superview];
+    if (self.messagePosition != RMessagePositionBottom) {
+        [[self class] activateConstraints:@[leadingConstraint, trailingConstraint, self.topToVCTopLayoutConstraint] inSuperview:self];
+    } else {
+        [[self class] activateConstraints:@[leadingConstraint, trailingConstraint, self.bottomToVCBottomLayoutConstraint] inSuperview:self];
+    }
   if (self.shouldBlurBackground) [self setupBlurBackground];
+    
+    // Initially set it off screen
+    [self setNeedsLayout];
+    [self layoutIfNeeded];
+    self.topToVCTopLayoutConstraint.constant = self.bounds.size.height - [self customVerticalOffset];
+    self.bottomToVCBottomLayoutConstraint.constant = self.bounds.size.height - [self customVerticalOffset];
 }
 
 - (void)setupBackgroundImageViewWithImage:(UIImage *)image
@@ -540,14 +538,6 @@ static NSMutableDictionary *globalDesignDictionary;
   [[self class] activateConstraints:vConstraints inSuperview:self];
 }
 
-- (void)setupLabelPreferredMaxLayoutWidth
-{
-  CGFloat iconImageWidthAndPadding = 0.f;
-  if (_iconImage) iconImageWidthAndPadding = _iconImage.size.width + 15.f;
-  _titleLabel.preferredMaxLayoutWidth = self.superview.bounds.size.width - iconImageWidthAndPadding - 30.f;
-  _subtitleLabel.preferredMaxLayoutWidth = _titleLabel.preferredMaxLayoutWidth;
-}
-
 - (void)executeMessageViewCallBack
 {
   if (self.callback) self.callback();
@@ -574,6 +564,7 @@ static NSMutableDictionary *globalDesignDictionary;
   if (self.iconRelativeCornerRadius > 0) {
     self.iconImageView.layer.cornerRadius = self.iconRelativeCornerRadius * self.iconImageView.bounds.size.width;
   }
+  [self setPositioningConstraintsAndLayout];
 }
 
 - (void)setupDesignDefaults
@@ -847,85 +838,9 @@ static NSMutableDictionary *globalDesignDictionary;
   }
 }
 
-- (void)layoutMessageForPresentation
+- (void)addToSuperviewForPresentation
 {
-  if ([self.viewController isKindOfClass:[UINavigationController class]] ||
-      [self.viewController.parentViewController isKindOfClass:[UINavigationController class]]) {
-    [self layoutMessageForNavigationControllerPresentation];
-  } else {
-    [self layoutMessageForStandardPresentation];
-  }
-}
-
-- (void)layoutMessageForNavigationControllerPresentation
-{
-  self.titleSubtitleContainerViewCenterYConstraint.constant = 0.f;
-
-  UINavigationController *messageNavigationController;
-
-  if ([self.viewController isKindOfClass:[UINavigationController class]]) {
-    messageNavigationController = (UINavigationController *)self.viewController;
-  } else {
-    messageNavigationController = (UINavigationController *)self.viewController.parentViewController;
-  }
-
-  BOOL messageNavigationBarHidden =
-    [RMessageView isNavigationBarHiddenForNavigationController:messageNavigationController];
-
-  if (self.messagePosition != RMessagePositionBottom) {
-    if (!messageNavigationBarHidden && self.messagePosition == RMessagePositionTop) {
-      // Present from below nav bar when presenting from the top and navigation bar is present
-
-        if ([messageNavigationController isKindOfClass:[UINavigationController class]] && [messageNavigationController.topViewController isKindOfClass:[TalkPageTopicComposeViewController class]]) {
-            [messageNavigationController.view insertSubview:self aboveSubview:messageNavigationController.navigationBar];
-            self.topToVCFinalConstant = [self customVerticalOffset];
-            return;
-        }
-        
-        [messageNavigationController.view insertSubview:self belowSubview:messageNavigationController.navigationBar];
-            
-        /* If view controller edges dont extend under top bars (navigation bar in our case) we must not factor in the
-         navigation bar frame when animating RMessage's final position */
-        if ([[self class] viewControllerEdgesExtendUnderTopBars:messageNavigationController]) {
-          self.topToVCFinalConstant = [UIApplication sharedApplication].statusBarFrame.size.height +
-                                      messageNavigationController.navigationBar.bounds.size.height +
-                                      [self customVerticalOffset];
-        } else {
-          self.topToVCFinalConstant = [self customVerticalOffset];
-        }
-        
-    } else {
-      /* Navigation bar hidden or being asked to present as nav bar overlay, so present above status bar and/or
-       navigation bar */
-      self.topToVCFinalConstant = [self customVerticalOffset];
-      self.titleSubtitleContainerViewCenterYConstraint.constant =
-        [UIApplication sharedApplication].statusBarFrame.size.height / 2.f;
-      [self.viewController.view addSubview:self];
-    }
-  } else {
-    // Present from bottom
-    [self layoutIfNeeded];
-    CGFloat offset = -self.bounds.size.height - [self customVerticalOffset];
-    if (messageNavigationController && !messageNavigationController.isToolbarHidden) {
-      // If tool bar present animate above toolbar
-      offset -= messageNavigationController.toolbar.bounds.size.height;
-    }
-    self.topToVCFinalConstant = offset;
     [self.viewController.view addSubview:self];
-  }
-}
-
-- (void)layoutMessageForStandardPresentation
-{
-  [self layoutIfNeeded];
-  if (self.messagePosition == RMessagePositionBottom) {
-    self.topToVCFinalConstant = -self.bounds.size.height - [self customVerticalOffset];
-  } else {
-    self.topToVCFinalConstant = [self customVerticalOffset];
-    self.titleSubtitleContainerViewCenterYConstraint.constant =
-      [UIApplication sharedApplication].statusBarFrame.size.height / 2.f;
-  }
-  [self.viewController.view addSubview:self];
 }
 
 - (void)animateMessage
@@ -945,8 +860,7 @@ static NSMutableDictionary *globalDesignDictionary;
                          [self.delegate messageViewIsPresenting:self];
                        }
                        if (!self.shouldBlurBackground) self.alpha = self.messageOpacity;
-                       self.topToVCLayoutConstraint.constant = self.topToVCFinalConstant;
-                       [self.superview layoutIfNeeded];
+                       [self setPositioningConstraintsAndLayout];
                      }
                      completion:^(BOOL finished) {
                        self.isPresenting = NO;
@@ -956,6 +870,12 @@ static NSMutableDictionary *globalDesignDictionary;
                        }
                      }];
   });
+}
+
+- (void)setPositioningConstraintsAndLayout {
+    self.topToVCTopLayoutConstraint.constant = 0 + [self customVerticalOffset];
+    self.bottomToVCBottomLayoutConstraint.constant = 0 + [self customVerticalOffset];
+    [self.superview layoutIfNeeded];
 }
 
 - (void)dismiss
@@ -972,7 +892,8 @@ static NSMutableDictionary *globalDesignDictionary;
     [UIView animateWithDuration:kRMessageAnimationDuration
                      animations:^{
                        if (!self.shouldBlurBackground) self.alpha = 0.f;
-                       self.topToVCLayoutConstraint.constant = self.topToVCStartConstant;
+                        self.topToVCTopLayoutConstraint.constant = self.bounds.size.height - [self customVerticalOffset];
+                        self.bottomToVCBottomLayoutConstraint.constant = self.bounds.size.height - [self customVerticalOffset];
                        [self.superview layoutIfNeeded];
                      }
                      completion:^(BOOL finished) {
@@ -990,11 +911,6 @@ static NSMutableDictionary *globalDesignDictionary;
 - (void)interfaceDidRotate
 {
   if (self.isPresenting) [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(dismiss) object:self];
-
-  // On completion of UI rotation recalculate positioning
-  [self layoutMessageForPresentation];
-  [self setupLabelPreferredMaxLayoutWidth];
-  self.topToVCLayoutConstraint.constant = self.topToVCFinalConstant;
 }
 
 /**

--- a/Wikipedia/Third Party Code/RMessage/RMessageView.xib
+++ b/Wikipedia/Third Party Code/RMessage/RMessageView.xib
@@ -1,44 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" id="iN0-l3-epB" userLabel="RMessageView" customClass="RMessageView">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="66"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="116"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="49I-AE-5sP">
-                    <rect key="frame" x="21" y="10" width="278" height="46"/>
+                    <rect key="frame" x="14" y="14" width="292" height="88"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="KnX-yz-VaF">
-                            <rect key="frame" x="0.0" y="0.0" width="253" height="46"/>
+                            <rect key="frame" x="0.0" y="0.0" width="267" height="88"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="751" text="Title" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bJU-tq-cfR">
-                                    <rect key="frame" x="0.0" y="0.0" width="253" height="20.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="267" height="20.5"/>
                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Subtitle" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="86Q-SR-N4H">
-                                    <rect key="frame" x="0.0" y="25.5" width="253" height="0.0"/>
+                                    <rect key="frame" x="0.0" y="31.5" width="267" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FRl-SV-1p2">
-                                    <rect key="frame" x="0.0" y="30.5" width="253" height="15.5"/>
+                                    <rect key="frame" x="0.0" y="58" width="267" height="30"/>
                                     <state key="normal" title="Button"/>
                                 </button>
                             </subviews>
                         </stackView>
                         <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="close" translatesAutoresizingMaskIntoConstraints="NO" id="SYg-rc-Dhl">
-                            <rect key="frame" x="258" y="0.0" width="20" height="20"/>
+                            <rect key="frame" x="272" y="0.0" width="20" height="20"/>
                             <color key="tintColor" systemColor="darkTextColor"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="20" id="hGq-XR-tNx"/>
@@ -56,13 +57,12 @@
                     </constraints>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="dXD-DB-DVb"/>
             <constraints>
-                <constraint firstItem="49I-AE-5sP" firstAttribute="top" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="topMargin" constant="10" id="Azz-KF-Xf8"/>
-                <constraint firstAttribute="trailingMargin" secondItem="49I-AE-5sP" secondAttribute="trailing" constant="5" id="N4l-Ol-H0N"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="49I-AE-5sP" secondAttribute="bottom" constant="10" id="Urt-nc-SD2"/>
-                <constraint firstItem="49I-AE-5sP" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="XoR-Zr-h6e"/>
-                <constraint firstItem="49I-AE-5sP" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" constant="5" id="uCe-Eo-QlD"/>
-                <constraint firstItem="49I-AE-5sP" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="topMargin" priority="749" constant="10" id="uoF-wG-j5j"/>
+                <constraint firstItem="49I-AE-5sP" firstAttribute="top" secondItem="dXD-DB-DVb" secondAttribute="top" constant="14" id="J8e-O0-QhJ"/>
+                <constraint firstItem="49I-AE-5sP" firstAttribute="leading" secondItem="dXD-DB-DVb" secondAttribute="leading" constant="14" id="Vo6-NK-be1"/>
+                <constraint firstItem="dXD-DB-DVb" firstAttribute="trailing" secondItem="49I-AE-5sP" secondAttribute="trailing" constant="14" id="b3g-GK-VcX"/>
+                <constraint firstItem="dXD-DB-DVb" firstAttribute="bottom" secondItem="49I-AE-5sP" secondAttribute="bottom" constant="14" id="mYh-kS-IcJ"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
@@ -73,10 +73,9 @@
                 <outlet property="subtitleLabel" destination="86Q-SR-N4H" id="b36-f7-jMs"/>
                 <outlet property="titleLabel" destination="bJU-tq-cfR" id="cQG-kC-CBc"/>
                 <outlet property="titleSubtitleContainerView" destination="49I-AE-5sP" id="gnK-Tn-Kb9"/>
-                <outlet property="titleSubtitleContainerViewCenterYConstraint" destination="XoR-Zr-h6e" id="nBn-eR-aks"/>
-                <outlet property="titleSubtitleContainerViewLeadingConstraint" destination="uCe-Eo-QlD" id="2Q4-Ww-1a7"/>
+                <outlet property="titleSubtitleContainerViewLeadingConstraint" destination="Vo6-NK-be1" id="K0g-VT-cLa"/>
             </connections>
-            <point key="canvasLocation" x="337" y="450"/>
+            <point key="canvasLocation" x="336" y="472.26386806596707"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T312314#8350922
https://phabricator.wikimedia.org/T311639#8280839

### Notes
These are design review tweaks for the alerts presented on talk pages. They dipped into wider-reaching changes in e139b2e and 9997c9a. One is to add a shadow to all banners, which would be easy to revert if design decides against it. The other is reworking the presentation constraints and view controller picking to better consider safe area. I could not figure out a low-touch way around some of the layout bugs we were seeing, and this probably is more stable approach in the medium-term (though, I think we should rewrite it entirely in the long term). I tested a few banners throughout the app and haven't noticed any glaring issues. I'll also call this change out in the tickets so that QA can keep an eye out for regressions here.

### Test Steps
1. Confirm subscription banner text is no longer blue for the light theme.
2. Confirm there's some bottom padding with subscription banners on devices that have a home button (I tested on iPhone 7).
3. Confirm you now see a bottom shadow on top banners, and a top shadow on bottom banners.
