### PR TITLE
Flash scrolling indicator on fundraising panel 

### DIFF
--- a/Wikipedia/Code/FundraisingAnnouncementPanel.swift
+++ b/Wikipedia/Code/FundraisingAnnouncementPanel.swift
@@ -33,6 +33,7 @@ final class FundraisingAnnouncementPanelViewController: ScrollableEducationPanel
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        scrollView.flashScrollIndicators()
         evaluateConstraintsOnNewSize(view.frame.size)
         subheadingTextView.textContainerInset = .zero
     }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T348278#9236165

### Notes
* Flash scrolling indicator on new fundraising panel in smaller screens

### Test Steps
1. Trigger the fundraising modal on an SE device or in landscape mode on any iPhone 
2. Set the device region or hard-code the locale to NL or IT, background the app, foreground the app, and refresh the explore feed. Open an article in the same wiki language as the chosen location
3. Make sure you can see the scrolling indicator

