### PR TITLE
[Watchlist] Add feature flags for watchlist and updated diffs

### DIFF
--- a/WMF Framework/FeatureFlags.swift
+++ b/WMF Framework/FeatureFlags.swift
@@ -5,5 +5,21 @@ public struct FeatureFlags {
     public static var needsNewTalkPage: Bool {
         return true
     }
+
+    public static var watchlistEnabled: Bool {
+        #if WMF_STAGING
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    public static var updatedDiffsEnabled: Bool {
+        #if WMF_STAGING
+        return true
+        #else
+        return false
+        #endif
+    }
     
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T336200

### Notes
Adds a feature flag for both the watchlist feature and the updated diffs view, with the Staging target set as always enabling these two.