### PR TITLE
Fix build server

### DIFF
--- a/Wikipedia/Experimental-Info.plist
+++ b/Wikipedia/Experimental-Info.plist
@@ -73,6 +73,8 @@
 		<string>org.wikimedia.wikipedia.article</string>
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
+	<key>UIApplicationShortcutWidget</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/Experimental-Info.plist
+++ b/Wikipedia/Experimental-Info.plist
@@ -73,8 +73,6 @@
 		<string>org.wikimedia.wikipedia.article</string>
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
-	<key>UIApplicationShortcutWidget</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/Experimental-Info.plist
+++ b/Wikipedia/Experimental-Info.plist
@@ -74,7 +74,7 @@
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
 	<key>UIApplicationShortcutWidget</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER).ContinueReadingWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/Local-Info.plist
+++ b/Wikipedia/Local-Info.plist
@@ -78,8 +78,6 @@
 		<string>org.wikimedia.wikipedia.article</string>
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
-	<key>UIApplicationShortcutWidget</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/Local-Info.plist
+++ b/Wikipedia/Local-Info.plist
@@ -78,6 +78,8 @@
 		<string>org.wikimedia.wikipedia.article</string>
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
+	<key>UIApplicationShortcutWidget</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/Local-Info.plist
+++ b/Wikipedia/Local-Info.plist
@@ -79,7 +79,7 @@
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
 	<key>UIApplicationShortcutWidget</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER).ContinueReadingWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/Staging-Info.plist
+++ b/Wikipedia/Staging-Info.plist
@@ -69,6 +69,8 @@
 		<string>org.wikimedia.wikipedia.article</string>
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
+	<key>UIApplicationShortcutWidget</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/Staging-Info.plist
+++ b/Wikipedia/Staging-Info.plist
@@ -70,7 +70,7 @@
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
 	<key>UIApplicationShortcutWidget</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER).ContinueReadingWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/Staging-Info.plist
+++ b/Wikipedia/Staging-Info.plist
@@ -69,8 +69,6 @@
 		<string>org.wikimedia.wikipedia.article</string>
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
-	<key>UIApplicationShortcutWidget</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/User Testing-Info.plist
+++ b/Wikipedia/User Testing-Info.plist
@@ -67,6 +67,8 @@
 		<string>org.wikimedia.wikipedia.article</string>
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
+	<key>UIApplicationShortcutWidget</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/User Testing-Info.plist
+++ b/Wikipedia/User Testing-Info.plist
@@ -68,7 +68,7 @@
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
 	<key>UIApplicationShortcutWidget</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER).ContinueReadingWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/User Testing-Info.plist
+++ b/Wikipedia/User Testing-Info.plist
@@ -67,8 +67,6 @@
 		<string>org.wikimedia.wikipedia.article</string>
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
-	<key>UIApplicationShortcutWidget</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/Wikipedia-Info.plist
+++ b/Wikipedia/Wikipedia-Info.plist
@@ -67,6 +67,8 @@
 		<string>org.wikimedia.wikipedia.article</string>
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
+	<key>UIApplicationShortcutWidget</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/Wikipedia-Info.plist
+++ b/Wikipedia/Wikipedia-Info.plist
@@ -68,7 +68,7 @@
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
 	<key>UIApplicationShortcutWidget</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER).ContinueReadingWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Wikipedia/Wikipedia-Info.plist
+++ b/Wikipedia/Wikipedia-Info.plist
@@ -67,8 +67,6 @@
 		<string>org.wikimedia.wikipedia.article</string>
 		<string>org.wikimedia.wikipedia.searchresults</string>
 	</array>
-	<key>UIApplicationShortcutWidget</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER).TopReadWidget</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>


### PR DESCRIPTION
**Phabricator:** 
N/A, but caused by https://phabricator.wikimedia.org/T319206

### Notes
Fixes the build server error:

> Invalid Info.plist value. The value for key UIApplicationShortcutWidget must be the bundle identifier of a Today extension in the app.

I missed a change needed when working on #4391. We removed two of our old-style redundant widgets because we started getting deprecation warnings, and suppressed the warnings on the continue reading widget. Updating this flag to our remaining Continue Reading widget ID fixes it.

### Test Steps
Build has already been deployed from this branch, so testing is done.

