### PR TITLE
Scroll to article URL fragments

### DIFF
--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -443,12 +443,20 @@ class ArticleViewController: ViewController, HintPresenting {
             callLoadCompletionIfNecessary()
         }
         
-        guard let request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, revisionID: revisionID, scheme: schemeHandler.scheme, cachePolicy: cachePolicy, isPageView: true) else {
+        guard var request = try? fetcher.mobileHTMLRequest(articleURL: articleURL, revisionID: revisionID, scheme: schemeHandler.scheme, cachePolicy: cachePolicy, isPageView: true) else {
             showGenericError()
             state = .error
             return
         }
 
+        // Add the URL fragment to request, if the fragment exists
+        if let articleFragment = URLComponents(url: articleURL, resolvingAgainstBaseURL: true)?.fragment,
+           let url = request.url,
+           var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true) {
+            urlComponents.fragment = articleFragment
+            request.url = urlComponents.url
+        }
+        
         articleAsLivingDocController.articleContentWillBeginLoading(traitCollection: traitCollection, theme: theme)
 
         webView.load(request)

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -786,6 +786,7 @@ class ArticleViewController: ViewController, HintPresenting {
         }
         
         articleAsLivingDocController.handleArticleAsLivingDocLinkForAnchor(anchor, articleURL: articleURL)
+        show(anchor: anchor)
     }
     
     // MARK: Table of contents


### PR DESCRIPTION
**Phabricator: https://phabricator.wikimedia.org/T321066** 

### Notes
* Currently, links with fragments (such as sections and equations) do not scroll to the fragment when opened in the app, unless that article is already open. This is fixed by adding the fragment to the web view's `request` before loading, which triggers the existing `restoreScrollStateIfNecessary` method to scroll the view to the fragment after the web view loads.
* Currently, if the user has an article open in the app and clicks on a link to a fragment in that same article, nothing happens. This is fixed by adding a statement to scroll to the fragment in this case.

### Test 1 Steps: External link with fragment, different article
1. Make sure the “Juice” article is not currently open in the app
2. Paste this link into Safari: https://en.wikipedia.org/wiki/Juice#Preparation
3. Select the link and “Open in Wikipedia”
4. Should open the “Juice” article in the app and scroll to the “Preparation” section

### Test 2 Steps: Internal link with fragment, same article
1. Open this article in the app: [https://en.wikipedia.org/wiki/Eigenvalues_and_eigenvectors](https://en.wikipedia.org/wiki/Eigenvalues_and_eigenvectors)
2. Scroll to the “Algebraic multiplicity” section
3. Click the “Equation ([4](https://en.wikipedia.org/wiki/Eigenvalues_and_eigenvectors#math_4))” link
4. Should scroll to equation 4

