### PR TITLE
Update category string for settings event

### DIFF
--- a/WMF Framework/Event Platform/EventPlatformClient.swift
+++ b/WMF Framework/Event Platform/EventPlatformClient.swift
@@ -149,7 +149,7 @@ import CocoaLumberjackSwift
         case talkPages = "/analytics/mobile_apps/ios_talk_page_interaction/2.0.0"
         case readingLists = "/analytics/mobile_apps/ios_reading_lists/2.1.0"
         case userHistory = "/analytics/mobile_apps/ios_user_history/1.0.0"
-        case search = "/analytics/mobile_apps/ios_search/2.0.0"
+        case search = "/analytics/mobile_apps/ios_search/2.1.0"
         case sessions = "/analytics/mobile_apps/app_session/1.0.0"
         case settings = "/analytics/mobile_apps/ios_setting_action/1.0.0"
         case login = "/analytics/mobile_apps/ios_login_action/1.0.1"

--- a/WMF Framework/Event Platform/MEPEventProviding.swift
+++ b/WMF Framework/Event Platform/MEPEventProviding.swift
@@ -12,7 +12,7 @@ public enum EventCategoryMEP: String, Codable {
     case shared
     case login
     case setting
-    case enableSyncPopover = "enable_to_sync_popover"
+    case enableSyncPopover = "enable_sync_popover"
     case loginToSyncPopover = "login_to_sync_popover"
     case unknown
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T335548

### Notes
* This PR fixes a bug with one of the events, where it was not being sent due to a mismatch on the event category string

### Test Steps
1.  Trigger the enable "EnableReadingListSyncPanel"  (I was able to trigger it after account creation). Alternatively, for event logging purposes, you can paste this function `SettingsFunnel.shared.logEnableSyncPopoverSyncEnabled()` on the ExploreViewController viewDidLoad() method.
2. Verify that the event is successfully sent with no errors


