### PR TITLE
Fix assertion failure for users with logging off

### DIFF
--- a/WMF Framework/Event Platform/EventPlatformClient.swift
+++ b/WMF Framework/Event Platform/EventPlatformClient.swift
@@ -88,7 +88,7 @@ import CocoaLumberjackSwift
     }
     
     public func needsReset() -> Bool {
-        return userSession.needsReset()
+        return userSession.needsReset() && isEnabled
     }
     
     public func resetBackgroundTimestamp() {


### PR DESCRIPTION
**Phabricator:**
https://phabricator.wikimedia.org/T327341

### Notes
This fixes an unnecessary assertion failure when testing with logging off.

### Test Steps
1. Launch device, do not enable logging.
2. Background app, change date & time to 30+ minutes later
3. Return to app. Ensure no assertion failure is hit upon foreground. App hits an assertion failure here in `main` for attempting to log the previous session and missing a persisted session start date.
