### PR TITLE
Native Editor - Add heading syntax highlighting

### DIFF
--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
@@ -213,6 +213,11 @@ extension WKSourceEditorTextFrameworkMediator: WKSourceEditorStorageDelegate {
         fonts.boldFont = isSyntaxHighlightingEnabled ? WKFont.for(.boldBody, compatibleWith: traitCollection) : baseFont
         fonts.italicsFont = isSyntaxHighlightingEnabled ? WKFont.for(.italicsBody, compatibleWith: traitCollection) : baseFont
         fonts.boldItalicsFont = isSyntaxHighlightingEnabled ? WKFont.for(.boldItalicsBody, compatibleWith: traitCollection) : baseFont
+        fonts.headingFont = isSyntaxHighlightingEnabled ? WKFont.for(.editorHeading, compatibleWith: traitCollection) : baseFont
+        fonts.subheading1Font = isSyntaxHighlightingEnabled ? WKFont.for(.editorSubheading1, compatibleWith: traitCollection) : baseFont
+        fonts.subheading2Font = isSyntaxHighlightingEnabled ? WKFont.for(.editorSubheading2, compatibleWith: traitCollection) : baseFont
+        fonts.subheading3Font = isSyntaxHighlightingEnabled ? WKFont.for(.editorSubheading3, compatibleWith: traitCollection) : baseFont
+        fonts.subheading4Font = isSyntaxHighlightingEnabled ? WKFont.for(.editorSubheading4, compatibleWith: traitCollection) : baseFont
         return fonts
     }
 }

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
@@ -35,6 +35,7 @@ final class WKSourceEditorTextFrameworkMediator: NSObject {
     private(set) var formatters: [WKSourceEditorFormatter] = []
     private(set) var boldItalicsFormatter: WKSourceEditorFormatterBoldItalics?
     private(set) var templateFormatter: WKSourceEditorFormatterTemplate?
+    private(set) var headingFormatter: WKSourceEditorFormatterHeading?
     
     var isSyntaxHighlightingEnabled: Bool = true {
         didSet {
@@ -103,11 +104,14 @@ final class WKSourceEditorTextFrameworkMediator: NSObject {
         
         let boldItalicsFormatter = WKSourceEditorFormatterBoldItalics(colors: colors, fonts: fonts)
         let templateFormatter = WKSourceEditorFormatterTemplate(colors: colors, fonts: fonts)
+        let headingFormatter = WKSourceEditorFormatterHeading(colors: colors, fonts: fonts)
         self.formatters = [WKSourceEditorFormatterBase(colors: colors, fonts: fonts, textAlignment: viewModel.textAlignment),
                 templateFormatter,
-                boldItalicsFormatter]
+                boldItalicsFormatter,
+                headingFormatter]
         self.boldItalicsFormatter = boldItalicsFormatter
         self.templateFormatter = templateFormatter
+        self.headingFormatter = headingFormatter
         
         if needsTextKit2 {
             if #available(iOS 16.0, *) {

--- a/Components/Sources/Components/Style/WKFont.swift
+++ b/Components/Sources/Components/Style/WKFont.swift
@@ -6,69 +6,85 @@ public enum WKFont {
     case headline
     case title
     case boldTitle
-	case body
+    case body
     case boldBody
     case italicsBody
     case boldItalicsBody
-	case smallBody
-	case callout
-	case subheadline
-	case boldSubheadline
+    case smallBody
+    case callout
+    case subheadline
+    case boldSubheadline
     case mediumSubheadline
     case caption1
     case footnote
-	case boldFootnote
+    case boldFootnote
+    case editorHeading
+    case editorSubheading1
+    case editorSubheading2
+    case editorSubheading3
+    case editorSubheading4
 
-	static func `for`(_ font: WKFont, compatibleWith traitCollection: UITraitCollection = WKAppEnvironment.current.traitCollection) -> UIFont {
-		switch font {
-		case .headline:
-			return UIFont.preferredFont(forTextStyle: .headline, compatibleWith: traitCollection)
-		case .title:
-			return UIFont.preferredFont(forTextStyle: .title1, compatibleWith: traitCollection)
-		case .boldTitle:
-			guard let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .title1, compatibleWith: traitCollection).withSymbolicTraits(.traitBold) else {
-				fatalError()
-			}
-			return UIFont(descriptor: descriptor, size: 0)
-		case .body:
-			return UIFont.preferredFont(forTextStyle: .body, compatibleWith: traitCollection)
-		case .boldBody:
-			guard let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body, compatibleWith: traitCollection).withSymbolicTraits(.traitBold) else {
-				fatalError()
-			}
-			return UIFont(descriptor: descriptor, size: 0)
-		case .italicsBody:
-			guard let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body, compatibleWith: traitCollection).withSymbolicTraits(.traitItalic) else {
-				fatalError()
-			}
-			return UIFont(descriptor: descriptor, size: 0)
-		case .boldItalicsBody:
-			guard let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body, compatibleWith: traitCollection).withSymbolicTraits(.traitBold.union(.traitItalic)) else {
-				fatalError()
-			}
-			return UIFont(descriptor: descriptor, size: 0)
-		case .smallBody:
-			return UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.systemFont(ofSize: 15, weight: .regular))
-		case .callout:
-			return UIFont.preferredFont(forTextStyle: .callout, compatibleWith: traitCollection)
-		case .subheadline:
-			return UIFont.preferredFont(forTextStyle: .subheadline, compatibleWith: traitCollection)
-		case .mediumSubheadline:
-			return UIFontMetrics(forTextStyle: .subheadline).scaledFont(for: UIFont.systemFont(ofSize: 15, weight: .medium))
-		case .boldSubheadline:
-			guard let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .subheadline, compatibleWith: traitCollection).withSymbolicTraits(.traitBold) else {
-				fatalError()
-			}
-			return UIFont(descriptor: descriptor, size: 0)
-		case .caption1:
-			return UIFont.preferredFont(forTextStyle: .caption1, compatibleWith: traitCollection)
-		case .footnote:
-			return UIFont.preferredFont(forTextStyle: .footnote, compatibleWith: traitCollection)
-		case .boldFootnote:
-			guard let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .footnote, compatibleWith: traitCollection).withSymbolicTraits(.traitBold) else {
-				fatalError()
-			}
-			return UIFont(descriptor: descriptor, size: 0)
-		}
+    static func `for`(_ font: WKFont, compatibleWith traitCollection: UITraitCollection = WKAppEnvironment.current.traitCollection) -> UIFont {
+        switch font {
+        case .headline:
+            return UIFont.preferredFont(forTextStyle: .headline, compatibleWith: traitCollection)
+        case .title:
+            return UIFont.preferredFont(forTextStyle: .title1, compatibleWith: traitCollection)
+        case .boldTitle:
+            guard let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .title1, compatibleWith: traitCollection).withSymbolicTraits(.traitBold) else {
+                fatalError()
+            }
+            return UIFont(descriptor: descriptor, size: 0)
+        case .body:
+            return UIFont.preferredFont(forTextStyle: .body, compatibleWith: traitCollection)
+        case .boldBody:
+            guard let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body, compatibleWith: traitCollection).withSymbolicTraits(.traitBold) else {
+                fatalError()
+            }
+            return UIFont(descriptor: descriptor, size: 0)
+        case .italicsBody:
+            guard let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body, compatibleWith: traitCollection).withSymbolicTraits(.traitItalic) else {
+                fatalError()
+            }
+            return UIFont(descriptor: descriptor, size: 0)
+        case .boldItalicsBody:
+            guard let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body, compatibleWith: traitCollection).withSymbolicTraits(.traitBold.union(.traitItalic)) else {
+                fatalError()
+            }
+            return UIFont(descriptor: descriptor, size: 0)
+        case .smallBody:
+            return UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.systemFont(ofSize: 15, weight: .regular))
+        case .callout:
+            return UIFont.preferredFont(forTextStyle: .callout, compatibleWith: traitCollection)
+        case .subheadline:
+            return UIFont.preferredFont(forTextStyle: .subheadline, compatibleWith: traitCollection)
+        case .mediumSubheadline:
+            return UIFontMetrics(forTextStyle: .subheadline).scaledFont(for: UIFont.systemFont(ofSize: 15, weight: .medium))
+        case .boldSubheadline:
+            guard let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .subheadline, compatibleWith: traitCollection).withSymbolicTraits(.traitBold) else {
+                fatalError()
+            }
+            return UIFont(descriptor: descriptor, size: 0)
+        case .caption1:
+            return UIFont.preferredFont(forTextStyle: .caption1, compatibleWith: traitCollection)
+        case .footnote:
+            return UIFont.preferredFont(forTextStyle: .footnote, compatibleWith: traitCollection)
+        case .boldFootnote:
+            guard let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .footnote, compatibleWith: traitCollection).withSymbolicTraits(.traitBold) else {
+                fatalError()
+            }
+            return UIFont(descriptor: descriptor, size: 0)
+        case .editorHeading:
+            return UIFontMetrics(forTextStyle: .headline).scaledFont(for: UIFont.systemFont(ofSize: 28, weight: .semibold), maximumPointSize: 32, compatibleWith: traitCollection)
+        case .editorSubheading1:
+            return UIFontMetrics(forTextStyle: .headline).scaledFont(for: UIFont.systemFont(ofSize: 26, weight: .semibold), compatibleWith: traitCollection)
+        case .editorSubheading2:
+            return UIFontMetrics(forTextStyle: .headline).scaledFont(for: UIFont.systemFont(ofSize: 24, weight: .semibold), compatibleWith: traitCollection)
+        case .editorSubheading3:
+            return UIFontMetrics(forTextStyle: .headline).scaledFont(for: UIFont.systemFont(ofSize: 22, weight: .semibold), compatibleWith: traitCollection)
+        case .editorSubheading4:
+            return UIFontMetrics(forTextStyle: .headline).scaledFont(for: UIFont.systemFont(ofSize: 20, weight: .semibold), compatibleWith: traitCollection)
+        }
+        
 	}
 }

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFonts.h
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFonts.h
@@ -7,6 +7,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) UIFont *boldFont;
 @property (nonatomic, strong) UIFont *italicsFont;
 @property (nonatomic, strong) UIFont *boldItalicsFont;
