### PR TITLE
Add NavigationEventsFunnel to MEP, update ReadingListsFunnel

### DIFF
--- a/WMF Framework/Event Platform/EventPlatformClient.swift
+++ b/WMF Framework/Event Platform/EventPlatformClient.swift
@@ -130,6 +130,7 @@ import CocoaLumberjackSwift
         case sessions = "app_session"
         case settings = "ios.setting_action"
         case login = "ios.login_action"
+        case navigation = "ios.navigation_events"
     }
     
     /**
@@ -145,12 +146,13 @@ import CocoaLumberjackSwift
         case editHistoryCompare = "/analytics/mobile_apps/ios_edit_history_compare/2.1.0"
         case remoteNotificationsInteraction = "/analytics/mobile_apps/ios_notification_interaction/2.1.0"
         case talkPages = "/analytics/mobile_apps/ios_talk_page_interaction/1.0.0"
-        case readingLists = "/analytics/mobile_apps/ios_reading_lists/2.0.0"
+        case readingLists = "/analytics/mobile_apps/ios_reading_lists/2.1.0"
         case userHistory = "/analytics/mobile_apps/ios_user_history/1.0.0"
         case search = "/analytics/mobile_apps/ios_search/2.0.0"
         case sessions = "/analytics/mobile_apps/app_session/1.0.0"
         case settings = "/analytics/mobile_apps/ios_setting_action/1.0.0"
         case login = "/analytics/mobile_apps/ios_login_action/1.0.1"
+        case navigation = "/analytics/mobile_apps/ios_navigation_events/1.0.0"
     }
 
     /**

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -1756,6 +1756,10 @@
 		830ECAD11FBDD8C00080B1EF /* ReadingListsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830ECACE1FBDD8C00080B1EF /* ReadingListsViewController.swift */; };
 		830ECAD21FBDD8C00080B1EF /* ReadingListsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830ECACE1FBDD8C00080B1EF /* ReadingListsViewController.swift */; };
 		830ECAD61FBDE77F0080B1EF /* ReadingListsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830ECAD51FBDE77F0080B1EF /* ReadingListsTests.swift */; };
+		83155BA62A0D70B7003D141D /* NavigationEventsFunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83155BA52A0D70B7003D141D /* NavigationEventsFunnel.swift */; };
+		83155BA72A0D70B7003D141D /* NavigationEventsFunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83155BA52A0D70B7003D141D /* NavigationEventsFunnel.swift */; };
+		83155BA82A0D70B7003D141D /* NavigationEventsFunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83155BA52A0D70B7003D141D /* NavigationEventsFunnel.swift */; };
+		83155BA92A0D70B7003D141D /* NavigationEventsFunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83155BA52A0D70B7003D141D /* NavigationEventsFunnel.swift */; };
 		831937E723E1CE80006A9FF3 /* String+LinkParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831937E623E1CE80006A9FF3 /* String+LinkParsing.swift */; };
 		831937E923E1CEAC006A9FF3 /* CharacterSet+LinkParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831937E823E1CEAC006A9FF3 /* CharacterSet+LinkParsing.swift */; };
 		831C15C62099EB3A001B04BF /* WMFArticle+Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831C15C52099EB3A001B04BF /* WMFArticle+Errors.swift */; };
@@ -4548,6 +4552,7 @@
 		830D71CE1F704DD40080078B /* ArticleFetchedResultsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleFetchedResultsViewController.swift; sourceTree = "<group>"; };
 		830ECACE1FBDD8C00080B1EF /* ReadingListsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListsViewController.swift; sourceTree = "<group>"; };
 		830ECAD51FBDE77F0080B1EF /* ReadingListsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListsTests.swift; sourceTree = "<group>"; };
+		83155BA52A0D70B7003D141D /* NavigationEventsFunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationEventsFunnel.swift; sourceTree = "<group>"; };
 		831835301FD1AC490025DD3D /* NavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBar.swift; sourceTree = "<group>"; usesTabs = 0; };
 		831937E623E1CE80006A9FF3 /* String+LinkParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+LinkParsing.swift"; sourceTree = "<group>"; };
 		831937E823E1CEAC006A9FF3 /* CharacterSet+LinkParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CharacterSet+LinkParsing.swift"; sourceTree = "<group>"; };
@@ -6876,6 +6881,7 @@
 				83B1218327FC8750006B8CCC /* RemoteNotificationsFunnel.swift */,
 				676E813229380D8A00F15258 /* TalkPagesFunnel.swift */,
 				83AE025B299D9CDD00C45F73 /* SearchFunnel.swift */,
