### PR TITLE
Log campaign ID in banner impression event

### DIFF
--- a/Wikipedia/Code/AppInteractionFunnel.swift
+++ b/Wikipedia/Code/AppInteractionFunnel.swift
@@ -90,8 +90,15 @@ import WMF
         logEvent(activeInterface: .setting, action: .donateStartClick)
     }
     
-    func logFundraisingCampaignModalImpression(project: WikimediaProject) {
-        logEvent(activeInterface: .articleBanner, action: .impression, project: project)
+    func logFundraisingCampaignModalImpression(project: WikimediaProject, campaignID: String?) {
+        
+        var actionData: [String: String]?
+        if let campaignID {
+            actionData = [:]
+            actionData?["campaign_id"] = campaignID
+        }
+        
+        logEvent(activeInterface: .articleBanner, action: .impression, actionData: actionData, project: project)
     }
     
     func logFundraisingCampaignModalDidTapClose(project: WikimediaProject) {

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -80,7 +80,7 @@ extension ArticleViewController {
     
     private func showNewDonateExperienceCampaignModal(asset: WKFundraisingCampaignConfig.WKAsset, project: WikimediaProject) {
         
-        AppInteractionFunnel.shared.logFundraisingCampaignModalImpression(project: project)
+        AppInteractionFunnel.shared.logFundraisingCampaignModalImpression(project: project, campaignID: asset.utmSource)
         
         let dataController = WKFundraisingCampaignDataController()
         
@@ -126,15 +126,7 @@ extension ArticleViewController {
         let firstAction = asset.actions[0]
         let donateURL = firstAction.url
         
-        var utmSource: String? = nil
-        if let donateURL = firstAction.url,
-           let queryItems = URLComponents(url: donateURL, resolvingAgainstBaseURL: false)?.queryItems {
-            for queryItem in queryItems {
-                if queryItem.name == "utm_source" {
-                    utmSource = queryItem.value
-                }
-            }
-        }
+        let utmSource = asset.utmSource
         
         let appVersion = Bundle.main.wmf_debugVersion()
         
@@ -277,4 +269,27 @@ extension ArticleViewController: WKDonateLoggingDelegate {
     }
     
     
+}
+
+extension WKFundraisingCampaignConfig.WKAsset {
+    
+    var utmSource: String? {
+        
+        guard actions.count > 0 else {
+            return nil
+        }
+        
+        let firstAction = actions[0]
+        var utmSource: String? = nil
+        if let donateURL = firstAction.url,
+           let queryItems = URLComponents(url: donateURL, resolvingAgainstBaseURL: false)?.queryItems {
+            for queryItem in queryItems {
+                if queryItem.name == "utm_source" {
+                    utmSource = queryItem.value
+                }
+            }
+        }
+        
+        return utmSource
+    }
 }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T346086
https://docs.google.com/presentation/d/1vZZwXb0rOGFlqvSy5PxxqRVy83ORPBAwYVHisfp4_o0/edit#slide=id.g27da775950c_0_91

### Notes
There was a missed campaign ID when logging the banner impression.

### Test Steps
1. Change device region to IT or NL. Launch app, enable logging in onboarding.
2. Background, foreground, then pull to refresh on Explore Feed
3. Visit an article to trigger a campaign modal appearance. Confirm in the console you see the `campaign_id` logged in the `action_data` on the `article_interface` `impression` event:

```
{
  ...
  "action_data" : "campaign_id:app_2023_enIT_iOS_control",
  "action" : "impression",
  "active_interface" : "article_banner",
   ...
} [EventPlatformClient#L621]
```

