### PR TITLE
Watchlist Onboarding Fixes

### DIFF
--- a/Components/Sources/Components/Components/Shared/Buttons/WKPrimaryButton.swift
+++ b/Components/Sources/Components/Components/Shared/Buttons/WKPrimaryButton.swift
@@ -15,10 +15,10 @@ struct WKPrimaryButton: View {
             Text(title)
                 .font(Font(WKFont.for(.boldSubheadline)))
                 .foregroundColor(Color(WKColor.white))
+                .frame(maxWidth: .infinity)
+                .frame(height: 46)
+                .background(Color(appEnvironment.theme.link))
+                .cornerRadius(8)
         })
-        .frame(maxWidth: .infinity)
-        .frame(height: 46)
-        .background(Color(appEnvironment.theme.link))
-        .cornerRadius(8)
     }
 }

--- a/Wikipedia/Code/AccountViewController.swift
+++ b/Wikipedia/Code/AccountViewController.swift
@@ -153,13 +153,7 @@ class AccountViewController: SubSettingsViewController {
             
             WatchlistFunnel.shared.logOpenWatchlistFromAccount()
             
-            let userDefaults = UserDefaults.standard
-
-            if !userDefaults.wmf_userHasOnboardedToWatchlists {
-                showWatchlistOnboarding()
-            } else {
-                goToWatchlist()
-            }
+            goToWatchlist()
 
         case .vanishAccount:
             let warningViewController = VanishAccountWarningViewHostingViewController(theme: theme)
@@ -167,24 +161,6 @@ class AccountViewController: SubSettingsViewController {
             present(warningViewController, animated: true)
         default:
             break
-        }
-    }
-
-    @objc func showWatchlistOnboarding() {
-        let trackChanges = WKOnboardingViewModel.WKOnboardingCellViewModel(icon: UIImage(named: "track-changes"), title: CommonStrings.watchlistTrackChangesTitle, subtitle: CommonStrings.watchlistTrackChangesSubtitle)
-        let watchArticles = WKOnboardingViewModel.WKOnboardingCellViewModel(icon: UIImage(named: "watch-articles"), title: CommonStrings.watchlistWatchChangesTitle, subtitle: CommonStrings.watchlistWatchChangesSubitle)
-        let setExpiration = WKOnboardingViewModel.WKOnboardingCellViewModel(icon: UIImage(named: "set-expiration"), title: CommonStrings.watchlistSetExpirationTitle, subtitle: CommonStrings.watchlistSetExpirationSubtitle)
-        let viewUpdates = WKOnboardingViewModel.WKOnboardingCellViewModel(icon: UIImage(named: "view-updates"), title: CommonStrings.watchlistViewUpdatesTitle, subtitle: CommonStrings.watchlistViewUpdatesSubitle)
-
-        let viewModel = WKOnboardingViewModel(title: CommonStrings.watchlistOnboardingTitle, cells: [trackChanges, watchArticles, setExpiration, viewUpdates], primaryButtonTitle: CommonStrings.continueButton, secondaryButtonTitle: CommonStrings.watchlistOnboardingLearnMore)
-
-        let viewController = WKOnboardingViewController(viewModel: viewModel)
-        viewController.hostingController.delegate = self
-        
-        WatchlistFunnel.shared.logWatchlistOnboardingAppearance()
-
-        present(viewController, animated: true) {
-            UserDefaults.standard.wmf_userHasOnboardedToWatchlists = true
         }
     }
 
@@ -260,33 +236,5 @@ extension AccountViewController: VanishAccountWarningViewDelegate {
 
         let viewController = VanishAccountContainerViewController(title: CommonStrings.vanishAccount.localizedCapitalized, theme: theme, username: username)
         navigationController?.pushViewController(viewController, animated: true)
-    }
-}
-
-extension AccountViewController: WKOnboardingViewDelegate {
-    func didClickPrimaryButton() {
-        
-        WatchlistFunnel.shared.logWatchlistOnboardingTapContinue()
-        
-        if let presentedViewController {
-            presentedViewController.dismiss(animated: true) {
-                self.goToWatchlist()
-            }
-        }
-    }
-
-    func didClickSecondaryButton() {
-        
-        WatchlistFunnel.shared.logWatchlistOnboardingTapLearnMore()
-
-        if let presentedViewController {
-            presentedViewController.dismiss(animated: true) {
-                guard let url = URL(string: "https://www.mediawiki.org/wiki/Wikimedia_Apps/iOS_FAQ#Watchlist") else {
-                    self.showGenericError()
-                    return
-                }
-                self.navigate(to: url)
-            }
-        }
     }
 }

