### PR TITLE
Monorepo: Reorder groups and remove empty reference

### DIFF
--- a/WKData/.swiftpm/xcode/xcshareddata/xcschemes/WKDataMocks.xcscheme
+++ b/WKData/.swiftpm/xcode/xcshareddata/xcschemes/WKDataMocks.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1500"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "WKData"
-               BuildableName = "WKData"
-               BlueprintName = "WKData"
+               BlueprintIdentifier = "WKDataMocks"
+               BuildableName = "WKDataMocks"
+               BlueprintName = "WKDataMocks"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -26,13 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <TestPlans>
-         <TestPlanReference
-            reference = "container:../Test Plans/WKData.xctestplan"
-            default = "YES">
-         </TestPlanReference>
-      </TestPlans>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -54,9 +49,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "WKData"
-            BuildableName = "WKData"
-            BlueprintName = "WKData"
+            BlueprintIdentifier = "WKDataMocks"
+            BuildableName = "WKDataMocks"
+            BlueprintName = "WKDataMocks"
             ReferencedContainer = "container:">
          </BuildableReference>
       </MacroExpansion>

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -7268,13 +7268,6 @@
 			name = ImageCache;
 			sourceTree = "<group>";
 		};
-		67D6C0152405A3E2005709B1 /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = "Recovered References";
-			sourceTree = "<group>";
-		};
 		67D9D1F42970D8B000BFCD4F /* Button Styles */ = {
 			isa = PBXGroup;
 			children = (
@@ -8866,7 +8859,6 @@
 				00021DE624D48EFD00476F97 /* Widgets */,
 				676C864526D40AEB00A704C1 /* NotificationServiceExtension */,
 				D4991436181D51DE00E6073C /* Products */,
-				67D6C0152405A3E2005709B1 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 			usesTabs = 0;

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -8845,19 +8845,19 @@
 		D499142C181D51DE00E6073C = {
 			isa = PBXGroup;
 			children = (
-				67F47C0E2AAA6E16006E17FA /* Packages */,
 				D499143E181D51DE00E6073C /* Wikipedia */,
+				67F47C0E2AAA6E16006E17FA /* Packages */,
+				D844D96D1D6CB2600042D692 /* WMF Framework */,
+				00021DE624D48EFD00476F97 /* Widgets */,
+				0E8380661D64989F0076EDE4 /* ContinueReadingWidget */,
+				D8479FAC1F222FE90025FD7A /* Wikipedia Stickers */,
+				676C864526D40AEB00A704C1 /* NotificationServiceExtension */,
 				D801C8501EB8E131001FA294 /* Localizations */,
+				D87021611EBA63EF000D02D6 /* Update Localizations */,
 				BC8309941A7BF935003FC5C7 /* Tests */,
 				674C176A2AAA869D007DC6CC /* Test Plans */,
-				0E8380661D64989F0076EDE4 /* ContinueReadingWidget */,
-				D844D96D1D6CB2600042D692 /* WMF Framework */,
-				D87021611EBA63EF000D02D6 /* Update Localizations */,
-				D8479FAC1F222FE90025FD7A /* Wikipedia Stickers */,
-				83ACAA9F24E6DC8E003B3035 /* Command Line Tools */,
 				B0606EAF20AA6FF0006EC6B9 /* WikipediaUITests */,
-				00021DE624D48EFD00476F97 /* Widgets */,
-				676C864526D40AEB00A704C1 /* NotificationServiceExtension */,
+				83ACAA9F24E6DC8E003B3035 /* Command Line Tools */,
 				D4991436181D51DE00E6073C /* Products */,
 			);
 			sourceTree = "<group>";


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T346850 (partially, related work)

### Notes
Removes an empty "Recovered References" group and reorders the groups a bit. These groups were a little all over the place before – tried to add a little sense of order.

### Screenshots/Videos

![reorder](https://github.com/wikimedia/wikipedia-ios/assets/5652327/de4da905-972a-42c7-9c7e-0a983d57400a)

