### PR TITLE
Talk page menu - render images as template

### DIFF
--- a/Wikipedia/Images.xcassets/language-talk-page.imageset/Contents.json
+++ b/Wikipedia/Images.xcassets/language-talk-page.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Wikipedia/Images.xcassets/user-contributions.imageset/Contents.json
+++ b/Wikipedia/Images.xcassets/user-contributions.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T310294#8335525

### Notes
* This PR fixes the rendering of images  in dark mode

### Test Steps
1. Set the app theme to default and set the device to dark mode (on device settings)
2. Check that all the overflow menu icons are visible
