### PR TITLE
Do not prevent users from viewing talk page if summary call fails

### DIFF
--- a/Wikipedia/Code/TalkPageDataController.swift
+++ b/Wikipedia/Code/TalkPageDataController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WMF
+import CocoaLumberjackSwift
 
 /// Class that coordinates network fetches for talk pages.
 /// Leans on file persistence for offline mode as-needed.
@@ -51,7 +52,9 @@ class TalkPageDataController {
         
         fetchArticleSummaryIfNeeded(dispatchGroup: group) { articleSummary, errors in
             finalArticleSummary = articleSummary
-            finalErrors.append(contentsOf: errors)
+            if errors.count > 0 {
+                DDLogError("Error fetching article summary for talk page header. Ignoring.")
+            }
         }
         
         fetchLatestRevisionID(dispatchGroup: group) { revisionID in


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T321853

### Notes
This fixes a discrepancy we were seeing between Android and iOS on Talk Page Archives. For Elizabeth II > FAQ and Elizabeth II > Archive index, Android showed ann empty state, whereas iOS shows an error state.

This is because the summary fetch fails for these archived pages, and those pages happen to parse as empty. My fix is to not consider a summary fetch as a breaking failure. The header is capable of displaying without it, so we should still allow the user to see an empty state.

### Test Steps
1. Go to Elizabeth II's talk page. Confirm talk page displays fine.
2. Go to archives, tap an archived page. Confirm talk page displays fine.
3. Go to FAQ or Archive index. Confirm talk page displays empty state.

