### PR TITLE
Fix onboarding crash on iPad

### DIFF
--- a/Wikipedia/Code/WMFWelcomeAnalyticsViewController.swift
+++ b/Wikipedia/Code/WMFWelcomeAnalyticsViewController.swift
@@ -32,7 +32,9 @@ class WMFWelcomeAnalyticsViewController: ThemeableViewController {
 
     @IBAction func showPrivacyAndTermsActionSheet(_ sender: AnyObject) {
 
-        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let alertPreferredStyle: UIAlertController.Style = UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet
+
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: alertPreferredStyle)
 
         let goToPrivacyPolicyAction = UIAlertAction(title: CommonStrings.privacyPolicyTitle, style: .default) { action in
             guard let url = URL.init(string: CommonStrings.privacyPolicyURLString) else {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T356206

### Notes
* This PR fixes a UIAlertController crash on iPad

### Test Steps
1. On a fresh install of the app, go through the onboarding
2. On the last step, click the button "Learn more about our privacy policy and terms of use"
3. Make sure you see an alert with the option to go to the terms of use, privacy policy, and the cancel action
4. No crashes should happen!
5. Test on an iPhone, no changes should happen here, and you should see a bottom action sheet
