### PR TITLE
Native Editor - Add list syntax highlighting 

### DIFF
--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
@@ -35,6 +35,7 @@ final class WKSourceEditorTextFrameworkMediator: NSObject {
     private(set) var formatters: [WKSourceEditorFormatter] = []
     private(set) var boldItalicsFormatter: WKSourceEditorFormatterBoldItalics?
     private(set) var templateFormatter: WKSourceEditorFormatterTemplate?
+    private(set) var listFormatter: WKSourceEditorFormatterList?
     
     var isSyntaxHighlightingEnabled: Bool = true {
         didSet {
@@ -103,11 +104,14 @@ final class WKSourceEditorTextFrameworkMediator: NSObject {
         
         let boldItalicsFormatter = WKSourceEditorFormatterBoldItalics(colors: colors, fonts: fonts)
         let templateFormatter = WKSourceEditorFormatterTemplate(colors: colors, fonts: fonts)
+        let listFormatter = WKSourceEditorFormatterList(colors: colors, fonts: fonts)
         self.formatters = [WKSourceEditorFormatterBase(colors: colors, fonts: fonts, textAlignment: viewModel.textAlignment),
                 templateFormatter,
-                boldItalicsFormatter]
+                boldItalicsFormatter,
+                listFormatter]
         self.boldItalicsFormatter = boldItalicsFormatter
         self.templateFormatter = templateFormatter
+        self.listFormatter = listFormatter
         
         if needsTextKit2 {
             if #available(iOS 16.0, *) {

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatter.h
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatter.h
@@ -4,6 +4,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WKSourceEditorFormatter : NSObject
+
+extern NSString *const WKSourceEditorCustomKeyColorOrange;
+
 - (instancetype)initWithColors:(nonnull WKSourceEditorColors *)colors fonts:(nonnull WKSourceEditorFonts *)fonts;
 - (void)addSyntaxHighlightingToAttributedString:(NSMutableAttributedString *)attributedString inRange:(NSRange)range;
 

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatter.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatter.m
@@ -3,6 +3,11 @@
 #import "WKSourceEditorFonts.h"
 
 @implementation WKSourceEditorFormatter
+
+#pragma mark - Common Custom Attributed String Keys
+// Font and Color custom attributes allow us to easily target already-formatted ranges. This is handy for speedy updates upon theme and text size change, as well as determining keyboard button selection states.
+NSString * const WKSourceEditorCustomKeyColorOrange = @"WKSourceEditorKeyColorOrange";
+
 - (nonnull instancetype)initWithColors:(nonnull WKSourceEditorColors *)colors fonts:(nonnull WKSourceEditorFonts *)fonts {
     self = [super init];
     return self;

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterBoldItalics.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterBoldItalics.m
@@ -18,9 +18,6 @@
 @implementation WKSourceEditorFormatterBoldItalics
 
 #pragma mark - Custom Attributed String Keys
-
-// Font and Color custom attributes allow us to easily target already-formatted ranges. This is handy for speedy updates upon theme and text size change, as well as determining keyboard button selection states.
-NSString * const WKSourceEditorCustomKeyColorOrange = @"WKSourceEditorKeyColorOrange";
 NSString * const WKSourceEditorCustomKeyFontBoldItalics = @"WKSourceEditorKeyFontBoldItalics";
 NSString * const WKSourceEditorCustomKeyFontBold = @"WKSourceEditorKeyFontBold";
 NSString * const WKSourceEditorCustomKeyFontItalics = @"WKSourceEditorKeyFontItalics";

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterList.h
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterList.h
@@ -1,0 +1,9 @@
+#import "WKSourceEditorFormatter.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKSourceEditorFormatterList : WKSourceEditorFormatter
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterList.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterList.m
@@ -1,0 +1,5 @@
+#import "WKSourceEditorFormatterList.h"
+
+@implementation WKSourceEditorFormatterList
+
+@end

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterList.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterList.m
@@ -1,5 +1,83 @@
 #import "WKSourceEditorFormatterList.h"
+#import "WKSourceEditorColors.h"
+
+@interface WKSourceEditorFormatterList ()
+
+@property (nonatomic, strong) NSDictionary *orangeAttributes;
+
+@property (nonatomic, strong) NSRegularExpression *bulletRegex;
+@property (nonatomic, strong) NSRegularExpression *numberRegex;
+
+@end
 
 @implementation WKSourceEditorFormatterList
+
+#pragma mark - Overrides
+
+- (instancetype)initWithColors:(WKSourceEditorColors *)colors fonts:(WKSourceEditorFonts *)fonts {
+    self = [super initWithColors:colors fonts:fonts];
+    if (self) {
+        _orangeAttributes = @{
+            NSForegroundColorAttributeName: colors.orangeForegroundColor,
+            WKSourceEditorCustomKeyColorOrange: [NSNumber numberWithBool:YES]
+        };
+        
+        _bulletRegex = [[NSRegularExpression alloc] initWithPattern:@"^(\\*+)(.*)$" options:NSRegularExpressionAnchorsMatchLines error:nil];
+        _numberRegex = [[NSRegularExpression alloc] initWithPattern:@"^(#+)(.*)$" options:NSRegularExpressionAnchorsMatchLines error:nil];
+    }
+    return self;
+}
+
+- (void)addSyntaxHighlightingToAttributedString:(nonnull NSMutableAttributedString *)attributedString inRange:(NSRange)range {
+
+    [self.bulletRegex enumerateMatchesInString:attributedString.string
+                                       options:0
+                                         range:range
+                                    usingBlock:^(NSTextCheckingResult *_Nullable result, NSMatchingFlags flags, BOOL *_Nonnull stop) {
+                                        NSRange fullMatch = [result rangeAtIndex:0];
+                                        NSRange bulletRange = [result rangeAtIndex:1];
+        
+                                        if (bulletRange.location != NSNotFound) {
+                                            [attributedString addAttributes:self.orangeAttributes range:bulletRange];
+                                        }
+                                    }];
+    
+    [self.numberRegex enumerateMatchesInString:attributedString.string
+                                       options:0
+                                         range:range
+                                    usingBlock:^(NSTextCheckingResult *_Nullable result, NSMatchingFlags flags, BOOL *_Nonnull stop) {
+                                        NSRange fullMatch = [result rangeAtIndex:0];
+                                        NSRange numberRange = [result rangeAtIndex:1];
+        
+                                        if (numberRange.location != NSNotFound) {
+                                            [attributedString addAttributes:self.orangeAttributes range:numberRange];
+                                        }
+                                    }];
+}
+
+- (void)updateColors:(WKSourceEditorColors *)colors inAttributedString:(NSMutableAttributedString *)attributedString inRange:(NSRange)range {
+    
+    // First update orangeAttributes property so that addSyntaxHighlighting has the correct color the next time it is called
+    NSMutableDictionary *mutAttributes = [[NSMutableDictionary alloc] initWithDictionary:self.orangeAttributes];
+    [mutAttributes setObject:colors.orangeForegroundColor forKey:NSForegroundColorAttributeName];
+    self.orangeAttributes = [[NSDictionary alloc] initWithDictionary:mutAttributes];
+    
+    // Then update entire attributed string orange color
+    [attributedString enumerateAttribute:WKSourceEditorCustomKeyColorOrange
+                     inRange:range
+                     options:nil
+                  usingBlock:^(id value, NSRange localRange, BOOL *stop) {
+        if ([value isKindOfClass: [NSNumber class]]) {
+            NSNumber *numValue = (NSNumber *)value;
+            if ([numValue boolValue] == YES) {
+                [attributedString addAttributes:self.orangeAttributes range:localRange];
+            }
+        }
+    }];
+}
+
+- (void)updateFonts:(WKSourceEditorFonts *)fonts inAttributedString:(NSMutableAttributedString *)attributedString inRange:(NSRange)range {
+    // No special font handling needed for lists
+}
 
 @end

--- a/Components/Sources/ComponentsObjC/include/ComponentsObjC.h
+++ b/Components/Sources/ComponentsObjC/include/ComponentsObjC.h
@@ -8,6 +8,7 @@
 #import "WKSourceEditorFormatterBase.h"
 #import "WKSourceEditorFormatterBoldItalics.h"
 #import "WKSourceEditorFormatterTemplate.h"
+#import "WKSourceEditorFormatterList.h"
 #import "WKSourceEditorStorageDelegate.h"
 
 #endif /* Header_h */

--- a/Components/Sources/ComponentsObjC/include/WKSourceEditorFormatterList.h
+++ b/Components/Sources/ComponentsObjC/include/WKSourceEditorFormatterList.h
@@ -1,0 +1,1 @@
+../WKSourceEditorFormatterList.h

--- a/Components/Tests/ComponentsTests/WKSourceEditorFormatterTests.swift
+++ b/Components/Tests/ComponentsTests/WKSourceEditorFormatterTests.swift
@@ -10,8 +10,9 @@ final class WKSourceEditorFormatterTests: XCTestCase {
     var baseFormatter: WKSourceEditorFormatterBase!
     var boldItalicsFormatter: WKSourceEditorFormatterBoldItalics!
     var templateFormatter: WKSourceEditorFormatterTemplate!
+    var listFormatter: WKSourceEditorFormatterList!
     var formatters: [WKSourceEditorFormatter] {
-        return [baseFormatter, templateFormatter, boldItalicsFormatter]
+        return [baseFormatter, templateFormatter, boldItalicsFormatter, listFormatter]
     }
 
     override func setUpWithError() throws {
@@ -31,6 +32,7 @@ final class WKSourceEditorFormatterTests: XCTestCase {
         self.baseFormatter = WKSourceEditorFormatterBase(colors: colors, fonts: fonts, textAlignment: .left)
         self.boldItalicsFormatter = WKSourceEditorFormatterBoldItalics(colors: colors, fonts: fonts)
         self.templateFormatter = WKSourceEditorFormatterTemplate(colors: colors, fonts: fonts)
+        self.listFormatter = WKSourceEditorFormatterList(colors: colors, fonts: fonts)
     }
 
     override func tearDownWithError() throws {
@@ -708,5 +710,113 @@ final class WKSourceEditorFormatterTests: XCTestCase {
         XCTAssertEqual(refRange.length, 6, "Incorrect ref formatting")
         XCTAssertEqual(refAttributes[.font] as! UIFont, fonts.baseFont, "Incorrect ref formatting")
         XCTAssertEqual(refAttributes[.foregroundColor] as! UIColor, colors.baseForegroundColor, "Incorrect ref formatting")
+    }
+    
+    func testListSingleBullet() {
+        let string = "* Testing"
+        let mutAttributedString = NSMutableAttributedString(string: string)
+
+        for formatter in formatters {
+            formatter.addSyntaxHighlighting(to: mutAttributedString, in: NSRange(location: 0, length: string.count))
+        }
+        
+        var bulletRange = NSRange(location: 0, length: 0)
+        let bulletAttributes = mutAttributedString.attributes(at: 0, effectiveRange: &bulletRange)
+        
+        var textRange = NSRange(location: 0, length: 0)
+        let textAttributes = mutAttributedString.attributes(at: 1, effectiveRange: &textRange)
+
+        // "*"
+        XCTAssertEqual(bulletRange.location, 0, "Incorrect list formatting")
+        XCTAssertEqual(bulletRange.length, 1, "Incorrect list formatting")
+        XCTAssertEqual(bulletAttributes[.font] as! UIFont, fonts.baseFont, "Incorrect list formatting")
+        XCTAssertEqual(bulletAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect list formatting")
+        
+        // " Testing"
+        XCTAssertEqual(textRange.location, 1, "Incorrect list formatting")
+        XCTAssertEqual(textRange.length, 8, "Incorrect list formatting")
+        XCTAssertEqual(textAttributes[.font] as! UIFont, fonts.baseFont, "Incorrect list formatting")
+        XCTAssertEqual(textAttributes[.foregroundColor] as! UIColor, colors.baseForegroundColor, "Incorrect list formatting")
+    }
+    
+    func testListSingleNumber() {
+        let string = "# Testing"
+        let mutAttributedString = NSMutableAttributedString(string: string)
+
+        for formatter in formatters {
+            formatter.addSyntaxHighlighting(to: mutAttributedString, in: NSRange(location: 0, length: string.count))
+        }
+        
+        var numberRange = NSRange(location: 0, length: 0)
+        let numberAttributes = mutAttributedString.attributes(at: 0, effectiveRange: &numberRange)
+        
+        var textRange = NSRange(location: 0, length: 0)
+        let textAttributes = mutAttributedString.attributes(at: 1, effectiveRange: &textRange)
+
+        // "*"
+        XCTAssertEqual(numberRange.location, 0, "Incorrect list formatting")
+        XCTAssertEqual(numberRange.length, 1, "Incorrect list formatting")
+        XCTAssertEqual(numberAttributes[.font] as! UIFont, fonts.baseFont, "Incorrect list formatting")
+        XCTAssertEqual(numberAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect list formatting")
+        
+        // " Testing"
+        XCTAssertEqual(textRange.location, 1, "Incorrect list formatting")
+        XCTAssertEqual(textRange.length, 8, "Incorrect list formatting")
+        XCTAssertEqual(textAttributes[.font] as! UIFont, fonts.baseFont, "Incorrect list formatting")
+        XCTAssertEqual(textAttributes[.foregroundColor] as! UIColor, colors.baseForegroundColor, "Incorrect list formatting")
+    }
+    
+    func testListMultipleBulletNoSpace() {
+        let string = "***Testing"
+        let mutAttributedString = NSMutableAttributedString(string: string)
+
+        for formatter in formatters {
+            formatter.addSyntaxHighlighting(to: mutAttributedString, in: NSRange(location: 0, length: string.count))
+        }
+        
+        var bulletRange = NSRange(location: 0, length: 0)
+        let bulletAttributes = mutAttributedString.attributes(at: 0, effectiveRange: &bulletRange)
+        
+        var textRange = NSRange(location: 0, length: 0)
+        let textAttributes = mutAttributedString.attributes(at: 3, effectiveRange: &textRange)
+
+        // "*"
+        XCTAssertEqual(bulletRange.location, 0, "Incorrect list formatting")
+        XCTAssertEqual(bulletRange.length, 3, "Incorrect list formatting")
+        XCTAssertEqual(bulletAttributes[.font] as! UIFont, fonts.baseFont, "Incorrect list formatting")
+        XCTAssertEqual(bulletAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect list formatting")
+        
+        // " Testing"
+        XCTAssertEqual(textRange.location, 3, "Incorrect list formatting")
+        XCTAssertEqual(textRange.length, 7, "Incorrect list formatting")
+        XCTAssertEqual(textAttributes[.font] as! UIFont, fonts.baseFont, "Incorrect list formatting")
+        XCTAssertEqual(textAttributes[.foregroundColor] as! UIColor, colors.baseForegroundColor, "Incorrect list formatting")
+    }
+    
+    func testListMultipleNumberNoSpace() {
+        let string = "###Testing"
+        let mutAttributedString = NSMutableAttributedString(string: string)
+
+        for formatter in formatters {
+            formatter.addSyntaxHighlighting(to: mutAttributedString, in: NSRange(location: 0, length: string.count))
+        }
+        
+        var numberRange = NSRange(location: 0, length: 0)
+        let numberAttributes = mutAttributedString.attributes(at: 0, effectiveRange: &numberRange)
+        
+        var textRange = NSRange(location: 0, length: 0)
+        let textAttributes = mutAttributedString.attributes(at: 3, effectiveRange: &textRange)
+
+        // "*"
+        XCTAssertEqual(numberRange.location, 0, "Incorrect list formatting")
+        XCTAssertEqual(numberRange.length, 3, "Incorrect list formatting")
+        XCTAssertEqual(numberAttributes[.font] as! UIFont, fonts.baseFont, "Incorrect list formatting")
+        XCTAssertEqual(numberAttributes[.foregroundColor] as! UIColor, colors.orangeForegroundColor, "Incorrect list formatting")
+        
+        // " Testing"
+        XCTAssertEqual(textRange.location, 3, "Incorrect list formatting")
+        XCTAssertEqual(textRange.length, 7, "Incorrect list formatting")
+        XCTAssertEqual(textAttributes[.font] as! UIFont, fonts.baseFont, "Incorrect list formatting")
+        XCTAssertEqual(textAttributes[.foregroundColor] as! UIColor, colors.baseForegroundColor, "Incorrect list formatting")
     }
 }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T348090

### Notes
This adds syntax highlighting for headings.

### Test Steps
1. On Staging app, go to an article.
2. On a new line, type one or more asterisks (*), then some letters. Confirm asterisks are orange.
3. On another new line, type one or more hashes (#), then some letters. Confirm hashes are orange.
4. Change theme in popover, confirm orange changes as expected in each theme.

