### PR TITLE
Fix automatic theme switching bug

### DIFF
--- a/Wikipedia/Code/WMFThemeableNavigationController.m
+++ b/Wikipedia/Code/WMFThemeableNavigationController.m
@@ -43,11 +43,11 @@
     
     NSString *themeName = [[NSUserDefaults standardUserDefaults] themeName];
     if ([WMFTheme isDefaultThemeName:themeName]) {
-     self.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+        self.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
     } else if ([WMFTheme isDarkThemeName:themeName]) {
-     self.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+        self.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
     } else {
-     self.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+        self.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
     }
 
     if (@available(iOS 15.0, *)) {

--- a/Wikipedia/Code/WMFThemeableNavigationController.m
+++ b/Wikipedia/Code/WMFThemeableNavigationController.m
@@ -40,7 +40,15 @@
     self.navigationBar.standardAppearance = appearance;
     self.navigationBar.scrollEdgeAppearance = appearance;
     self.navigationBar.compactAppearance = appearance;
-    self.overrideUserInterfaceStyle = theme.isDark ? UIUserInterfaceStyleDark : UIUserInterfaceStyleLight;
+    
+    NSString *themeName = [[NSUserDefaults standardUserDefaults] themeName];
+    if ([WMFTheme isDefaultThemeName:themeName]) {
+     self.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+    } else if ([WMFTheme isDarkThemeName:themeName]) {
+     self.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+    } else {
+     self.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+    }
 
     if (@available(iOS 15.0, *)) {
         //do nothing


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T336093

### Notes
This was a regression from merging https://github.com/wikimedia/wikipedia-ios/pull/4506. Per findings in https://github.com/wikimedia/wikipedia-ios-components/pull/10#pullrequestreview-1454170194, setting this property while in Default theme can cause `traitCollectionDidChange` to not fire when the system mode changes. Keeping the style to `.unspecified` in default theme fixes it. 

### Test Steps
1. Go over test steps in https://phabricator.wikimedia.org/T336093 - confirm mode now correctly switches when in Default theme.
2. Go over test steps in https://phabricator.wikimedia.org/T326207 - confirm placeholder color fix still works.