+				83155BA52A0D70B7003D141D /* NavigationEventsFunnel.swift */,
 			);
 			name = "WIkimedia Event Logging";
 			sourceTree = "<group>";
@@ -11452,6 +11458,7 @@
 				7A4D227D21B1CD8600D889BD /* TextFormattingTableViewCell.swift in Sources */,
 				B0524B75214856A400D8FD8D /* UIViewController+DescriptionWelcomeStoryboard.swift in Sources */,
 				6734115422735788005B31DA /* OldTalkPageFetcher.swift in Sources */,
+				83155BA62A0D70B7003D141D /* NavigationEventsFunnel.swift in Sources */,
 				0ED2E9FA1CB2B3B300D1C844 /* UIVIewController+WMFCommonRotationSupport.swift in Sources */,
 				6741245027E97DBC0071177D /* NotificationsCenterDetailViewModel+ActionExtensions.swift in Sources */,
 				00E2EA8926E28A9700B1A741 /* NotificationsCenterCellStyle.swift in Sources */,
@@ -12424,6 +12431,7 @@
 				B0524B78214856A400D8FD8D /* UIViewController+DescriptionWelcomeStoryboard.swift in Sources */,
 				D8A42A9A1E815A9C00D8E281 /* UIViewController+WMFStoryboardUtilities.m in Sources */,
 				67985A892524E05F00EBF353 /* ArticleAsLivingDocHintViewController.swift in Sources */,
+				83155BA92A0D70B7003D141D /* NavigationEventsFunnel.swift in Sources */,
 				7A6ED50C20ADBF950001849F /* SessionsFunnel.swift in Sources */,
 				6741245327E97DBC0071177D /* NotificationsCenterDetailViewModel+ActionExtensions.swift in Sources */,
 				00E2EA8C26E28A9700B1A741 /* NotificationsCenterCellStyle.swift in Sources */,
@@ -12985,6 +12993,7 @@
 				D8CE25161E698E2400DAE2E0 /* UIView+WMFSubviews.swift in Sources */,
 				830C0DD623D9AFBE006471C4 /* UIViewController+Push.swift in Sources */,
 				67E8B085226A57E900537BC9 /* TalkPageTopicListViewController.swift in Sources */,
+				83155BA82A0D70B7003D141D /* NavigationEventsFunnel.swift in Sources */,
 				83ED2E26289ACB1100462C65 /* VanishAccountCustomUIHostingController.swift in Sources */,
 				D87B13A61F276B0F00B27227 /* ShareActivityController.swift in Sources */,
 				D8CE25181E698E2400DAE2E0 /* WMFReferencePopoverMessageViewController.m in Sources */,
@@ -13580,6 +13589,7 @@
 				D8EC3E021E9BDA35006712EB /* WMFPageHistoryRevision.m in Sources */,
 				830C0DD723D9AFBE006471C4 /* UIViewController+Push.swift in Sources */,
 				67E8B08C226A57E900537BC9 /* TalkPageTopicListViewController.swift in Sources */,
+				83155BA72A0D70B7003D141D /* NavigationEventsFunnel.swift in Sources */,
 				83ED2E25289ACB1100462C65 /* VanishAccountCustomUIHostingController.swift in Sources */,
 				D8EC3E091E9BDA35006712EB /* WMFEmptyView.m in Sources */,
 				7A35CB891FD82B6300AAF3B7 /* ReadingListDetailViewController.swift in Sources */,

--- a/Wikipedia.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Wikipedia.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
       "state" : {
-        "revision" : "80ada1f753b0d53d9b57c465936a7c4169375002",
-        "version" : "3.7.4"
+        "revision" : "0188d31089b5881a269e01777be74c7316924346",
+        "version" : "3.8.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-        "version" : "1.4.2"
+        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
+        "version" : "1.5.2"
       }
     },
     {
@@ -24,7 +24,7 @@
       "location" : "https://github.com/wikimedia/wikipedia-ios-components.git",
       "state" : {
         "branch" : "main",
-        "revision" : "e9d5031d5c75492be55b4143b397cd43227de7ed"
+        "revision" : "7ed24c3e5075c7a3e19fc580714bb35e624d3b75"
       }
     }
   ],

