### PR TITLE
Clear out featured article widget cache if article data changed

### DIFF
--- a/WMF Framework/SharedContainerCache.swift
+++ b/WMF Framework/SharedContainerCache.swift
@@ -81,3 +81,12 @@ public final class SharedContainerCache<T: Codable>: SharedContainerCacheHouseke
 @objc public protocol SharedContainerCacheHousekeepingProtocol: AnyObject {
     static func deleteStaleCachedItems(in subdirectoryPathComponent: String)
 }
+
+@objc public class SharedContainerCacheClearFeaturedArticleWrapper: NSObject {
+    @objc public static func clearOutFeaturedArticleWidgetCache() {
+        let sharedCache = SharedContainerCache<WidgetCache>(fileName: "Widget Cache", defaultCache: { WidgetCache(settings: .default, featuredContent: nil) })
+        var updatedCache = sharedCache.loadCache()
+        updatedCache.featuredContent = nil
+        sharedCache.saveCache(updatedCache)
+    }
+}

--- a/WMF Framework/SummaryExtensions.swift
+++ b/WMF Framework/SummaryExtensions.swift
@@ -63,6 +63,11 @@ extension WMFArticle {
             imageWidth = NSNumber(value: 0)
             imageHeight = NSNumber(value: 0)
         }
+        
+        if let thumbnail = summary.thumbnail {
+            thumbnailURLString = thumbnail.source
+            thumbnailURL = thumbnail.url
+        }
        
         wikidataDescription = summary.articleDescription
         wikidataID = summary.wikidataID

--- a/WMF Framework/WMFArticle+Extensions.h
+++ b/WMF Framework/WMFArticle+Extensions.h
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable WMFArticle *)fetchOrCreateArticleWithURL:(nullable NSURL *)articleURL updatedWithSearchResult:(nullable MWKSearchResult *)searchResult;
 
-- (nullable WMFArticle *)fetchOrCreateArticleWithURL:(nullable NSURL *)articleURL updatedWithFeedPreview:(nullable WMFFeedArticlePreview *)feedPreview pageViews:(nullable NSDictionary<NSDate *, NSNumber *> *)pageViews;
+- (nullable WMFArticle *)fetchOrCreateArticleWithURL:(nullable NSURL *)articleURL updatedWithFeedPreview:(nullable WMFFeedArticlePreview *)feedPreview pageViews:(nullable NSDictionary<NSDate *, NSNumber *> *)pageViews isFeatured:(BOOL)isFeatured;
 
 - (nullable WMFArticle *)fetchArticleWithWikidataID:(nullable NSString *)wikidataID;
 

--- a/WMF Framework/WMFArticle+Extensions.m
+++ b/WMF Framework/WMFArticle+Extensions.m
@@ -245,45 +245,55 @@
     return article;
 }
 
-- (nullable WMFArticle *)fetchOrCreateArticleWithURL:(nullable NSURL *)articleURL updatedWithFeedPreview:(nullable WMFFeedArticlePreview *)feedPreview pageViews:(nullable NSDictionary<NSDate *, NSNumber *> *)pageViews {
+- (nullable WMFArticle *)fetchOrCreateArticleWithURL:(nullable NSURL *)articleURL updatedWithFeedPreview:(nullable WMFFeedArticlePreview *)feedPreview pageViews:(nullable NSDictionary<NSDate *, NSNumber *> *)pageViews isFeatured:(BOOL)isFeatured {
     NSParameterAssert(articleURL);
     if (!articleURL) {
         return nil;
     }
 
-    WMFArticle *preview = [self fetchOrCreateArticleWithURL:articleURL];
+    WMFArticle *article = [self fetchOrCreateArticleWithURL:articleURL];
+    
+    if (isFeatured) {
+        WMFFeedArticlePreview *oldFeedPreview = [article feedArticlePreview];
+        if (![oldFeedPreview isEqual:feedPreview]) {
+            [SharedContainerCacheClearFeaturedArticleWrapper clearOutFeaturedArticleWidgetCache];
+        }
+    }
+    
     if ([feedPreview.displayTitleHTML length] > 0) {
-        preview.displayTitleHTML = feedPreview.displayTitleHTML;
+        article.displayTitleHTML = feedPreview.displayTitleHTML;
     } else if ([feedPreview.displayTitle length] > 0) {
-        preview.displayTitleHTML = feedPreview.displayTitle;
+        article.displayTitleHTML = feedPreview.displayTitle;
     }
     
     if ([feedPreview.wikidataDescription length] > 0) {
-        preview.wikidataDescription = feedPreview.wikidataDescription;
+        article.wikidataDescription = feedPreview.wikidataDescription;
     }
     if ([feedPreview.snippet length] > 0) {
-        preview.snippet = feedPreview.snippet;
+        article.snippet = feedPreview.snippet;
     }
     if (feedPreview.thumbnailURL != nil) {
-        preview.thumbnailURL = feedPreview.thumbnailURL;
+
+        article.thumbnailURL = feedPreview.thumbnailURL;
     }
     if (pageViews != nil) {
-        if (preview.pageViews == nil) {
-            preview.pageViews = pageViews;
+        if (article.pageViews == nil) {
+            article.pageViews = pageViews;
         } else {
-            preview.pageViews = [preview.pageViews mtl_dictionaryByAddingEntriesFromDictionary:pageViews];
+            article.pageViews = [article.pageViews mtl_dictionaryByAddingEntriesFromDictionary:pageViews];
         }
     }
     if (feedPreview.imageURLString != nil) {
-        preview.imageURLString = feedPreview.imageURLString;
+        article.imageURLString = feedPreview.imageURLString;
     }
     if (feedPreview.imageWidth != nil) {
-        preview.imageWidth = feedPreview.imageWidth;
+        article.imageWidth = feedPreview.imageWidth;
     }
     if (feedPreview.imageHeight != nil) {
-        preview.imageHeight = feedPreview.imageHeight;
+        article.imageHeight = feedPreview.imageHeight;
     }
-    return preview;
+    
+    return article;
 }
 
 @end

--- a/WMF Framework/WMFArticle+Extensions.swift
+++ b/WMF Framework/WMFArticle+Extensions.swift
@@ -51,4 +51,24 @@ extension WMFArticle {
             savedDate = newValue ? Date() : nil
         }
     }
+    
+    @objc public func feedArticlePreview() -> WMFFeedArticlePreview? {
+        
+        var dictionary: [AnyHashable: Any] = [
+            "displayTitle": displayTitle as Any,
+            "displayTitleHTML": displayTitleHTML,
+            "thumbnailURL": thumbnailURL as Any,
+            "imageURLString": imageURLString as Any,
+            "wikidataDescription": wikidataDescription as Any,
+            "snippet": snippet as Any,
+            "imageWidth": imageWidth as Any,
+            "imageHeight": imageHeight as Any
+        ]
+        
+        if let articleURLString = key?.decomposedStringWithCanonicalMapping {
+            dictionary["articleURL"] = URL(string: articleURLString)
+        }
+        
+        return try? WMFFeedArticlePreview(dictionary: dictionary)
+    }
 }

