### PR TITLE
Load main Core Data store asynchronously

### DIFF
--- a/WMF Framework/Widget/WidgetController.swift
+++ b/WMF Framework/Widget/WidgetController.swift
@@ -128,8 +128,6 @@ public final class WidgetController: NSObject {
                 self.completions.forEach { $0(dataStore) }
                 self.completions.removeAll()
             }
-        } needsMigrateBlock: {
-            DDLogDebug("Needed a migration from the widgets")
         }
     }
     

--- a/Wikipedia/Code/MWKDataStore.h
+++ b/Wikipedia/Code/MWKDataStore.h
@@ -52,6 +52,7 @@ typedef NS_OPTIONS(NSUInteger, RemoteConfigOption) {
 - (instancetype)init;
 
 - (instancetype)initWithContainerURL:(NSURL *)containerURL NS_DESIGNATED_INITIALIZER;
+- (void)finishSetup:(nullable dispatch_block_t)completion;
 
 /// Call to cancel any async tasks and wait for completion
 - (void)teardown:(nullable dispatch_block_t)completion;
@@ -61,7 +62,7 @@ typedef NS_OPTIONS(NSUInteger, RemoteConfigOption) {
 @property (readonly, strong, nonatomic) WMFConfiguration *configuration;
 @property (readonly, strong, nonatomic) WMFPermanentCacheController *cacheController;
 
-- (void)performLibraryUpdates:(dispatch_block_t)completion needsMigrateBlock:(dispatch_block_t)needsMigrateBlock;
+- (void)performLibraryUpdates:(dispatch_block_t)completion;
 - (void)performInitialLibrarySetup;
 #if TEST
 - (void)performTestLibrarySetup;

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -43,7 +43,7 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
 @property (readwrite, copy, nonatomic) NSString *basePath;
 @property (readwrite, strong, nonatomic) NSCache *articleCache;
 
-@property (nonatomic, strong) NSPersistentStoreCoordinator *persistentStoreCoordinator;
+@property (nonatomic, strong) NSPersistentContainer *persistentContainer;
 @property (nonatomic, strong) NSManagedObjectContext *viewContext;
 @property (nonatomic, strong) NSManagedObjectContext *feedImportContext;
 
@@ -101,19 +101,26 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
         self.containerURL = containerURL;
         self.basePath = [self.containerURL URLByAppendingPathComponent:@"Data" isDirectory:YES].path;
         [self setupLegacyDataStore];
-        [self setupCoreDataStackWithContainerURL:containerURL];
-        [self setupCoreDataSynchronizersWithContainerURL:containerURL];
+    }
+    return self;
+}
+
+- (void)finishSetup:(nullable dispatch_block_t)completion {
+    [self setupCoreDataStackWithContainerURL:self.containerURL completion:^{
+        [self setupCoreDataSynchronizersWithContainerURL:self.containerURL];
         [self startSynchronizingLibraryContexts];
         [self setupHistoryAndSavedPageLists];
         self.languageLinkController = [[MWKLanguageLinkController alloc] initWithManagedObjectContext:self.viewContext];
         self.feedContentController = [[WMFExploreFeedContentController alloc] initWithDataStore:self];
         [self.feedContentController updateContentSources];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveMemoryWarningWithNotification:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
-        self.remoteNotificationsController = [[RemoteNotificationsController alloc] initWithSession:session configuration:configuration languageLinkController:self.languageLinkController authManager:authenticationManager];
+        self.remoteNotificationsController = [[RemoteNotificationsController alloc] initWithSession:self.session configuration:self.configuration languageLinkController:self.languageLinkController authManager:self.authenticationManager];
         self.notificationsController = [[WMFNotificationsController alloc] initWithDataStore:self languageLinkController:self.languageLinkController];
-        self.articleSummaryController = [[WMFArticleSummaryController alloc] initWithSession:session configuration:configuration dataStore:self];
-    }
-    return self;
+        self.articleSummaryController = [[WMFArticleSummaryController alloc] initWithSession:self.session configuration:self.configuration dataStore:self];
+        if (completion) {
+            completion();
+        }
+    }];
 }
 
 - (void)teardown:(nullable dispatch_block_t)completion {
@@ -192,42 +199,43 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
     return [NSKeyedUnarchiver unarchivedObjectOfClasses:allowedClasses fromData:data error:error];
 }
 