--- a/Wikipedia/Code/ArticleViewController+ArticleInformation.swift
+++ b/Wikipedia/Code/ArticleViewController+ArticleInformation.swift
@@ -68,6 +68,7 @@ extension ArticleViewController: WMFLanguagesViewControllerDelegate {
     func languagesController(_ controller: WMFLanguagesViewController, didSelectLanguage language: MWKLanguageLink) {
         dismiss(animated: true) {
             self.navigate(to: language.articleURL)
+            NavigationEventsFunnel.shared.logEvent(action: .articleToolbarLangSuccess)
         }
     }
 }

--- a/Wikipedia/Code/ArticleViewController+ArticleToolbarHandling.swift
+++ b/Wikipedia/Code/ArticleViewController+ArticleToolbarHandling.swift
@@ -1,6 +1,7 @@
 extension ArticleViewController: ArticleToolbarHandling {
     func showTableOfContents(from controller: ArticleToolbarController) {
         showTableOfContents()
+        NavigationEventsFunnel.shared.logEvent(action: .articleToolbarTOC)
     }
     
     func hideTableOfContents(from controller: ArticleToolbarController) {
@@ -12,9 +13,11 @@ extension ArticleViewController: ArticleToolbarHandling {
     }
     
     func toggleSave(from controller: ArticleToolbarController) {
+        NavigationEventsFunnel.shared.logEvent(action: .articleToolbarSave)
         let isSaved = dataStore.savedPageList.toggleSavedPage(for: articleURL)
         if isSaved {
             readingListsFunnel.logArticleSaveInCurrentArticle(articleURL)
+            NavigationEventsFunnel.shared.logEvent(action: .articleToolbarSaveSuccess)
         } else {
             readingListsFunnel.logArticleUnsaveInCurrentArticle(articleURL)
         }
@@ -22,6 +25,7 @@ extension ArticleViewController: ArticleToolbarHandling {
     
     func showThemePopover(from controller: ArticleToolbarController) {
         themesPresenter.showReadingThemesControlsPopup(on: self, responder: self, theme: theme)
+        NavigationEventsFunnel.shared.logEvent(action: .articleToolbarAppearence)
     }
     
     func saveButtonWasLongPressed(from controller: ArticleToolbarController) {
@@ -29,17 +33,21 @@ extension ArticleViewController: ArticleToolbarHandling {
         let nc = WMFThemeableNavigationController(rootViewController: addArticlesToReadingListVC, theme: theme)
         nc.setNavigationBarHidden(false, animated: false)
         present(nc, animated: true)
+        NavigationEventsFunnel.shared.logEvent(action: .articleToolbarSave)
     }
     
     func showLanguagePicker(from controller: ArticleToolbarController) {
+        NavigationEventsFunnel.shared.logEvent(action: .articleToolbarLang)
         showLanguages()
     }
     
     func share(from controller: ArticleToolbarController) {
+        NavigationEventsFunnel.shared.logEvent(action: .articleToolbarShare)
         shareArticle()
     }
     
     func showFindInPage(from controller: ArticleToolbarController) {
+        NavigationEventsFunnel.shared.logEvent(action: .articleToolbarSearch)
         showFindInPage()
     }
 }

--- a/Wikipedia/Code/ArticleViewController+FindInPage.swift
+++ b/Wikipedia/Code/ArticleViewController+FindInPage.swift
@@ -56,6 +56,7 @@ extension ArticleViewController {
         view.delegate = self
         view.apply(theme: theme)
         findInPage.view = view
+        NavigationEventsFunnel.shared.logEvent(action: .articleToolbarSearchSuccess)
     }
     
     func showFindInPage() {

--- a/Wikipedia/Code/ArticleViewController+Sharing.swift
+++ b/Wikipedia/Code/ArticleViewController+Sharing.swift
@@ -6,6 +6,7 @@ extension ArticleViewController {
                 return
             }
             self.shareArticle(with: selectedText)
+            NavigationEventsFunnel.shared.logEvent(action: .articleToolbarShareSuccess)
         })
     }
     

--- a/Wikipedia/Code/NavigationEventsFunnel.swift
+++ b/Wikipedia/Code/NavigationEventsFunnel.swift
@@ -31,16 +31,16 @@ final internal class NavigationEventsFunnel: NSObject {
         case settingsRate = "setting_rate"
         case settingsHelp = "setting_help"
         case settingsAbout = "setting_about"
-        case article_toolbar_toc
-        case article_toolbar_lang
-        case article_toolbar_lang_success
-        case article_toolbar_save
-        case article_toolbar_save_success
-        case article_toolbar_share
-        case article_toolbar_share_success
-        case article_toolbar_appearance
-        case article_toolbar_search
-        case article_toolbar_search_success
+        case articleToolbarTOC = "article_toolbar_toc"
+        case articleToolbarLang = "article_toolbar_lang"
+        case articleToolbarLangSuccess = "article_toolbar_lang_success"
+        case articleToolbarSave = "article_toolbar_save"
+        case articleToolbarSaveSuccess = "article_toolbar_save_success"
+        case articleToolbarShare = "article_toolbar_share"
+        case articleToolbarShareSuccess = "article_toolbar_share_success"
+        case articleToolbarAppearence = "article_toolbar_appearance"
+        case articleToolbarSearch = "article_toolbar_search"
+        case articleToolbarSearchSuccess = "article_toolbar_search_success"
     }
 
     private struct Event: EventInterface {

--- a/Wikipedia/Code/NavigationEventsFunnel.swift
+++ b/Wikipedia/Code/NavigationEventsFunnel.swift
@@ -1,35 +1,36 @@
 import Foundation
 
-final internal class NavigationEventsFunnel {
-    internal static let shared = NavigationEventsFunnel()
+@objc(WMFNavigationEventsFunnel)
+final internal class NavigationEventsFunnel: NSObject {
+    @objc internal static let shared = NavigationEventsFunnel()
 
     internal enum NavigationAction: String, Codable {
         case explore
         case places
         case saved
-        case saved_all
-        case saved_lists
+        case savedAll = "saved_all"
+        case savedLists = "saved_lists"
         case history
         case search
-        case setting_open_nav
-        case setting_open_explore
-        case setting_account
-        case setting_close
-        case setting_fundraise
-        case setting_languages
-        case setting_search
-        case setting_explorefeed
-        case setting_notifications
-        case setting_read_prefs
-        case setting_storagesync
-        case setting_read_danger
-        case setting_cleardata
-        case setting_privacy
-        case setting_tos
-        case setting_usage_reports
-        case setting_rate
-        case setting_help
-        case setting_about
+        case settingsOpenNav = "setting_open_nav"
+        case settingsOpenExplore = "setting_open_explore"
+        case settingsAccount = "setting_account"
+        case settingsClose = "setting_close"
+        case settingsFundraise = "setting_fundraise"
+        case settingsLanguages = "setting_languages"
+        case settingsSearch = "setting_search"
+        case settingsExploreFeed = "setting_explorefeed"
+        case settingsNotifications = "setting_notifications"
+        case settingsReadPrefs = "setting_read_prefs"
+        case settingsStorageSync = "setting_storagesync"
+        case settingsReadDanger = "setting_read_danger"
+        case settingsClearData = "setting_cleardata"
+        case settingsPrivacy = "setting_privacy"
+        case settingsTOS = "setting_tos"
+        case settingsUsageReports = "setting_usage_reports"
+        case settingsRate = "setting_rate"
+        case settingsHelp = "setting_help"
+        case settingsAbout = "setting_about"
         case article_toolbar_toc
         case article_toolbar_lang
         case article_toolbar_lang_success
@@ -52,4 +53,107 @@ final internal class NavigationEventsFunnel {
         EventPlatformClient.shared.submit(stream: .navigation, event: event)
     }
 
+    @objc func logTappedExplore() {
+            logEvent(action: .explore)
+        }
+
+        @objc func logTappedPlaces() {
+            logEvent(action: .places)
+        }
+
+        @objc func logTappedSaved() {
+            logEvent(action: .saved)
+        }
+
+        @objc func logTappedHistory() {
+            logEvent(action: .history)
+        }
+
+        @objc func logTappedSearch() {
+            logEvent(action: .search)
+        }
+
+        @objc func logTappedSettingsFromTabBar() {
+            logEvent(action: .settingsOpenNav)
+        }
+
+        @objc func logTappedSettingsFromExplore() {
+            logEvent(action: .settingsOpenExplore)
+        }
+
+        func logTappedSavedAllArticles() {
+            logEvent(action: .savedAll)
+        }
+
+        func logTappedSavedReadingLists() {
+            logEvent(action: .savedLists)
+        }
+
+        @objc func logTappedSettingsCloseButton() {
+            logEvent(action: .settingsClose)
+        }
+
+        @objc func logTappedSettingsLoginLogout() {
+            logEvent(action: .settingsAccount)
+        }
+
+        @objc func logTappedSettingsSupportWikipedia() {
+            logEvent(action: .settingsFundraise)
+        }
+
+        @objc func logTappedSettingsLanguages() {
+            logEvent(action: .settingsLanguages)
+        }
+
+        @objc func logTappedSettingsSearch() {
+            logEvent(action: .settingsSearch)
+        }
+
+        @objc func logTappedSettingsExploreFeed() {
+            logEvent(action: .settingsExploreFeed)
+        }
+
+        @objc func logTappedSettingsNotifications() {
+            logEvent(action: .settingsNotifications)
+        }
+
+        @objc func logTappedSettingsReadingPreferences() {
+            logEvent(action: .settingsReadPrefs)
+        }
+
+        @objc func logTappedSettingsArticleStorageAndSyncing() {
+            logEvent(action: .settingsStorageSync)
+        }
+
+        @objc func logTappedSettingsReadingListDangerZone() {
+            logEvent(action: .settingsReadDanger)
+        }
+
+        @objc func logTappedSettingsClearCachedData() {
+            logEvent(action: .settingsClearData)
+        }
+
+        @objc func logTappedSettingsPrivacyPolicy() {
+            logEvent(action: .settingsPrivacy)
+        }
+
+        @objc func logTappedSettingsTermsOfUse() {
+            logEvent(action: .settingsTOS)
+        }
+
+        @objc func logTappedSettingsSendUsageReports() {
+            logEvent(action: .settingsUsageReports)
+        }
+
+        @objc func logTappedSettingsRateTheApp() {
+            logEvent(action: .settingsRate)
+        }
+
+        @objc func logTappedSettingsHelp() {
+            logEvent(action: .settingsHelp)
+        }
+
+        @objc func logTappedSettingsAbout() {
+            logEvent(action: .settingsAbout)
+        }
 }

--- a/Wikipedia/Code/NavigationEventsFunnel.swift
+++ b/Wikipedia/Code/NavigationEventsFunnel.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+final internal class NavigationEventsFunnel {
+    internal static let shared = NavigationEventsFunnel()
+
+    internal enum NavigationAction: String, Codable {
+        case explore
+        case places
+        case saved
+        case saved_all
+        case saved_lists
+        case history
+        case search
+        case setting_open_nav
+        case setting_open_explore
+        case setting_account
+        case setting_close
+        case setting_fundraise
+        case setting_languages
+        case setting_search
+        case setting_explorefeed
+        case setting_notifications
+        case setting_read_prefs
+        case setting_storagesync
+        case setting_read_danger
+        case setting_cleardata
+        case setting_privacy
+        case setting_tos
+        case setting_usage_reports
+        case setting_rate
+        case setting_help
+        case setting_about
+        case article_toolbar_toc
+        case article_toolbar_lang
+        case article_toolbar_lang_success
+        case article_toolbar_save
+        case article_toolbar_save_success
+        case article_toolbar_share
+        case article_toolbar_share_success
+        case article_toolbar_appearance
+        case article_toolbar_search
+        case article_toolbar_search_success
+    }
+
+    private struct Event: EventInterface {
+        static var schema: EventPlatformClient.Schema = .navigation
+        let action: NavigationAction
+    }
+
+    func logEvent(action: NavigationAction) {
+        let event = Event(action: action)
+        EventPlatformClient.shared.submit(stream: .navigation, event: event)
+    }
+
+}

--- a/Wikipedia/Code/ReadingListEntryCollectionViewController.swift
+++ b/Wikipedia/Code/ReadingListEntryCollectionViewController.swift
@@ -453,7 +453,7 @@ extension ReadingListEntryCollectionViewController {
             return
         }
         navigate(to: articleURL)
-        ReadingListsFunnel.shared.logReadStartIReadingList(articleURL)
+        ReadingListsFunnel.shared.logReadStartReadingList(articleURL)
     }
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {

--- a/Wikipedia/Code/ReadingListsFunnel.swift
+++ b/Wikipedia/Code/ReadingListsFunnel.swift
@@ -12,6 +12,9 @@
         case receiveFinish = "receive_finish"
         case surveyShown = "survey_shown"
         case surveyClicked = "survey_clicked"
+        case allArticlesTab = "all_articles_tab"
+        case readingListsTab = "reading_lists_tab"
+        case editButton = "edit_tab"
     }
 
     private struct Event: EventInterface {
@@ -126,7 +129,7 @@
         logUnsave(category: .saved, label: .items, measure: articlesCount, wiki_id: language)
     }
     
-    public func logReadStartIReadingList(_ articleURL: URL) {
+    public func logReadStartReadingList(_ articleURL: URL) {
         logEvent(action: .readStart, category: .saved, label: .items, measure: 1, wiki_id: articleURL.wmf_languageCode)
     }
     
@@ -170,6 +173,18 @@
     
     public func logTappedTakeSurvey() {
         logEvent(action: .surveyClicked, category: .shared, label: nil)
+    }
+
+    public func logTappedAllArticlesTab() {
+        logEvent(action: .allArticlesTab, category: .saved, label: nil)
+    }
+
+    public func logTappedReadingListsTab() {
+        logEvent(action: .readingListsTab, category: .saved, label: nil)
+    }
+
+    public func logTappedEditButton() {
+        logEvent(action: .editButton, category: .saved, label: nil)
     }
 }
 

--- a/Wikipedia/Code/SavedViewController.swift
+++ b/Wikipedia/Code/SavedViewController.swift
@@ -326,7 +326,6 @@ extension SavedViewController: CollectionViewEditControllerNavigationDelegate {
     func didChangeEditingState(from oldEditingState: EditingState, to newEditingState: EditingState, rightBarButton: UIBarButtonItem?, leftBarButton: UIBarButtonItem?) {
         defer {
             navigationBar.updateNavigationItems()
-            ReadingListsFunnel.shared.logTappedEditButton()
         }
         navigationItem.rightBarButtonItem = rightBarButton
         navigationItem.rightBarButtonItem?.tintColor = theme.colors.link
@@ -347,6 +346,7 @@ extension SavedViewController: CollectionViewEditControllerNavigationDelegate {
         if searchBar.isFirstResponder {
             searchBar.resignFirstResponder()
         }
+        ReadingListsFunnel.shared.logTappedEditButton()
     }
     
     func newEditingState(for currentEditingState: EditingState, fromEditBarButtonWithSystemItem systemItem: UIBarButtonItem.SystemItem) -> EditingState {

--- a/Wikipedia/Code/SavedViewController.swift
+++ b/Wikipedia/Code/SavedViewController.swift
@@ -74,6 +74,7 @@ class SavedViewController: ViewController {
         toggleButtons.first { $0.tag != sender.tag }?.isSelected = false
         sender.isSelected = true
         currentView = View(rawValue: sender.tag) ?? .savedArticles
+        logTappedView(currentView)
     }
 
     @objc func toggleCurrentView(_ newViewRawValue: Int) {
@@ -167,6 +168,15 @@ class SavedViewController: ViewController {
         vc.view.removeFromSuperview()
         vc.willMove(toParent: nil)
         vc.removeFromParent()
+    }
+
+    private func logTappedView(_ view: View) {
+        switch view {
+        case .savedArticles:
+            NavigationEventsFunnel.shared.logEvent(action: .savedAll)
+        case .readingLists:
+            NavigationEventsFunnel.shared.logEvent(action: .savedLists)
+        }
     }
     
     // MARK: - View lifecycle

--- a/Wikipedia/Code/SavedViewController.swift
+++ b/Wikipedia/Code/SavedViewController.swift
@@ -103,6 +103,7 @@ class SavedViewController: ViewController {
                 activeEditableCollection = savedArticlesViewController
                 extendedNavBarViewType = isCurrentViewEmpty ? .none : .search
                 evaluateEmptyState()
+                ReadingListsFunnel.shared.logTappedAllArticlesTab()
             case .readingLists :
                 readingListsViewController?.editController.navigationDelegate = self
                 savedArticlesViewController?.editController.navigationDelegate = nil
@@ -113,6 +114,7 @@ class SavedViewController: ViewController {
                 activeEditableCollection = readingListsViewController
                 extendedNavBarViewType = isCurrentViewEmpty ? .none : .createNewReadingList
                 evaluateEmptyState()
+                ReadingListsFunnel.shared.logTappedReadingListsTab()
             }
         }
     }
@@ -314,6 +316,7 @@ extension SavedViewController: CollectionViewEditControllerNavigationDelegate {
     func didChangeEditingState(from oldEditingState: EditingState, to newEditingState: EditingState, rightBarButton: UIBarButtonItem?, leftBarButton: UIBarButtonItem?) {
         defer {
             navigationBar.updateNavigationItems()
+            ReadingListsFunnel.shared.logTappedEditButton()
         }
         navigationItem.rightBarButtonItem = rightBarButton
         navigationItem.rightBarButtonItem?.tintColor = theme.colors.link

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -102,6 +102,9 @@ extension WMFAppViewController {
 extension WMFAppViewController: SettingsPresentationDelegate {
 
     public func userDidTapSettings(from viewController: UIViewController?) {
+        if viewController is ExploreViewController {
+            NavigationEventsFunnel.shared.logTappedSettingsFromExplore()
+        }
         showSettings(animated: true)
     }
 

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1659,6 +1659,10 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
     [self wmf_hideKeyboard];
 }
 
+- (void)tabBar:(UITabBar *)tabBar didSelectItem:(UITabBarItem *)item {
+    [self logTappedTabBarItem:item inTabBar:tabBar];
+}
+
 - (BOOL)tabBarController:(UITabBarController *)tabBarController shouldSelectViewController:(UIViewController *)viewController {
     if (viewController == tabBarController.selectedViewController) {
         switch (tabBarController.selectedIndex) {
@@ -2079,6 +2083,38 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 
 - (void)setRemoteNotificationRegistrationStatusWithDeviceToken:(nullable NSData *)deviceToken error:(nullable NSError *)error {
     [self.notificationsController setRemoteNotificationRegistrationStatusWithDeviceToken:deviceToken error:error];
+}
+
+#pragma mark - Navigation logging
+
+- (void)logTappedTabBarItem:(UITabBarItem *)item inTabBar:(UITabBar *)tabBar {
+    if (tabBar.items.count != self.viewControllers.count || self.tabBar != tabBar) {
+        NSAssert(false, @"Unexpected tab bar setup for logging tap events.");
+        return;
+    }
+
+    NSInteger index = [self.tabBar.items indexOfObject:item];
+    if (index != NSNotFound) {
+        UIViewController *selectedViewController = self.viewControllers[index];
+
+        if ([selectedViewController isKindOfClass:[ExploreViewController class]] && [NSUserDefaults standardUserDefaults].defaultTabType == WMFAppDefaultTabTypeExplore) {
+            [[WMFNavigationEventsFunnel shared] logTappedExplore];
+        } else if ([selectedViewController isKindOfClass:[WMFSettingsViewController class]] && [NSUserDefaults standardUserDefaults].defaultTabType == WMFAppDefaultTabTypeSettings) {
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsFromTabBar];
+        } else if ([selectedViewController isKindOfClass:[WMFPlacesViewController class]]) {
+            [[WMFNavigationEventsFunnel shared] logTappedPlaces];
+        } else if ([selectedViewController isKindOfClass:[WMFSavedViewController class]]) {
+            [[WMFNavigationEventsFunnel shared] logTappedSaved];
+        } else if ([selectedViewController isKindOfClass:[WMFHistoryViewController class]]) {
+            [[WMFNavigationEventsFunnel shared] logTappedHistory];
+        } else if ([selectedViewController isKindOfClass:[SearchViewController class]]) {
+            [[WMFNavigationEventsFunnel shared] logTappedSearch];
+        }
+    }
+}
+
+- (void)logTappedSettingsFromExplore {
+    [[WMFNavigationEventsFunnel shared] logTappedSettingsFromExplore];
 }
 
 #pragma mark - User was logged out

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -2113,9 +2113,6 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
     }
 }
 
-- (void)logTappedSettingsFromExplore {
-    [[WMFNavigationEventsFunnel shared] logTappedSettingsFromExplore];
-}
 
 #pragma mark - User was logged out
 

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -203,6 +203,62 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
     }
 }
 
+- (void)logNavigationEventsForMenuType:(WMFSettingsMenuItemType)type {
+
+    switch (type) {
+        case WMFSettingsMenuItemType_LoginAccount:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsLoginLogout];
+            break;
+        case WMFSettingsMenuItemType_SearchLanguage:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsLanguages];
+            break;
+        case WMFSettingsMenuItemType_Search:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsSearch];
+            break;
+        case WMFSettingsMenuItemType_ExploreFeed:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsExploreFeed];
+            break;
+        case WMFSettingsMenuItemType_Notifications:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsNotifications];
+            break;
+        case WMFSettingsMenuItemType_Appearance:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsReadingPreferences];
+            break;
+        case WMFSettingsMenuItemType_StorageAndSyncing:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsArticleStorageAndSyncing];
+            break;
+        case WMFSettingsMenuItemType_StorageAndSyncingDebug:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsReadingListDangerZone];
+            break;
+        case WMFSettingsMenuItemType_Support:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsSupportWikipedia];
+            break;
+        case WMFSettingsMenuItemType_PrivacyPolicy:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsPrivacyPolicy];
+            break;
+        case WMFSettingsMenuItemType_Terms:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsTermsOfUse];
+            break;
+        case WMFSettingsMenuItemType_RateApp:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsRateTheApp];
+            break;
+        case WMFSettingsMenuItemType_SendFeedback:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsHelp];
+            break;
+        case WMFSettingsMenuItemType_About:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsAbout];
+            break;
+        case WMFSettingsMenuItemType_ClearCache:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsClearCachedData];
+            break;
+        case WMFSettingsMenuItemType_SendUsageReports:
+            [[WMFNavigationEventsFunnel shared] logTappedSettingsSendUsageReports];
+            break;
+        default:
+            break;
+    }
+}
+
 #pragma mark - Cell tap handling
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
@@ -265,6 +321,10 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
         default:
             break;
     }
