### PR TITLE
Native Editor - Fix shared method keys in bold italic formatter

### DIFF
--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterBoldItalics.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterBoldItalics.m
@@ -280,7 +280,6 @@ NSString * const WKSourceEditorCustomKeyFontItalics = @"WKSourceEditorKeyFontIta
 - (BOOL)attributedString:(NSMutableAttributedString *)attributedString isBoldInRange:(NSRange)range {
     return [self attributedString:attributedString isFormattedInRange:range formattingKey:WKSourceEditorCustomKeyFontBold];
 }
-
 - (BOOL)attributedString:(NSMutableAttributedString *)attributedString isItalicsInRange:(NSRange)range {
     return [self attributedString:attributedString isFormattedInRange:range formattingKey:WKSourceEditorCustomKeyFontItalics];
 }
@@ -294,14 +293,13 @@ NSString * const WKSourceEditorCustomKeyFontItalics = @"WKSourceEditorKeyFontIta
         
         if (attributedString.length > range.location) {
             NSDictionary<NSAttributedStringKey,id> *attrs = [attributedString attributesAtIndex:range.location effectiveRange:nil];
-            
-            if (attrs[WKSourceEditorCustomKeyFontBoldItalics] != nil || attrs[WKSourceEditorCustomKeyFontItalics] != nil) {
+            if (attrs[WKSourceEditorCustomKeyFontBoldItalics] != nil || attrs[formattingKey] != nil) {
                 isFormatted = YES;
             } else {
                 // Edge case, check previous character if we are up against a closing bold or italic
                 if (attrs[WKSourceEditorCustomKeyColorOrange]) {
                     attrs = [attributedString attributesAtIndex:range.location - 1 effectiveRange:nil];
-                    if (attrs[WKSourceEditorCustomKeyFontBold] != nil || attrs[WKSourceEditorCustomKeyFontItalics] != nil) {
+                    if (attrs[WKSourceEditorCustomKeyFontBoldItalics] != nil || attrs[formattingKey] != nil) {
                         isFormatted = YES;
                     }
                 }


### PR DESCRIPTION
**Phabricator:** 
N/A

### Notes
I noticed these keys are off in `main`.  

### Test Steps
1. Place cursor inside bolded text. Open formatting menu. Confirm only bold is selected.
2. Place cursor inside italic text. Open formatting menu. Confirm only italics is selected.

Bugs:
![3](https://github.com/wikimedia/wikipedia-ios/assets/3620196/8e179040-a23a-4544-baff-c8474a10a00c)
![2](https://github.com/wikimedia/wikipedia-ios/assets/3620196/8bf67897-d166-4136-a9e2-cad9c3762472)
![1](https://github.com/wikimedia/wikipedia-ios/assets/3620196/51142620-c19d-48fd-9873-6f17fb8c9994)