--- a/WMF Framework/Widget/WidgetController.swift
+++ b/WMF Framework/Widget/WidgetController.swift
@@ -40,6 +40,21 @@ public final class WidgetController: NSObject {
         WidgetCenter.shared.reloadAllTimelines()
 	}
     
+    public func reloadFeaturedArticleWidgetIfNecessary() {
+        guard !Bundle.main.isAppExtension else {
+            return
+        }
+
+        let dataStore = MWKDataStore.shared()
+        let appLanguage = dataStore.languageLinkController.appLanguage
+        if let siteURL = appLanguage?.siteURL, let languageCode = appLanguage?.languageCode {
+            let updatedWidgetSettings = WidgetSettings(siteURL: siteURL, languageCode: languageCode, languageVariantCode: appLanguage?.languageVariantCode)
+            updateCacheWith(settings: updatedWidgetSettings)
+        }
+        
+        WidgetCenter.shared.reloadTimelines(ofKind: SupportedWidget.featuredArticle.rawValue)
+    }
+    
     /// For requesting background time from widgets
     /// - Parameter userCompletion: the completion block to call with the result
     /// - Parameter task: block that takes the `MWKDataStore` to use for updates and the completion block to call when done as parameters

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -418,8 +418,14 @@ class ArticleViewController: ViewController, HintPresenting {
             return
         }
         
+        var oldFeedPreview: WMFFeedArticlePreview?
+        if isWidgetCachedFeaturedArticle {
+            oldFeedPreview = article.feedArticlePreview()
+        }
+        
         articleLoadWaitGroup?.enter()
         let cachePolicy: URLRequest.CachePolicy? = oldState == .reloading ? .reloadRevalidatingCacheData : nil
