### PR TITLE
Remove updated diffs feature flag

### DIFF
--- a/WMF Framework/FeatureFlags.swift
+++ b/WMF Framework/FeatureFlags.swift
@@ -13,9 +13,5 @@ public struct FeatureFlags {
         return false
         #endif
     }
-
-    public static var updatedDiffsEnabled: Bool {
-        return true
-    }
     
 }

--- a/Wikipedia/Code/DiffListContextCell.swift
+++ b/Wikipedia/Code/DiffListContextCell.swift
@@ -41,20 +41,12 @@ class DiffListContextCell: UICollectionViewCell {
         headingLabel.text = viewModel.heading
         
         if self.viewModel == nil {
-            if FeatureFlags.updatedDiffsEnabled {
-                expandButton.setTitle(nil, for: .normal)
-                expandButton.setImage(viewModel.expandButtonImage, for: .normal)
-            } else {
-                expandButton.setTitle(viewModel.expandButtonTitle, for: .normal)
-            }
+            expandButton.setTitle(nil, for: .normal)
+            expandButton.setImage(viewModel.expandButtonImage, for: .normal)
         } else {
             expandButton.alpha = 0
-            if FeatureFlags.updatedDiffsEnabled {
-                expandButton.setTitle(nil, for: .normal)
-                expandButton.setImage(viewModel.expandButtonImage, for: .normal)
-            } else {
-                expandButton.setTitle(viewModel.expandButtonTitle, for: .normal)
-            }
+            expandButton.setTitle(nil, for: .normal)
+            expandButton.setImage(viewModel.expandButtonImage, for: .normal)
             UIView.animate(withDuration: 0.2) {
                 self.expandButton.alpha = 1
             }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T335579 (partially)

### Notes
Previously we intended to feature flag the updated diff work. We abandoned this with the complexity surrounding feature flagging work in XIBs. This PR just removes that feature flagging and sets the previously flagged behavior to default. Our current rollback plan for updated diffs is that if we need to revert, to revert to a commit before #4552 was merged.

### Test Steps
1. Open article history for an article and tap a revision
2. Confirm the in page view shows the "up/down" chevrons and not the "show/hide" text

