### PR TITLE
Send revision ID on save success event log

### DIFF
--- a/Wikipedia/Code/ArticleViewController+Editing.swift
+++ b/Wikipedia/Code/ArticleViewController+Editing.swift
@@ -184,7 +184,7 @@ extension ArticleViewController: SectionEditorViewControllerDelegate {
         case .success(let changes):
             dismiss(animated: true)
             waitForNewContentAndRefresh(changes.newRevisionID)
-            EditAttemptFunnel.shared.logSaveSuccess(articleURL: self.articleURL)
+            EditAttemptFunnel.shared.logSaveSuccess(articleURL: self.articleURL, revisionId: Int(changes.newRevisionID))
         }
     }
     

--- a/Wikipedia/Code/EditAttemptFunnel.swift
+++ b/Wikipedia/Code/EditAttemptFunnel.swift
@@ -22,6 +22,7 @@ public final class EditAttemptFunnel {
         let version: Int
         let page_title: String?
         let page_ns: Int?
+        let revision_id: Int?
     }
 
     private enum EditAction: String, Codable {
@@ -36,14 +37,14 @@ public final class EditAttemptFunnel {
         case abort = "abort"
     }
 
-    private func logEvent(articleURL: URL, action: EditAction) {
+    private func logEvent(articleURL: URL, action: EditAction, revisionId: Int? = nil) {
         let editorInterface = "wikitext"
         let integrationID = "app-ios"
         let platform = UIDevice.current.userInterfaceIdiom == .pad ? "tablet" : "phone"
 
         let userId = getUserID(articleURL: articleURL)
 
-        let event = Event(action: action, editing_session_id: "", editor_interface: editorInterface, integration: integrationID, mw_version: "", platform: platform, user_editcount: 0, user_id: userId, version: 1, page_title: articleURL.wmf_title, page_ns: articleURL.namespace?.rawValue)
+        let event = Event(action: action, editing_session_id: "", editor_interface: editorInterface, integration: integrationID, mw_version: "", platform: platform, user_editcount: 0, user_id: userId, version: 1, page_title: articleURL.wmf_title, page_ns: articleURL.namespace?.rawValue, revision_id: revisionId)
         
         let container = EventContainer(event: event)
         EventPlatformClient.shared.submit(stream: .editAttempt, event: container, needsMinimal: true)
@@ -61,8 +62,8 @@ public final class EditAttemptFunnel {
         logEvent(articleURL: articleURL, action: .saveAttempt)
     }
 
-    func logSaveSuccess(articleURL: URL) {
-        logEvent(articleURL: articleURL, action: .saveSuccess)
+    func logSaveSuccess(articleURL: URL, revisionId: Int) {
+        logEvent(articleURL: articleURL, action: .saveSuccess, revisionId: revisionId)
     }
 
     func logSaveFailure(articleURL: URL) {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T337331

### Notes
* We missed sending the revision ID on the `saveSuccess()` event log

### Test Steps
1. On an article, create an edit and save it. Check either on a network traffic debugger on the analytics platform that the events contain a `revision_id` field.


