### PR TITLE
Native Editor - add find

### DIFF
--- a/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.swift
+++ b/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.swift
@@ -137,7 +137,7 @@ class WKFindAndReplaceView: WKComponentView {
     
     @IBAction private func tappedFindClear() {
         findTextField.text = ""
-        debouncedTextfieldDidChange()
+        debouncedFindTextfieldDidChange()
     }
     
     @IBAction private func tappedReplaceClear() {
@@ -161,8 +161,10 @@ class WKFindAndReplaceView: WKComponentView {
     }
     
     @IBAction private func textFieldDidChange(_ sender: UITextField) {
-        NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(debouncedTextfieldDidChange), object: nil)
-        perform(#selector(debouncedTextfieldDidChange), with: nil, afterDelay: 1.0)
+        if sender == self.findTextField {
+            NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(debouncedFindTextfieldDidChange), object: nil)
+            perform(#selector(debouncedFindTextfieldDidChange), with: nil, afterDelay: 1.0)
+        }
     }
     
     // MARK: - Private Helpers
@@ -212,7 +214,7 @@ class WKFindAndReplaceView: WKComponentView {
         replacePlaceholderLabel.textColor = theme.secondaryText
     }
     
-    @objc private func debouncedTextfieldDidChange() {
+    @objc private func debouncedFindTextfieldDidChange() {
 
         guard let text = findTextField.text else {
             return

--- a/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.swift
+++ b/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.swift
@@ -165,7 +165,7 @@ class WKFindAndReplaceView: WKComponentView {
     @IBAction private func textFieldDidChange(_ sender: UITextField) {
         if sender == self.findTextField {
             NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(debouncedFindTextfieldDidChange), object: nil)
-            perform(#selector(debouncedFindTextfieldDidChange), with: nil, afterDelay: 1.0)
+            perform(#selector(debouncedFindTextfieldDidChange), with: nil, afterDelay: 0.5)
         }
     }
     

--- a/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.swift
+++ b/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.swift
@@ -111,12 +111,6 @@ class WKFindAndReplaceView: WKComponentView {
         } else {
             currentMatchLabel.text = nil
         }
-
-        if let findText = viewModel.findText {
-            findTextField.text = findText
-        } else {
-            findTextField.text = nil
-        }
     }
     
     // MARK: - Overrides
@@ -220,12 +214,11 @@ class WKFindAndReplaceView: WKComponentView {
     
     @objc private func debouncedTextfieldDidChange() {
 
-        viewModel?.findText = findTextField.text
-
         guard let text = findTextField.text else {
             return
         }
 
+        // TODO: also call from keyboard search button
         delegate?.findAndReplaceView(self, didChangeFindText: text)
     }
 }

--- a/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.swift
+++ b/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.swift
@@ -18,7 +18,7 @@ class WKFindAndReplaceView: WKComponentView {
     @IBOutlet private var findStackView: UIStackView!
     @IBOutlet private var nextPrevButtonStackView: UIStackView!
     @IBOutlet private(set) var findTextField: UITextField!
-    @IBOutlet private var currentMatchLabel: UILabel!
+    @IBOutlet private var currentMatchInfoLabel: UILabel!
     @IBOutlet private var findClearButton: UIButton!
     @IBOutlet private var closeButton: UIButton!
     @IBOutlet private var nextButton: UIButton!
@@ -80,8 +80,8 @@ class WKFindAndReplaceView: WKComponentView {
         replaceTypeLabel.text = WKSourceEditorLocalizedStrings.current.findReplaceTypeSingle
         replaceTypeLabel.isAccessibilityElement = false
 
-        currentMatchLabel.adjustsFontForContentSizeCategory = true
-        currentMatchLabel.font = WKFont.for(.caption1, compatibleWith: appEnvironment.traitCollection)
+        currentMatchInfoLabel.adjustsFontForContentSizeCategory = true
+        currentMatchInfoLabel.font = WKFont.for(.caption1, compatibleWith: appEnvironment.traitCollection)
 
         replaceTypeLabel.adjustsFontForContentSizeCategory = true
         replaceTypeLabel.font = WKFont.for(.caption1, compatibleWith: appEnvironment.traitCollection)
@@ -109,9 +109,9 @@ class WKFindAndReplaceView: WKComponentView {
         let findIsEmpty = (findTextField.text ?? "").isEmpty
         if let currentMatchInfo = viewModel.currentMatchInfo,
            !findIsEmpty {
-            currentMatchLabel.text = "\(currentMatchInfo)"
+            currentMatchInfoLabel.text = "\(currentMatchInfo)"
         } else {
-            currentMatchLabel.text = nil
+            currentMatchInfoLabel.text = nil
         }
     }
     
@@ -179,14 +179,14 @@ class WKFindAndReplaceView: WKComponentView {
             findStackView.insertArrangedSubview(nextPrevButtonStackView, at: 0)
             outerStackViewLeadingConstraint.constant = 10
             outerStackViewTrailingConstraint.constant = 5
-            accessibilityElements = [previousButton, nextButton, findTextField, currentMatchLabel, findClearButton, closeButton].compactMap { $0 as Any }
+            accessibilityElements = [previousButton, nextButton, findTextField, currentMatchInfoLabel, findClearButton, closeButton].compactMap { $0 as Any }
         case .findAndReplace:
             replaceStackView.isHidden = false
             closeButton.isHidden = true
             findStackView.addArrangedSubview(nextPrevButtonStackView)
             outerStackViewLeadingConstraint.constant = 18
             outerStackViewTrailingConstraint.constant = 18
-            accessibilityElements = [findTextField, currentMatchLabel, findClearButton, previousButton, nextButton, replaceTextField, replaceClearButton, replaceButton, replaceSwitchButton].compactMap { $0 as Any }
+            accessibilityElements = [findTextField, currentMatchInfoLabel, findClearButton, previousButton, nextButton, replaceTextField, replaceClearButton, replaceButton, replaceSwitchButton].compactMap { $0 as Any }
         }
     }
     
@@ -203,7 +203,7 @@ class WKFindAndReplaceView: WKComponentView {
         nextButton.tintColor = theme.inputAccessoryButtonTint
         magnifyImageView.tintColor = theme.inputAccessoryButtonTint
         findClearButton.tintColor = theme.inputAccessoryButtonTint
-        currentMatchLabel.textColor = theme.secondaryText
+        currentMatchInfoLabel.textColor = theme.secondaryText
         
         replaceTextField.keyboardAppearance = theme.keyboardAppearance
         replaceTextfieldContainer.backgroundColor = theme.keyboardBarSearchFieldBackground

--- a/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.swift
+++ b/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.swift
@@ -113,6 +113,9 @@ class WKFindAndReplaceView: WKComponentView {
         } else {
             currentMatchInfoLabel.text = nil
         }
+        
+        nextButton.isEnabled = viewModel.nextPrevButtonsAreEnabled
+        previousButton.isEnabled = viewModel.nextPrevButtonsAreEnabled
     }
     
     // MARK: - Overrides

--- a/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.swift
+++ b/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.swift
@@ -106,7 +106,9 @@ class WKFindAndReplaceView: WKComponentView {
         
         updateConfiguration(configuration: viewModel.configuration)
         
-        if let currentMatchInfo = viewModel.currentMatchInfo {
+        let findIsEmpty = (findTextField.text ?? "").isEmpty
+        if let currentMatchInfo = viewModel.currentMatchInfo,
+           !findIsEmpty {
             currentMatchLabel.text = "\(currentMatchInfo)"
         } else {
             currentMatchLabel.text = nil

--- a/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.xib
+++ b/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -235,7 +234,7 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="closeButton" destination="cVz-34-psT" id="ugE-BQ-Wie"/>
-                <outlet property="currentMatchLabel" destination="6cQ-Pa-aFx" id="K9Y-CS-Rke"/>
+                <outlet property="currentMatchInfoLabel" destination="6cQ-Pa-aFx" id="K9Y-CS-Rke"/>
                 <outlet property="findClearButton" destination="upA-Ii-L3S" id="3pS-KY-Bv2"/>
                 <outlet property="findStackView" destination="2D8-r6-Pwy" id="xj7-Ab-A1q"/>
                 <outlet property="findTextField" destination="SWF-dB-rso" id="Prh-oK-N8B"/>

--- a/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.xib
+++ b/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceView.xib
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -25,7 +26,7 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zYQ-km-WBU">
                                             <rect key="frame" x="0.0" y="2" width="62" height="34"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bHU-iI-iHx">
+                                                <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bHU-iI-iHx">
                                                     <rect key="frame" x="0.0" y="0.0" width="31" height="34"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="34" id="Nk9-Lb-p5T"/>
@@ -35,7 +36,7 @@
                                                         <action selector="tappedPrevious" destination="iN0-l3-epB" eventType="touchUpInside" id="wX5-Bl-uAB"/>
                                                     </connections>
                                                 </button>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ygy-QU-ZCs">
+                                                <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ygy-QU-ZCs">
                                                     <rect key="frame" x="31" y="0.0" width="31" height="34"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="34" id="gJU-4L-Bxp"/>

--- a/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceViewModel.swift
+++ b/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceViewModel.swift
@@ -7,13 +7,11 @@ struct WKFindAndReplaceViewModel {
         case findAndReplace
     }
     
-    var findText: String?
     var currentMatchInfo: String?
     
     let configuration: Configuration = .findAndReplace
     
     mutating func reset() {
-        findText = nil
         currentMatchInfo = nil
     }
 }

--- a/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceViewModel.swift
+++ b/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceViewModel.swift
@@ -8,10 +8,12 @@ struct WKFindAndReplaceViewModel {
     }
     
     var currentMatchInfo: String?
+    var nextPrevButtonsAreEnabled: Bool = false
     
     let configuration: Configuration = .findAndReplace
     
     mutating func reset() {
         currentMatchInfo = nil
+        nextPrevButtonsAreEnabled = false
     }
 }

--- a/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceViewModel.swift
+++ b/Components/Sources/Components/Components/Editors/Common Views/Input Accessory Views/Find and Replace/WKFindAndReplaceViewModel.swift
@@ -7,5 +7,13 @@ struct WKFindAndReplaceViewModel {
         case findAndReplace
     }
     
+    var findText: String?
+    var currentMatchInfo: String?
+    
     let configuration: Configuration = .findAndReplace
+    
+    mutating func reset() {
+        findText = nil
+        currentMatchInfo = nil
+    }
 }

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
@@ -173,15 +173,6 @@ final class WKSourceEditorTextFrameworkMediator: NSObject {
         }
     }
     
-    @objc private func debouncedEnsureLayoutTextkit1() {
-        
-        guard !needsTextKit2 else {
-            return
-        }
-        
-       textView.layoutManager.ensureLayout(forCharacterRange: NSRange(location: 0, length: textView.attributedText.length))
-    }
-    
     func selectionState(selectedDocumentRange: NSRange) -> WKSourceEditorSelectionState {
         
         if needsTextKit2 {
@@ -227,7 +218,34 @@ final class WKSourceEditorTextFrameworkMediator: NSObject {
         }
     }
     
-    func textkit2SelectionData(selectedDocumentRange: NSRange) -> (paragraphAttributedString: NSMutableAttributedString, paragraphSelectedRange: NSRange)? {
+    func findStart(text: String) {
+        
+    }
+    
+    func findNext() {
+        
+    }
+    
+    func findPrevious() {
+        
+    }
+    
+    func findReset() {
+        
+    }
+    
+    // MARK: Private
+    
+    @objc private func debouncedEnsureLayoutTextkit1() {
+        
+        guard !needsTextKit2 else {
+            return
+        }
+        
+       textView.layoutManager.ensureLayout(forCharacterRange: NSRange(location: 0, length: textView.attributedText.length))
+    }
+    
+    private func textkit2SelectionData(selectedDocumentRange: NSRange) -> (paragraphAttributedString: NSMutableAttributedString, paragraphSelectedRange: NSRange)? {
         guard needsTextKit2 else {
             return nil
         }
@@ -252,6 +270,8 @@ final class WKSourceEditorTextFrameworkMediator: NSObject {
         return nil
     }
 }
+
+// MARK: WKSourceEditorStorageDelegate
 
 extension WKSourceEditorTextFrameworkMediator: WKSourceEditorStorageDelegate {
     
@@ -286,6 +306,8 @@ extension WKSourceEditorTextFrameworkMediator: WKSourceEditorStorageDelegate {
     }
 }
 
+// MARK: NSTextContentStorageDelegate
+
  extension WKSourceEditorTextFrameworkMediator: NSTextContentStorageDelegate {
 
     func textContentStorage(_ textContentStorage: NSTextContentStorage, textParagraphWith range: NSRange) -> NSTextParagraph? {
@@ -308,6 +330,8 @@ extension WKSourceEditorTextFrameworkMediator: WKSourceEditorStorageDelegate {
         return NSTextParagraph(attributedString: attributedString)
     }
 }
+
+// MARK: NSTextContentStorage Extensions
 
 fileprivate extension NSTextContentStorage {
     func textRangeForDocumentNSRange(_ documentNSRange: NSRange) -> NSTextRange? {

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
@@ -58,6 +58,7 @@ final class WKSourceEditorTextFrameworkMediator: NSObject {
     private(set) var listFormatter: WKSourceEditorFormatterList?
     private(set) var headingFormatter: WKSourceEditorFormatterHeading?
     private(set) var strikethroughFormatter: WKSourceEditorFormatterStrikethrough?
+    private(set) var findAndReplaceFormatter: WKSourceEditorFormatterFindAndReplace?
     
     var isSyntaxHighlightingEnabled: Bool = true {
         didSet {
@@ -129,17 +130,20 @@ final class WKSourceEditorTextFrameworkMediator: NSObject {
         let listFormatter = WKSourceEditorFormatterList(colors: colors, fonts: fonts)
         let headingFormatter = WKSourceEditorFormatterHeading(colors: colors, fonts: fonts)
         let strikethroughFormatter = WKSourceEditorFormatterStrikethrough(colors: colors, fonts: fonts)
+        let findAndReplaceFormatter = WKSourceEditorFormatterFindAndReplace(colors: colors, fonts: fonts)
         self.formatters = [WKSourceEditorFormatterBase(colors: colors, fonts: fonts, textAlignment: viewModel.textAlignment),
                 templateFormatter,
                 boldItalicsFormatter,
                 listFormatter,
                 headingFormatter,
-                strikethroughFormatter]
+                strikethroughFormatter,
+                findAndReplaceFormatter]
         self.boldItalicsFormatter = boldItalicsFormatter
         self.templateFormatter = templateFormatter
         self.listFormatter = listFormatter
         self.headingFormatter = headingFormatter
         self.strikethroughFormatter = strikethroughFormatter
+        self.findAndReplaceFormatter = findAndReplaceFormatter
         
         if needsTextKit2 {
             if #available(iOS 16.0, *) {

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
@@ -247,26 +247,33 @@ final class WKSourceEditorTextFrameworkMediator: NSObject {
             textKit1Storage?.syntaxHighlightProcessingEnabled = true
         }
         
-        findNext()
+        findNext(afterRange: textView.selectedRange)
 
         self.delegate?.scrollToCurrentMatch()
     }
     
-    func findNext() {
+    func findNext(afterRange: NSRange?) {
         guard let fullAttributedString else {
             return
         }
         
+        let afterRangeValue: NSValue?
+        if let afterRange {
+            afterRangeValue = NSValue(range: afterRange)
+        } else {
+            afterRangeValue = nil
+        }
         if needsTextKit2 {
             if #available(iOS 16.0, *) {
+                
                 textView.textLayoutManager?.textContentManager?.performEditingTransaction {
-                    self.findAndReplaceFormatter?.highlightNextMatch(inFullAttributedString: fullAttributedString)
+                    self.findAndReplaceFormatter?.highlightNextMatch(inFullAttributedString: fullAttributedString, afterRangeValue: afterRangeValue)
 
                 }
             }
         } else {
             textKit1Storage?.syntaxHighlightProcessingEnabled = false
-            findAndReplaceFormatter?.highlightNextMatch(inFullAttributedString: fullAttributedString)
+            findAndReplaceFormatter?.highlightNextMatch(inFullAttributedString: fullAttributedString, afterRangeValue: afterRangeValue)
             textKit1Storage?.syntaxHighlightProcessingEnabled = true
         }
         

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
@@ -164,7 +164,7 @@ final class WKSourceEditorTextFrameworkMediator: NSObject {
                 })
             }
         } else {
-            textKit1Storage?.syntaxHighlightProcessingEnabled = false
+            textKit1Storage?.syntaxHighlightProcessingEnabled = true
             textKit1Storage?.updateColorsAndFonts()
             textKit1Storage?.syntaxHighlightProcessingEnabled = false
             

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
@@ -164,7 +164,10 @@ final class WKSourceEditorTextFrameworkMediator: NSObject {
                 })
             }
         } else {
+            textKit1Storage?.syntaxHighlightProcessingEnabled = false
             textKit1Storage?.updateColorsAndFonts()
+            textKit1Storage?.syntaxHighlightProcessingEnabled = false
+            
             NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(debouncedEnsureLayoutTextkit1), object: nil)
             perform(#selector(debouncedEnsureLayoutTextkit1), with: nil, afterDelay: 0.1)
         }

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorTextFrameworkMediator.swift
@@ -258,6 +258,10 @@ extension WKSourceEditorTextFrameworkMediator: WKSourceEditorStorageDelegate {
         colors.orangeForegroundColor = isSyntaxHighlightingEnabled ? WKAppEnvironment.current.theme.editorOrange : WKAppEnvironment.current.theme.text
         colors.purpleForegroundColor = isSyntaxHighlightingEnabled ?  WKAppEnvironment.current.theme.editorPurple : WKAppEnvironment.current.theme.text
         colors.greenForegroundColor = isSyntaxHighlightingEnabled ?  WKAppEnvironment.current.theme.editorGreen : WKAppEnvironment.current.theme.text
+        colors.matchForegroundColor = WKAppEnvironment.current.theme.editorMatchForeground
+        colors.matchBackgroundColor = WKAppEnvironment.current.theme.editorMatchBackground
+        colors.selectedMatchBackgroundColor = WKAppEnvironment.current.theme.editorSelectedMatchBackground
+        colors.replacedMatchBackgroundColor = WKAppEnvironment.current.theme.editorReplacedMatchBackground
         return colors
     }
     

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
@@ -185,7 +185,8 @@ public class WKSourceEditorViewController: WKComponentViewController {
         } else {
             // TODO: select a range on screen. Test by searching for a nonexisting string, then closing find.
         }
-        
+        textView.isEditable = true
+        textView.isSelectable = true
         textView.becomeFirstResponder()
         inputAccessoryViewType = .expanding
         resetFind()
@@ -259,6 +260,7 @@ private extension WKSourceEditorViewController {
         }
         
         viewModel.currentMatchInfo = "\(findFormatter.selectedMatchIndex + 1) / \(findFormatter.matchCount)"
+        
         findAccessoryView.update(viewModel: viewModel)
     }
 }
@@ -271,10 +273,12 @@ extension WKSourceEditorViewController: UITextViewDelegate {
             postUpdateButtonSelectionStatesNotification(withDelay: false)
             return
         }
-        let isRangeSelected = textView.selectedRange.length > 0
+        
         if inputAccessoryViewType == .find {
-            resetFind()
+            return
         }
+        
+        let isRangeSelected = textView.selectedRange.length > 0
         inputAccessoryViewType = isRangeSelected ? .highlight : .expanding
         postUpdateButtonSelectionStatesNotification(withDelay: false)
     }
@@ -287,6 +291,8 @@ extension WKSourceEditorViewController: WKEditorToolbarExpandingViewDelegate {
     func toolbarExpandingViewDidTapFind(toolbarView: WKEditorToolbarExpandingView) {
         inputAccessoryViewType = .find
         delegate?.sourceEditorViewControllerDidTapFind(sourceEditorViewController: self)
+        textView.isEditable = false
+        textView.isSelectable = false
     }
     
     func toolbarExpandingViewDidTapFormatText(toolbarView: WKEditorToolbarExpandingView) {

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
@@ -255,11 +255,14 @@ private extension WKSourceEditorViewController {
             return
         }
         
-        guard findFormatter.selectedMatchIndex != NSNotFound else {
-            return
+        if findFormatter.selectedMatchIndex != NSNotFound {
+            viewModel.currentMatchInfo = "\(findFormatter.selectedMatchIndex + 1) / \(findFormatter.matchCount)"
+        } else if findFormatter.matchCount == 0 {
+            viewModel.currentMatchInfo = "0 / 0"
+        } else {
+            viewModel.currentMatchInfo = nil
         }
         
-        viewModel.currentMatchInfo = "\(findFormatter.selectedMatchIndex + 1) / \(findFormatter.matchCount)"
         
         findAccessoryView.update(viewModel: viewModel)
     }

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
@@ -422,10 +422,8 @@ extension WKSourceEditorViewController: WKEditorInputViewDelegate {
 extension WKSourceEditorViewController: WKFindAndReplaceViewDelegate {
     func findAndReplaceView(_ view: WKFindAndReplaceView, didChangeFindText text: String) {
         resetFind()
-        // TODO: show spinner on find
         textFrameworkMediator.findStart(text: text)
         updateFindCurrentMatchInfo()
-        // TODO: end spinner on find
         // TODO: enable next / prev buttons
     }
     

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
@@ -55,9 +55,9 @@ public class WKSourceEditorViewController: WKComponentViewController {
     
     private lazy var findAccessoryView: WKFindAndReplaceView = {
         let view = UINib(nibName: String(describing: WKFindAndReplaceView.self), bundle: Bundle.module).instantiate(withOwner: nil).first as! WKFindAndReplaceView
-        let viewModel = WKFindAndReplaceViewModel()
-        view.configure(viewModel: viewModel)
+        view.update(viewModel: WKFindAndReplaceViewModel())
         view.accessibilityIdentifier = WKSourceEditorAccessibilityIdentifiers.current?.findToolbar
+        view.delegate = self
         return view
     }()
     
@@ -180,6 +180,7 @@ public class WKSourceEditorViewController: WKComponentViewController {
     public func closeFind() {
         textView.becomeFirstResponder()
         inputAccessoryViewType = .expanding
+        resetFind()
     }
     
     public func toggleSyntaxHighlighting() {
@@ -227,6 +228,15 @@ private extension WKSourceEditorViewController {
             NotificationCenter.default.post(name: Notification.WKSourceEditorSelectionState, object: nil, userInfo: [Notification.WKSourceEditorSelectionStateKey: selectionState])
         }
     }
+    
+    func resetFind() {
+        guard var viewModel = findAccessoryView.viewModel else {
+            return
+        }
+
+        viewModel.reset()
+        findAccessoryView.update(viewModel: viewModel)
+    }
 }
 
 // MARK: - UITextViewDelegate
@@ -238,6 +248,9 @@ extension WKSourceEditorViewController: UITextViewDelegate {
             return
         }
         let isRangeSelected = textView.selectedRange.length > 0
+        if inputAccessoryViewType == .find {
+            resetFind()
+        }
         inputAccessoryViewType = isRangeSelected ? .highlight : .expanding
         postUpdateButtonSelectionStatesNotification(withDelay: false)
     }
@@ -355,5 +368,21 @@ extension WKSourceEditorViewController: WKEditorInputViewDelegate {
         editorInputViewIsShowing = false
         let isRangeSelected = textView.selectedRange.length > 0
         inputAccessoryViewType = isRangeSelected ? .highlight : .expanding
+    }
+}
+
+// MARK: - WKFindAndReplaceViewDelegate
+
+extension WKSourceEditorViewController: WKFindAndReplaceViewDelegate {
+    func findAndReplaceView(_ view: WKFindAndReplaceView, didChangeFindText text: String) {
+        print("start find")
+    }
+    
+    func findAndReplaceViewDidTapNext(_ view: WKFindAndReplaceView) {
+        print("find next")
+    }
+    
+    func findAndReplaceViewDidTapPrevious(_ view: WKFindAndReplaceView) {
+        print("find previous")
     }
 }

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
@@ -418,7 +418,7 @@ extension WKSourceEditorViewController: WKFindAndReplaceViewDelegate {
     
     func findAndReplaceViewDidTapNext(_ view: WKFindAndReplaceView) {
         
-        textFrameworkMediator.findNext()
+        textFrameworkMediator.findNext(afterRange: nil)
         updateFindCurrentMatchInfo()
     }
     

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
@@ -250,7 +250,6 @@ private extension WKSourceEditorViewController {
         guard var viewModel = findAccessoryView.viewModel else {
             return
         }
-        // TODO: disable next / prev buttons
         viewModel.reset()
         findAccessoryView.update(viewModel: viewModel)
         if clearFindTextField {
@@ -259,7 +258,7 @@ private extension WKSourceEditorViewController {
         textFrameworkMediator.findReset()
     }
     
-    func updateFindCurrentMatchInfo() {
+    func updateFindViewModelState() {
         
         guard var viewModel = findAccessoryView.viewModel,
               let findFormatter = textFrameworkMediator.findAndReplaceFormatter else {
@@ -274,7 +273,7 @@ private extension WKSourceEditorViewController {
             viewModel.currentMatchInfo = nil
         }
         
-        
+        viewModel.nextPrevButtonsAreEnabled = findFormatter.matchCount > 0
         findAccessoryView.update(viewModel: viewModel)
     }
 }
@@ -426,19 +425,18 @@ extension WKSourceEditorViewController: WKFindAndReplaceViewDelegate {
     func findAndReplaceView(_ view: WKFindAndReplaceView, didChangeFindText text: String) {
         resetFind(clearFindTextField: false)
         textFrameworkMediator.findStart(text: text)
-        updateFindCurrentMatchInfo()
-        // TODO: enable next / prev buttons
+        updateFindViewModelState()
     }
     
     func findAndReplaceViewDidTapNext(_ view: WKFindAndReplaceView) {
         
         textFrameworkMediator.findNext(afterRange: nil)
-        updateFindCurrentMatchInfo()
+        updateFindViewModelState()
     }
     
     func findAndReplaceViewDidTapPrevious(_ view: WKFindAndReplaceView) {
         textFrameworkMediator.findPrevious()
-        updateFindCurrentMatchInfo()
+        updateFindViewModelState()
     }
 }
 

--- a/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
+++ b/Components/Sources/Components/Components/Editors/Source Editor/WKSourceEditorViewController.swift
@@ -197,7 +197,7 @@ public class WKSourceEditorViewController: WKComponentViewController {
         }
         
         inputAccessoryViewType = .expanding
-        resetFind()
+        resetFind(clearFindTextField: true)
     }
     
     public func toggleSyntaxHighlighting() {
@@ -246,13 +246,16 @@ private extension WKSourceEditorViewController {
         }
     }
     
-    func resetFind() {
+    func resetFind(clearFindTextField: Bool) {
         guard var viewModel = findAccessoryView.viewModel else {
             return
         }
         // TODO: disable next / prev buttons
         viewModel.reset()
         findAccessoryView.update(viewModel: viewModel)
+        if clearFindTextField {
+            findAccessoryView.findTextField.text = ""
+        }
         textFrameworkMediator.findReset()
     }
     
@@ -421,7 +424,7 @@ extension WKSourceEditorViewController: WKEditorInputViewDelegate {
 
 extension WKSourceEditorViewController: WKFindAndReplaceViewDelegate {
     func findAndReplaceView(_ view: WKFindAndReplaceView, didChangeFindText text: String) {
-        resetFind()
+        resetFind(clearFindTextField: false)
         textFrameworkMediator.findStart(text: text)
         updateFindCurrentMatchInfo()
         // TODO: enable next / prev buttons

--- a/Components/Sources/Components/Style/WKColor.swift
+++ b/Components/Sources/Components/Style/WKColor.swift
@@ -38,5 +38,8 @@ enum WKColor {
 	
 	static let darkSearchFieldBackground = UIColor(0x8E8E93, alpha: 0.12)
 	static let lightSearchFieldBackground = UIColor(0xFFFFFF, alpha: 0.15)
+    static let lightMatchBackground = WKColor.yellow600.withAlphaComponent(0.3)
+    static let darkMatchBackground = UIColor(0xF7D779).withAlphaComponent(0.7)
+    static let matchReplacedBackground = UIColor(0xD0E4fC)
 
 }

--- a/Components/Sources/Components/Style/WKTheme.swift
+++ b/Components/Sources/Components/Style/WKTheme.swift
@@ -27,6 +27,10 @@ public struct WKTheme: Equatable {
     public let editorOrange: UIColor
     public let editorPurple: UIColor
     public let editorGreen: UIColor
+    public let editorMatchForeground: UIColor
+    public let editorMatchBackground: UIColor
+    public let editorSelectedMatchBackground: UIColor
+    public let editorReplacedMatchBackground: UIColor
 
 	public static let light = WKTheme(
         name: "Light",
@@ -52,7 +56,11 @@ public struct WKTheme: Equatable {
 		diffCompareAccent: WKColor.orange600,
         editorOrange: WKColor.orange600,
         editorPurple: WKColor.purple600,
-        editorGreen: WKColor.green600
+        editorGreen: WKColor.green600,
+        editorMatchForeground: .black,
+        editorMatchBackground: WKColor.lightMatchBackground,
+        editorSelectedMatchBackground: WKColor.yellow600,
+        editorReplacedMatchBackground: WKColor.matchReplacedBackground
 	)
     
     public static let sepia = WKTheme(
@@ -79,7 +87,11 @@ public struct WKTheme: Equatable {
 		diffCompareAccent: WKColor.orange600,
         editorOrange: WKColor.orange600,
         editorPurple: WKColor.purple600,
-        editorGreen: WKColor.green600
+        editorGreen: WKColor.green600,
+        editorMatchForeground: .black,
+        editorMatchBackground: WKColor.lightMatchBackground,
+        editorSelectedMatchBackground: WKColor.yellow600,
+        editorReplacedMatchBackground: WKColor.matchReplacedBackground
     )
 
 	public static let dark = WKTheme(
@@ -106,7 +118,11 @@ public struct WKTheme: Equatable {
 		diffCompareAccent: WKColor.orange600,
         editorOrange: WKColor.yellow600,
         editorPurple: WKColor.red100,
-        editorGreen: WKColor.green600
+        editorGreen: WKColor.green600,
+        editorMatchForeground: .black,
+        editorMatchBackground: WKColor.darkMatchBackground,
+        editorSelectedMatchBackground: WKColor.yellow600,
+        editorReplacedMatchBackground: WKColor.matchReplacedBackground
 	)
 
 	public static let black = WKTheme(
@@ -133,7 +149,11 @@ public struct WKTheme: Equatable {
 		diffCompareAccent: WKColor.orange600,
         editorOrange: WKColor.yellow600,
         editorPurple: WKColor.red100,
-        editorGreen: WKColor.green600
+        editorGreen: WKColor.green600,
+        editorMatchForeground: .black,
+        editorMatchBackground: WKColor.darkMatchBackground,
+        editorSelectedMatchBackground: WKColor.yellow600,
+        editorReplacedMatchBackground: WKColor.matchReplacedBackground
 	)
 
 }

--- a/Components/Sources/ComponentsObjC/WKSourceEditorColors.h
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorColors.h
@@ -7,6 +7,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) UIColor *orangeForegroundColor;
 @property (nonatomic, strong) UIColor *purpleForegroundColor;
 @property (nonatomic, strong) UIColor *greenForegroundColor;
+@property (nonatomic, strong) UIColor *matchForegroundColor;
+@property (nonatomic, strong) UIColor *matchBackgroundColor;
+@property (nonatomic, strong) UIColor *selectedMatchBackgroundColor;
+@property (nonatomic, strong) UIColor *replacedMatchBackgroundColor;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterFindAndReplace.h
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterFindAndReplace.h
@@ -7,9 +7,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly) NSInteger selectedMatchIndex;
 @property (nonatomic, assign, readonly) NSInteger matchCount;
 @property (nonatomic, assign, readonly) NSRange selectedMatchRange;
+@property (nonatomic, assign, readonly) NSRange lastReplacedRange;
 
 - (void)startMatchSessionWithFullAttributedString: (NSMutableAttributedString *)fullAttributedString searchText:(NSString *)searchText;
-- (void)highlightNextMatchInFullAttributedString: (NSMutableAttributedString *)fullAttributedString;
+- (void)highlightNextMatchInFullAttributedString:(NSMutableAttributedString *)fullAttributedString afterRangeValue:(nullable NSValue *)afterRangeValue;
 - (void)highlightPreviousMatchInFullAttributedString: (NSMutableAttributedString *)fullAttributedString;
 - (void)endMatchSessionWithFullAttributedString: (NSMutableAttributedString *)fullAttributedString;
 

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterFindAndReplace.h
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterFindAndReplace.h
@@ -4,6 +4,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface WKSourceEditorFormatterFindAndReplace : WKSourceEditorFormatter
 
+@property (nonatomic, assign, readonly) NSInteger selectedMatchIndex;
+@property (nonatomic, assign, readonly) NSInteger matchCount;
+@property (nonatomic, assign, readonly) NSRange selectedMatchRange;
+
+- (void)startMatchSessionWithFullAttributedString: (NSMutableAttributedString *)fullAttributedString searchText:(NSString *)searchText;
+- (void)highlightNextMatchInFullAttributedString: (NSMutableAttributedString *)fullAttributedString;
+- (void)highlightPreviousMatchInFullAttributedString: (NSMutableAttributedString *)fullAttributedString;
+- (void)endMatchSessionWithFullAttributedString: (NSMutableAttributedString *)fullAttributedString;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterFindAndReplace.h
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterFindAndReplace.h
@@ -1,0 +1,9 @@
+#import "WKSourceEditorFormatter.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKSourceEditorFormatterFindAndReplace : WKSourceEditorFormatter
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterFindAndReplace.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterFindAndReplace.m
@@ -2,14 +2,60 @@
 #import "WKSourceEditorColors.h"
 #import "WKSourceEditorFonts.h"
 
+@interface WKSourceEditorFormatterFindAndReplace ()
+
+@property (nonatomic, assign, readwrite) NSInteger selectedMatchIndex;
+
+@property (nonatomic, copy, nullable) NSString *searchText;
+@property (nonatomic, strong, nullable) NSRegularExpression *searchRegex;
+
+@property (nonatomic, copy) NSAttributedString *fullAttributedString;
+@property (nonatomic, strong) NSMutableArray<NSValue *> *matchesAgainstFullAttributedString;
+
+@property (nonatomic, copy) NSDictionary *matchAttributes;
+@property (nonatomic, copy) NSDictionary *selectedMatchAttributes;
+@property (nonatomic, copy) NSDictionary *replacedMatchAttributes;
+
+@end
+
 @implementation WKSourceEditorFormatterFindAndReplace
+
+#pragma mark - Custom Attributed String Keys
+
+NSString * const WKSourceEditorCustomKeyMatch = @"WKSourceEditorCustomKeyMatch";
+NSString * const WKSourceEditorCustomKeySelectedMatch = @"WKSourceEditorCustomKeySelectedMatch";
+NSString * const WKSourceEditorCustomKeyReplacedMatch = @"WKSourceEditorCustomKeyReplacedMatch";
 
 #pragma mark - Overrides
 
 - (instancetype)initWithColors:(WKSourceEditorColors *)colors fonts:(WKSourceEditorFonts *)fonts {
     self = [super initWithColors:colors fonts:fonts];
     if (self) {
-        
+        _selectedMatchIndex = NSNotFound;
+
+       _searchText = nil;
+       _searchRegex = nil;
+
+       _fullAttributedString = nil;
+       _matchesAgainstFullAttributedString = [[NSMutableArray alloc] init];
+
+       _matchAttributes = @{
+           NSForegroundColorAttributeName: colors.matchForegroundColor,
+           NSBackgroundColorAttributeName: colors.matchBackgroundColor,
+           WKSourceEditorCustomKeyMatch: [NSNumber numberWithBool:YES]
+       };
+
+       _selectedMatchAttributes = @{
+           NSForegroundColorAttributeName: colors.matchForegroundColor,
+           NSBackgroundColorAttributeName: colors.selectedMatchBackgroundColor,
+           WKSourceEditorCustomKeySelectedMatch: [NSNumber numberWithBool:YES]
+       };
+
+       _replacedMatchAttributes = @{
+           NSForegroundColorAttributeName: colors.matchForegroundColor,
+           NSBackgroundColorAttributeName: colors.replacedMatchBackgroundColor,
+           WKSourceEditorCustomKeyReplacedMatch: [NSNumber numberWithBool:YES]
+       };
     }
     
     return self;
@@ -17,13 +63,224 @@
 
 - (void)addSyntaxHighlightingToAttributedString:(nonnull NSMutableAttributedString *)attributedString inRange:(NSRange)range {
     
+    if (self.matchCount == 0) {
+        return;
+    }
+
+    // This override is only needed for TextKit 2. The attributed string passed in here is regenerated fresh via the textContentStorage(_ textContentStorage: NSTextContentStorage, textParagraphWith range: NSRange) delegate method, so we need to reapply attributes.
+
+    // TextKit 2 only passes in the paragraph attributed string here, as opposed to the full document attributed string with TextKit 1. This conditional singles out TextKit 2.
+    
+    // Note: test this for a one line document, I think it breaks
+    if (range.location == 0 && range.length != self.fullAttributedString.length) {
+        
+        NSRange paragraphRange = [self.fullAttributedString.string rangeOfString:attributedString.string];
+        
+        [self.matchesAgainstFullAttributedString enumerateObjectsUsingBlock:^(NSValue * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+            NSRange fullStringMatchRange = obj.rangeValue;
+            
+            // Find matches that only lie in paragraph range
+            if (NSIntersectionRange(paragraphRange, fullStringMatchRange).length > 0) {
+
+                NSDictionary *attributes = idx == self.selectedMatchIndex ? self.selectedMatchAttributes : self.matchAttributes;
+
+                // Translate full string match back to paragraph match range
+                NSRange paragraphMatchRange = NSMakeRange(fullStringMatchRange.location - paragraphRange.location, fullStringMatchRange.length);
+
+                //Then reapply attributes to paragraph match range.
+                if (attributedString.length > paragraphMatchRange.location && attributedString.length > paragraphMatchRange.location + paragraphMatchRange.length) {
+                    [self resetKeysForAttributedString:attributedString range:paragraphMatchRange];
+                    [attributedString addAttributes:attributes range:paragraphMatchRange];
+                }
+            }
+        }];
+    }
 }
 
 - (void)updateColors:(WKSourceEditorColors *)colors inAttributedString:(NSMutableAttributedString *)attributedString inRange:(NSRange)range {
     
+    NSMutableDictionary *mutMatchAttributes = [[NSMutableDictionary alloc] initWithDictionary:self.matchAttributes];
+    [mutMatchAttributes setObject:colors.matchBackgroundColor forKey:NSBackgroundColorAttributeName];
+    self.matchAttributes = [[NSDictionary alloc] initWithDictionary:mutMatchAttributes];
+
+    NSMutableDictionary *mutSelectedMatchAttributes = [[NSMutableDictionary alloc] initWithDictionary:self.selectedMatchAttributes];
+    [mutSelectedMatchAttributes setObject:colors.selectedMatchBackgroundColor forKey:NSBackgroundColorAttributeName];
+    self.selectedMatchAttributes = [[NSDictionary alloc] initWithDictionary:mutSelectedMatchAttributes];
+
+    NSMutableDictionary *mutReplacedMatchAttributes = [[NSMutableDictionary alloc] initWithDictionary:self.replacedMatchAttributes];
+    [mutReplacedMatchAttributes setObject:colors.replacedMatchBackgroundColor forKey:NSBackgroundColorAttributeName];
+    self.replacedMatchAttributes = [[NSDictionary alloc] initWithDictionary:mutReplacedMatchAttributes];
+
+    [attributedString enumerateAttribute:WKSourceEditorCustomKeyMatch
+                     inRange:range
+                     options:nil
+                  usingBlock:^(id value, NSRange localRange, BOOL *stop) {
+        if ([value isKindOfClass: [NSNumber class]]) {
+            NSNumber *numValue = (NSNumber *)value;
+            if ([numValue boolValue] == YES) {
+                [attributedString addAttributes:self.matchAttributes range:localRange];
+            }
+        }
+    }];
+
+    [attributedString enumerateAttribute:WKSourceEditorCustomKeySelectedMatch
+                     inRange:range
+                     options:nil
+                  usingBlock:^(id value, NSRange localRange, BOOL *stop) {
+        if ([value isKindOfClass: [NSNumber class]]) {
+            NSNumber *numValue = (NSNumber *)value;
+            if ([numValue boolValue] == YES) {
+                [attributedString addAttributes:self.selectedMatchAttributes range:localRange];
+            }
+        }
+    }];
+    
+    [attributedString enumerateAttribute:WKSourceEditorCustomKeyReplacedMatch
+                     inRange:range
+                     options:nil
+                  usingBlock:^(id value, NSRange localRange, BOOL *stop) {
+        if ([value isKindOfClass: [NSNumber class]]) {
+            NSNumber *numValue = (NSNumber *)value;
+            if ([numValue boolValue] == YES) {
+                [attributedString addAttributes:self.replacedMatchAttributes range:localRange];
+            }
+        }
+    }];
 }
 
 - (void)updateFonts:(WKSourceEditorFonts *)fonts inAttributedString:(NSMutableAttributedString *)attributedString inRange:(NSRange)range {
+
+}
+
+#pragma mark - Getters and Setters
+
+- (NSInteger)matchCount {
+    return self.matchesAgainstFullAttributedString.count;
+}
+
+- (NSRange)selectedMatchRange {
+    if (self.matchesAgainstFullAttributedString.count > self.selectedMatchIndex) {
+        NSValue *value = self.matchesAgainstFullAttributedString[self.selectedMatchIndex];
+        return value.rangeValue;
+    }
+
+    return NSMakeRange(NSNotFound, 0);
+}
+
+#pragma mark - Public
+
+- (void)startMatchSessionWithFullAttributedString: (NSMutableAttributedString *)fullAttributedString searchText:(NSString *)searchText {
+    
+    self.searchText = searchText;
+    self.searchRegex = [[NSRegularExpression alloc] initWithPattern:searchText options:NSRegularExpressionCaseInsensitive error:nil];
+    self.fullAttributedString = fullAttributedString;
+
+    [fullAttributedString beginEditing];
+    NSMutableArray *matchValues = [[NSMutableArray alloc] init];
+    [self.searchRegex enumerateMatchesInString:fullAttributedString.string
+                                        options:0
+                                          range:NSMakeRange(0, fullAttributedString.length)
+                                     usingBlock:^(NSTextCheckingResult *_Nullable result, NSMatchingFlags flags, BOOL *_Nonnull stop) {
+            NSRange match = [result rangeAtIndex:0];
+
+            if (match.location != NSNotFound) {
+                [self resetKeysForAttributedString:fullAttributedString range:match];
+                [fullAttributedString addAttributes:self.matchAttributes range:match];
+                [matchValues addObject:[NSValue valueWithRange:match]];
+            }
+        }];
+    [fullAttributedString endEditing];
+
+    self.matchesAgainstFullAttributedString = matchValues;
+}
+
+- (void)highlightNextMatchInFullAttributedString:(NSMutableAttributedString *)fullAttributedString {
+    
+    if (self.matchesAgainstFullAttributedString.count == 0) {
+        return;
+    }
+    
+    NSInteger lastSelectedMatchIndex = self.selectedMatchIndex;
+
+    // Increment index
+    if ((self.selectedMatchIndex == NSNotFound) || (self.selectedMatchIndex == self.matchesAgainstFullAttributedString.count - 1)) {
+        self.selectedMatchIndex = 0;
+    } else {
+        self.selectedMatchIndex += 1;
+    }
+
+    [self updateMatchHighlightsInFullAttributedString:fullAttributedString lastSelectedMatchIndex:lastSelectedMatchIndex];
+}
+
+- (void)highlightPreviousMatchInFullAttributedString:(NSMutableAttributedString *)fullAttributedString {
+    
+    if (self.matchesAgainstFullAttributedString.count == 0) {
+        return;
+    }
+    
+    NSInteger lastSelectedMatchIndex = self.selectedMatchIndex;
+
+    // Decrement index
+    if ((self.selectedMatchIndex == NSNotFound) || (self.selectedMatchIndex == 0)) {
+        self.selectedMatchIndex = self.matchesAgainstFullAttributedString.count - 1;
+    } else {
+        self.selectedMatchIndex -= 1;
+    }
+
+    [self updateMatchHighlightsInFullAttributedString:fullAttributedString lastSelectedMatchIndex:lastSelectedMatchIndex];
+}
+
+
+- (void)endMatchSessionWithFullAttributedString:(NSMutableAttributedString *)fullAttributedString {
+    self.selectedMatchIndex = NSNotFound;
+
+    self.searchText = nil;
+    self.searchRegex = nil;
+
+    self.fullAttributedString = nil;
+    [self.matchesAgainstFullAttributedString removeAllObjects];
+
+    [fullAttributedString beginEditing];
+    NSRange allRange = NSMakeRange(0, fullAttributedString.length);
+    [self resetKeysForAttributedString:fullAttributedString range:allRange];
+    [fullAttributedString endEditing];
+}
+
+#pragma mark - Private
+
+- (void)updateMatchHighlightsInFullAttributedString: (NSMutableAttributedString *)fullAttributedString lastSelectedMatchIndex: (NSInteger)lastSelectedMatchIndex {
+    
+    [fullAttributedString beginEditing];
+
+    // Pull next range and color as selected
+    NSValue *nextMatchRangeValue = self.matchesAgainstFullAttributedString[self.selectedMatchIndex];
+    NSRange nextMatchRange = nextMatchRangeValue.rangeValue;
+
+    if (fullAttributedString.length > nextMatchRange.location && fullAttributedString.length > nextMatchRange.location + nextMatchRange.length) {
+        [self resetKeysForAttributedString:fullAttributedString range:nextMatchRange];
+        [fullAttributedString addAttributes:self.selectedMatchAttributes range:nextMatchRange];
+    }
+
+    // Color last selected match as regular
+    if (lastSelectedMatchIndex != NSNotFound && self.matchesAgainstFullAttributedString.count > lastSelectedMatchIndex) {
+        NSValue *lastSelectedMatchRangeValue = self.matchesAgainstFullAttributedString[lastSelectedMatchIndex];
+        NSRange lastSelectedMatchRange = lastSelectedMatchRangeValue.rangeValue;
+
+        if (fullAttributedString.length > lastSelectedMatchRange.location && fullAttributedString.length > lastSelectedMatchRange.location + lastSelectedMatchRange.length) {
+            [self resetKeysForAttributedString:fullAttributedString range:lastSelectedMatchRange];
+            [fullAttributedString addAttributes:self.matchAttributes range:lastSelectedMatchRange];
+        }
+    }
+
+    [fullAttributedString endEditing];
+}
+
+- (void)resetKeysForAttributedString: (NSMutableAttributedString *)attributedString range: (NSRange) range {
+    [attributedString removeAttribute:NSForegroundColorAttributeName range:range];
+    [attributedString removeAttribute:NSBackgroundColorAttributeName range:range];
+    [attributedString removeAttribute:WKSourceEditorCustomKeyMatch range:range];
+    [attributedString removeAttribute:WKSourceEditorCustomKeySelectedMatch range:range];
+    [attributedString removeAttribute:WKSourceEditorCustomKeyReplacedMatch range:range];
 
 }
 

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterFindAndReplace.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterFindAndReplace.m
@@ -174,25 +174,7 @@ NSString * const WKSourceEditorCustomKeyReplacedMatch = @"WKSourceEditorCustomKe
     self.searchText = searchText;
     self.searchRegex = [[NSRegularExpression alloc] initWithPattern:searchText options:NSRegularExpressionCaseInsensitive error:nil];
     
-    self.fullAttributedString = fullAttributedString;
-
-    [fullAttributedString beginEditing];
-    NSMutableArray *matchValues = [[NSMutableArray alloc] init];
-    [self.searchRegex enumerateMatchesInString:fullAttributedString.string
-                                        options:0
-                                          range:NSMakeRange(0, fullAttributedString.length)
-                                     usingBlock:^(NSTextCheckingResult *_Nullable result, NSMatchingFlags flags, BOOL *_Nonnull stop) {
-            NSRange match = [result rangeAtIndex:0];
-
-            if (match.location != NSNotFound) {
-                [self resetKeysForAttributedString:fullAttributedString range:match];
-                [fullAttributedString addAttributes:self.matchAttributes range:match];
-                [matchValues addObject:[NSValue valueWithRange:match]];
-            }
-        }];
-    [fullAttributedString endEditing];
-
-    self.matchesAgainstFullAttributedString = matchValues;
+    [self calculateMatchesInFullAttributedString:fullAttributedString];
 }
 
 - (void)highlightNextMatchInFullAttributedString:(NSMutableAttributedString *)fullAttributedString afterRangeValue: (nullable NSValue *)afterRangeValue {
@@ -247,6 +229,7 @@ NSString * const WKSourceEditorCustomKeyReplacedMatch = @"WKSourceEditorCustomKe
     [self updateMatchHighlightsInFullAttributedString:fullAttributedString lastSelectedMatchIndex:lastSelectedMatchIndex];
 }
 
+
 - (void)endMatchSessionWithFullAttributedString:(NSMutableAttributedString *)fullAttributedString {
     self.selectedMatchIndex = NSNotFound;
 
@@ -263,6 +246,28 @@ NSString * const WKSourceEditorCustomKeyReplacedMatch = @"WKSourceEditorCustomKe
 }
 
 #pragma mark - Private
+
+- (void)calculateMatchesInFullAttributedString: (NSMutableAttributedString *)fullAttributedString {
+    self.fullAttributedString = fullAttributedString;
+
+    [fullAttributedString beginEditing];
+    NSMutableArray *matchValues = [[NSMutableArray alloc] init];
+    [self.searchRegex enumerateMatchesInString:fullAttributedString.string
+                                        options:0
+                                          range:NSMakeRange(0, fullAttributedString.length)
+                                     usingBlock:^(NSTextCheckingResult *_Nullable result, NSMatchingFlags flags, BOOL *_Nonnull stop) {
+            NSRange match = [result rangeAtIndex:0];
+
+            if (match.location != NSNotFound) {
+                [self resetKeysForAttributedString:fullAttributedString range:match];
+                [fullAttributedString addAttributes:self.matchAttributes range:match];
+                [matchValues addObject:[NSValue valueWithRange:match]];
+            }
+        }];
+    [fullAttributedString endEditing];
+
+    self.matchesAgainstFullAttributedString = matchValues;
+}
 
 - (void)updateMatchHighlightsInFullAttributedString: (NSMutableAttributedString *)fullAttributedString lastSelectedMatchIndex: (NSInteger)lastSelectedMatchIndex {
     

--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatterFindAndReplace.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatterFindAndReplace.m
@@ -1,0 +1,30 @@
+#import "WKSourceEditorFormatterFindAndReplace.h"
+#import "WKSourceEditorColors.h"
+#import "WKSourceEditorFonts.h"
+
+@implementation WKSourceEditorFormatterFindAndReplace
+
+#pragma mark - Overrides
+
+- (instancetype)initWithColors:(WKSourceEditorColors *)colors fonts:(WKSourceEditorFonts *)fonts {
+    self = [super initWithColors:colors fonts:fonts];
+    if (self) {
+        
+    }
+    
+    return self;
+}
+
+- (void)addSyntaxHighlightingToAttributedString:(nonnull NSMutableAttributedString *)attributedString inRange:(NSRange)range {
+    
+}
+
+- (void)updateColors:(WKSourceEditorColors *)colors inAttributedString:(NSMutableAttributedString *)attributedString inRange:(NSRange)range {
+    
+}
+
+- (void)updateFonts:(WKSourceEditorFonts *)fonts inAttributedString:(NSMutableAttributedString *)attributedString inRange:(NSRange)range {
+
+}
+
+@end

--- a/Components/Sources/ComponentsObjC/WKSourceEditorTextStorage.h
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorTextStorage.h
@@ -8,6 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface WKSourceEditorTextStorage : NSTextStorage
 
 @property (nonatomic, weak) id<WKSourceEditorStorageDelegate> storageDelegate;
+@property (nonatomic, assign) BOOL syntaxHighlightProcessingEnabled;
 
 - (void)updateColorsAndFonts;
 

--- a/Components/Sources/ComponentsObjC/WKSourceEditorTextStorage.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorTextStorage.m
@@ -5,7 +5,6 @@
 @interface WKSourceEditorTextStorage ()
 
 @property (nonatomic, strong) NSMutableAttributedString *backingStore;
-@property (nonatomic, assign) BOOL needsSyntaxHighlightingCalculation;
 
 @end
 
@@ -14,7 +13,7 @@
 - (nonnull instancetype)init {
     if (self = [super init]) {
         _backingStore = [[NSMutableAttributedString alloc] init];
-        _needsSyntaxHighlightingCalculation = YES;
+        _syntaxHighlightProcessingEnabled = YES;
     }
     return self;
 }
@@ -45,7 +44,7 @@
 
 - (void)processEditing {
 
-    if (self.needsSyntaxHighlightingCalculation) {
+    if (self.syntaxHighlightProcessingEnabled) {
         [self addSyntaxHighlightingToEditedRange:self.editedRange];
     }
     
@@ -58,7 +57,6 @@
     WKSourceEditorColors *colors = [self.storageDelegate colors];
     WKSourceEditorFonts *fonts = [self.storageDelegate fonts];
     
-    self.needsSyntaxHighlightingCalculation = NO;
     [self beginEditing];
     NSRange allRange = NSMakeRange(0, self.backingStore.length);
     for (WKSourceEditorFormatter *formatter in [self.storageDelegate formatters]) {
@@ -67,8 +65,6 @@
     }
     
     [self endEditing];
-    
-    self.needsSyntaxHighlightingCalculation = YES;
 }
 
 // MARK: - Private

--- a/Components/Sources/ComponentsObjC/include/ComponentsObjC.h
+++ b/Components/Sources/ComponentsObjC/include/ComponentsObjC.h
@@ -11,6 +11,7 @@
 #import "WKSourceEditorFormatterList.h"
 #import "WKSourceEditorFormatterHeading.h"
 #import "WKSourceEditorFormatterStrikethrough.h"
+#import "WKSourceEditorFormatterFindAndReplace.h"
 #import "WKSourceEditorStorageDelegate.h"
 
 #endif /* Header_h */

--- a/Components/Sources/ComponentsObjC/include/WKSourceEditorFormatterFindAndReplace.h
+++ b/Components/Sources/ComponentsObjC/include/WKSourceEditorFormatterFindAndReplace.h
@@ -1,0 +1,1 @@
+../WKSourceEditorFormatterFindAndReplace.h

--- a/Components/Tests/ComponentsTests/WKSourceEditorFormatterTests.swift
+++ b/Components/Tests/ComponentsTests/WKSourceEditorFormatterTests.swift
@@ -1173,7 +1173,7 @@ final class WKSourceEditorFormatterTests: XCTestCase {
         
         // word
         var match1Range = NSRange(location: 0, length: 0)
-        let match1Attributes = mutAttributedString.attributes(at: 10, effectiveRange: &match1Range)
+        var match1Attributes = mutAttributedString.attributes(at: 10, effectiveRange: &match1Range)
         
         // '''
         var boldCloseRange = NSRange(location: 0, length: 0)
@@ -1185,7 +1185,7 @@ final class WKSourceEditorFormatterTests: XCTestCase {
         
         // word
         var match2Range = NSRange(location: 0, length: 0)
-        let match2Attributes = mutAttributedString.attributes(at: 37, effectiveRange: &match2Range)
+        var match2Attributes = mutAttributedString.attributes(at: 37, effectiveRange: &match2Range)
         
         // "."
         var base3Range = NSRange(location: 0, length: 0)
@@ -1234,5 +1234,13 @@ final class WKSourceEditorFormatterTests: XCTestCase {
         XCTAssertEqual(base3Range.length, 1, "Incorrect base formatting")
         XCTAssertEqual(base3Attributes[.font] as! UIFont, fonts.baseFont, "Incorrect base formatting")
         XCTAssertEqual(base3Attributes[.foregroundColor] as! UIColor, colors.baseForegroundColor, "Incorrect base formatting")
+        
+        // Check that selected background color has now switched to 2nd instance
+        findAndReplaceFormatter.highlightNextMatch(inFullAttributedString: mutAttributedString, afterRangeValue: nil)
+        match1Attributes = mutAttributedString.attributes(at: 10, effectiveRange: &match1Range)
+        match2Attributes = mutAttributedString.attributes(at: 37, effectiveRange: &match2Range)
+
+        XCTAssertEqual(match1Attributes[.backgroundColor] as! UIColor, colors.matchBackgroundColor, "Incorrect match formatting")
+        XCTAssertEqual(match2Attributes[.backgroundColor] as! UIColor, colors.selectedMatchBackgroundColor, "Incorrect match formatting")
     }
 }

--- a/Components/Tests/ComponentsTests/WKSourceEditorTextFrameworkMediatorTests.swift
+++ b/Components/Tests/ComponentsTests/WKSourceEditorTextFrameworkMediatorTests.swift
@@ -9,7 +9,7 @@ final class WKSourceEditorTextFrameworkMediatorTests: XCTestCase {
         mediator.updateColorsAndFonts()
         return mediator
     }()
-
+    
     func testBoldItalicsButtonSelectionState() throws {
         
         let text = "One\nTwo '''Three ''Four'' Five''' Six ''Seven'' Eight\nNine"
@@ -83,7 +83,7 @@ final class WKSourceEditorTextFrameworkMediatorTests: XCTestCase {
     func testClosingBoldSelectionStateCursor() throws {
         let text = "One '''Two''' Three"
         mediator.textView.attributedText = NSAttributedString(string: text)
-
+        
         let selectionStates = mediator.selectionState(selectedDocumentRange: NSRange(location: 10, length: 0))
         XCTAssertTrue(selectionStates.isBold)
     }
@@ -91,7 +91,7 @@ final class WKSourceEditorTextFrameworkMediatorTests: XCTestCase {
     func testClosingItalicsSelectionStateCursor() throws {
         let text = "One ''Two'' Three"
         mediator.textView.attributedText = NSAttributedString(string: text)
-
+        
         let selectionStates = mediator.selectionState(selectedDocumentRange: NSRange(location: 9, length: 0))
         XCTAssertTrue(selectionStates.isItalics)
     }
@@ -99,7 +99,7 @@ final class WKSourceEditorTextFrameworkMediatorTests: XCTestCase {
     func testHorizontalTemplateButtonSelectionStateCursor() throws {
         let text = "Testing simple {{Currentdate}} template example."
         mediator.textView.attributedText = NSAttributedString(string: text)
-
+        
         // "Testing"
         let selectionStates1 = mediator.selectionState(selectedDocumentRange: NSRange(location: 4, length: 0))
         XCTAssertFalse(selectionStates1.isHorizontalTemplate)
@@ -116,7 +116,7 @@ final class WKSourceEditorTextFrameworkMediatorTests: XCTestCase {
     func testHorizontalTemplateButtonSelectionStateRange() throws {
         let text = "Testing simple {{Currentdate}} template example."
         mediator.textView.attributedText = NSAttributedString(string: text)
-
+        
         // "Testing"
         let selectionStates1 = mediator.selectionState(selectedDocumentRange: NSRange(location: 4, length: 3))
         XCTAssertFalse(selectionStates1.isHorizontalTemplate)
@@ -133,7 +133,7 @@ final class WKSourceEditorTextFrameworkMediatorTests: XCTestCase {
     func testVerticalTemplateStartButtonSelectionStateCursor() throws {
         let text = "{{Infobox officeholder"
         mediator.textView.attributedText = NSAttributedString(string: text)
-
+        
         // "Testing"
         let selectionStates1 = mediator.selectionState(selectedDocumentRange: NSRange(location: 4, length: 0))
         XCTAssertFalse(selectionStates1.isHorizontalTemplate)
@@ -142,7 +142,7 @@ final class WKSourceEditorTextFrameworkMediatorTests: XCTestCase {
     func testVerticalTemplateParameterButtonSelectionStateCursor() throws {
         let text = "| genus = Felis"
         mediator.textView.attributedText = NSAttributedString(string: text)
-
+        
         // "Testing"
         let selectionStates1 = mediator.selectionState(selectedDocumentRange: NSRange(location: 4, length: 0))
         XCTAssertFalse(selectionStates1.isHorizontalTemplate)
@@ -151,7 +151,7 @@ final class WKSourceEditorTextFrameworkMediatorTests: XCTestCase {
     func testVerticalTemplateEndButtonSelectionStateCursor() throws {
         let text = "}}"
         mediator.textView.attributedText = NSAttributedString(string: text)
-
+        
         // "Testing"
         let selectionStates1 = mediator.selectionState(selectedDocumentRange: NSRange(location: 1, length: 0))
         XCTAssertFalse(selectionStates1.isHorizontalTemplate)
@@ -208,12 +208,12 @@ final class WKSourceEditorTextFrameworkMediatorTests: XCTestCase {
     func testHorizontalTemplateButtonSelectionStateFormattedRange() throws {
         let text = "Testing inner formatted {{cite web | url=https://en.wikipedia.org | title = The '''Free''' Encyclopedia}} template example."
         mediator.textView.attributedText = NSAttributedString(string: text)
-
+        
         // "cite web | url=https://en.wikipedia.org | title = The '''Free''' Encyclopedia"
         let selectionStates = mediator.selectionState(selectedDocumentRange: NSRange(location: 26, length: 77))
         XCTAssertTrue(selectionStates.isHorizontalTemplate)
     }
-
+    
     func testHeadingSelectionState() throws {
         
         let text = "== Test =="
@@ -313,11 +313,11 @@ final class WKSourceEditorTextFrameworkMediatorTests: XCTestCase {
         XCTAssertFalse(selectionStates2.isSubheading3)
         XCTAssertTrue(selectionStates2.isSubheading4)
     }
-
+    
     func testStrikethroughSelectionState() throws {
         let text = "Testing <s>Strikethrough</s> Testing."
         mediator.textView.attributedText = NSAttributedString(string: text)
-
+        
         let selectionStates1 = mediator.selectionState(selectedDocumentRange: NSRange(location: 0, length: 7))
         let selectionStates2 = mediator.selectionState(selectedDocumentRange: NSRange(location: 11, length: 13))
         let selectionStates3 = mediator.selectionState(selectedDocumentRange: NSRange(location: 29, length: 7))
@@ -329,12 +329,40 @@ final class WKSourceEditorTextFrameworkMediatorTests: XCTestCase {
     func testStrikethroughSelectionStateCursor() throws {
         let text = "Testing <s>Strikethrough</s> Testing."
         mediator.textView.attributedText = NSAttributedString(string: text)
-
+        
         let selectionStates1 = mediator.selectionState(selectedDocumentRange: NSRange(location: 3, length: 0))
         let selectionStates2 = mediator.selectionState(selectedDocumentRange: NSRange(location: 17, length: 0))
         let selectionStates3 = mediator.selectionState(selectedDocumentRange: NSRange(location: 33, length: 0))
         XCTAssertFalse(selectionStates1.isStrikethrough)
         XCTAssertTrue(selectionStates2.isStrikethrough)
         XCTAssertFalse(selectionStates3.isStrikethrough)
+    }
+    
+    func testFindWithResults() throws {
+        let text = "Find a '''word''' and highlight that word."
+        mediator.textView.attributedText = NSAttributedString(string: text)
+        
+        mediator.findStart(text: "word")
+        guard let formatter = mediator.findAndReplaceFormatter else {
+            XCTFail("Missing find formatter.")
+            return
+        }
+        
+        XCTAssertEqual(formatter.selectedMatchIndex, 0, "Find - Incorrect selected match index")
+        XCTAssertEqual(formatter.matchCount, 2, "Find - Incorrect match count")
+    }
+    
+    func testFindWithoutResults() throws {
+        let text = "Find a '''word''' and highlight that word."
+        mediator.textView.attributedText = NSAttributedString(string: text)
+        
+        mediator.findStart(text: "cat")
+        guard let formatter = mediator.findAndReplaceFormatter else {
+            XCTFail("Missing find formatter.")
+            return
+        }
+        
+        XCTAssertEqual(formatter.selectedMatchIndex, NSNotFound, "Find - Incorrect selected match index")
+        XCTAssertEqual(formatter.matchCount, 0, "Find - Incorrect match count")
     }
 }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T348091

### Notes
This adds find functionality to the native editor. I will put up the replace pieces in a followup PR. 

Note:
I notice that iOS 17 / TextKit 2 doesn't always reliably scroll to the correct selected match. I haven't found a quick fix for this yet, but if it becomes too big of a problem we can easily switch to the TextKit 1 implementation.

### Test Steps
1. Launch app in Staging scheme, navigate to the editor.
2. Tap the find formatting button
3.  Type in an existing word in the find text field. Confirm you see find results highlighted and counts displayed. 
4. Tap the previous and next buttons, confirm you can traverse matches.