+@property (nonatomic, strong) UIFont *headingFont;
+@property (nonatomic, strong) UIFont *subheading1Font;
+@property (nonatomic, strong) UIFont *subheading2Font;
+@property (nonatomic, strong) UIFont *subheading3Font;
+@property (nonatomic, strong) UIFont *subheading4Font;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatter.h
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatter.h
@@ -4,6 +4,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WKSourceEditorFormatter : NSObject
+
+extern NSString *const WKSourceEditorCustomKeyColorOrange;
+
 - (instancetype)initWithColors:(nonnull WKSourceEditorColors *)colors fonts:(nonnull WKSourceEditorFonts *)fonts;
 - (void)addSyntaxHighlightingToAttributedString:(NSMutableAttributedString *)attributedString inRange:(NSRange)range;
 

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatter.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatter.m
@@ -3,6 +3,11 @@
 #import "WKSourceEditorFonts.h"
 
 @implementation WKSourceEditorFormatter
+
+#pragma mark - Common Custom Attributed String Keys
+// Font and Color custom attributes allow us to easily target already-formatted ranges. This is handy for speedy updates upon theme and text size change, as well as determining keyboard button selection states.
+NSString * const WKSourceEditorCustomKeyColorOrange = @"WKSourceEditorKeyColorOrange";
+
 - (nonnull instancetype)initWithColors:(nonnull WKSourceEditorColors *)colors fonts:(nonnull WKSourceEditorFonts *)fonts {
     self = [super init];
     return self;

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterBase.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterBase.m
@@ -29,9 +29,12 @@
 
 - (void)addSyntaxHighlightingToAttributedString:(NSMutableAttributedString *)attributedString inRange:(NSRange)range {
     
-    // reset old attributes
+    // reset base attributes
     [attributedString removeAttribute:NSFontAttributeName range:range];
     [attributedString removeAttribute:NSForegroundColorAttributeName range:range];
+    
+    // reset shared custom attributes
+    [attributedString removeAttribute:WKSourceEditorCustomKeyColorOrange range:range];
     
     [attributedString addAttributes:self.attributes range:range];
 }

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterBoldItalics.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterBoldItalics.m
@@ -59,7 +59,6 @@ NSString * const WKSourceEditorCustomKeyFontItalics = @"WKSourceEditorKeyFontIta
 - (void)addSyntaxHighlightingToAttributedString:(nonnull NSMutableAttributedString *)attributedString inRange:(NSRange)range {
     
     // Reset
-    [attributedString removeAttribute:WKSourceEditorCustomKeyColorOrange range:range];
     [attributedString removeAttribute:WKSourceEditorCustomKeyFontBoldItalics range:range];
     [attributedString removeAttribute:WKSourceEditorCustomKeyFontBold range:range];
     [attributedString removeAttribute:WKSourceEditorCustomKeyFontItalics range:range];

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterBoldItalics.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterBoldItalics.m
@@ -18,9 +18,6 @@
 @implementation WKSourceEditorFormatterBoldItalics
 
 #pragma mark - Custom Attributed String Keys
-
-// Font and Color custom attributes allow us to easily target already-formatted ranges. This is handy for speedy updates upon theme and text size change, as well as determining keyboard button selection states.
-NSString * const WKSourceEditorCustomKeyColorOrange = @"WKSourceEditorKeyColorOrange";
 NSString * const WKSourceEditorCustomKeyFontBoldItalics = @"WKSourceEditorKeyFontBoldItalics";
 NSString * const WKSourceEditorCustomKeyFontBold = @"WKSourceEditorKeyFontBold";
 NSString * const WKSourceEditorCustomKeyFontItalics = @"WKSourceEditorKeyFontItalics";

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterHeading.h
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterHeading.h
@@ -1,0 +1,9 @@
+#import "WKSourceEditorFormatter.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKSourceEditorFormatterHeading : WKSourceEditorFormatter
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterHeading.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterHeading.m
@@ -39,22 +39,22 @@ NSString * const WKSourceEditorCustomKeyFontSubheading4 = @"WKSourceEditorCustom
         
         _headingFontAttributes = @{
             NSFontAttributeName: fonts.headingFont,
-            WKSourceEditorCustomKeyFontSubheading1: [NSNumber numberWithBool:YES]
+            WKSourceEditorCustomKeyFontHeading: [NSNumber numberWithBool:YES]
         };
         
         _subheading1FontAttributes = @{
             NSFontAttributeName: fonts.subheading1Font,
-            WKSourceEditorCustomKeyFontSubheading2: [NSNumber numberWithBool:YES]
+            WKSourceEditorCustomKeyFontSubheading1: [NSNumber numberWithBool:YES]
         };
         
         _subheading2FontAttributes = @{
             NSFontAttributeName: fonts.subheading2Font,
-            WKSourceEditorCustomKeyFontSubheading3: [NSNumber numberWithBool:YES]
+            WKSourceEditorCustomKeyFontSubheading2: [NSNumber numberWithBool:YES]
         };
         
         _subheading3FontAttributes = @{
             NSFontAttributeName: fonts.subheading3Font,
-            WKSourceEditorCustomKeyFontSubheading4: [NSNumber numberWithBool:YES]
+            WKSourceEditorCustomKeyFontSubheading3: [NSNumber numberWithBool:YES]
         };
         
         _subheading4FontAttributes = @{

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterHeading.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterHeading.m
@@ -76,7 +76,6 @@ NSString * const WKSourceEditorCustomKeyFontSubheading4 = @"WKSourceEditorCustom
 - (void)addSyntaxHighlightingToAttributedString:(nonnull NSMutableAttributedString *)attributedString inRange:(NSRange)range {
     
     // Reset
-    [attributedString removeAttribute:WKSourceEditorCustomKeyColorOrange range:range];
     [attributedString removeAttribute:WKSourceEditorCustomKeyFontHeading range:range];
     [attributedString removeAttribute:WKSourceEditorCustomKeyFontSubheading1 range:range];
     [attributedString removeAttribute:WKSourceEditorCustomKeyFontSubheading2 range:range];

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterHeading.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterHeading.m
@@ -1,0 +1,236 @@
+#import "WKSourceEditorFormatterHeading.h"
+#import "WKSourceEditorColors.h"
+#import "WKSourceEditorFonts.h"
+
+@interface WKSourceEditorFormatterHeading ()
+@property (nonatomic, strong) NSDictionary *headingFontAttributes;
+@property (nonatomic, strong) NSDictionary *subheading1FontAttributes;
+@property (nonatomic, strong) NSDictionary *subheading2FontAttributes;
+@property (nonatomic, strong) NSDictionary *subheading3FontAttributes;
+@property (nonatomic, strong) NSDictionary *subheading4FontAttributes;
+@property (nonatomic, strong) NSDictionary *orangeAttributes;
+
+@property (nonatomic, strong) NSRegularExpression *headingRegex;
+@property (nonatomic, strong) NSRegularExpression *subheading1Regex;
+@property (nonatomic, strong) NSRegularExpression *subheading2Regex;
+@property (nonatomic, strong) NSRegularExpression *subheading3Regex;
+@property (nonatomic, strong) NSRegularExpression *subheading4Regex;
+@end
+
+@implementation WKSourceEditorFormatterHeading
+
+#pragma mark - Custom Attributed String Keys
+
+NSString * const WKSourceEditorCustomKeyFontHeading = @"WKSourceEditorCustomKeyFontHeading";
+NSString * const WKSourceEditorCustomKeyFontSubheading1 = @"WKSourceEditorCustomKeyFontSubheading1";
+NSString * const WKSourceEditorCustomKeyFontSubheading2 = @"WKSourceEditorCustomKeyFontSubheading2";
+NSString * const WKSourceEditorCustomKeyFontSubheading3 = @"WKSourceEditorCustomKeyFontSubheading3";
+NSString * const WKSourceEditorCustomKeyFontSubheading4 = @"WKSourceEditorCustomKeyFontSubheading4";
+
+#pragma mark - Public
+
+- (instancetype)initWithColors:(WKSourceEditorColors *)colors fonts:(WKSourceEditorFonts *)fonts {
+    self = [super initWithColors:colors fonts:fonts];
+    if (self) {
+        _orangeAttributes = @{
+            NSForegroundColorAttributeName: colors.orangeForegroundColor,
+            WKSourceEditorCustomKeyColorOrange: [NSNumber numberWithBool:YES]
+        };
+        
+        _headingFontAttributes = @{
+            NSFontAttributeName: fonts.headingFont,
+            WKSourceEditorCustomKeyFontSubheading1: [NSNumber numberWithBool:YES]
+        };
+        
+        _subheading1FontAttributes = @{
+            NSFontAttributeName: fonts.subheading1Font,
+            WKSourceEditorCustomKeyFontSubheading2: [NSNumber numberWithBool:YES]
+        };
+        
+        _subheading2FontAttributes = @{
+            NSFontAttributeName: fonts.subheading2Font,
+            WKSourceEditorCustomKeyFontSubheading3: [NSNumber numberWithBool:YES]
+        };
+        
+        _subheading3FontAttributes = @{
+            NSFontAttributeName: fonts.subheading3Font,
+            WKSourceEditorCustomKeyFontSubheading4: [NSNumber numberWithBool:YES]
+        };
+        
+        _subheading4FontAttributes = @{
+            NSFontAttributeName: fonts.subheading4Font,
+            WKSourceEditorCustomKeyFontSubheading4: [NSNumber numberWithBool:YES]
+        };
+        
+        _headingRegex = [[NSRegularExpression alloc] initWithPattern:@"^(={2})([^=]*)(={2})(?!=)$" options:NSRegularExpressionAnchorsMatchLines error:nil];
+        _subheading1Regex = [[NSRegularExpression alloc] initWithPattern:@"^(={3})([^=]*)(={3})(?!=)$" options:NSRegularExpressionAnchorsMatchLines error:nil];
+        _subheading2Regex = [[NSRegularExpression alloc] initWithPattern:@"^(={4})([^=]*)(={4})(?!=)$" options:NSRegularExpressionAnchorsMatchLines error:nil];
+        _subheading3Regex = [[NSRegularExpression alloc] initWithPattern:@"^(={5})([^=]*)(={5})(?!=)$" options:NSRegularExpressionAnchorsMatchLines error:nil];
+        _subheading4Regex = [[NSRegularExpression alloc] initWithPattern:@"^(={6})([^=]*)(={6})(?!=)$" options:NSRegularExpressionAnchorsMatchLines error:nil];
+    }
+    return self;
+}
+
+#pragma mark - Overrides
+
+- (void)addSyntaxHighlightingToAttributedString:(nonnull NSMutableAttributedString *)attributedString inRange:(NSRange)range {
+    
+    // Reset
+    [attributedString removeAttribute:WKSourceEditorCustomKeyColorOrange range:range];
+    [attributedString removeAttribute:WKSourceEditorCustomKeyFontHeading range:range];
+    [attributedString removeAttribute:WKSourceEditorCustomKeyFontSubheading1 range:range];
+    [attributedString removeAttribute:WKSourceEditorCustomKeyFontSubheading2 range:range];
+    [attributedString removeAttribute:WKSourceEditorCustomKeyFontSubheading3 range:range];
+    [attributedString removeAttribute:WKSourceEditorCustomKeyFontSubheading4 range:range];
+    
+    [self enumerateAndHighlightAttributedString:attributedString range:range regex:self.headingRegex attributes:self.headingFontAttributes];
+    [self enumerateAndHighlightAttributedString:attributedString range:range regex:self.subheading1Regex attributes:self.subheading1FontAttributes];
+    [self enumerateAndHighlightAttributedString:attributedString range:range regex:self.subheading2Regex attributes:self.subheading2FontAttributes];
+    [self enumerateAndHighlightAttributedString:attributedString range:range regex:self.subheading3Regex attributes:self.subheading3FontAttributes];
+    [self enumerateAndHighlightAttributedString:attributedString range:range regex:self.subheading4Regex attributes:self.subheading4FontAttributes];
+}
+
+- (void)updateColors:(WKSourceEditorColors *)colors inAttributedString:(NSMutableAttributedString *)attributedString inRange:(NSRange)range {
+    
+    [self updateColorAttributesWithColors:colors];
+    [self enumerateAndUpdateColorsInAttributedString:attributedString range:range];
+}
+
+- (void)updateFonts:(WKSourceEditorFonts *)fonts inAttributedString:(NSMutableAttributedString *)attributedString inRange:(NSRange)range {
+    
+    [self updateFontAttributesWithFonts:fonts];
+    [self enumerateAndUpdateFontsInAttributedString:attributedString range:range];
+}
+
+#pragma mark - Private
+
+- (void)enumerateAndHighlightAttributedString: (nonnull NSMutableAttributedString *)attributedString range:(NSRange)range regex:(NSRegularExpression *)regex attributes:(NSDictionary<NSAttributedStringKey, id> *)fontAttributes {
+    
+    [regex enumerateMatchesInString:attributedString.string
+                            options:0
+                              range:range
+                         usingBlock:^(NSTextCheckingResult *_Nullable result, NSMatchingFlags flags, BOOL *_Nonnull stop) {
+        NSRange fullMatch = [result rangeAtIndex:0];
+        NSRange openingRange = [result rangeAtIndex:1];
+        NSRange textRange = [result rangeAtIndex:2];
+        NSRange closingRange = [result rangeAtIndex:3];
+        
+        if (fullMatch.location != NSNotFound) {
+            [attributedString addAttributes:fontAttributes range:fullMatch];
+        }
+        
+        if (openingRange.location != NSNotFound) {
+            [attributedString addAttributes:self.orangeAttributes range:openingRange];
+        }
+        
+        if (closingRange.location != NSNotFound) {
+            [attributedString addAttributes:self.orangeAttributes range:closingRange];
+        }
+    }];
+}
+
+- (void)updateColorAttributesWithColors: (WKSourceEditorColors *)colors {
+    NSMutableDictionary *mutAttributes = [[NSMutableDictionary alloc] initWithDictionary:self.orangeAttributes];
+    [mutAttributes setObject:colors.orangeForegroundColor forKey:NSForegroundColorAttributeName];
+    self.orangeAttributes = [[NSDictionary alloc] initWithDictionary:mutAttributes];
+}
+
+- (void)enumerateAndUpdateColorsInAttributedString: (NSMutableAttributedString *)attributedString range: (NSRange)range {
+    [attributedString enumerateAttribute:WKSourceEditorCustomKeyColorOrange
+                                 inRange:range
+                                 options:nil
+                              usingBlock:^(id value, NSRange localRange, BOOL *stop) {
+        if ([value isKindOfClass: [NSNumber class]]) {
+            NSNumber *numValue = (NSNumber *)value;
+            if ([numValue boolValue] == YES) {
+                [attributedString addAttributes:self.orangeAttributes range:localRange];
+            }
+        }
+    }];
+}
+
+- (void)updateFontAttributesWithFonts: (WKSourceEditorFonts *)fonts {
+    NSMutableDictionary *mutHeadingAttributes = [[NSMutableDictionary alloc] initWithDictionary:self.headingFontAttributes];
+    [mutHeadingAttributes setObject:fonts.headingFont forKey:NSFontAttributeName];
+    self.headingFontAttributes = [[NSDictionary alloc] initWithDictionary:mutHeadingAttributes];
+    
+    NSMutableDictionary *mutSubheading1Attributes = [[NSMutableDictionary alloc] initWithDictionary:self.subheading1FontAttributes];
+    [mutSubheading1Attributes setObject:fonts.subheading1Font forKey:NSFontAttributeName];
+    self.subheading1FontAttributes = [[NSDictionary alloc] initWithDictionary:mutSubheading1Attributes];
+    
+    NSMutableDictionary *mutSubheading2Attributes = [[NSMutableDictionary alloc] initWithDictionary:self.subheading2FontAttributes];
+    [mutSubheading2Attributes setObject:fonts.subheading2Font forKey:NSFontAttributeName];
+    self.subheading2FontAttributes = [[NSDictionary alloc] initWithDictionary:mutSubheading2Attributes];
+    
+    NSMutableDictionary *mutSubheading3Attributes = [[NSMutableDictionary alloc] initWithDictionary:self.subheading3FontAttributes];
+    [mutSubheading3Attributes setObject:fonts.subheading3Font forKey:NSFontAttributeName];
+    self.subheading3FontAttributes = [[NSDictionary alloc] initWithDictionary:mutSubheading3Attributes];
+    
+    NSMutableDictionary *mutSubheading4Attributes = [[NSMutableDictionary alloc] initWithDictionary:self.subheading4FontAttributes];
+    [mutSubheading4Attributes setObject:fonts.subheading4Font forKey:NSFontAttributeName];
+    self.subheading4FontAttributes = [[NSDictionary alloc] initWithDictionary:mutSubheading4Attributes];
+}
+
+- (void)enumerateAndUpdateFontsInAttributedString: (NSMutableAttributedString *)attributedString range: (NSRange)range {
+    [attributedString enumerateAttribute:WKSourceEditorCustomKeyFontHeading
+                                 inRange:range
+                                 options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                              usingBlock:^(id value, NSRange localRange, BOOL *stop) {
+        if ([value isKindOfClass: [NSNumber class]]) {
+            NSNumber *numValue = (NSNumber *)value;
+            if ([numValue boolValue] == YES) {
+                [attributedString addAttributes:self.headingFontAttributes range:localRange];
+            }
+        }
+    }];
+    
+    [attributedString enumerateAttribute:WKSourceEditorCustomKeyFontSubheading1
+                                 inRange:range
+                                 options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                              usingBlock:^(id value, NSRange localRange, BOOL *stop) {
+        if ([value isKindOfClass: [NSNumber class]]) {
+            NSNumber *numValue = (NSNumber *)value;
+            if ([numValue boolValue] == YES) {
+                [attributedString addAttributes:self.subheading1FontAttributes range:localRange];
+            }
+        }
+    }];
+    
+    [attributedString enumerateAttribute:WKSourceEditorCustomKeyFontSubheading2
+                                 inRange:range
+                                 options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                              usingBlock:^(id value, NSRange localRange, BOOL *stop) {
+        if ([value isKindOfClass: [NSNumber class]]) {
+            NSNumber *numValue = (NSNumber *)value;
+            if ([numValue boolValue] == YES) {
+                [attributedString addAttributes:self.subheading2FontAttributes range:localRange];
+            }
+        }
+    }];
+    
+    [attributedString enumerateAttribute:WKSourceEditorCustomKeyFontSubheading3
+                                 inRange:range
+                                 options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                              usingBlock:^(id value, NSRange localRange, BOOL *stop) {
+        if ([value isKindOfClass: [NSNumber class]]) {
+            NSNumber *numValue = (NSNumber *)value;
+            if ([numValue boolValue] == YES) {
+                [attributedString addAttributes:self.subheading3FontAttributes range:localRange];
+            }
+        }
+    }];
+    
+    [attributedString enumerateAttribute:WKSourceEditorCustomKeyFontSubheading4
+                                 inRange:range
+                                 options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                              usingBlock:^(id value, NSRange localRange, BOOL *stop) {
+        if ([value isKindOfClass: [NSNumber class]]) {
+            NSNumber *numValue = (NSNumber *)value;
+            if ([numValue boolValue] == YES) {
+                [attributedString addAttributes:self.subheading4FontAttributes range:localRange];
+            }
+        }
+    }];
+}
+
+@end

--- a/Components/Sources/ComponentsObjC/include/ComponentsObjC.h
+++ b/Components/Sources/ComponentsObjC/include/ComponentsObjC.h
@@ -8,6 +8,7 @@
 #import "WKSourceEditorFormatterBase.h"
 #import "WKSourceEditorFormatterBoldItalics.h"
 #import "WKSourceEditorFormatterTemplate.h"
+#import "WKSourceEditorFormatterHeading.h"
 #import "WKSourceEditorStorageDelegate.h"
 
 #endif /* Header_h */

--- a/Components/Sources/ComponentsObjC/include/WKSourceEditorFormatterHeading.h
+++ b/Components/Sources/ComponentsObjC/include/WKSourceEditorFormatterHeading.h
@@ -1,0 +1,1 @@
+../WKSourceEditorFormatterHeading.h

--- a/Components/Tests/ComponentsTests/WKSourceEditorFormatterTests.swift
+++ b/Components/Tests/ComponentsTests/WKSourceEditorFormatterTests.swift
@@ -10,8 +10,9 @@ final class WKSourceEditorFormatterTests: XCTestCase {
     var baseFormatter: WKSourceEditorFormatterBase!
     var boldItalicsFormatter: WKSourceEditorFormatterBoldItalics!
     var templateFormatter: WKSourceEditorFormatterTemplate!
+    var headingFormatter: WKSourceEditorFormatterHeading!
     var formatters: [WKSourceEditorFormatter] {
-        return [baseFormatter, templateFormatter, boldItalicsFormatter]
+        return [baseFormatter, templateFormatter, boldItalicsFormatter, headingFormatter]
     }
 
     override func setUpWithError() throws {
@@ -27,10 +28,16 @@ final class WKSourceEditorFormatterTests: XCTestCase {
         self.fonts.boldFont = WKFont.for(.boldBody, compatibleWith: traitCollection)
         self.fonts.italicsFont = WKFont.for(.italicsBody, compatibleWith: traitCollection)
         self.fonts.boldItalicsFont = WKFont.for(.boldItalicsBody, compatibleWith: traitCollection)
+        self.fonts.headingFont = WKFont.for(.editorHeading, compatibleWith: traitCollection)
+        self.fonts.subheading1Font = WKFont.for(.editorSubheading1, compatibleWith: traitCollection)
+        self.fonts.subheading2Font = WKFont.for(.editorSubheading2, compatibleWith: traitCollection)
+        self.fonts.subheading3Font = WKFont.for(.editorSubheading3, compatibleWith: traitCollection)
+        self.fonts.subheading4Font = WKFont.for(.editorSubheading4, compatibleWith: traitCollection)
         
         self.baseFormatter = WKSourceEditorFormatterBase(colors: colors, fonts: fonts, textAlignment: .left)
         self.boldItalicsFormatter = WKSourceEditorFormatterBoldItalics(colors: colors, fonts: fonts)
         self.templateFormatter = WKSourceEditorFormatterTemplate(colors: colors, fonts: fonts)
+        self.headingFormatter = WKSourceEditorFormatterHeading(colors: colors, fonts: fonts)
     }
 
     override func tearDownWithError() throws {
@@ -708,5 +715,204 @@ final class WKSourceEditorFormatterTests: XCTestCase {
         XCTAssertEqual(refRange.length, 6, "Incorrect ref formatting")
         XCTAssertEqual(refAttributes[.font] as! UIFont, fonts.baseFont, "Incorrect ref formatting")
         XCTAssertEqual(refAttributes[.foregroundColor] as! UIColor, colors.baseForegroundColor, "Incorrect ref formatting")
+    }
+    
+    func testHeading() {
+        let string = "== Test =="
+        let mutAttributedString = NSMutableAttributedString(string: string)
+        
+        for formatter in formatters {
+            formatter.addSyntaxHighlighting(to: mutAttributedString, in: NSRange(location: 0, length: string.count))
+        }
+        
+        var openingRange = NSRange(location: 0, length: 0)
+        let openingAttributes = mutAttributedString.attributes(at: 0, effectiveRange: &openingRange)
+        
+        var contentRange = NSRange(location: 0, length: 0)
+        let contentAttributes = mutAttributedString.attributes(at: 2, effectiveRange: &contentRange)
+        
+        var closingRange = NSRange(location: 0, length: 0)
+        let closingAttributes = mutAttributedString.attributes(at: 8, effectiveRange: &closingRange)
+        
+        // "=="
+        XCTAssertEqual(openingRange.location, 0, "Incorrect heading formatting")
+        XCTAssertEqual(openingRange.length, 2, "Incorrect heading formatting")
+        XCTAssertEqual(openingAttributes[.font] as! UIFont, fonts.headingFont, "Incorrect heading formatting")
+        XCTAssertEqual(openingAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect heading formatting")
+        
+        // " Heading Test "
+        XCTAssertEqual(contentRange.location, 2, "Incorrect heading formatting")
+        XCTAssertEqual(contentRange.length, 6, "Incorrect heading formatting")
+        XCTAssertEqual(contentAttributes[.font] as! UIFont, fonts.headingFont, "Incorrect heading formatting")
+        XCTAssertEqual(contentAttributes[.foregroundColor] as! UIColor, colors.baseForegroundColor, "Incorrect heading formatting")
+        
+        // "=="
+        XCTAssertEqual(closingRange.location, 8, "Incorrect heading formatting")
+        XCTAssertEqual(closingRange.length, 2, "Incorrect heading formatting")
+        XCTAssertEqual(closingAttributes[.font] as! UIFont, fonts.headingFont, "Incorrect heading formatting")
+        XCTAssertEqual(closingAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect heading formatting")
+    }
+    
+    func testSubheading1() {
+        let string = "=== Test ==="
+        let mutAttributedString = NSMutableAttributedString(string: string)
+        
+        for formatter in formatters {
+            formatter.addSyntaxHighlighting(to: mutAttributedString, in: NSRange(location: 0, length: string.count))
+        }
+        
+        var openingRange = NSRange(location: 0, length: 0)
+        let openingAttributes = mutAttributedString.attributes(at: 0, effectiveRange: &openingRange)
+        
+        var contentRange = NSRange(location: 0, length: 0)
+        let contentAttributes = mutAttributedString.attributes(at: 3, effectiveRange: &contentRange)
+        
+        var closingRange = NSRange(location: 0, length: 0)
+        let closingAttributes = mutAttributedString.attributes(at: 9, effectiveRange: &closingRange)
+        
+        // "=="
+        XCTAssertEqual(openingRange.location, 0, "Incorrect subheading1 formatting")
+        XCTAssertEqual(openingRange.length, 3, "Incorrect subheading1 formatting")
+        XCTAssertEqual(openingAttributes[.font] as! UIFont, fonts.subheading1Font, "Incorrect subheading1 formatting")
+        XCTAssertEqual(openingAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect subheading1 formatting")
+        
+        // " Test "
+        XCTAssertEqual(contentRange.location, 3, "Incorrect subheading1 formatting")
+        XCTAssertEqual(contentRange.length, 6, "Incorrect subheading1 formatting")
+        XCTAssertEqual(contentAttributes[.font] as! UIFont, fonts.subheading1Font, "Incorrect subheading1 formatting")
+        XCTAssertEqual(contentAttributes[.foregroundColor] as! UIColor, colors.baseForegroundColor, "Incorrect subheading1 formatting")
+        
+        // "=="
+        XCTAssertEqual(closingRange.location, 9, "Incorrect subheading1 formatting")
+        XCTAssertEqual(closingRange.length, 3, "Incorrect subheading1 formatting")
+        XCTAssertEqual(closingAttributes[.font] as! UIFont, fonts.subheading1Font, "Incorrect subheading1 formatting")
+        XCTAssertEqual(closingAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect subheading1 formatting")
+    }
+    
+    func testSubheading2() {
+        let string = "==== Test ===="
+        let mutAttributedString = NSMutableAttributedString(string: string)
+        
+        for formatter in formatters {
+            formatter.addSyntaxHighlighting(to: mutAttributedString, in: NSRange(location: 0, length: string.count))
+        }
+        
+        var openingRange = NSRange(location: 0, length: 0)
+        let openingAttributes = mutAttributedString.attributes(at: 0, effectiveRange: &openingRange)
+        
+        var contentRange = NSRange(location: 0, length: 0)
+        let contentAttributes = mutAttributedString.attributes(at: 4, effectiveRange: &contentRange)
+        
+        var closingRange = NSRange(location: 0, length: 0)
+        let closingAttributes = mutAttributedString.attributes(at: 10, effectiveRange: &closingRange)
+        
+        // "=="
+        XCTAssertEqual(openingRange.location, 0, "Incorrect subheading2 formatting")
+        XCTAssertEqual(openingRange.length, 4, "Incorrect subheading2 formatting")
+        XCTAssertEqual(openingAttributes[.font] as! UIFont, fonts.subheading2Font, "Incorrect subheading2 formatting")
+        XCTAssertEqual(openingAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect subheading2 formatting")
+        
+        // " Test "
+        XCTAssertEqual(contentRange.location, 4, "Incorrect subheading2 formatting")
+        XCTAssertEqual(contentRange.length, 6, "Incorrect subheading2 formatting")
+        XCTAssertEqual(contentAttributes[.font] as! UIFont, fonts.subheading2Font, "Incorrect subheading2 formatting")
+        XCTAssertEqual(contentAttributes[.foregroundColor] as! UIColor, colors.baseForegroundColor, "Incorrect subheading2 formatting")
+        
+        // "=="
+        XCTAssertEqual(closingRange.location, 10, "Incorrect subheading2 formatting")
+        XCTAssertEqual(closingRange.length, 4, "Incorrect subheading2 formatting")
+        XCTAssertEqual(closingAttributes[.font] as! UIFont, fonts.subheading2Font, "Incorrect subheading2 formatting")
+        XCTAssertEqual(closingAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect subheading2 formatting")
+    }
+    
+    func testSubheading3() {
+        let string = "===== Test ====="
+        let mutAttributedString = NSMutableAttributedString(string: string)
+        
+        for formatter in formatters {
+            formatter.addSyntaxHighlighting(to: mutAttributedString, in: NSRange(location: 0, length: string.count))
+        }
+        
+        var openingRange = NSRange(location: 0, length: 0)
+        let openingAttributes = mutAttributedString.attributes(at: 0, effectiveRange: &openingRange)
+        
+        var contentRange = NSRange(location: 0, length: 0)
+        let contentAttributes = mutAttributedString.attributes(at: 5, effectiveRange: &contentRange)
+        
+        var closingRange = NSRange(location: 0, length: 0)
+        let closingAttributes = mutAttributedString.attributes(at: 11, effectiveRange: &closingRange)
+        
+        // "=="
+        XCTAssertEqual(openingRange.location, 0, "Incorrect subheading3 formatting")
+        XCTAssertEqual(openingRange.length, 5, "Incorrect subheading3 formatting")
+        XCTAssertEqual(openingAttributes[.font] as! UIFont, fonts.subheading3Font, "Incorrect subheading3 formatting")
+        XCTAssertEqual(openingAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect subheading3 formatting")
+        
+        // " Test "
+        XCTAssertEqual(contentRange.location, 5, "Incorrect subheading3 formatting")
+        XCTAssertEqual(contentRange.length, 6, "Incorrect subheading3 formatting")
+        XCTAssertEqual(contentAttributes[.font] as! UIFont, fonts.subheading3Font, "Incorrect subheading3 formatting")
+        XCTAssertEqual(contentAttributes[.foregroundColor] as! UIColor, colors.baseForegroundColor, "Incorrect subheading3 formatting")
+        
+        // "=="
+        XCTAssertEqual(closingRange.location, 11, "Incorrect subheading3 formatting")
+        XCTAssertEqual(closingRange.length, 5, "Incorrect subheading3 formatting")
+        XCTAssertEqual(closingAttributes[.font] as! UIFont, fonts.subheading3Font, "Incorrect subheading3 formatting")
+        XCTAssertEqual(closingAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect subheading3 formatting")
+    }
+    
+    func testSubeading4() {
+        let string = "====== Test ======"
+        let mutAttributedString = NSMutableAttributedString(string: string)
+        
+        for formatter in formatters {
+            formatter.addSyntaxHighlighting(to: mutAttributedString, in: NSRange(location: 0, length: string.count))
+        }
+        
+        var openingRange = NSRange(location: 0, length: 0)
+        let openingAttributes = mutAttributedString.attributes(at: 0, effectiveRange: &openingRange)
+        
+        var contentRange = NSRange(location: 0, length: 0)
+        let contentAttributes = mutAttributedString.attributes(at: 6, effectiveRange: &contentRange)
+        
+        var closingRange = NSRange(location: 0, length: 0)
+        let closingAttributes = mutAttributedString.attributes(at: 12, effectiveRange: &closingRange)
+        
+        // "=="
+        XCTAssertEqual(openingRange.location, 0, "Incorrect subheading4 formatting")
+        XCTAssertEqual(openingRange.length, 6, "Incorrect subheading4 formatting")
+        XCTAssertEqual(openingAttributes[.font] as! UIFont, fonts.subheading4Font, "Incorrect subheading4 formatting")
+        XCTAssertEqual(openingAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect subheading4 formatting")
+        
+        // " Test "
+        XCTAssertEqual(contentRange.location, 6, "Incorrect subheading4 formatting")
+        XCTAssertEqual(contentRange.length, 6, "Incorrect subheading4 formatting")
+        XCTAssertEqual(contentAttributes[.font] as! UIFont, fonts.subheading4Font, "Incorrect subheading4 formatting")
+        XCTAssertEqual(contentAttributes[.foregroundColor] as! UIColor, colors.baseForegroundColor, "Incorrect subheading4 formatting")
+        
+        // "=="
+        XCTAssertEqual(closingRange.location, 12, "Incorrect subheading4 formatting")
+        XCTAssertEqual(closingRange.length, 6, "Incorrect subheading4 formatting")
+        XCTAssertEqual(closingAttributes[.font] as! UIFont, fonts.subheading4Font, "Incorrect subheading4 formatting")
+        XCTAssertEqual(closingAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect subheading4 formatting")
+    }
+    
+    func testInlineHeading() {
+        let string = "Test == Test == Test"
+        let mutAttributedString = NSMutableAttributedString(string: string)
+        
+        for formatter in formatters {
+            formatter.addSyntaxHighlighting(to: mutAttributedString, in: NSRange(location: 0, length: string.count))
+        }
+        
+        var range = NSRange(location: 0, length: 0)
+        let attributes = mutAttributedString.attributes(at: 0, effectiveRange: &range)
+        
+        // "Test == Test == Test"
+        // Inline headings should not format - they must be on their own line.
+        XCTAssertEqual(range.location, 0, "Incorrect inline heading formatting")
+        XCTAssertEqual(range.length, 20, "Incorrect inline heading formatting")
+        XCTAssertEqual(attributes[.font] as! UIFont, fonts.baseFont, "Incorrect inline heading formatting")
+        XCTAssertEqual(attributes[.foregroundColor] as! UIColor, colors.baseForegroundColor, "Incorrect inline heading formatting")
     }
 }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T348073

### Notes
This adds syntax highlighting for headings.

### Test Steps
1. Go to an article on Staging scheme. Tap the "Edit" button in an article navigation view.
2. Confirm headings syntax highlight as expected. Edit the number of equal signs on an editing. Confirm font size grows and shrinks as expected.
3. Change font size in popover. Confirm font size grows and shrinks on headings in relation to other text as expected.
4. Change theme in popover. Confirm heading colors change as expected.
5. Toggle off syntax highlighting. Confirm syntax highlighting toggles as expected.

### Screenshots/Videos

