### PR TITLE
Diffs: top align from/to container stack view

### DIFF
--- a/Wikipedia/Code/DiffHeaderCompareView.swift
+++ b/Wikipedia/Code/DiffHeaderCompareView.swift
@@ -10,6 +10,7 @@ class DiffHeaderCompareView: SetupView {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = traitCollection.horizontalSizeClass == .compact ? .vertical : .horizontal
         stackView.spacing = 16
+        stackView.alignment = .top
         return stackView
     }()
 


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T347425

### Notes
Fixes an alignment issue where the from/to revision metadata was not rendering as expected.

### Test Steps
1. Open a diff comparison view between two revisions where one revision does not contain an edit description. (Here's an example I tested with: https://en.wikipedia.org/w/index.php?title=YouTube&diff=1187392832&oldid=1187244209)
2. In the header from/to edit metadata stacks, confirm the labels appear top aligned and are not filled with extraneous inter-item space.

![diff_header](https://github.com/wikimedia/wikipedia-ios/assets/5652327/b6b52ff7-e799-4f3e-be29-9706abc00f2d)
