### PR TITLE
Fix Simplified Chinese issues

### DIFF
--- a/WMF Framework/MWKDataStore+LanguageVariantMigration.swift
+++ b/WMF Framework/MWKDataStore+LanguageVariantMigration.swift
@@ -57,7 +57,7 @@ extension MWKDataStore {
         // Ensure that that settings using the old format codes are updated to the BCP47 format
         var languageCodeMigrationMapping = migrationMapping
         languageCodeMigrationMapping["nb"] = "no"
-        languageCodeMigrationMapping["zh-hans"] = "zh-Hans-CN"
+        languageCodeMigrationMapping["zh-hans"] = "zh-Hans"
         languageCodeMigrationMapping["zh-hk"] = "zh-Hant-HK"
         languageCodeMigrationMapping["zh-mo"] = "zh-Hant-MO"
         languageCodeMigrationMapping["zh-my"] = "zh-Hans-MY"

--- a/Wikipedia/Code/wikipedia-language-variants.json
+++ b/Wikipedia/Code/wikipedia-language-variants.json
@@ -1,7 +1,7 @@
 {
     "zh": [
         {
-            "languageVariantCode": "zh-Hans-CN",
+            "languageVariantCode": "zh-Hans",
             "languageName": "简体",
             "localName": "Simplified Chinese",
             "languageCode": "zh"

--- a/WikipediaUnitTests/Code/LocaleTests.swift
+++ b/WikipediaUnitTests/Code/LocaleTests.swift
@@ -27,7 +27,7 @@ class LocaleTests: XCTestCase {
     }
     
     func testZHHeaders() {
-        let languages = Locale.uniqueWikipediaLanguages(with: ["zh-Hans-CN", "zh-Hans-SG", "zh-Hant-MO", "zh-Hant-TW", "zh-Hant-HK"])
+        let languages = Locale.uniqueWikipediaLanguages(with: ["zh-Hans", "zh-Hans-SG", "zh-Hant-MO", "zh-Hant-TW", "zh-Hant-HK"])
         let expectedResult = ["zh-Hans", "zh-Hans-SG", "zh-Hant-MO", "zh-Hant-TW", "zh-Hant-HK"]
         XCTAssertEqual(languages, expectedResult)
         


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T348723

### Notes
I think back when we worked on #4550, we should have switched to a `zh-Hans` variant code instead of `zh-Hans-CN`. Looking at the [API call](https://www.mediawiki.org/w/api.php?action=query&format=json&meta=siteinfo&formatversion=2&siprop=languages%7Clanguagevariants&siinlanguagecode=en) referenced in the task, that seems to be the expected bcp47 code.

### Test Steps
1. Change device language to Simplified Chinese
2. Fresh install app
3. Confirm the you see a language selected in onboarding, the Explore feed loads, and you can login, logout and select the Support Wikipedia cell without crashing.
4. Confirm loading an article shows Simplified Chinese characters.
