### PR TITLE
MEP session tweaks

### DIFF
--- a/WMF Framework/Event Platform/EventPlatformClient.swift
+++ b/WMF Framework/Event Platform/EventPlatformClient.swift
@@ -83,9 +83,12 @@ import CocoaLumberjackSwift
         userSession.reset()
     }
     
-    public typealias DidResetSession = Bool
-    public func appDidBecomeActive() -> DidResetSession {
-        return userSession.appDidBecomeActive()
+    public func generateSessionID() {
+        userSession.generateSessionID()
+    }
+    
+    public func needsReset() -> Bool {
+        return userSession.needsReset()
     }
     
     public func appDidBackground() {
@@ -521,10 +524,11 @@ import CocoaLumberjackSwift
      *   1st preferred language – in which case use
      *   `MWKLanguageLinkController.sharedInstance().appLanguage.siteURL().host`
      */
-    public func submit<E: EventInterface>(stream: Stream, event: E, domain: String? = nil) {
+    public func submit<E: EventInterface>(stream: Stream, event: E, domain: String? = nil, completion: (() -> Void)? = nil) {
         let date = Date() // Record the date synchronously so there's no delay
         encodeQueue.async {
             self._submit(stream: stream, event: event, date: date, domain: domain)
+            completion?()
         }
     }
 

--- a/WMF Framework/Event Platform/EventPlatformClient.swift
+++ b/WMF Framework/Event Platform/EventPlatformClient.swift
@@ -78,9 +78,9 @@ import CocoaLumberjackSwift
         return userSession.sessionStartDate
     }
         
-    public func reset() {
+    public func resetAll() {
         samplingController.removeAllSamplingCache()
-        userSession.reset()
+        userSession.resetAll()
     }
     
     public func generateSessionID() {
@@ -89,6 +89,10 @@ import CocoaLumberjackSwift
     
     public func needsReset() -> Bool {
         return userSession.needsReset()
+    }
+    
+    public func resetBackgroundTimestamp() {
+        userSession.resetBackgroundTimestamp()
     }
     
     public func appDidBackground() {

--- a/WMF Framework/Event Platform/EventPlatformClient.swift
+++ b/WMF Framework/Event Platform/EventPlatformClient.swift
@@ -73,10 +73,25 @@ import CocoaLumberjackSwift
     var sessionID: String {
         return userSession.sessionID
     }
-
-    public func resetCaching() {
-        samplingController.removeAllSamplingCache()
+    
+    public var sessionStartDate: Date? {
+        return userSession.sessionStartDate
     }
+        
+    public func reset() {
+        samplingController.removeAllSamplingCache()
+        userSession.reset()
+    }
+    
+    public typealias DidResetSession = Bool
+    public func appDidBecomeActive() -> DidResetSession {
+        return userSession.appDidBecomeActive()
+    }
+    
+    public func appDidBackground() {
+        userSession.appDidBackground()
+    }
+    
     /**
      * Store events until the library is finished initializing
      *

--- a/WMF Framework/Event Platform/EventPlatformClientWorker.swift
+++ b/WMF Framework/Event Platform/EventPlatformClientWorker.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-@objc(WMFMetricsClientBridge)
-public class MetricsClientBridge: NSObject {
+@objc(WMFEventPlatformClientWorker)
+public class EventPlatformClientWorker: NSObject {
     
     let client = EventPlatformClient.shared
     
-    @objc(sharedInstance) public static let shared: MetricsClientBridge = {
-        return MetricsClientBridge()
+    @objc(sharedInstance) public static let shared: EventPlatformClientWorker = {
+        return EventPlatformClientWorker()
     }()
 }
 
 // MARK: PeriodicWorker
 
-extension MetricsClientBridge: PeriodicWorker {
+extension EventPlatformClientWorker: PeriodicWorker {
     public func doPeriodicWork(_ completion: @escaping () -> Void) {
         guard let storageManager = self.client.storageManager else {
             return
@@ -25,7 +25,7 @@ extension MetricsClientBridge: PeriodicWorker {
 
 // MARK: BackgroundFetcher
 
-extension MetricsClientBridge: BackgroundFetcher {
+extension EventPlatformClientWorker: BackgroundFetcher {
     public func performBackgroundFetch(_ completion: @escaping (UIBackgroundFetchResult) -> Void) {
         doPeriodicWork {
             completion(.noData)

--- a/WMF Framework/Event Platform/MetricsClientBridge.swift
+++ b/WMF Framework/Event Platform/MetricsClientBridge.swift
@@ -4,28 +4,10 @@ import Foundation
 public class MetricsClientBridge: NSObject {
     
     let client = EventPlatformClient.shared
-    let session = UserSession.shared
     
     @objc(sharedInstance) public static let shared: MetricsClientBridge = {
         return MetricsClientBridge()
     }()
-    
-    @objc public func appInBackground() {
-        session.logSessionEndTimestamp()
-    }
-    
-    @objc public func appInForeground() {
-        session.appInForeground()
-    }
-    
-    @objc public func appWillClose() {
-        session.appWillClose()
-    }
-    
-    @objc public func reset() {
-        session.reset()
-    }
-    
 }
 
 // MARK: PeriodicWorker

--- a/WMF Framework/UserSession.swift
+++ b/WMF Framework/UserSession.swift
@@ -41,7 +41,7 @@ public final class UserSession: NSObject {
     /**
      * Reset the session ID
      */
-    func reset() {
+    func resetAll() {
         UserDefaults.standard.wmf_sessionID = nil
         UserDefaults.standard.wmf_sessionStartTimestamp = nil
         UserDefaults.standard.wmf_sessionBackgroundTimestamp = nil
@@ -53,6 +53,10 @@ public final class UserSession: NSObject {
      */
     func needsReset() -> Bool {
         return self.hasSessionTimedOut()
+    }
+    
+    func resetBackgroundTimestamp() {
+        UserDefaults.standard.wmf_sessionBackgroundTimestamp = nil
     }
 
     /**

--- a/WMF Framework/UserSession.swift
+++ b/WMF Framework/UserSession.swift
@@ -33,6 +33,10 @@ public final class UserSession: NSObject {
     var sessionStartDate: Date? {
         return UserDefaults.standard.wmf_sessionStartTimestamp
     }
+    
+    func generateSessionID() {
+        _ = self.sessionID
+    }
 
     /**
      * Reset the session ID
@@ -47,14 +51,8 @@ public final class UserSession: NSObject {
      * If it has been more than 30 minutes since the app entered background state,
      * a new session is started.
      */
-    typealias DidResetSession = Bool
-    func appDidBecomeActive() -> DidResetSession {
-        if self.hasSessionTimedOut() {
-            self.reset()
-            return true
-        }
-        
-        return false
+    func needsReset() -> Bool {
+        return self.hasSessionTimedOut()
     }
 
     /**
@@ -93,6 +91,6 @@ public final class UserSession: NSObject {
             return false
         }
         
-        return lastTimestamp.timeIntervalSinceNow < -100
+        return lastTimestamp.timeIntervalSinceNow < -1800
     }
 }

--- a/WMF Framework/UserSession.swift
+++ b/WMF Framework/UserSession.swift
@@ -8,10 +8,8 @@ public final class UserSession: NSObject {
     @objc public static let shared: UserSession = {
         return UserSession()
     }()
-
-    private let queue = DispatchQueue(label: "UserSessionClient-" + UUID().uuidString)
-
-    public var hasSessionTimedOut: Bool = false
+    
+    // MARK: Internal
 
     /**
      * Return a session identifier
@@ -20,19 +18,58 @@ public final class UserSession: NSObject {
      * The identifier is a string of 20 zero-padded hexadecimal digits
      * representing a uniformly random 80-bit integer.
      */
-    internal var sessionID: String {
-        queue.sync {
-            var _sessionID = UserDefaults.standard.wmf_sessionID
-            guard let sID = _sessionID else {
-                let newID = generateID()
-                _sessionID = newID
-                UserDefaults.standard.wmf_sessionID = _sessionID
-                return newID
-            }
-            return sID
+    var sessionID: String {
+        var _sessionID = UserDefaults.standard.wmf_sessionID
+        guard let sID = _sessionID else {
+            let newID = generateID()
+            _sessionID = newID
+            UserDefaults.standard.wmf_sessionID = _sessionID
+            UserDefaults.standard.wmf_sessionStartTimestamp = Date()
+            return newID
         }
+        return sID
+    }
+    
+    var sessionStartDate: Date? {
+        return UserDefaults.standard.wmf_sessionStartTimestamp
     }
 
+    /**
+     * Reset the session ID
+     */
+    func reset() {
+        UserDefaults.standard.wmf_sessionID = nil
+        UserDefaults.standard.wmf_sessionStartTimestamp = nil
+        UserDefaults.standard.wmf_sessionBackgroundTimestamp = nil
+    }
+
+    /**
+     * If it has been more than 30 minutes since the app entered background state,
+     * a new session is started.
+     */
+    typealias DidResetSession = Bool
+    func appDidBecomeActive() -> DidResetSession {
+        if self.hasSessionTimedOut() {
+            self.reset()
+            return true
+        }
+        
+        return false
+    }
+
+    /**
+     * This method should be called upon app background
+     *
+     * We now persist session ID on app close to match session handling with Android
+     * session ends when 30 minutes of inactivity have passed.
+     */
+    func appDidBackground() {
+        UserDefaults.standard.wmf_sessionBackgroundTimestamp = Date()
+    }
+    
+    
+    // MARK: Private
+    
     /**
      * Generates a new identifier using the same algorithm as EPC libraries for
      * web and Android
@@ -44,90 +81,22 @@ public final class UserSession: NSObject {
         }
         return id
     }
-
-    /**
-     * Called when user toggles logging permissions in Settings
-     *
-     * This assumes storageManager's deviceID will be reset separately by a
-     * different owner (EventLoggingService's `reset()` method)
-     */
-    public func reset() {
-        resetSession()
-    }
-
-    /**
-     * Sets the session start date if there is no valid session
-     */
-    public var sessionStartDate: Date? {
-        queue.sync {
-            guard let sessionStart = _sessionStartDate else {
-                let newStart = Date()
-                _sessionStartDate = newStart
-                return newStart
-            }
-            return sessionStart
-        }
-    }
-
-    private var _sessionStartDate: Date?
-
-    /**
-     * Unset the session
-     */
-    public func resetSession() {
-        queue.async {
-            UserDefaults.standard.wmf_sessionID = nil
-        }
-    }
-
+    
     /**
      * Check if session expired, based on last active timestamp
      *
      * A new session ID is required if it has been more than 30 minutes since the
      * user was last active (e.g. when app entered background).
      */
-    public func sessionTimedOut() -> Bool {
+    private func hasSessionTimedOut() -> Bool {
+        
         /*
          * A TimeInterval value is always specified in seconds.
          */
-        if let lastTimestamp = UserDefaults.standard.wmf_sessionLastTimestamp {
-            hasSessionTimedOut = lastTimestamp.timeIntervalSinceNow < -1800
-            return hasSessionTimedOut
+        
+        if let lastTimestamp = UserDefaults.standard.wmf_sessionBackgroundTimestamp {
+            return lastTimestamp.timeIntervalSinceNow < -1800
         }
         return true
     }
-
-    /**
-     * This method is called by the application delegate in
-     * `applicationDidBecomeActive()` and re-enables event logging.
-     *
-     * If it has been more than 30 minutes since the app entered background state,
-     * a new session is started.
-     */
-    public func appInForeground() {
-        if sessionTimedOut() {
-            resetSession()
-        }
-    }
-
-    /**
-     * This method is called by the application delegate in
-     * `applicationWillTerminate()`
-     *
-     * We now persist session ID on app close to match session handling with Android
-     * session ends when 30 minutes of inactivity have passed.
-     */
-    public func appWillClose() {
-        UserDefaults.standard.wmf_sessionLastTimestamp = Date()
-    }
-
-    /**
-     * This method is called by the application delegate in
-     * `applicationWillResignActive()` and disables event logging.
-     */
-    @objc public func logSessionEndTimestamp() {
-        UserDefaults.standard.wmf_sessionLastTimestamp = Date()
-
-    }
-
 }

--- a/WMF Framework/UserSession.swift
+++ b/WMF Framework/UserSession.swift
@@ -89,14 +89,10 @@ public final class UserSession: NSObject {
      * user was last active (e.g. when app entered background).
      */
     private func hasSessionTimedOut() -> Bool {
-        
-        /*
-         * A TimeInterval value is always specified in seconds.
-         */
-        
-        if let lastTimestamp = UserDefaults.standard.wmf_sessionBackgroundTimestamp {
-            return lastTimestamp.timeIntervalSinceNow < -1800
+        guard let lastTimestamp = UserDefaults.standard.wmf_sessionBackgroundTimestamp else {
+            return false
         }
-        return true
+        
+        return lastTimestamp.timeIntervalSinceNow < -100
     }
 }

--- a/WMF Framework/UserSession.swift
+++ b/WMF Framework/UserSession.swift
@@ -26,6 +26,7 @@ public final class UserSession: NSObject {
             guard let sID = _sessionID else {
                 let newID = generateID()
                 _sessionID = newID
+                UserDefaults.standard.wmf_sessionID = _sessionID
                 return newID
             }
             return sID

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -1147,7 +1147,7 @@
 		67FBE33C29705FC200A2E4AD /* TalkPageArchivesItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67FBE33929705FC200A2E4AD /* TalkPageArchivesItem.swift */; };
 		67FBE33D29705FC200A2E4AD /* TalkPageArchivesItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67FBE33929705FC200A2E4AD /* TalkPageArchivesItem.swift */; };
 		67FF9C6B28076ADA000963D1 /* NSError+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67FF9C6A28076ADA000963D1 /* NSError+Utilities.swift */; };
-		7004A5BA268CEE680029C46B /* MetricsClientBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7004A5B9268CEE680029C46B /* MetricsClientBridge.swift */; };
+		7004A5BA268CEE680029C46B /* EventPlatformClientWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7004A5B9268CEE680029C46B /* EventPlatformClientWorker.swift */; };
 		702096B9256C3D5700E27041 /* SamplingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702096B8256C3D5700E27041 /* SamplingController.swift */; };
 		70B798142575714100C10BCA /* EventPlatformEvents.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 70B798122575714100C10BCA /* EventPlatformEvents.xcdatamodeld */; };
 		70B79820257577B800C10BCA /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B7981F257577B800C10BCA /* StorageManager.swift */; };
@@ -4364,7 +4364,7 @@
 		67FBE334297056EB00A2E4AD /* TalkPageArchivesFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageArchivesFetcher.swift; sourceTree = "<group>"; };
 		67FBE33929705FC200A2E4AD /* TalkPageArchivesItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageArchivesItem.swift; sourceTree = "<group>"; };
 		67FF9C6A28076ADA000963D1 /* NSError+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSError+Utilities.swift"; sourceTree = "<group>"; };
-		7004A5B9268CEE680029C46B /* MetricsClientBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsClientBridge.swift; sourceTree = "<group>"; };
+		7004A5B9268CEE680029C46B /* EventPlatformClientWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPlatformClientWorker.swift; sourceTree = "<group>"; };
 		702096B8256C3D5700E27041 /* SamplingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplingController.swift; sourceTree = "<group>"; };
 		70B798132575714100C10BCA /* EventPlatformEvents.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = EventPlatformEvents.xcdatamodel; sourceTree = "<group>"; };
 		70B7981F257577B800C10BCA /* StorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
@@ -7522,7 +7522,7 @@
 				70B7982A25758E6D00C10BCA /* EPEventRecord+CoreDataClass.swift */,
 				70B7983525758EB800C10BCA /* EPEventRecord+CoreDataProperties.swift */,
 				70B798122575714100C10BCA /* EventPlatformEvents.xcdatamodeld */,
-				7004A5B9268CEE680029C46B /* MetricsClientBridge.swift */,
+				7004A5B9268CEE680029C46B /* EventPlatformClientWorker.swift */,
 			);
 			path = "Event Platform";
 			sourceTree = "<group>";
@@ -12143,7 +12143,7 @@
 				67A6F13E23BFEF4200736539 /* ArticleCacheController.swift in Sources */,
 				67D6C00A240581ED005709B1 /* CacheItemMigrationPolicy.swift in Sources */,
 				D80ED2591EE178A800CE8C50 /* Gradient.swift in Sources */,
-				7004A5BA268CEE680029C46B /* MetricsClientBridge.swift in Sources */,
+				7004A5BA268CEE680029C46B /* EventPlatformClientWorker.swift in Sources */,
 				D844DA0A1D6CC5240042D692 /* NSLocale+WMFExtras.swift in Sources */,
 				0042806C25E6E395004945B3 /* FLAnimatedImage.m in Sources */,
 				830177FA1FBF3E490005681C /* ReadingListsAPIController.swift in Sources */,

--- a/Wikipedia/Code/AppDelegate.m
+++ b/Wikipedia/Code/AppDelegate.m
@@ -100,7 +100,6 @@ static NSString *const WMFBackgroundDatabaseHousekeeperTaskIdentifier = @"org.wi
 - (void)applicationDidBecomeActive:(UIApplication *)application {
     // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     [self resumeAppIfNecessary];
-    [[WMFMetricsClientBridge sharedInstance] appInForeground];
 }
 
 - (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL))completionHandler {
@@ -188,7 +187,6 @@ static NSString *const WMFBackgroundDatabaseHousekeeperTaskIdentifier = @"org.wi
     // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
     // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     [[NSUserDefaults standardUserDefaults] wmf_setAppResignActiveDate:[NSDate date]];
-    [[WMFMetricsClientBridge sharedInstance] appInBackground];
 }
 
 - (void)applicationDidEnterBackground:(UIApplication *)application {
@@ -202,7 +200,6 @@ static NSString *const WMFBackgroundDatabaseHousekeeperTaskIdentifier = @"org.wi
 - (void)applicationWillTerminate:(UIApplication *)application {
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     [self updateDynamicIconShortcutItems];
-    [[WMFMetricsClientBridge sharedInstance] appWillClose];
 }
 
 #pragma mark - Background Fetch

--- a/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
+++ b/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
@@ -32,7 +32,8 @@ let WMFDidShowNotificationsCenterPushOptInPanel = "WMFDidShowNotificationsCenter
 let WMFSubscribedToEchoNotifications = "WMFSubscribedToEchoNotifications"
 let WMFTappedToImportSharedReadingListSurvey = "WMFTappedToImportSharedReadingListSurvey"
 public let WMFAlwaysDisplayEditNotices = "WMFAlwaysDisplayEditNotices"
-let WMFLastSessionDate =  "WMFLastSessionDate"
+let WMFSessionBackgroundDate =  "WMFSessionBackgroundDate"
+let WMFSessionStartDate =  "WMFSessionStartDate"
 
 @objc public enum WMFAppDefaultTabType: Int {
     case explore
@@ -536,12 +537,21 @@ let WMFLastSessionDate =  "WMFLastSessionDate"
         }
     }
 
-    @objc var wmf_sessionLastTimestamp: Date? {
+    @objc var wmf_sessionBackgroundTimestamp: Date? {
         get {
-            return object(forKey: WMFLastSessionDate) as? Date
+            return object(forKey: WMFSessionBackgroundDate) as? Date
         }
         set {
-            set(newValue, forKey: WMFLastSessionDate)
+            set(newValue, forKey: WMFSessionBackgroundDate)
+        }
+    }
+    
+    @objc var wmf_sessionStartTimestamp: Date? {
+        get {
+            return object(forKey: WMFSessionStartDate) as? Date
+        }
+        set {
+            set(newValue, forKey: WMFSessionStartDate)
         }
     }
 

--- a/Wikipedia/Code/SessionsFunnel.swift
+++ b/Wikipedia/Code/SessionsFunnel.swift
@@ -8,11 +8,6 @@
     private var pageLoadTimes: [Double] = []
     private var pageLoadAverage: Double?
 
-    private enum Action: String, Codable {
-        case sessionStart = "session_start"
-        case sessionEnd = "session_end"
-    }
-
     public struct Event: EventInterface {
         public static let schema: EventPlatformClient.Schema = .sessions
         let length_ms: Int?
@@ -23,17 +18,17 @@
         let page_load_latency_ms: Int?
     }
 
-    private func logEvent(measure: Double? = nil, completion: @escaping () -> Void) {
-        let measureTime: Int?
-        if let measure {
-            measureTime = Int(round(measure))
+    private func logEvent(sessionMilliseconds: Double? = nil, completion: @escaping () -> Void) {
+        let lengthMS: Int?
+        if let sessionMilliseconds {
+            lengthMS = Int(round(sessionMilliseconds))
         } else {
-            measureTime = nil
+            lengthMS = nil
         }
 
         let pageLatency = SessionData(page_load_latency_ms: Int(round(pageLoadAverage ?? Double())))
 
-        let finalEvent = SessionsFunnel.Event(length_ms: measureTime, session_data: pageLatency)
+        let finalEvent = SessionsFunnel.Event(length_ms: lengthMS, session_data: pageLatency)
         EventPlatformClient.shared.submit(stream: .sessions, event: finalEvent, completion: completion)
     }
 
@@ -86,7 +81,7 @@
         let sessionSeconds = fabs(sessionStartDate.timeIntervalSince(compareDate))
         let sessionMilliseconds = sessionSeconds * 1000
         
-        logEvent(measure: sessionMilliseconds) {
+        logEvent(sessionMilliseconds: sessionMilliseconds) {
             UserHistoryFunnel.shared.logSnapshot()
             completion()
         }

--- a/Wikipedia/Code/SessionsFunnel.swift
+++ b/Wikipedia/Code/SessionsFunnel.swift
@@ -37,10 +37,11 @@
             logPreviousSessionEnd {
                 DispatchQueue.main.async {
                     self.resetPageLoadMetrics()
-                    EventPlatformClient.shared.reset()
+                    EventPlatformClient.shared.resetAll()
                 }
             }
-            
+        } else {
+            EventPlatformClient.shared.resetBackgroundTimestamp()
         }
     }
     
@@ -58,7 +59,7 @@
         logPreviousSessionEnd {
             DispatchQueue.main.async {
                 self.resetPageLoadMetrics()
-                EventPlatformClient.shared.reset()
+                EventPlatformClient.shared.resetAll()
                 UserDefaults.standard.wmf_sendUsageReports = false
                 completion()
             }
@@ -71,6 +72,7 @@
     private func logPreviousSessionEnd(completion: @escaping () -> Void) {
         guard let sessionStartDate = EventPlatformClient.shared.sessionStartDate else {
             assertionFailure("Session start date cannot be nil")
+            completion()
             return
         }
 

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -292,13 +292,13 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
     self.periodicWorkerController = [[WMFPeriodicWorkerController alloc] initWithInterval:30 initialDelay:1 leeway:15];
     self.periodicWorkerController.delegate = self;
     [self.periodicWorkerController add:self.dataStore.readingListsController];
-    [self.periodicWorkerController add:[WMFMetricsClientBridge sharedInstance]];
+    [self.periodicWorkerController add:[WMFEventPlatformClientWorker sharedInstance]];
 
     self.backgroundFetcherController = [[WMFBackgroundFetcherController alloc] init];
     self.backgroundFetcherController.delegate = self;
     [self.backgroundFetcherController add:self.dataStore.readingListsController];
     [self.backgroundFetcherController add:(id<WMFBackgroundFetcher>)self.dataStore.feedContentController];
-    [self.backgroundFetcherController add:[WMFMetricsClientBridge sharedInstance]];
+    [self.backgroundFetcherController add:[WMFEventPlatformClientWorker sharedInstance]];
 }
 
 - (void)loadMainUI {

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -374,7 +374,7 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
 
 // When the user launches from a terminated state, resume might not finish before didBecomeActive, so these tasks are held until both items complete
 - (void)performTasksThatShouldOccurAfterBecomeActiveAndResume {
-    [[SessionsFunnel shared] setSessionStart];
+    [[SessionsFunnel shared] appDidBecomeActive];
     [self checkRemoteAppConfigIfNecessary];
     [self.periodicWorkerController start];
     [self.savedArticlesFetcher start];
@@ -1019,7 +1019,7 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
 }
 
 - (void)pauseApp {
-    [self logSessionEnd];
+    [[SessionsFunnel shared] appDidBackground];
 
     if (![self uiIsLoaded]) {
         [self endPauseAppBackgroundTask];
@@ -1056,13 +1056,6 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
     [super didReceiveMemoryWarning];
     self.settingsViewController = nil;
     [self.dataStore clearMemoryCache];
-}
-
-#pragma mark - Logging
-
-- (void)logSessionEnd {
-    [[UserSession shared] logSessionEndTimestamp];
-    [[UserHistoryFunnel shared] logSnapshot];
 }
 
 #pragma mark - Shortcut

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -188,13 +188,21 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
 - (void)updateStateForMenuItemType:(WMFSettingsMenuItemType)type isSwitchOnValue:(BOOL)isOn {
     switch (type) {
         case WMFSettingsMenuItemType_SendUsageReports: {
-            NSUserDefaults.standardUserDefaults.wmf_sendUsageReports = isOn;
             if (isOn) {
+                NSUserDefaults.standardUserDefaults.wmf_sendUsageReports = YES;
                 [[UserHistoryFunnel shared] logStartingSnapshot];
             } else {
                 [[UserHistoryFunnel shared] logSnapshot];
                 [[SessionsFunnel shared] settingsLoggingToggledOff];
+                
+                // Give funnels a little bit of time to log event before disabling.
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                    NSUserDefaults.standardUserDefaults.wmf_sendUsageReports = NO;
+                });
             }
+            
+            
+            
         } break;
         default:
             break;

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -188,17 +188,12 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
 - (void)updateStateForMenuItemType:(WMFSettingsMenuItemType)type isSwitchOnValue:(BOOL)isOn {
     switch (type) {
         case WMFSettingsMenuItemType_SendUsageReports: {
-            WMFMetricsClientBridge *metricsClientBridge = [WMFMetricsClientBridge sharedInstance];
             NSUserDefaults.standardUserDefaults.wmf_sendUsageReports = isOn;
             if (isOn) {
-                [metricsClientBridge reset];
-                [[SessionsFunnel shared] setSessionStart];
                 [[UserHistoryFunnel shared] logStartingSnapshot];
             } else {
-                [[SessionsFunnel shared] logSessionLastActivity];
-                [[SessionsFunnel shared] logPreviousSessionEnd];
                 [[UserHistoryFunnel shared] logSnapshot];
-                [metricsClientBridge reset];
+                [[SessionsFunnel shared] settingsLoggingToggledOff];
             }
         } break;
         default:

--- a/Wikipedia/Code/WMFWelcomeAnalyticsViewController.swift
+++ b/Wikipedia/Code/WMFWelcomeAnalyticsViewController.swift
@@ -47,7 +47,12 @@ class WMFWelcomeAnalyticsViewController: ThemeableViewController {
     }
     
     @IBAction func toggleAnalytics(withSender sender: UISwitch) {
-        UserDefaults.standard.wmf_sendUsageReports = sender.isOn
+        if sender.isOn {
+            SessionsFunnel.shared.settingsLoggingToggledOn()
+        } else {
+            SessionsFunnel.shared.settingsLoggingToggledOff(completion: {})
+        }
+        
         updateToggleLabelTitleForUsageReportsIsOn(sender.isOn)
     }
     


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T327341

### Notes
This is a follow-on from #4473 that attempts to fix some bugs I was seeing with session handling.

I changed a few things here:
1. To match the communication flow of the other funnels, I tried to have any UI (i.e. Settings or Onboarding toggle) or app lifecycle (foreground, background) event call `SessionsFunnel`, which in turn calls `EventPlatformClient` as-needed. I found this easier to understand, but I'm open changes if others disagree. `UserSession` still exists, but only `EventPlatformClient` communicates with it.
2. After testing, I noticed logging the user's last session needs to be called with a completion block, before resetting their sessionID or turning off analytics. Without this, there were times when the `app_session` event sent with the new session ID instead of the previous one, or didn't send at all because `wmf_sendUsageReports` was set to off before we tried to save the last `app_session` event.
3. Before we generated session ID as-needed, which meant even when toggling on their settings toggle, the session ID wouldn't be generated and the session length wouldn't start counting until they triggered the first analytics event. Usually that happened right away, but not always. In these situations, toggling off analytics caused crashes (because the session start date was never determined, so the `app_session` event didn't know what to do). So now to keep everything more predictable, I am generating the session ID and setting the session start date as soon as they toggle on. This feels more accurate to what we're trying to measure in `app_session` anyway.

### Test Steps
1. Fresh install app. Turn on analytics in onboarding screen.
2. Trigger various events, and watch the console log. Confirm the session ID stays the same for these events.
3. Background the app, then foreground. Trigger more events. Confirm the sessionID stays the same for these events.
4. Terminate the app, then relaunch. Trigger more events. Confirm the session ID stays the same for these events.
5. Background the app, then change the device time to 30+ minutes into the future. Foreground the app and confirm you see an `app_session` event in the console with your session ID. Trigger more events. Confirm these events send with a new session ID.
6. Go to Settings > toggle off analytics. Confirm you see an `app_session` event in the console with your new session ID. 
