### PR TITLE
Reading list import logging

### DIFF
--- a/Wikipedia/Code/CreateReadingListViewController.swift
+++ b/Wikipedia/Code/CreateReadingListViewController.swift
@@ -128,6 +128,11 @@ class CreateReadingListViewController: WMFScrollViewController, UITextFieldDeleg
 // MARK: Actions
     
     @objc func closeButtonTapped(_ sender: UIButton) {
+        
+        if isInImportingMode {
+            ReadingListsFunnel.shared.logCancelImport()
+        }
+        
         navigationController?.dismiss(animated: true)
     }
     
@@ -274,6 +279,13 @@ private extension CreateReadingListViewController {
         }
         
         self.importedReadingList = importedReadingList
+        
+        var loggingArticleCount = 0
+        for (_, value) in importedReadingList.list {
+            loggingArticleCount = loggingArticleCount + value.count
+        }
+        
+        ReadingListsFunnel.shared.logStartImport(articlesCount: loggingArticleCount)
 
         pageURLsFromImportedReadingList(importedReadingList) { [weak self] result in
             switch result {

--- a/Wikipedia/Code/EventLoggingFunnel.h
+++ b/Wikipedia/Code/EventLoggingFunnel.h
@@ -18,6 +18,7 @@ extern EventLoggingCategory const EventLoggingCategoryArticle;
 extern EventLoggingCategory const EventLoggingCategorySearch;
 extern EventLoggingCategory const EventLoggingCategoryAddToList;
 extern EventLoggingCategory const EventLoggingCategorySaved;
+extern EventLoggingCategory const EventLoggingCategoryShared;
 extern EventLoggingCategory const EventLoggingCategoryLogin;
 extern EventLoggingCategory const EventLoggingCategorySetting;
 extern EventLoggingCategory const EventLoggingCategoryLoginToSyncPopover;

--- a/Wikipedia/Code/EventLoggingFunnel.m
+++ b/Wikipedia/Code/EventLoggingFunnel.m
@@ -9,6 +9,7 @@ EventLoggingCategory const EventLoggingCategoryArticle = @"article";
 EventLoggingCategory const EventLoggingCategorySearch = @"search";
 EventLoggingCategory const EventLoggingCategoryAddToList = @"add_to_list";
 EventLoggingCategory const EventLoggingCategorySaved = @"saved";
+EventLoggingCategory const EventLoggingCategoryShared = @"shared";
 EventLoggingCategory const EventLoggingCategoryLogin = @"login";
 EventLoggingCategory const EventLoggingCategorySetting = @"setting";
 EventLoggingCategory const EventLoggingCategoryLoginToSyncPopover = @"login_to_sync_popover";

--- a/Wikipedia/Code/ReadingListDetailViewController.swift
+++ b/Wikipedia/Code/ReadingListDetailViewController.swift
@@ -159,8 +159,10 @@ class ReadingListDetailViewController: ViewController {
             }
 
             self.seenSurveyPrompt = true
+            ReadingListsFunnel.shared.logPresentedSurveyPrompt()
 
             self.wmf_showReadingListImportSurveyPanel(primaryButtonTapHandler: { (sender) in
+                ReadingListsFunnel.shared.logTappedTakeSurvey()
                 self.navigate(to: surveyURL, useSafari: true)
                 // dismiss handler is called
             }, secondaryButtonTapHandler: { (sender) in

--- a/Wikipedia/Code/ReadingListsFunnel.swift
+++ b/Wikipedia/Code/ReadingListsFunnel.swift
@@ -17,8 +17,7 @@
     }
     
     private override init() {
-        // TODO: Update version number for new schema with import shared reading list actions/category
-        super.init(schema: "MobileWikiAppiOSReadingLists", version: 18280648)
+        super.init(schema: "MobileWikiAppiOSReadingLists", version: 24086844)
     }
     
     private func event(category: EventLoggingCategory, label: EventLoggingLabel?, action: Action, measure: Int? = nil, measureAge: Int? = nil, measurePosition: Int? = nil) -> [String: Any] {

--- a/Wikipedia/Code/ReadingListsFunnel.swift
+++ b/Wikipedia/Code/ReadingListsFunnel.swift
@@ -15,13 +15,16 @@
         super.init(schema: "MobileWikiAppiOSReadingLists", version: 18280648)
     }
     
-    private func event(category: EventLoggingCategory, label: EventLoggingLabel?, action: Action, measure: Int = 1, measureAge: Int? = nil, measurePosition: Int? = nil) -> [String: Any] {
+    private func event(category: EventLoggingCategory, label: EventLoggingLabel?, action: Action, measure: Int? = nil, measureAge: Int? = nil, measurePosition: Int? = nil) -> [String: Any] {
         let category = category.rawValue
         let action = action.rawValue
         
-        var event: [String: Any] = ["category": category, "action": action, "measure": measure, "primary_language": primaryLanguage(), "is_anon": isAnon]
+        var event: [String: Any] = ["category": category, "action": action, "primary_language": primaryLanguage(), "is_anon": isAnon]
         if let label = label?.rawValue {
             event["label"] = label
+        }
+        if let measure = measure {
+            event["measure"] = measure
         }
         if let measurePosition = measurePosition {
             event["measure_position"] = measurePosition
@@ -131,7 +134,7 @@
     }
     
     public func logReadStartIReadingList(_ articleURL: URL) {
-        log(event(category: .saved, label: .items, action: .readStart), language: articleURL.wmf_languageCode)
+        log(event(category: .saved, label: .items, action: .readStart, measure: 1), language: articleURL.wmf_languageCode)
     }
     
     // - MARK: Saved - reading lists
@@ -141,7 +144,7 @@
     }
     
     public func logCreateInReadingLists() {
-        log(event(category: .saved, label: .lists, action: .createList))
+        log(event(category: .saved, label: .lists, action: .createList, measure: 1))
     }
     
     // - MARK: Add articles to reading list
@@ -151,6 +154,6 @@
     }
     
     public func logCreateInAddToReadingList() {
-        log(event(category: .addToList, label: nil, action: .createList))
+        log(event(category: .addToList, label: nil, action: .createList, measure: 1))
     }
 }

--- a/Wikipedia/Code/ReadingListsFunnel.swift
+++ b/Wikipedia/Code/ReadingListsFunnel.swift
@@ -9,9 +9,15 @@
         case createList = "createlist"
         case deleteList = "deletelist"
         case readStart = "read_start"
+        case receiveStart = "receive_start"
+        case receiveCancel = "receive_cancel"
+        case receiveFinish = "receive_finish"
+        case surveyShown = "survey_shown"
+        case surveyClicked = "survey_clicked"
     }
     
     private override init() {
+        // TODO: Update version number for new schema with import shared reading list actions/category
         super.init(schema: "MobileWikiAppiOSReadingLists", version: 18280648)
     }
     
@@ -155,5 +161,27 @@
     
     public func logCreateInAddToReadingList() {
         log(event(category: .addToList, label: nil, action: .createList, measure: 1))
+    }
+    
+    // - MARK: Import Shared Reading Lists
+    
+    public func logStartImport(articlesCount: Int) {
+        log(event(category: .shared, label: nil, action: .receiveStart, measure: articlesCount))
+    }
+    
+    public func logCancelImport() {
+        log(event(category: .shared, label: nil, action: .receiveCancel))
+    }
+    
+    public func logCompletedImport(articlesCount: Int) {
+        log(event(category: .shared, label: nil, action: .receiveFinish, measure: articlesCount))
+    }
+    
+    public func logPresentedSurveyPrompt() {
+        log(event(category: .shared, label: nil, action: .surveyShown))
+    }
+    
+    public func logTappedTakeSurvey() {
+        log(event(category: .shared, label: nil, action: .surveyClicked))
     }
 }

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -242,7 +242,8 @@ extension WMFAppViewController: CreateReadingListDelegate {
         do {
             createReadingListViewController.createReadingListButton.isEnabled = false
             let readingList = try dataStore.readingListsController.createReadingList(named: name, description: description, with: articles)
-           showImportedReadingList(readingList)
+            ReadingListsFunnel.shared.logCompletedImport(articlesCount: articles.count)
+            showImportedReadingList(readingList)
 
         } catch let error {
             switch error {


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T322805

### Notes
This PR adds the event logging for importing shared reading lists. 

### Test Steps
1. Fresh install an app, then toggle on logging either via the onboarding flow or app Settings.
2. Inspect traffic via a proxy, look for traffic with `MobileWikiAppiOSReadingLists` in the url.
3. Trigger the reading list import modal by visiting [the landing page](https://en.m.wikipedia.beta.wmflabs.org/wiki/Special:ReadingLists?limport=eyJsaXN0Ijp7ImVuIjpbNTk4NzQsMzE4ODMsMjQ4NjgsMTQzODFdLCJydSI6WzU5ODc0LDMxODgzLDI0ODY4LDE0MzgxXX19) in Safari.
4. Via proxy, confirm you see an event call with `category: shared`, `action: receive_start`, and `measure: 8` (the number of articles that are shared in this particular landing page link).
5. Tap X. Confirm you see an event with `category: shared` and `action: receive_cancel`
6. Repeat step 3, then tap `Create reading list` button. Confirm you see an event with `category: shared`, `action: receive_finish`, and `measure: 8`.
7. Wait until survey appears on the reading list detail screen.  Confirm you see an event with `category: shared`, `action: survey_shown`.
8. Tap the take survey button. Confirm you see an event with `category: shared`, `action: survey_clicked`.

