### PR TITLE
Do not allow navigation bar to hide when scrolling on in-app donate webview

### DIFF
--- a/Wikipedia/Code/SinglePageWebViewController.swift
+++ b/Wikipedia/Code/SinglePageWebViewController.swift
@@ -105,6 +105,7 @@ class SinglePageWebViewController: ViewController {
             let searchItem = AppSearchBarButtonItem.newAppSearchBarButtonItem
             navigationItem.setRightBarButtonItems([searchItem, safariItem], animated: false)
 
+            navigationBar.isInteractiveHidingEnabled = false
             setupWButton()
         }
 

--- a/Wikipedia/Code/SinglePageWebViewController.swift
+++ b/Wikipedia/Code/SinglePageWebViewController.swift
@@ -105,7 +105,9 @@ class SinglePageWebViewController: ViewController {
             let searchItem = AppSearchBarButtonItem.newAppSearchBarButtonItem
             navigationItem.setRightBarButtonItems([searchItem, safariItem], animated: false)
 
-            navigationBar.isInteractiveHidingEnabled = false
+            if url.isDonationURL {
+                navigationBar.isInteractiveHidingEnabled = false
+            }
             setupWButton()
         }
 


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T333108#9229278

### Notes
This PR attempts to improve this design feedback:

> If you are partially scrolled down the page when you tap through, the dialog is scrolled down and partially cut-off (see second screenshot above)

In the in-app donate web flow, a recurring donation dialog appears after the user taps certain payment methods. If the user is scrolled down as this dialog is triggered, the navigation bar hides and the user appears stuck.

Since this dialog is a part of the web logic, we are limited in our fixes. This PR prevents the navigation bar from hiding as a user scrolls, so that they can at least back out of the flow if they need to.

### Test Steps
1. Change device region to NL or IT.
2. On Staging scheme, fresh install and launch app.
3. On Explore feed, background, then foreground, then pull to refresh on Explore feed to fetch latest campaigns.
4. In Settings, you should now see a "Donate to Wikipedia" cell. Tapping that should send you to the in-app donate web view.
5. Tap a payment option, scroll down a bit on the page, then tap PayPal. A dialog for recurring payment should appear.
6. Navigation bar should remain visible so that user can back out.