### PR TITLE
Components - Rename `WKEmptyViewDelegate` protocol methods

### DIFF
--- a/Components/Sources/Components/Components/Empty View/WKEmptyView.swift
+++ b/Components/Sources/Components/Components/Empty View/WKEmptyView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 public protocol WKEmptyViewDelegate: AnyObject {
-    func didTapSearch()
-    func didTapFilters()
-    func didShow(type: WKEmptyViewStateType)
+    func emptyViewDidTapSearch()
+    func emptyViewDidTapFilters()
+    func emptyViewDidShow(type: WKEmptyViewStateType)
 }
 
 public struct WKEmptyView: View {
@@ -39,7 +39,7 @@ public struct WKEmptyView: View {
                                 .multilineTextAlignment(.center)
                         }
                         if type == .noItems {
-                            WKResizableButton(title: viewModel.localizedStrings.buttonTitle, action: delegate?.didTapSearch)
+                            WKResizableButton(title: viewModel.localizedStrings.buttonTitle, action: delegate?.emptyViewDidTapSearch)
                                 .padding([.leading, .trailing], 32)
                         }
                         Spacer()
@@ -50,7 +50,7 @@ public struct WKEmptyView: View {
             }
         }
         .onAppear {
-            delegate?.didShow(type: type)
+            delegate?.emptyViewDidShow(type: type)
         }
     }
 
@@ -74,7 +74,7 @@ struct WKEmptyViewFilterView: View {
             .foregroundColor(Color(appEnvironment.theme.secondaryText))
             .frame(height: 30)
             .environment(\.openURL, OpenURLAction { url in
-                    delegate?.didTapFilters()
+                    delegate?.emptyViewDidTapFilters()
                     return .handled
                 })
     }

--- a/Components/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
+++ b/Components/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
@@ -209,16 +209,16 @@ extension WKWatchlistViewController: WKWatchlistFilterDelegate {
 }
 
 extension WKWatchlistViewController: WKEmptyViewDelegate {
-    public func didShow(type: WKEmptyViewStateType) {
+    public func emptyViewDidShow(type: WKEmptyViewStateType) {
         loggingDelegate?.logWatchlistEmptyViewDidShow(type: type)
     }
     
-    public func didTapSearch() {
+    public func emptyViewDidTapSearch() {
         delegate?.watchlistEmptyViewUserDidTapSearch()
         loggingDelegate?.logWatchlistEmptyViewUserDidTapSearch()
     }
     
-    public func didTapFilters() {
+    public func emptyViewDidTapFilters() {
         showFilterView()
         loggingDelegate?.logWatchlistEmptyViewUserDidTapModifyFilters()
     }


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
Just a minor update to the delegate method names for `WKEmptyViewDelegate`. In general, I'd recommend we choose some pattern of delegate method name prefixing like this going forward with our new Components. Depending on the object choosing to conform to the protocol, it's hard to know if a generic name like `didTapSearch` is specific to the object itself or the delegate conformance it's implementing. But prefixing with the view itself (similar to `tableView(...)` delegate methods for example) provides sharper context.

### Test Steps
1. Confirm no regression with Watchlist's compliance of empty view delegate methods.