+        
         self.dataStore.articleSummaryController.updateOrCreateArticleSummaryForArticle(withKey: key, cachePolicy: cachePolicy) { (article, error) in
             defer {
                 self.articleLoadWaitGroup?.leave()
@@ -429,6 +435,14 @@ class ArticleViewController: ViewController, HintPresenting {
                 return
             }
             self.article = article
+            
+            if let oldFeedPreview,
+               let newFeedPreview = article.feedArticlePreview(),
+            oldFeedPreview != newFeedPreview {
+                SharedContainerCacheClearFeaturedArticleWrapper.clearOutFeaturedArticleWidgetCache()
+                WidgetController.shared.reloadFeaturedArticleWidgetIfNecessary()
+            }
+            
             // Handle redirects
             guard let newKey = article.inMemoryKey, newKey != key, let newURL = article.url else {
                 return
@@ -1022,6 +1036,16 @@ private extension ArticleViewController {
         toolbarController.apply(theme: theme)
         toolbarController.setSavedState(isSaved: article.isAnyVariantSaved)
         setToolbarHidden(false, animated: false)
+    }
+    
+    var isWidgetCachedFeaturedArticle: Bool {
+        let sharedCache = SharedContainerCache<WidgetCache>(fileName: "Widget Cache", defaultCache: { WidgetCache(settings: .default, featuredContent: nil) })
+        guard let widgetFeaturedArticleURLString = sharedCache.loadCache().featuredContent?.featuredArticle?.contentURL.desktop.page,
+              let widgetFeaturedArticleURL = URL(string: widgetFeaturedArticleURLString) else {
+            return false
+        }
+        
+        return widgetFeaturedArticleURL == articleURL
     }
     
 }

--- a/Wikipedia/Code/WMFFeedContentSource.m
+++ b/Wikipedia/Code/WMFFeedContentSource.m
@@ -189,7 +189,7 @@ NSInteger const WMFFeedInTheNewsNotificationViewCountDays = 5;
         return;
     }
 
-    [moc fetchOrCreateArticleWithURL:featuredURL updatedWithFeedPreview:preview pageViews:nil];
+    [moc fetchOrCreateArticleWithURL:featuredURL updatedWithFeedPreview:preview pageViews:nil isFeatured:YES];
 
     if (featured == nil) {
         [moc createGroupOfKind:WMFContentGroupKindFeaturedArticle forDate:date withSiteURL:self.siteURL associatedContent:@[featuredURL]];
@@ -206,7 +206,7 @@ NSInteger const WMFFeedInTheNewsNotificationViewCountDays = 5;
 
     [topRead.articlePreviews enumerateObjectsUsingBlock:^(WMFFeedTopReadArticlePreview *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
         NSURL *url = [obj articleURL];
-        [moc fetchOrCreateArticleWithURL:url updatedWithFeedPreview:obj pageViews:pageViews[url]];
+        [moc fetchOrCreateArticleWithURL:url updatedWithFeedPreview:obj pageViews:pageViews[url] isFeatured: NO];
     }];
 
     WMFContentGroup *group = [self topReadForDate:date inManagedObjectContext:moc];
@@ -289,7 +289,7 @@ NSInteger const WMFFeedInTheNewsNotificationViewCountDays = 5;
         [story.articlePreviews enumerateObjectsUsingBlock:^(WMFFeedArticlePreview *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
             NSURL *url = [obj articleURL];
             NSDictionary<NSDate *, NSNumber *> *pageViewsForURL = pageViews[url];
-            [moc fetchOrCreateArticleWithURL:url updatedWithFeedPreview:obj pageViews:pageViewsForURL];
+            [moc fetchOrCreateArticleWithURL:url updatedWithFeedPreview:obj pageViews:pageViewsForURL isFeatured: NO];
         }];
 
         NSString *featuredArticleTitleBasedOnSemanticLookup = [WMFFeedNewsStory semanticFeaturedArticleTitleFromStoryHTML:story.storyHTML siteURL:self.siteURL];

--- a/Wikipedia/Code/WMFOnThisDayContentSource.m
+++ b/Wikipedia/Code/WMFOnThisDayContentSource.m
@@ -87,7 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
                     [moc performBlock:^{
                         [onThisDayEvents enumerateObjectsUsingBlock:^(WMFFeedOnThisDayEvent *_Nonnull event, NSUInteger idx, BOOL *_Nonnull stop) {
                             [event.articlePreviews enumerateObjectsUsingBlock:^(WMFFeedArticlePreview *_Nonnull articlePreview, NSUInteger idx, BOOL *_Nonnull stop) {
-                                [moc fetchOrCreateArticleWithURL:[articlePreview articleURL] updatedWithFeedPreview:articlePreview pageViews:nil];
+                                [moc fetchOrCreateArticleWithURL:[articlePreview articleURL] updatedWithFeedPreview:articlePreview pageViews:nil isFeatured:NO];
                             }];
                             event.score = [event calculateScore];
                             event.index = @(idx);


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T331902

### Notes
This PR clears out the featured article widget cache from the app when new article data indicates it has changed. This is so that the featured article widget bypasses this [cache check](https://github.com/wikimedia/wikipedia-ios/blob/main/WMF%20Framework/Widget/WidgetController.swift#L216), so that old data isn't stuck on the widget for a day.

### Test Steps
1. With a proxy, locally map the explore feed daily call (https://en.wikipedia.org/api/rest_v1/feed/featured/2023/03/14) with some incorrect local data for the `tfa` object (Changing the `thumbnail.source` and `originalimage.source` values is a good test).
2. Run the app from this branch. Add the featured article home screen widget. Confirm you see the incorrect image in the widget.
3. Now uncheck the map local flag from your proxy so that the real data is fetched.
4. Tap your home screen widget so that you are taken to article view.
5. Background and go back to your home screen widget. Confirm it refreshes with the correct data.
6. Delete the app, repeat steps 1 - 3.
7. At this point, instead of tapping the home screen widget, foreground the app, go to the Explore tab and pull to refresh the Explore feed.
8. Background and go back to your home screen widget. Confirm it refreshes with the correct data.

### Screenshots
![out](https://user-images.githubusercontent.com/3620196/225165694-6b5f4360-d33b-4d23-974e-37a152b21254.gif)

