### PR TITLE
Fix bug with missing WKData app languages

### DIFF
--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -244,8 +244,6 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
     self.editHintController = [[WMFEditHintController alloc] init];
 
     self.navigationItem.backButtonDisplayMode = UINavigationItemBackButtonDisplayModeGeneric;
-    
-    [self setupWKDataEnvironment];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
@@ -846,6 +844,7 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
                     [self endMigrationBackgroundTask];
                     [self checkRemoteAppConfigIfNecessary];
                     [self setupControllers];
+                    [self setupWKDataEnvironment];
                     if (!self.isWaitingToResumeApp) {
                         [self resumeApp:NULL];
                     }


### PR DESCRIPTION
**Phabricator:** 
N/A

### Notes
This is a watchlist regression that I suspect may have occurred after https://github.com/wikimedia/wikipedia-ios/pull/4553 was merged. I noticed the WKDataEnvironment app languages were not populating correctly upon app launch.

### Test Steps (Optional)
Temporarily point Components package directly to the https://github.com/wikimedia/wikipedia-ios-components/pull/18 branch (`watchlist-fixes`), though note this PR is not a blocker for this merge.

1. On Staging scheme, launch app while logged in.
2. Go to Settings > Account > Watchlist, confirm you see data printed out to the console.
