### PR TITLE
Watchlist - Add user page, user talk page, and user contributions menu button actions

### DIFF
--- a/WMF Framework/Remote Notifications/Model/WikimediaProject+RemoteNotifications.swift
+++ b/WMF Framework/Remote Notifications/Model/WikimediaProject+RemoteNotifications.swift
@@ -172,6 +172,10 @@ extension WikimediaProject {
         }
     }
     
+    public func mediaWikiAPIURL(configuration: Configuration) -> URL? {
+        return mediaWikiAPIURL(configuration: configuration, queryParameters: nil)
+    }
+
     func mediaWikiAPIURL(configuration: Configuration, queryParameters: RemoteNotificationsAPIController.Query.Parameters?) -> URL? {
 
         switch self {

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -19869,7 +19869,7 @@
 			repositoryURL = "https://github.com/wikimedia/wikipedia-ios-components.git";
 			requirement = {
 				kind = revision;
-				revision = b7f2a5667c9d17bc9ba9a808ea2272aee358a2ad;
+				revision = fcffed2440a6602f88f04a231b277d2bc4cd91fc;
 			};
 		};
 		67A770C6251BFE0400F94EF9 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {

--- a/Wikipedia.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Wikipedia.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,7 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wikimedia/wikipedia-ios-components.git",
       "state" : {
-        "revision" : "b7f2a5667c9d17bc9ba9a808ea2272aee358a2ad"
+        "revision" : "fcffed2440a6602f88f04a231b277d2bc4cd91fc"
       }
     },
     {

--- a/Wikipedia/Code/ViewControllerRouter.swift
+++ b/Wikipedia/Code/ViewControllerRouter.swift
@@ -198,7 +198,7 @@ class ViewControllerRouter: NSObject {
                     filters
                 )
                 
-                var attributedString = (try? AttributedString(markdown: localizedString)) ?? AttributedString(localizedString)
+                let attributedString = (try? AttributedString(markdown: localizedString)) ?? AttributedString(localizedString)
                 return attributedString
             }
 
@@ -227,7 +227,7 @@ class ViewControllerRouter: NSObject {
 
             if let image = UIImage(named: "watchlist-empty-state") {
                 let emptyViewModel = WKEmptyViewModel(localizedStrings: localizedStringsEmptyView, image: image, numberOfFilters: viewModel.activeFilterCount)
-                let watchlistViewController = WKWatchlistViewController(viewModel: viewModel, filterViewModel: watchlistFilterViewModel, emptyViewModel: emptyViewModel, delegate: appViewController, menuButtonDelegate: nil, reachabilityHandler: reachabilityHandler)
+                let watchlistViewController = WKWatchlistViewController(viewModel: viewModel, filterViewModel: watchlistFilterViewModel, emptyViewModel: emptyViewModel, delegate: appViewController, reachabilityHandler: reachabilityHandler)
 
                 targetNavigationController?.pushViewController(watchlistViewController, animated: true)
                 completion()

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -218,8 +218,23 @@ extension WMFAppViewController: WKWatchlistDelegate {
 
     }
 
-    public func watchlistUserDidTapUser(username: String, action: Components.WKWatchlistUserButtonAction) {
+    public func watchlistUserDidTapUser(project: WKProject, username: String, action: Components.WKWatchlistUserButtonAction) {
+        let wikimediaProject = WikimediaProject(wkProject: project)
+        guard let siteURL = wikimediaProject.mediaWikiAPIURL(configuration: .current) else {
+            return
+        }
 
+        switch action {
+        case .userPage:
+            navigate(to: siteURL.wmf_URL(withPath: "/wiki/User:\(username)", isMobile: true))
+        case .userTalkPage:
+            navigate(to: siteURL.wmf_URL(withPath: "/wiki/User_talk:\(username)", isMobile: true))
+        case .userContributions:
+            navigate(to: siteURL.wmf_URL(withPath: "/wiki/Special:Contributions/\(username)", isMobile: true))
+        case .thank:
+            // TODO
+            break
+        }
     }
 
 }

--- a/Wikipedia/Code/WikimediaProject.swift
+++ b/Wikipedia/Code/WikimediaProject.swift
@@ -139,7 +139,18 @@ public enum WikimediaProject: Hashable {
             return nil
         }
     }
-    
+
+    public init(wkProject: WKProject) {
+        switch wkProject {
+        case .wikipedia(let wKLanguage):
+            self = .wikipedia(wKLanguage.languageCode, "", wKLanguage.languageVariantCode)
+        case .wikidata:
+            self = .wikidata
+        case .commons:
+            self = .commons
+        }
+    }
+
     // MARK: Routing Helpers
     
     public var supportsNativeArticleTalkPages: Bool {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T335606 (partially)

### Notes
Adds user page, user talk page, and user contributions menu button item actions. ~~Depends on https://github.com/wikimedia/wikipedia-ios-components/pull/32~~ merged.

### Test Steps
1. Open watchlist
2. Tap a user button, and confirm the actions above route the user the appropriate place in a new view. Thank is currently unimplemented.
