### PR TITLE
Protected page messages followup

### DIFF
--- a/WMF Framework/Router.swift
+++ b/WMF Framework/Router.swift
@@ -13,6 +13,7 @@ public class Router: NSObject {
         case audio(_: URL)
         case onThisDay(_: Int?)
         case readingListsImport(encodedPayload: String)
+        case login
     }
     
     unowned let configuration: Configuration
@@ -85,6 +86,11 @@ public class Router: NSObject {
                let username = loggedInUsername,
                let newURL = url.wmf_URL(withPath: "/wiki/Special:Contributions/\(username)", isMobile: true) {
                 return .inAppLink(newURL)
+            }
+            
+            if language.uppercased() == "EN" || language.uppercased() == "TEST",
+               title == "UserLogin" {
+                return .login
             }
             
             if title == "ReadingLists",
@@ -183,6 +189,13 @@ public class Router: NSObject {
         
         guard let title = maybeTitle else {
             return nil
+        }
+        
+        let language = project.languageCode ?? "en"
+        
+        if language.uppercased() == "EN" || language.uppercased() == "TEST",
+           title == "Special:UserLogin" {
+            return .login
         }
         
         if maybeLimit != nil,

--- a/Wikipedia/Code/Article as a Living Document/ArticleAsLivingDocViewController.swift
+++ b/Wikipedia/Code/Article as a Living Document/ArticleAsLivingDocViewController.swift
@@ -423,7 +423,8 @@ extension ArticleAsLivingDocViewController: ArticleAsLivingDocHorizontallyScroll
         guard let fullURL = delegate?.articleURL.resolvingRelativeWikiHref(url.absoluteString) else {
             return
         }
-        switch Configuration.current.router.destination(for: fullURL) {
+        let loggedInUsername = MWKDataStore.shared().authenticationManager.loggedInUsername
+        switch Configuration.current.router.destination(for: fullURL, loggedInUsername: loggedInUsername) {
         case .article(let articleURL): showInternalLink(url: articleURL)
         default: navigate(to: fullURL)
         }

--- a/Wikipedia/Code/ArticleContextMenuPresenting.swift
+++ b/Wikipedia/Code/ArticleContextMenuPresenting.swift
@@ -98,7 +98,8 @@ extension ArticleContextMenuPresenting {
     }
 
     func getPeekViewControllerAsync(for linkURL: URL, completion: @escaping (UIViewController?) -> Void) {
-        let destination = configuration.router.destination(for: linkURL)
+        let loggedInUsername = MWKDataStore.shared().authenticationManager.loggedInUsername
+        let destination = configuration.router.destination(for: linkURL, loggedInUsername: loggedInUsername)
         getPeekViewControllerAsync(for: destination, completion: completion)
     }
 

--- a/Wikipedia/Code/SectionEditorViewController.swift
+++ b/Wikipedia/Code/SectionEditorViewController.swift
@@ -158,7 +158,7 @@ class SectionEditorViewController: ViewController {
     }
 
     private func presentEditNoticesIfNecessary() {
-        guard UserDefaults.standard.wmf_alwaysDisplayEditNotices && lastBlockedDisplayError == nil else {
+        guard UserDefaults.standard.wmf_alwaysDisplayEditNotices && lastBlockedDisplayError == nil && self.userGroupLevelCanEdit else {
             return
         }
 

--- a/Wikipedia/Code/URL+LinkParsing.swift
+++ b/Wikipedia/Code/URL+LinkParsing.swift
@@ -205,7 +205,8 @@ extension URL {
     }
 
     public var doesOpenInBrowser: Bool {
-        return Configuration.current.router.doesOpenInBrowser(for: self)
+        let loggedInUsername = MWKDataStore.shared().authenticationManager.loggedInUsername
+        return Configuration.current.router.doesOpenInBrowser(for: self, loggedInUsername: loggedInUsername)
     }
 }
 

--- a/Wikipedia/Code/ViewControllerRouter.swift
+++ b/Wikipedia/Code/ViewControllerRouter.swift
@@ -42,6 +42,12 @@ class ViewControllerRouter: NSObject {
         self.appViewController = appViewController
         self.router = router
     }
+    
+    private func presentLoginViewController(with completion: @escaping () -> Void) -> Bool {
+        
+        appViewController.wmf_showLoginViewController(theme: appViewController.theme)
+        return true
+    }
 
     private func presentOrPush(_ viewController: UIViewController, with completion: @escaping () -> Void) -> Bool {
         guard let navigationController = appViewController.currentNavigationController else {
@@ -185,6 +191,8 @@ class ViewControllerRouter: NSObject {
             let createReadingListVC = CreateReadingListViewController(theme: theme, articles: [], encodedPageIds: encodedPayload, dataStore: appViewController.dataStore)
             createReadingListVC.delegate = appViewController
             return presentOrPush(createReadingListVC, with: completion)
+        case .login:
+            return presentLoginViewController(with: completion)
         default:
             completion()
             return false

--- a/Wikipedia/Code/ViewControllerRouter.swift
+++ b/Wikipedia/Code/ViewControllerRouter.swift
@@ -89,7 +89,8 @@ class ViewControllerRouter: NSObject {
     @objc(routeURL:userInfo:completion:)
     public func route(_ url: URL, userInfo: [AnyHashable: Any]? = nil, completion: @escaping () -> Void) -> Bool {
         let theme = appViewController.theme
-        let destination = router.destination(for: url)
+        let loggedInUsername = MWKDataStore.shared().authenticationManager.loggedInUsername
+        let destination = router.destination(for: url, loggedInUsername: loggedInUsername)
         switch destination {
         case .article(let articleURL):
             appViewController.swiftCompatibleShowArticle(with: articleURL, animated: true, completion: completion)

--- a/WikipediaUnitTests/Code/URLParsingAndRoutingTests.swift
+++ b/WikipediaUnitTests/Code/URLParsingAndRoutingTests.swift
@@ -22,10 +22,42 @@ class URLParsingAndRoutingTests: XCTestCase {
     
     func testMainPage() {
         let enMainPageURL = URL(string: "https://en.m.wikipedia.org/wiki/Main_Page")!
-        let dest = router.destination(for: enMainPageURL)
+        let dest = router.destination(for: enMainPageURL, loggedInUsername: nil)
         switch dest {
         case .inAppLink(let linkURL):
             XCTAssertEqual(linkURL, enMainPageURL.canonical)
+        default:
+            XCTAssertTrue(false)
+        }
+    }
+    
+    func testSpecialDestinations() {
+        let myTalkURL = URL(string: "https://en.wikipedia.org/wiki/Special:MyTalk")!
+        let myTalkDest = router.destination(for: myTalkURL, loggedInUsername: "Jimbo Wales")
+        
+        switch myTalkDest {
+        case .userTalk:
+            XCTAssertTrue(true)
+        default:
+            XCTAssertTrue(false)
+        }
+        
+        let myContributionsURL = URL(string: "https://en.wikipedia.org/wiki/Special:MyContributions")!
+        let myContributionsDest = router.destination(for: myContributionsURL, loggedInUsername: "Jimbo Wales")
+        
+        switch myContributionsDest {
+        case .inAppLink:
+            XCTAssertTrue(true)
+        default:
+            XCTAssertTrue(false)
+        }
+        
+        let importReadingListsURL = URL(string: "https://en.wikipedia.org/wiki/Special:ReadingLists?limport=eyJsaXN0Ijp7ImVuIjpbMjE4NjksMzI3NDUsNDQ0NjksNDQ0NzQsODI3ODBdfX0=")!
+        let importReadingListsDest = router.destination(for: importReadingListsURL, loggedInUsername: nil)
+        
+        switch importReadingListsDest {
+        case .readingListsImport:
+            XCTAssertTrue(true)
         default:
             XCTAssertTrue(false)
         }
@@ -37,7 +69,7 @@ class URLParsingAndRoutingTests: XCTestCase {
             return
         }
         
-        var dest = router.destination(for: components.url!)
+        var dest = router.destination(for: components.url!, loggedInUsername: nil)
         switch dest {
         case .userTalk(let linkURL):
             XCTAssertEqual(linkURL, components.url!.canonical)
@@ -46,7 +78,7 @@ class URLParsingAndRoutingTests: XCTestCase {
         }
 
         components.path = "/wiki//æ/_raising"
-        dest = router.destination(for: components.url!)
+        dest = router.destination(for: components.url!, loggedInUsername: nil)
         switch dest {
         case .article(let linkURL):
             XCTAssertEqual(linkURL, components.url!.canonical)
@@ -56,7 +88,7 @@ class URLParsingAndRoutingTests: XCTestCase {
         
         components.host = "fr.m.wikipedia.org"
         components.path = "/wiki/France"
-        dest = router.destination(for: components.url!)
+        dest = router.destination(for: components.url!, loggedInUsername: nil)
         switch dest {
         case .article(let linkURL):
             XCTAssertEqual(linkURL, components.url!.canonical)
@@ -66,7 +98,7 @@ class URLParsingAndRoutingTests: XCTestCase {
         
         // Special should work on frwiki because it's a canonical namespace
         components.path = "/wiki/Special:MobileDiff/24601"
-        dest = router.destination(for: components.url!)
+        dest = router.destination(for: components.url!, loggedInUsername: nil)
         switch dest {
         case .articleDiffSingle(let linkURL, _, let toRevID):
             XCTAssertEqual(linkURL, components.url!.canonical)
@@ -77,7 +109,7 @@ class URLParsingAndRoutingTests: XCTestCase {
         
         components.host = "zh.m.wikipedia.org"
         components.path = "/wiki/特殊:MobileDiff/24601"
-        dest = router.destination(for: components.url!)
+        dest = router.destination(for: components.url!, loggedInUsername: nil)
         switch dest {
         case .articleDiffSingle(let linkURL, _, let toRevID):
             XCTAssertEqual(linkURL, components.url!.canonical)

--- a/WikipediaUnitTests/Code/URLParsingAndRoutingTests.swift
+++ b/WikipediaUnitTests/Code/URLParsingAndRoutingTests.swift
@@ -52,6 +52,26 @@ class URLParsingAndRoutingTests: XCTestCase {
             XCTAssertTrue(false)
         }
         
+        let userLoginURL1 = URL(string: "https://en.wikipedia.org/wiki/Special:UserLogin")!
+        let userLoginDest1 = router.destination(for: userLoginURL1, loggedInUsername: nil)
+        
+        switch userLoginDest1 {
+        case .login:
+            XCTAssertTrue(true)
+        default:
+            XCTAssertTrue(false)
+        }
+        
+        let userLoginURL2 = URL(string: "https://en.wikipedia.org/w/index.php?title=Special:UserLogin")!
+        let userLoginDest2 = router.destination(for: userLoginURL2, loggedInUsername: nil)
+        
+        switch userLoginDest2 {
+        case .login:
+            XCTAssertTrue(true)
+        default:
+            XCTAssertTrue(false)
+        }
+        
         let importReadingListsURL = URL(string: "https://en.wikipedia.org/wiki/Special:ReadingLists?limport=eyJsaXN0Ijp7ImVuIjpbMjE4NjksMzI3NDUsNDQ0NjksNDQ0NzQsODI3ODBdfX0=")!
         let importReadingListsDest = router.destination(for: importReadingListsURL, loggedInUsername: nil)
         


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T313772

### Notes
These are a couple of follow-ons I wanted to add after testing some protected articles.

7071a20 - This makes no difference in the UI, but I noticed a console complaint that it was trying to present edit notices on top of the page protection modal. This fixes it so that the console complaint goes away.
aea7095 & 9920baa - I noticed an EN page protection error message that has a link to prompt a user to log in or create an account. Unfortunately it sent them to a web view, which does not share login data with the native app. This instead navigates them to our native login screen and adds tests. Unfortunately this may only work for EN. We can fix it for the other languages when we pick up https://phabricator.wikimedia.org/T328678.

### Test Steps
1. On EN Wikipedia, try to edit article Donald Trump. Confirm you don't see a console error for edit notice presentation.
2. On EN Wikipedia while logged out, try to edit article Barack Obama. Confirm you see a page protection error. In the text, find the links for "log in" and "create one". Tap them, and confirm they dismiss the editor and present the login modal.