--- a/Wikipedia/Code/ViewControllerRouter.swift
+++ b/Wikipedia/Code/ViewControllerRouter.swift
@@ -179,8 +179,6 @@ class ViewControllerRouter: NSObject {
         case .login:
             return presentLoginViewController(with: completion)
         case .watchlist:
-            
-            
             let userDefaults = UserDefaults.standard
 
             let targetNavigationController = watchlistTargetNavigationController()

--- a/Wikipedia/Code/ViewControllerRouter.swift
+++ b/Wikipedia/Code/ViewControllerRouter.swift
@@ -179,66 +179,15 @@ class ViewControllerRouter: NSObject {
         case .login:
             return presentLoginViewController(with: completion)
         case .watchlist:
-            var targetNavigationController = appViewController.navigationController
-            if let presentedNavigationController = appViewController.presentedViewController as? UINavigationController,
-               presentedNavigationController.viewControllers[0] is WMFSettingsViewController {
-                targetNavigationController = presentedNavigationController
-            }
+            
+            
+            let userDefaults = UserDefaults.standard
 
-            let localizedByteChange: (Int) -> String = { bytes in
-                String.localizedStringWithFormat(
-                    WMFLocalizedString("watchlist-byte-change", value:"{{PLURAL:%1$d|%1$d byte|%1$d bytes}}", comment: "Amount of bytes changed for a revision displayed in watchlist - %1$@ is replaced with the number of bytes."),
-                    bytes
-                )
-            }
-
-            let htmlStripped: (String) -> String = { inputString in
-                return inputString.removingHTML
-            }
-
-            let attributedFilterString: (Int) -> AttributedString = { filters in
-                let localizedString = String.localizedStringWithFormat(
-                    WMFLocalizedString("watchlist-number-filters", value:"Modify [{{PLURAL:%1$d|%1$d filter|%1$d filters}}](wikipedia://watchlist/filter) to see more Watchlist items", comment: "Amount of filters active in watchlist - %1$@ is replaced with the number of filters."),
-                    filters
-                )
-                
-                let attributedString = (try? AttributedString(markdown: localizedString)) ?? AttributedString(localizedString)
-                return attributedString
-            }
-
-
-            let localizedStrings = WKWatchlistViewModel.LocalizedStrings(title: CommonStrings.watchlist, filter: CommonStrings.watchlistFilter, userButtonUserPage: CommonStrings.userButtonPage, userButtonTalkPage: CommonStrings.userButtonTalkPage, userButtonContributions: CommonStrings.userButtonContributions, userButtonThank: CommonStrings.userButtonThank, userAccessibility: CommonStrings.userTitle, summaryAccessibility: CommonStrings.editSummaryTitle, userAccessibilityButtonDiff: CommonStrings.watchlistGoToDiff, localizedProjectNames: watchlistFilterViewModel.localizedStrings.localizedProjectNames, byteChange: localizedByteChange,  htmlStripped: htmlStripped)
-
-            let presentationConfiguration = WKWatchlistViewModel.PresentationConfiguration(showNavBarUponAppearance: true, hideNavBarUponDisappearance: true)
-
-            let viewModel = WKWatchlistViewModel(localizedStrings: localizedStrings, presentationConfiguration: presentationConfiguration)
-
-            let localizedStringsEmptyView = WKEmptyViewModel.LocalizedStrings(title: CommonStrings.watchlistEmptyViewTitle, subtitle: CommonStrings.watchlistEmptyViewSubtitle, titleFilter: CommonStrings.watchlistEmptyViewFilterTitle, buttonTitle: CommonStrings.watchlistEmptyViewButtonTitle, attributedFilterString: attributedFilterString)
-
-            let reachabilityNotifier = ReachabilityNotifier(Configuration.current.defaultSiteDomain) { (reachable, _) in
-                if reachable {
-                    WMFAlertManager.sharedInstance.dismissAllAlerts()
-                } else {
-                    WMFAlertManager.sharedInstance.showErrorAlertWithMessage(CommonStrings.noInternetConnection, sticky: true, dismissPreviousAlerts: true)
-                }
-            }
-
-            let reachabilityHandler: WKWatchlistViewController.ReachabilityHandler = { state in
-                switch state {
-                case .appearing:
-                    reachabilityNotifier.start()
-                case .disappearing:
-                    reachabilityNotifier.stop()
-                }
-            }
-
-            if let image = UIImage(named: "watchlist-empty-state") {
-                let emptyViewModel = WKEmptyViewModel(localizedStrings: localizedStringsEmptyView, image: image, numberOfFilters: viewModel.activeFilterCount)
-
-                let watchlistViewController = WKWatchlistViewController(viewModel: viewModel, filterViewModel: watchlistFilterViewModel, emptyViewModel: emptyViewModel, delegate: appViewController, loggingDelegate: appViewController, reachabilityHandler: reachabilityHandler)
-
-                targetNavigationController?.pushViewController(watchlistViewController, animated: true)
-                completion()
+            let targetNavigationController = watchlistTargetNavigationController()
+            if !userDefaults.wmf_userHasOnboardedToWatchlists {
+                showWatchlistOnboarding(targetNavigationController: targetNavigationController)
+            } else {
+                goToWatchlist(targetNavigationController: targetNavigationController)
             }
 
             return true
@@ -267,6 +216,15 @@ class ViewControllerRouter: NSObject {
         }
 
         return source
+    }
+    
+    private func watchlistTargetNavigationController() -> UINavigationController? {
+        var targetNavigationController = appViewController.navigationController
+        if let presentedNavigationController = appViewController.presentedViewController as? UINavigationController,
+           presentedNavigationController.viewControllers[0] is WMFSettingsViewController {
+            targetNavigationController = presentedNavigationController
+        }
+        return targetNavigationController
     }
     
     private var watchlistFilterViewModel: WKWatchlistFilterViewModel {
@@ -319,5 +277,110 @@ class ViewControllerRouter: NSObject {
             overrideUserInterfaceStyle = WKAppEnvironment.current.theme.userInterfaceStyle
         }
         return WKWatchlistFilterViewModel(localizedStrings: localizedStrings, overrideUserInterfaceStyle: overrideUserInterfaceStyle, loggingDelegate: appViewController)
+    }
+    
+    func showWatchlistOnboarding(targetNavigationController: UINavigationController?) {
+        let trackChanges = WKOnboardingViewModel.WKOnboardingCellViewModel(icon: UIImage(named: "track-changes"), title: CommonStrings.watchlistTrackChangesTitle, subtitle: CommonStrings.watchlistTrackChangesSubtitle)
+        let watchArticles = WKOnboardingViewModel.WKOnboardingCellViewModel(icon: UIImage(named: "watch-articles"), title: CommonStrings.watchlistWatchChangesTitle, subtitle: CommonStrings.watchlistWatchChangesSubitle)
+        let setExpiration = WKOnboardingViewModel.WKOnboardingCellViewModel(icon: UIImage(named: "set-expiration"), title: CommonStrings.watchlistSetExpirationTitle, subtitle: CommonStrings.watchlistSetExpirationSubtitle)
+        let viewUpdates = WKOnboardingViewModel.WKOnboardingCellViewModel(icon: UIImage(named: "view-updates"), title: CommonStrings.watchlistViewUpdatesTitle, subtitle: CommonStrings.watchlistViewUpdatesSubitle)
+
+        let viewModel = WKOnboardingViewModel(title: CommonStrings.watchlistOnboardingTitle, cells: [trackChanges, watchArticles, setExpiration, viewUpdates], primaryButtonTitle: CommonStrings.continueButton, secondaryButtonTitle: CommonStrings.watchlistOnboardingLearnMore)
+
+        let viewController = WKOnboardingViewController(viewModel: viewModel)
+        viewController.hostingController.delegate = self
+        
+        WatchlistFunnel.shared.logWatchlistOnboardingAppearance()
+
+        targetNavigationController?.present(viewController, animated: true) {
+            UserDefaults.standard.wmf_userHasOnboardedToWatchlists = true
+        }
+    }
+    
+    func goToWatchlist(targetNavigationController: UINavigationController?) {
+        let localizedByteChange: (Int) -> String = { bytes in
+            String.localizedStringWithFormat(
+                WMFLocalizedString("watchlist-byte-change", value:"{{PLURAL:%1$d|%1$d byte|%1$d bytes}}", comment: "Amount of bytes changed for a revision displayed in watchlist - %1$@ is replaced with the number of bytes."),
+                bytes
+            )
+        }
+
+        let htmlStripped: (String) -> String = { inputString in
+            return inputString.removingHTML
+        }
+
+        let attributedFilterString: (Int) -> AttributedString = { filters in
+            let localizedString = String.localizedStringWithFormat(
+                WMFLocalizedString("watchlist-number-filters", value:"Modify [{{PLURAL:%1$d|%1$d filter|%1$d filters}}](wikipedia://watchlist/filter) to see more Watchlist items", comment: "Amount of filters active in watchlist - %1$@ is replaced with the number of filters."),
+                filters
+            )
+            
+            let attributedString = (try? AttributedString(markdown: localizedString)) ?? AttributedString(localizedString)
+            return attributedString
+        }
+
+        let localizedStrings = WKWatchlistViewModel.LocalizedStrings(title: CommonStrings.watchlist, filter: CommonStrings.watchlistFilter, userButtonUserPage: CommonStrings.userButtonPage, userButtonTalkPage: CommonStrings.userButtonTalkPage, userButtonContributions: CommonStrings.userButtonContributions, userButtonThank: CommonStrings.userButtonThank, userAccessibility: CommonStrings.userTitle, summaryAccessibility: CommonStrings.editSummaryTitle, userAccessibilityButtonDiff: CommonStrings.watchlistGoToDiff, localizedProjectNames: watchlistFilterViewModel.localizedStrings.localizedProjectNames, byteChange: localizedByteChange,  htmlStripped: htmlStripped)
+
+        let presentationConfiguration = WKWatchlistViewModel.PresentationConfiguration(showNavBarUponAppearance: true, hideNavBarUponDisappearance: true)
+
+        let viewModel = WKWatchlistViewModel(localizedStrings: localizedStrings, presentationConfiguration: presentationConfiguration)
+
+        let localizedStringsEmptyView = WKEmptyViewModel.LocalizedStrings(title: CommonStrings.watchlistEmptyViewTitle, subtitle: CommonStrings.watchlistEmptyViewSubtitle, titleFilter: CommonStrings.watchlistEmptyViewFilterTitle, buttonTitle: CommonStrings.watchlistEmptyViewButtonTitle, attributedFilterString: attributedFilterString)
+
+        let reachabilityNotifier = ReachabilityNotifier(Configuration.current.defaultSiteDomain) { (reachable, _) in
+            if reachable {
+                WMFAlertManager.sharedInstance.dismissAllAlerts()
+            } else {
+                WMFAlertManager.sharedInstance.showErrorAlertWithMessage(CommonStrings.noInternetConnection, sticky: true, dismissPreviousAlerts: true)
+            }
+        }
+
+        let reachabilityHandler: WKWatchlistViewController.ReachabilityHandler = { state in
+            switch state {
+            case .appearing:
+                reachabilityNotifier.start()
+            case .disappearing:
+                reachabilityNotifier.stop()
+            }
+        }
+
+        if let image = UIImage(named: "watchlist-empty-state") {
+            let emptyViewModel = WKEmptyViewModel(localizedStrings: localizedStringsEmptyView, image: image, numberOfFilters: viewModel.activeFilterCount)
+
+            let watchlistViewController = WKWatchlistViewController(viewModel: viewModel, filterViewModel: watchlistFilterViewModel, emptyViewModel: emptyViewModel, delegate: appViewController, loggingDelegate: appViewController, reachabilityHandler: reachabilityHandler)
+
+            targetNavigationController?.pushViewController(watchlistViewController, animated: true)
+        }
+    }
+}
+
+extension ViewControllerRouter: WKOnboardingViewDelegate {
+    func didClickPrimaryButton() {
+        
+        let targetNavigationController = watchlistTargetNavigationController()
+        
+        WatchlistFunnel.shared.logWatchlistOnboardingTapContinue()
+        
+        if let presentedViewController = targetNavigationController?.presentedViewController {
+            presentedViewController.dismiss(animated: true) { [weak self] in
+                self?.goToWatchlist(targetNavigationController: targetNavigationController)
+            }
+        }
+    }
+
+    func didClickSecondaryButton() {
+        
+        let targetNavigationController = watchlistTargetNavigationController()
+        
+        WatchlistFunnel.shared.logWatchlistOnboardingTapLearnMore()
+
+        if let presentedViewController = targetNavigationController?.presentedViewController {
+            presentedViewController.dismiss(animated: true) { [weak self] in
+                guard let url = URL(string: "https://www.mediawiki.org/wiki/Wikimedia_Apps/iOS_FAQ#Watchlist") else {
+                    return
+                }
+                self?.appViewController.navigate(to: url)
+            }
+        }
     }
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T335609

### Notes
These are a couple of fixes I wanted to get in for Watchlist Onboarding.

63f3827 changes the primary button tap target so that the blue area registers as a tap. Before only the text triggered the tap.
a593d29 moves the presentation logic into `ViewControllerRouter` so that tapping "View Watchlist" from the article and diff view toasts also trigger onboarding if needed.

### Test Steps
1. Trigger onboarding from Account. Confirm you can tap the blue area on the primary button and go to your Watchlist.
2. Reinstall app. From an article, watch an article from the More menu, then tap the "View Watchlist" button from the success toast. Confirm you see onboarding. Confirm repeating this step does not show onboarding.
3. Repeat step 2 from the diff view. 
