### PR TITLE
Undo granular updating change

### DIFF
--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -37,8 +37,6 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         NotificationCenter.default.addObserver(self, selector: #selector(articleDeleted(_:)), name: NSNotification.Name.WMFArticleDeleted, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(pushNotificationBannerDidDisplayInForeground(_:)), name: .pushNotificationBannerDidDisplayInForeground, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(viewContextDidReset(_:)), name: NSNotification.Name.WMFViewContextDidReset, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(applicationWillResignActive(_:)), name: UIApplication.willResignActiveNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(applicationWillEnterForeground(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
 
 #if UI_TEST
         if UserDefaults.standard.wmf_isFastlaneSnapshotInProgress() {
@@ -1021,14 +1019,6 @@ extension ExploreViewController: ExploreCardCollectionViewCellDelegate {
     
     @objc func viewContextDidReset(_ note: Notification) {
         collectionView.reloadData()
-    }
-    
-    @objc func applicationWillEnterForeground(_ note: Notification) {
-        isGranularUpdatingEnabled = true
-    }
-    
-    @objc func applicationWillResignActive(_ note: Notification) {
-        isGranularUpdatingEnabled = false
     }
 
     private func menuActionSheetForGroup(_ group: WMFContentGroup) -> UIAlertController? {


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T335077

### Notes
There's a new TestFlight crash that I think is caused by my last commit in #4515. Reverting the change since I don't think it's necessary for improving background crashing.

### Test Steps
1. Launch app, confirm Explore feed loads fine.
2. Background app, then foreground. Confirm no crashing.