-- (void)setupCoreDataStackWithContainerURL:(NSURL *)containerURL {
-    NSURL *modelURL = [[NSBundle wmf] URLForResource:@"Wikipedia" withExtension:@"momd"];
+- (void)setupCoreDataStackWithContainerURL:(NSURL *)containerURL completion:(nullable dispatch_block_t)completion {
+    NSString *modelName = @"Wikipedia";
+    NSURL *modelURL = [[NSBundle wmf] URLForResource:modelName withExtension:@"momd"];
     NSManagedObjectModel *model = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
     NSString *coreDataDBName = @"Wikipedia.sqlite";
 
+    NSPersistentContainer *container = [[NSPersistentContainer alloc] initWithName:modelName managedObjectModel:model];
     NSURL *coreDataDBURL = [containerURL URLByAppendingPathComponent:coreDataDBName isDirectory:NO];
-    NSPersistentStoreCoordinator *persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:model];
-    NSDictionary *options = @{NSMigratePersistentStoresAutomaticallyOption: @YES,
-                              NSInferMappingModelAutomaticallyOption: @YES};
-    NSError *persistentStoreError = nil;
-    if (nil == [persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:coreDataDBURL options:options error:&persistentStoreError]) {
-        // TODO: Metrics
-        DDLogError(@"Error adding persistent store: %@", persistentStoreError);
-        NSError *moveError = nil;
-        NSFileManager *fileManager = [NSFileManager defaultManager];
-        NSString *uuid = [[NSUUID UUID] UUIDString];
-        NSURL *moveURL = [[containerURL URLByAppendingPathComponent:uuid] URLByAppendingPathExtension:@"sqlite"];
-        [fileManager moveItemAtURL:coreDataDBURL toURL:moveURL error:&moveError];
-        if (moveError) {
+    NSPersistentStoreDescription *description = [[NSPersistentStoreDescription alloc] initWithURL:coreDataDBURL];
+    [description setOption:@YES forKey:NSMigratePersistentStoresAutomaticallyOption];
+    [description setOption:@YES forKey:NSInferMappingModelAutomaticallyOption];
+    description.shouldAddStoreAsynchronously = YES;
+    container.persistentStoreDescriptions = @[description];
+    
+    [container loadPersistentStoresWithCompletionHandler:^(NSPersistentStoreDescription * _Nonnull description, NSError * _Nullable error) {
+        if (error) {
             // TODO: Metrics
-            [fileManager removeItemAtURL:coreDataDBURL error:nil];
+            DDLogError(@"Error adding persistent store: %@", error);
+            if (completion) {
+                completion();
+            }
+            return;
         }
-        persistentStoreError = nil;
-        if (nil == [persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:coreDataDBURL options:options error:&persistentStoreError]) {
-            // TODO: Metrics
-            DDLogError(@"Second error after adding persistent store: %@", persistentStoreError);
-        }
-    }
-
-    self.persistentStoreCoordinator = persistentStoreCoordinator;
-    self.viewContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
-    self.viewContext.persistentStoreCoordinator = persistentStoreCoordinator;
-    self.viewContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy;
-    self.viewContext.automaticallyMergesChangesFromParent = YES;
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(managedObjectContextDidSave:) name:NSManagedObjectContextDidSaveNotification object:self.viewContext];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(viewContextDidChange:) name:NSManagedObjectContextObjectsDidChangeNotification object:self.viewContext];
+        
+        dispatch_async(dispatch_get_main_queue(), ^(void) {
+            self.persistentContainer = container;
+            self.viewContext = container.viewContext;
+            self.viewContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy;
+            self.viewContext.automaticallyMergesChangesFromParent = YES;
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(managedObjectContextDidSave:) name:NSManagedObjectContextDidSaveNotification object:self.viewContext];
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(viewContextDidChange:) name:NSManagedObjectContextObjectsDidChangeNotification object:self.viewContext];
+            
+            if (completion) {
+                completion();
+            }
+        });
+    }];
 }
 
 - (void)viewContextDidChange:(NSNotification *)note {
@@ -277,8 +285,7 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
 
 - (void)performBackgroundCoreDataOperationOnATemporaryContext:(nonnull void (^)(NSManagedObjectContext *moc))mocBlock {
     WMFAssertMainThread(@"Background Core Data operations must be started from the main thread.");
-    NSManagedObjectContext *backgroundContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
-    backgroundContext.persistentStoreCoordinator = _persistentStoreCoordinator;
+    NSManagedObjectContext *backgroundContext = self.persistentContainer.newBackgroundContext;
     backgroundContext.automaticallyMergesChangesFromParent = YES;
     backgroundContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy;
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
@@ -292,8 +299,7 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
 - (NSManagedObjectContext *)feedImportContext {
     WMFAssertMainThread(@"feedImportContext must be created on the main thread");
     if (!_feedImportContext) {
-        _feedImportContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
-        _feedImportContext.persistentStoreCoordinator = _persistentStoreCoordinator;
+        _feedImportContext = self.persistentContainer.newBackgroundContext;
         _feedImportContext.automaticallyMergesChangesFromParent = YES;
         _feedImportContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy;
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(managedObjectContextDidSave:) name:NSManagedObjectContextDidSaveNotification object:_feedImportContext];
@@ -482,7 +488,7 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
 
 /// Library updates are separate from Core Data migration and can be used to orchestrate migrations that are more complex than automatic Core Data migration allows.
 /// They can also be used to perform migrations when the underlying Core Data model has not changed version but the apps' logic has changed in a way that requires data migration.
-- (void)performLibraryUpdates:(dispatch_block_t)completion needsMigrateBlock:(dispatch_block_t)needsMigrateBlock {
+- (void)performLibraryUpdates:(dispatch_block_t)completion {
     dispatch_block_t combinedCompletion = ^{
         [WMFPermanentCacheController setupCoreDataStack:^(NSManagedObjectContext *_Nullable moc, NSError *_Nullable error) {
             if (error) {
@@ -510,7 +516,6 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
         return;
     }
 
-    needsMigrateBlock();
     [self performBackgroundCoreDataOperationOnATemporaryContext:^(NSManagedObjectContext *moc) {
         [self performUpdatesFromLibraryVersion:currentUserLibraryVersion inManagedObjectContext:moc];
         combinedCompletion();

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -831,25 +831,24 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
     //    };
 
     self.migrationActive = YES;
-
-    [self.dataStore
-        performLibraryUpdates:^{
-            dispatch_async(dispatch_get_main_queue(), ^{
-                self.migrationComplete = YES;
-                self.migrationActive = NO;
-                [self endMigrationBackgroundTask];
-                [self checkRemoteAppConfigIfNecessary];
-                [self setupControllers];
-                if (!self.isWaitingToResumeApp) {
-                    [self resumeApp:NULL];
-                }
-            });
-        }
-        needsMigrateBlock:^{
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [(WMFRootNavigationController *)self.navigationController triggerMigratingAnimation];
-            });
-        }];
+    [(WMFRootNavigationController *)self.navigationController triggerMigratingAnimation];
+    
+    MWKDataStore *dataStore = self.dataStore; // Triggers init
+    [dataStore finishSetup:^{
+        [dataStore
+            performLibraryUpdates:^{
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    self.migrationComplete = YES;
+                    self.migrationActive = NO;
+                    [self endMigrationBackgroundTask];
+                    [self checkRemoteAppConfigIfNecessary];
+                    [self setupControllers];
+                    if (!self.isWaitingToResumeApp) {
+                        [self resumeApp:NULL];
+                    }
+                });
+            }];
+    }];
 }
 
 #pragma mark - Start/Pause/Resume App

--- a/WikipediaUnitTests/ArticleTestHelpers.swift
+++ b/WikipediaUnitTests/ArticleTestHelpers.swift
@@ -79,13 +79,22 @@ class ArticleTestHelpers {
     }
     static var fixtureData: FixtureData?
     
-    static let dataStore = MWKDataStore.temporary()
-    static let cacheController: PermanentCacheController = {
-        let tempPath = WMFRandomTemporaryPath()!
-        let randomURL = NSURL.fileURL(withPath: tempPath)
-        let temporaryCacheURL = randomURL.appendingPathComponent("Permanent Cache", isDirectory: true)
-        return PermanentCacheController.testController(with: temporaryCacheURL, dataStore: dataStore)
-    }()
+    static var dataStore: MWKDataStore!
+    static var cacheController: PermanentCacheController!
+    
+    static func setup(completion: @escaping () -> Void) {
+        MWKDataStore.createTemporaryDataStore(completion: { dataStore in
+            
+            let tempPath = WMFRandomTemporaryPath()!
+            let randomURL = NSURL.fileURL(withPath: tempPath)
+            let temporaryCacheURL = randomURL.appendingPathComponent("Permanent Cache", isDirectory: true)
+            let permCache = PermanentCacheController.testController(with: temporaryCacheURL, dataStore: dataStore)
+            
+            self.dataStore = dataStore
+            self.cacheController = permCache
+            completion()
+        })
+    }
     
     static func pullDataFromFixtures(inBundle bundle: Bundle) {
         

--- a/WikipediaUnitTests/Code/ArticleCacheReadingTests.swift
+++ b/WikipediaUnitTests/Code/ArticleCacheReadingTests.swift
@@ -5,11 +5,15 @@ import XCTest
 class ArticleCacheReadingTests: XCTestCase {
     let timeout: TimeInterval = 10
     
-    override func setUp() {
-        super.setUp()
-        LSNocilla.sharedInstance().start()
-        ArticleTestHelpers.pullDataFromFixtures(inBundle: wmf_bundle())
-        ArticleTestHelpers.stubCompleteMobileHTMLResponse(inBundle: wmf_bundle())
+    override func setUp(completion: @escaping (Error?) -> Void) {
+        
+        ArticleTestHelpers.setup {
+            LSNocilla.sharedInstance().start()
+            ArticleTestHelpers.pullDataFromFixtures(inBundle: self.wmf_bundle())
+            ArticleTestHelpers.stubCompleteMobileHTMLResponse(inBundle: self.wmf_bundle())
+            completion(nil)
+        }
+        
     }
     
     override func tearDown() {

--- a/WikipediaUnitTests/Code/DataStoreTests.swift
+++ b/WikipediaUnitTests/Code/DataStoreTests.swift
@@ -3,10 +3,18 @@ import XCTest
 @testable import WMF
 
 class DataStoreTests: XCTestCase {
+    
+    var dataStore: MWKDataStore!
+    override func setUp(completion: @escaping (Error?) -> Void) {
+        MWKDataStore.createTemporaryDataStore { dataStore in
+            self.dataStore = dataStore
+            completion(nil)
+        }
+    }
+    
     /// The reading lists VCs and the reading lists controller assume that the default reading list has been created.
     /// Ensure it's created when a new data store is created.
     func testInitialMigrationCreatesDefaultReadingList() {
-        let dataStore = MWKDataStore.temporary()
         XCTAssertNotNil(dataStore.viewContext.defaultReadingList)
     }
 }

--- a/WikipediaUnitTests/Code/MWKDataStore+TemporaryDataStore.h
+++ b/WikipediaUnitTests/Code/MWKDataStore+TemporaryDataStore.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Create a data store which persists objects in a random folder in the application's @c tmp directory.
  * @see WMFRandomTemporaryDirectoryPath()
  */
-+ (instancetype)temporaryDataStore;
++ (void)createTemporaryDataStoreWithCompletion:(void (^)(MWKDataStore *))completion;
 
 @end
 

--- a/WikipediaUnitTests/Code/MWKDataStore+TemporaryDataStore.m
+++ b/WikipediaUnitTests/Code/MWKDataStore+TemporaryDataStore.m
@@ -6,11 +6,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation MWKDataStore (Testing)
 
-+ (instancetype)temporaryDataStore {
++ (void)createTemporaryDataStoreWithCompletion:(void (^)(MWKDataStore *))completion {
     MWKDataStore *dataStore = [[MWKDataStore alloc] initWithContainerURL:[NSURL fileURLWithPath:WMFRandomTemporaryPath()]];
-    [dataStore performInitialLibrarySetup];
-    [dataStore performTestLibrarySetup];
-    return dataStore;
+    [dataStore finishSetup:^{
+        [dataStore performInitialLibrarySetup];
+        [dataStore performTestLibrarySetup];
+        if (completion) {
+            completion(dataStore);
+        }
+    }];
 }
 
 @end

--- a/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
+++ b/WikipediaUnitTests/Code/MWKLanguageLinkControllerTests.m
@@ -13,10 +13,8 @@
 
 @implementation MWKLanguageLinkControllerTests
 
-- (void)setUp {
-    [super setUp];
-
-    // force language link controller to grab device language, not previous values set by another test
+- (void)setUpWithCompletionHandler:(void (^)(NSError * _Nullable))completion {
+    
     [[NSUserDefaults standardUserDefaults] wmf_resetToDefaultValues];
 
     NSAssert([[NSLocale preferredLanguages] containsObject:@"en-US"] || [[NSLocale preferredLanguages] containsObject:@"en"],
@@ -24,10 +22,13 @@
               " Instead, these were the preferred languages: %@",
              [NSLocale preferredLanguages]);
 
-    // all tests must start w/ a clean slate
-    self.controller = MWKDataStore.temporaryDataStore.languageLinkController;
-    self.filter = [[MWKLanguageFilter alloc] initWithLanguageDataSource:self.controller];
-    [self.controller resetPreferredLanguages];
+    
+    [MWKDataStore createTemporaryDataStoreWithCompletion:^(MWKDataStore * _Nonnull dataStore) {
+        self.controller = dataStore.languageLinkController;
+        self.filter = [[MWKLanguageFilter alloc] initWithLanguageDataSource:self.controller];
+        [self.controller resetPreferredLanguages];
+        completion(nil);
+    }];
 }
 
 - (void)testReadPreviouslySelectedLanguagesReturnsEmpty {
@@ -68,7 +69,6 @@
 }
 
 - (void)testLanguagesPropertiesAreNonnull {
-    self.controller = MWKDataStore.temporaryDataStore.languageLinkController;
     XCTAssertTrue(self.controller.allLanguages.count > 0);
     XCTAssertTrue(self.controller.otherLanguages.count > 0);
     XCTAssertTrue(self.controller.preferredLanguages.count > 0);

--- a/WikipediaUnitTests/Code/ReadingListsTests.swift
+++ b/WikipediaUnitTests/Code/ReadingListsTests.swift
@@ -4,9 +4,11 @@ class ReadingListsTests: XCTestCase {
     
     var dataStore: MWKDataStore!
     
-    override func setUp() {
-        super.setUp()
-        dataStore = MWKDataStore.temporary()
+    override func setUp(completion: @escaping (Error?) -> Void) {
+        MWKDataStore.createTemporaryDataStore(completion: { dataStore in
+            self.dataStore = dataStore
+            completion(nil)
+        })
     }
     
     override func tearDown() {

--- a/WikipediaUnitTests/Code/WMFArticleTests.swift
+++ b/WikipediaUnitTests/Code/WMFArticleTests.swift
@@ -2,7 +2,15 @@ import XCTest
 @testable import WMF
 
 class WMFArticleTests: XCTestCase {
-    let dataStore: MWKDataStore = MWKDataStore.temporary()
+    
+    var dataStore: MWKDataStore!
+    
+    override func setUp(completion: @escaping (Error?) -> Void) {
+        MWKDataStore.createTemporaryDataStore(completion: { dataStore in
+            self.dataStore = dataStore
+            completion(nil)
+        })
+    }
     
     var a: WMFArticle!
     var b: WMFArticle!

--- a/WikipediaUnitTests/Manual Tests/ArticleCacheReadingManualTests.swift
+++ b/WikipediaUnitTests/Manual Tests/ArticleCacheReadingManualTests.swift
@@ -3,11 +3,12 @@
 import XCTest
 
 class ArticleCacheReadingManualTests: XCTestCase {
-
-    override func setUp() {
-        super.setUp()
-        
-        ArticleTestHelpers.pullDataFromFixtures(inBundle: wmf_bundle())
+    
+    override func setUp(completion: @escaping (Error?) -> Void) {
+        ArticleTestHelpers.setup {
+            ArticleTestHelpers.pullDataFromFixtures(inBundle: self.wmf_bundle())
+            completion(nil)
+        }
     }
     
     override func tearDown() {
@@ -18,7 +19,7 @@ class ArticleCacheReadingManualTests: XCTestCase {
     
     func testBasicNetworkNoConnectionWithCachedArticle() {
 
-        XCTFail("Reminder: these tests need to be on device and in airplane mode, otherwise they won't work. Comment out this failure once this is done and re-run.")
+       XCTFail("Reminder: these tests need to be on device and in airplane mode, otherwise they won't work. Comment out this failure once this is done and re-run.")
 
         ArticleTestHelpers.writeCachedPiecesToCachingSystem()
 

--- a/WikipediaUnitTests/Manual Tests/ReadingListManualPerformanceTests.swift
+++ b/WikipediaUnitTests/Manual Tests/ReadingListManualPerformanceTests.swift
@@ -4,9 +4,11 @@ class ReadingListManualPerformanceTests: XCTestCase {
     
     var dataStore: MWKDataStore!
 
-    override func setUp() {
-        super.setUp()
-        dataStore = MWKDataStore.temporary()
+    override func setUp(completion: @escaping (Error?) -> Void) {
+        MWKDataStore.createTemporaryDataStore { dataStore in
+            self.dataStore = dataStore
+            completion(nil)
+        }
     }
     
     override func tearDown() {


### PR DESCRIPTION
**Phabricator:**
https://phabricator.wikimedia.org/T340886

### Notes
7.3.1 showed a significant slowdown in `didFinishLaunching` when I tested by upgrading from 7.3.0 with saved articles. I suspect it may be due to bumping up the Core Data model version number when cleaning out old talk pages (my [suggestion](https://github.com/wikimedia/wikipedia-ios/pull/4448#pullrequestreview-1283735464)).

Our old way of setting up the Core Data stack loaded persistent stores on the main thread and was triggered (indirectly) from `didFinishLaunching`.

For this PR I reworked the Core Data stack setup to use a `NSPersistentContainer` and `NSPersistentStoreDescription`. `NSPersistentStoreDescription` has a `shouldAddStoreAsynchronously` which allows us to set up the stack asynchronously,  which allows this automatic migration to occur asynchronously as well.

### Test Steps
1. Run the App Store version 7.3.0. Save some articles.
2. Run from this branch. Confirm app launches and saved articles still work.
3. Run again from this branch. Confirm app launches and saved articles still work.

### Screenshots

Before (note green `didFinishLaunching` time):
![before](https://github.com/wikimedia/wikipedia-ios/assets/3620196/774c28b8-6eb9-44c1-9b06-82a1b21c5e71)

After:
![after](https://github.com/wikimedia/wikipedia-ios/assets/3620196/e00d27fe-18d1-4273-b08f-b45f63c47dd6)

