### PR TITLE
Hide native Apple Pay flow for CN

### DIFF
--- a/Wikipedia/Code/UIViewController+DonateHelpers.swift
+++ b/Wikipedia/Code/UIViewController+DonateHelpers.swift
@@ -12,6 +12,13 @@ import PassKit
 @objc extension UIViewController {
     
     func canOfferNativeDonateForm(countryCode: String, currencyCode: String, languageCode: String, bannerID: String?, appVersion: String?) -> Bool {
+        
+        // Hide native Apple Pay path for users with a CN region setting
+        // https://phabricator.wikimedia.org/T352180
+        guard countryCode != "CN" else {
+            return false
+        }
+        
         return nativeDonateFormViewModel(countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, bannerID: bannerID, appVersion: appVersion, loggingDelegate: nil) != nil
     }
     
@@ -27,12 +34,6 @@ import PassKit
         
         guard PKPaymentAuthorizationController.canMakePayments(),
               PKPaymentAuthorizationController.canMakePayments(usingNetworks: paymentMethods.applePayPaymentNetworks, capabilities: .capability3DS) else {
-            return nil
-        }
-        
-        // This effectively hides native Apple Pay path for users with a CN region setting
-        // https://phabricator.wikimedia.org/T352180
-        guard countryCode != "CN" else {
             return nil
         }
         

--- a/Wikipedia/Code/UIViewController+DonateHelpers.swift
+++ b/Wikipedia/Code/UIViewController+DonateHelpers.swift
@@ -30,6 +30,12 @@ import PassKit
             return nil
         }
         
+        // This effectively hides native Apple Pay path for users with a CN region setting
+        // https://phabricator.wikimedia.org/T352180
+        guard countryCode != "CN" else {
+            return nil
+        }
+        
         let formatter = NumberFormatter.wkCurrencyFormatter
         formatter.currencyCode = currencyCode
         


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T352180

### Notes
This hides the native Apple Pay flow for users with their device region set to CN. It pushes them straight to the in-app web view so that they can pick a different payment method.

### Test Steps
1. Edit Wikipedia scheme. change region to United States under Run > Options. Run in PR branch on Simulator (try not to fresh install to lean on caching and avoid FR tech endpoint rate limiting).
2. In app Settings, tap Donate. Confirm you see payment method choice action sheet. Confirm you can reach the native donate form.
3. Repeat step 1, but this time set region to "China mainland"
4. Repeat step 2, confirm you do not see an action sheet after tapping donate, and instead are pushed to the in-app web view.