### PR TITLE
Crash fixes

### DIFF
--- a/Wikipedia/Code/ArticleTableOfContentsDisplayController.swift
+++ b/Wikipedia/Code/ArticleTableOfContentsDisplayController.swift
@@ -91,6 +91,12 @@ class ArticleTableOfContentsDisplayController: Themeable {
         delegate?.getVisibleSection(with: { (sectionId, _) in
             self.viewController.isVisible = true
             self.selectAndScroll(to: sectionId, animated: false)
+            
+            // Attempt to fix TOC presentation crashes.
+            guard !self.viewController.isBeingPresented && self.delegate !== self.viewController else {
+                return
+            }
+            
             self.delegate?.present(self.viewController, animated: animated)
         })
     }

--- a/Wikipedia/Code/SchemeHandler/SchemeHandler.swift
+++ b/Wikipedia/Code/SchemeHandler/SchemeHandler.swift
@@ -181,6 +181,13 @@ private extension SchemeHandler {
                         SessionsFunnel.shared.clearPageLoadStartTime()
                     }
                 } else {
+                    
+                    // May fix potential crashes if we have already called urlSchemeTask.didFinish() or webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) has already been called.
+                    // https://developer.apple.com/documentation/webkit/wkurlschemetask/2890839-didreceive
+                    guard self.schemeTaskIsActive(urlSchemeTask: urlSchemeTask) else {
+                        return
+                    }
+                    
                     urlSchemeTask.didReceive(response)
                 }
             }

--- a/Wikipedia/Code/Session.swift
+++ b/Wikipedia/Code/Session.swift
@@ -742,6 +742,8 @@ class SessionDelegate: NSObject, URLSessionDelegate, URLSessionDataDelegate {
                 }
                 
                 callbacks.removeValue(forKey: taskIdentifier)
+
+                return
             }
         }
         


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T280700
https://phabricator.wikimedia.org/T280699

### Notes
Our crash rate has been creeping up the past few releases, so this is an attempt to address the highest ones. As usual with these, I could not repro, so I tried to do something light-touch in both instances to see if it improves things.

4f4d3c4567a85b43a8737e3f3c234b5fde37e7d8 - This tries to fix crashes originating from `TableOfContentsAnimator`. I was able to reproduce the stack traces by both putting presentation calls back-to-back in this area, as well as presenting on top of view controller itself:

```
self.delegate?.present(self.viewController, animated: animated)
self.delegate?.present(self.viewController, animated: animated)
```

```
self.viewController.present(self.viewController, animated: animated)
```

6f9402b356e48cb2069696dc499c7c8b8c9c7953 - This tries to fix our crash originating from `SchemeHandler.kickoffDataTask`. Just going off of the Apple Docs I found on the crash line, I think we are calling `urlSchemeTask.didReceive(response)` at some point after `urlSchemeTask.didFinish()` has been called, which will throw an exception.

### Test Steps
1. Regression test opening the article Table of Contents.
2. Regression test loading an article with an Internet connection, then save it for offline. Then enter airplane mode and load the article again.