### PR TITLE
Add asynchronous setup call to fix the on this day widget

### DIFF
--- a/WMF Framework/Widget/WidgetController.swift
+++ b/WMF Framework/Widget/WidgetController.swift
@@ -121,12 +121,14 @@ public final class WidgetController: NSObject {
         isCreatingDataStore = true
         backgroundActivity = ProcessInfo.processInfo.beginActivity(options: [.background, .suddenTerminationDisabled, .automaticTerminationDisabled], reason: "Wikipedia Extension - " + UUID().uuidString)
         let dataStore = MWKDataStore()
-        dataStore.performLibraryUpdates {
-            DispatchQueue.main.async {
-                self._dataStore = dataStore
-                self.isCreatingDataStore = false
-                self.completions.forEach { $0(dataStore) }
-                self.completions.removeAll()
+        dataStore.finishSetup {
+            dataStore.performLibraryUpdates {
+                DispatchQueue.main.async {
+                    self._dataStore = dataStore
+                    self.isCreatingDataStore = false
+                    self.completions.forEach { $0(dataStore) }
+                    self.completions.removeAll()
+                }
             }
         }
     }


### PR DESCRIPTION
**Phabricator:** 
N/A

### Notes
There was a regression after https://github.com/wikimedia/wikipedia-ios/pull/4553 where my On This Day widget stopped loading. It showed the "Your app language does not support On This Day" error message despite having it set to EN.

I missed a `finishSetup` call at this point to ensure the Core Data stack was loaded asynchronously for the On This Day widget. I think this change is fairly low risk, being that On This Day is the last home screen widget that uses this method of data loading.

### Test Steps
1. Change device time to 1 week ago, add On This Day widget to home screen.
2. Move device time 1 day forward, confirm widget refreshes.
3. Repeat step 2 until current day. 