### PR TITLE
Remove excessive newlines in talk page headers

### DIFF
--- a/WMF Framework/URLComponents+Extensions.swift
+++ b/WMF Framework/URLComponents+Extensions.swift
@@ -80,6 +80,20 @@ extension URLComponents {
         percentEncodedPath = fullComponents.joined(separator: "/") // NSString.path(with: components) removes the trailing slash that the reading list API needs
     }
     
+    /// Removes all percent-encoding, then encodes charcters that are not allowed in each component.
+    mutating func encodeWhereNecessary() {
+        // The getters remove percent-encoding, then the setters add encoding
+        // where necessary for that component
+        scheme = scheme
+        host = host // uses punycode for domains with ASCII characters
+        port = port
+        path = path
+        query = query
+        fragment = fragment
+        user = user
+        password = password
+    }
+    
     public func wmf_URLWithLanguageVariantCode(_ code: String?) -> URL? {
         return (self as NSURLComponents).wmf_URL(withLanguageVariantCode: code)
     }

--- a/Wikipedia/Code/NSMutableAttributedString+RemoveNewLine.swift
+++ b/Wikipedia/Code/NSMutableAttributedString+RemoveNewLine.swift
@@ -11,4 +11,14 @@ extension NSMutableAttributedString {
         }
         return self
     }
+    
+    /// When there are more than two consecutive `\n` newline characters (there may be other whitespace between the newlines), removes all but two occurances
+    public func removingRepetitiveNewlineCharacters() -> Self {
+        var range = (string as NSString).range(of: "(\\s*\\n){3,}", options: .regularExpression)
+        while NSMaxRange(range) != NSNotFound {
+            replaceCharacters(in: range, with: "\n\n")
+            range = (string as NSString).range(of: "(\\s*\\n){3,}", options: .regularExpression)
+        }
+        return self
+    }
 }

--- a/Wikipedia/Code/TalkPageCoffeeRollView.swift
+++ b/Wikipedia/Code/TalkPageCoffeeRollView.swift
@@ -76,7 +76,7 @@ final class TalkPageCoffeeRollView: SetupView {
     }
     
     private func updateFonts() {
-        textView.attributedText = viewModel.coffeeRollText?.byAttributingHTML(with: .callout, boldWeight: .semibold, matching: traitCollection, color: theme.colors.primaryText, linkColor: theme.colors.link, handlingLists: true, handlingSuperSubscripts: true).removingInitialNewlineCharacters()
+        textView.attributedText = viewModel.coffeeRollText?.byAttributingHTML(with: .callout, boldWeight: .semibold, matching: traitCollection, color: theme.colors.primaryText, linkColor: theme.colors.link, handlingLists: true, handlingSuperSubscripts: true).removingInitialNewlineCharacters().removingRepetitiveNewlineCharacters()
     }
     
     private func updateSemanticContentAttribute(_ semanticContentAttribute: UISemanticContentAttribute) {

--- a/WikipediaUnitTests/Code/URLParsingAndRoutingTests.swift
+++ b/WikipediaUnitTests/Code/URLParsingAndRoutingTests.swift
@@ -148,12 +148,12 @@ class URLParsingAndRoutingTests: XCTestCase {
 
     func testSpecialCharactersEncodedOffWiki() {
         let url = URL(string: "https://de.wikipedia.org/wiki/Grinnell_College")!
-        XCTAssertEqual(url.resolvingRelativeWikiHref("//www.p%C3%BCzzledpint.com")?.absoluteString, "https://www.p%C3%BCzzledpint.com")
+        XCTAssertEqual(url.resolvingRelativeWikiHref("//www.p%C3%BCzzledpint.com")?.absoluteString, "https://www.xn--pzzledpint-9db.com")
     }
 
     func testSpecialCharactersUnencodedOffWiki() {
         let url = URL(string: "https://de.wikipedia.org/wiki/Grinnell_College")!
-        XCTAssertEqual(url.resolvingRelativeWikiHref("//www.püzzledpint.com")?.absoluteString, "https://www.p%C3%BCzzledpint.com")
+        XCTAssertEqual(url.resolvingRelativeWikiHref("//www.püzzledpint.com")?.absoluteString, "https://www.xn--pzzledpint-9db.com")
     }
 
     func testQuestionMark() {


### PR DESCRIPTION
**Phabricator: https://phabricator.wikimedia.org/T322955** 

### Notes
* Currently, there are sometimes sequences of consecutive newlines in the headers of talk pages, which creates large gaps in the text. This makes it difficult to read the pages
* This is fixed by cutting off consecutive newlines so that there are no more than two in a sequence

### Test Steps
1. Navigate to an article (Example: [Black Panther](https://en.wikipedia.org/wiki/Black_Panther:_Wakanda_Forever))
2. Navigate to the article talk page
3. Tap read more and view the topics
4. There should be no large gaps of multiple newlines between the text

### Screenshots/Videos
### Before change:
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-31 at 14 10 46](https://user-images.githubusercontent.com/53921230/210153613-92f1fe48-ca34-4040-a637-3fa233f347a2.png)

### After change:
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-31 at 14 12 35](https://user-images.githubusercontent.com/53921230/210153618-dc0af4ed-9cc5-4832-9710-8533885ee9db.png)


