### PR TITLE
Log watchlist filter button tap event

### DIFF
--- a/Components/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
+++ b/Components/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
@@ -129,7 +129,8 @@ public final class WKWatchlistViewController: WKCanvasViewController {
             guard let self else {
                 return
             }
-            
+			
+			loggingDelegate?.logWatchlistUserDidTapNavBarFilterButton()
             self.showFilterView()
         }
         let barButton = UIBarButtonItem(title: viewModel.localizedStrings.filter, primaryAction: action)

--- a/Components/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
+++ b/Components/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
@@ -129,8 +129,8 @@ public final class WKWatchlistViewController: WKCanvasViewController {
             guard let self else {
                 return
             }
-			
-			loggingDelegate?.logWatchlistUserDidTapNavBarFilterButton()
+
+            loggingDelegate?.logWatchlistUserDidTapNavBarFilterButton()
             self.showFilterView()
         }
         let barButton = UIBarButtonItem(title: viewModel.localizedStrings.filter, primaryAction: action)


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T343040

### Notes
Adds missing call to log filter button tap event.

### Test Steps
1. Set a breakpoint here: https://github.com/wikimedia/wikipedia-ios/blob/38acaf337b5867458b4ac74e29bc8c3851db7b12/Wikipedia/Code/WatchlistFunnel.swift#L264
2. Open Watchlist, tap Filter button
3. Confirm breakpoint for event is hit
