### PR TITLE
Attempt to fix RMessageView crash

### DIFF
--- a/Wikipedia/Third Party Code/RMessage/RMessage.m
+++ b/Wikipedia/Third Party Code/RMessage/RMessage.m
@@ -216,6 +216,10 @@ static NSLock *mLock, *nLock;
 
 + (void)prepareNotificationForPresentation:(RMessageView *)messageView
 {
+    if (!messageView) {
+        return;
+    }
+    
   [mLock lock];
   [[RMessage sharedMessage].messages addObject:messageView];
   [mLock unlock];

--- a/Wikipedia/Third Party Code/RMessage/RMessageView.m
+++ b/Wikipedia/Third Party Code/RMessage/RMessageView.m
@@ -253,7 +253,18 @@ static NSMutableDictionary *globalDesignDictionary;
     if (designError) return nil;
 
     [self setupDesign];
-    [self setupLayout];
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addToSuperviewForPresentation];
+      
+      // This check fixes an NSLayoutConstraint crash
+      // https://phabricator.wikimedia.org/T323163
+      if (self.superview) {
+          [self setupLayout];
+      } else {
+          [self removeFromSuperview];
+          return nil;
+      }
+      
     if (dismissingEnabled) {
       [self setupGestureRecognizers];
     } else {
@@ -451,13 +462,7 @@ static NSMutableDictionary *globalDesignDictionary;
 
 - (void)setupLayout
 {
-  self.translatesAutoresizingMaskIntoConstraints = NO;
-
-  // Add RMessage to superview
-  [self addToSuperviewForPresentation];
-
   if (self.messagePosition != RMessagePositionBottom) {
-    [self layoutIfNeeded];
     self.topToVCTopLayoutConstraint = [NSLayoutConstraint constraintWithItem:self.superview
                                                                 attribute:NSLayoutAttributeTop
                                                                 relatedBy:NSLayoutRelationEqual


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T323163

### Notes
This is an attempt to fix our RMessageView crashes. I cannot reproduce it, but I suspect the [superview reference](https://github.com/wikimedia/wikipedia-ios/blob/main/Wikipedia/Third%20Party%20Code/RMessage/RMessageView.m#L461) when setting up the constraints is occasionally nil, because when I replace that parameter with nil I see the same crash and call stack.

I think the better fix would be to have the superview set up all of these constraints, but that's too big of a change at this point in the release. So for now I'm just adding some defensive work to stop the display entirely if the superview is nil to avoid the crash.

### Test Steps
1. Regression test these toasts - subscribe/unsubscribe to a talk page topic, go to airplane mode, and confirm messages display fine as before.
2. Force a situation where the [new code](https://github.com/wikimedia/wikipedia-ios/blob/T323163/Wikipedia/Third%20Party%20Code/RMessage/RMessageView.m#L261-L266) is run with comments:

```
      //if (self.superview) {
      //    [self setupLayout];
      //} else {
          [self removeFromSuperview];
          return nil;
      //}
```

and repeat Step 1. Confirm toasts no longer display, and there are no crashes.