### PR TITLE
Add last scrolled anchor to the share link

### DIFF
--- a/Wikipedia/Code/ArticleViewController+TableOfContents.swift
+++ b/Wikipedia/Code/ArticleViewController+TableOfContents.swift
@@ -66,6 +66,8 @@ extension ArticleViewController : ArticleTableOfContentsDisplayControllerDelegat
                 }
             }
         }
+
+        article.viewedFragment = item.anchor
     }
 
     public func tableOfContentsControllerDidCancel(_ controller: TableOfContentsViewController) {

--- a/Wikipedia/Code/ShareActivityController.swift
+++ b/Wikipedia/Code/ShareActivityController.swift
@@ -144,7 +144,7 @@ class ShareActivityController: UIActivityViewController {
             items.append(text)
         }
         
-        if let shareURL = article.url?.wmf_URLForTextSharing {
+        if let shareURL = article.url?.wmf_URL(withOptionalFragment: article.viewedFragment)?.wmf_URLForTextSharing {
             items.append(shareURL)
         }
 
@@ -162,7 +162,7 @@ class ShareActivityController: UIActivityViewController {
         items.append(WMFItemSourceWrapperExcludingActivityTypes(itemSource: textActivitySource, excludedActivityTypes: [.copyToPasteboard]))
 
         // shareURL is the only item that should be included in the UIActivity.ActivityType.copyToPasteboard activity.
-        if let shareURL = article.url?.wmf_URLForTextSharing {
+        if let shareURL = article.url?.wmf_URL(withOptionalFragment: article.viewedFragment)?.wmf_URLForTextSharing {
             items.append(shareURL)
         }
 
@@ -180,7 +180,7 @@ class ShareActivityController: UIActivityViewController {
         items.append(WMFItemSourceWrapperExcludingActivityTypes(itemSource: textActivitySource, excludedActivityTypes: [.copyToPasteboard]))
         
         // shareURL is the only item that should be included in the UIActivity.ActivityType.copyToPasteboard activity.
-        if let shareURL = article.url?.wmf_URLForTextSharing {
+        if let shareURL = article.url?.wmf_URL(withOptionalFragment: article.viewedFragment)?.wmf_URLForTextSharing {
             items.append(shareURL)
         }
         
@@ -202,7 +202,7 @@ class ShareActivityController: UIActivityViewController {
             items.append(image)
             shareURL = article.url?.wmf_URLForImageSharing
         } else {
-            shareURL = article.url?.wmf_URLForTextSharing
+            shareURL = article.url?.wmf_URL(withOptionalFragment: article.viewedFragment)?.wmf_URLForTextSharing
         }
         
         if let shareURL = shareURL {

--- a/Wikipedia/Code/URL+LinkParsing.swift
+++ b/Wikipedia/Code/URL+LinkParsing.swift
@@ -84,6 +84,14 @@ extension URL {
     public func wmf_URL(withFragment fragment: String) -> URL? {
         return (self as NSURL).wmf_URL(withFragment: fragment)
     }
+
+    public func wmf_URL(withOptionalFragment fragment: String?) -> URL? {
+        if let fragment {
+            return self.wmf_URL(withFragment: fragment)
+        } else {
+            return self
+        }
+    }
     
     public func wmf_URL(withPath path: String, isMobile: Bool) -> URL? {
         return (self as NSURL).wmf_URL(withPath: path, isMobile: isMobile)


### PR DESCRIPTION
**Phabricator:** 

### Notes
* This enables sharing a specific section instead of only the general article URL.

### Test Steps
1. Open the app
2. Open an article
3. Open the table of contents sidebar
4. Select a header
5. Share the article

The shared link will include the anchor of the selected header.

### Screenshots/Videos

