### PR TITLE
Add Watchlist reachability handling and loading state

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -19869,7 +19869,7 @@
 			repositoryURL = "https://github.com/wikimedia/wikipedia-ios-components.git";
 			requirement = {
 				kind = revision;
-				revision = 4ad4889457c993841102fd9f2d7eec166de8569e;
+				revision = 0e4a66db36919c57d31a57efbdf6294f9c6b255e;
 			};
 		};
 		67A770C6251BFE0400F94EF9 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {

--- a/Wikipedia.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Wikipedia.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,7 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wikimedia/wikipedia-ios-components.git",
       "state" : {
-        "revision" : "4ad4889457c993841102fd9f2d7eec166de8569e"
+        "revision" : "0e4a66db36919c57d31a57efbdf6294f9c6b255e"
       }
     },
     {

--- a/Wikipedia/Code/ViewControllerRouter.swift
+++ b/Wikipedia/Code/ViewControllerRouter.swift
@@ -194,11 +194,27 @@ class ViewControllerRouter: NSObject {
                 )
             }
 
+            let reachabilityNotifier = ReachabilityNotifier(Configuration.current.defaultSiteDomain) { (reachable, _) in
+                if reachable {
+                    WMFAlertManager.sharedInstance.dismissAllAlerts()
+                } else {
+                    WMFAlertManager.sharedInstance.showErrorAlertWithMessage(CommonStrings.noInternetConnection, sticky: true, dismissPreviousAlerts: true)
+                }
+            }
+
+            let reachabilityHandler: WKWatchlistViewController.ReachabilityHandler = { state in
+                switch state {
+                case .appearing:
+                    reachabilityNotifier.start()
+                case .disappearing:
+                    reachabilityNotifier.stop()
+                }
+            }
+
             let localizedStrings = WKWatchlistViewModel.LocalizedStrings(title: CommonStrings.watchlist, filter: CommonStrings.watchlistFilter, userButtonUserPage: CommonStrings.userButtonPage, userButtonTalkPage: CommonStrings.userButtonTalkPage, userButtonContributions: CommonStrings.userButtonContributions, userButtonThank: CommonStrings.userButtonThank, byteChange: localizedByteChange)
             let presentationConfiguration = WKWatchlistViewModel.PresentationConfiguration(showNavBarUponAppearance: true, hideNavBarUponDisappearance: true)
             let viewModel = WKWatchlistViewModel(localizedStrings: localizedStrings, presentationConfiguration: presentationConfiguration)
-            let watchlistViewController = WKWatchlistViewController(viewModel: viewModel, filterViewModel: watchlistFilterViewModel, delegate: appViewController, menuButtonDelegate: nil)
-            
+            let watchlistViewController = WKWatchlistViewController(viewModel: viewModel, filterViewModel: watchlistFilterViewModel, delegate: appViewController, menuButtonDelegate: nil, reachabilityHandler: reachabilityHandler)
             targetNavigationController?.pushViewController(watchlistViewController, animated: true)
             completion()
             return true

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -210,7 +210,7 @@ extension WMFAppViewController: WKWatchlistDelegate {
         //
     }
     
-    public func watchlistUserDidTapDiff(revisionID: UInt, oldRevisionID: UInt) {
+    public func watchlistUserDidTapDiff(project: WKProject, articleTitle: String, revisionID: UInt, oldRevisionID: UInt) {
         //
     }
     


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T335606

### Notes
Adds reachability handler for watchlist to display a no internet connection toast over the view if the user is offline, in addition to the other work detailed in this PR: https://github.com/wikimedia/wikipedia-ios-components/pull/27

Dependent on https://github.com/wikimedia/wikipedia-ios/pull/4614 and  https://github.com/wikimedia/wikipedia-ios-components/pull/27

### Test Steps
1. Open the Watchlist
2. Confirm a loading spinner is displayed before the content is loaded
3. Enter airplane mode
4. Confirm the `No internet connection` toast is displayed
5. Exit airplane mode
6. Confirm the `No internet connection` toast no longer appears

