### PR TITLE
Clear article cache after clearing history

### DIFF
--- a/Wikipedia/Code/HistoryViewController.swift
+++ b/Wikipedia/Code/HistoryViewController.swift
@@ -49,6 +49,7 @@ class HistoryViewController: ArticleFetchedResultsViewController {
     override func deleteAll() {
         do {
             try dataStore.viewContext.clearReadHistory()
+            dataStore.clearMemoryCache()
         } catch let error {
             showError(error)
         }


### PR DESCRIPTION
**Phabricator: https://phabricator.wikimedia.org/T317587** 

### Notes
* Currently, articles on the Explore page do not load properly after the history is cleared
* Articles are cached as `WMFArticle`s, a subclass of `NSManagedObject`
* When the Explore page first loads, all of the articles to be displayed on it are fetched from an `NSManagedObjectContext` (MWKDataStore.m, line 930) and cached (MWKDataStore.m, line 933)
* When the history "Clear" button is pressed, `HistoryViewController.deleteAll()` (HistoryViewController.swift, line 49) is called, which calls `NSManagedObjectContext.clearReadHistory()`, which calls `NSManagedObjectContext.reset()`
* `NSManagedObjectContext.reset()` is useful for clearing memory and improving performance, [but it does so by invalidating the `NSManagedObject`s fetched from it](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext/1506807-reset), including the cached articles
* The problem is that when the Explore page is loaded again, the articles in cache are invalid but not `nil`, so rather than re-fetching the articles the code tries to extract data from the invalid cached objects (MWKDataStore.m, line 925)
* This is fixed by clearing the cache every time history is cleared

### Test Steps
1. Visit at least one article to fill the history
2. Navigate to the history tab, press "Clear", then confirm to delete
3. Navigate back to the Explore page
4. Articles should load properly rather than some being blank