+
+    if (cell.tag != WMFSettingsMenuItemType_SendUsageReports) {
+            [self logNavigationEventsForMenuType:cell.tag];
+        }
 
     [self.tableView deselectRowAtIndexPath:indexPath
                                   animated:YES];

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -131,6 +131,7 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
 }
 
 - (void)closeButtonPressed {
+    [[WMFNavigationEventsFunnel shared] logTappedSettingsCloseButton];
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
@@ -179,6 +180,7 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
 
 - (void)disclosureSwitchChanged:(UISwitch *)disclosureSwitch {
     WMFSettingsMenuItemType type = (WMFSettingsMenuItemType)disclosureSwitch.tag;
+    [self logNavigationEventsForMenuType:type];
     [self updateStateForMenuItemType:type isSwitchOnValue:disclosureSwitch.isOn completion:^{
         [self loadSections];
     }];

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -324,7 +324,7 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
 
     if (cell.tag != WMFSettingsMenuItemType_SendUsageReports) {
             [self logNavigationEventsForMenuType:cell.tag];
-        }
+    }
 
     [self.tableView deselectRowAtIndexPath:indexPath
                                   animated:YES];


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T336508 & https://phabricator.wikimedia.org/T328487

### Notes
* We're adding the NavigationEventsFunnel to MEP. It existed in the legacy platform but was left out of the initial iteration of the migration
* We're enhancing this funnel with new fields to observe interaction with the article view toolbar
* We're adding new fields so we better understand interaction on the saved reading lists view

### Test Steps
1. Run the app, interact with the article view toolbar, and navigate around settings and the whole app
2. Interact with the reading lists view
3. Confirm that you see the events being sent with an HTTP request debugger

