### PR TITLE
Native Editor - Log EditAttemptStep actions in the source editor flow

### DIFF
--- a/Wikipedia/Code/ArticleViewController+Editing.swift
+++ b/Wikipedia/Code/ArticleViewController+Editing.swift
@@ -8,14 +8,14 @@ extension ArticleViewController {
         } else {
             showEditorForSection(with: id, selectedTextEditInfo: selectedTextEditInfo)
         }
-        EditAttemptFunnel.shared.logInit(articleURL: articleURL)
+        EditAttemptFunnel.shared.logInit(pageURL: articleURL)
     }
     
     func showEditorForFullSource(selectedTextEditInfo: SelectedTextEditInfo? = nil) {
         let pageEditorViewController = PageEditorViewController(pageURL: articleURL, sectionID: nil, editFlow: .editorPreviewSave, dataStore: dataStore, articleSelectedInfo: selectedTextEditInfo, delegate: self, theme: theme)
         
         presentEditor(editorViewController: pageEditorViewController)
-        EditAttemptFunnel.shared.logInit(articleURL: articleURL)
+        EditAttemptFunnel.shared.logInit(pageURL: articleURL)
     }
     
     func showEditorForSection(with id: Int, selectedTextEditInfo: SelectedTextEditInfo? = nil) {
@@ -105,7 +105,7 @@ extension ArticleViewController {
         sheet.addAction(editLeadSectionAction)
         
         sheet.addAction(UIAlertAction(title: CommonStrings.cancelActionTitle, style: .cancel) { _ in
-            EditAttemptFunnel.shared.logAbort(articleURL: self.articleURL)
+            EditAttemptFunnel.shared.logAbort(pageURL: self.articleURL)
         })
         present(sheet, animated: true)
     }
@@ -200,18 +200,18 @@ extension ArticleViewController: SectionEditorViewControllerDelegate {
         switch result {
         case .failure(let error):
             showError(error)
-            EditAttemptFunnel.shared.logSaveFailure(articleURL: self.articleURL)
+            EditAttemptFunnel.shared.logSaveFailure(pageURL: self.articleURL)
         case .success(let changes):
             dismiss(animated: true)
             waitForNewContentAndRefresh(changes.newRevisionID)
-            EditAttemptFunnel.shared.logSaveSuccess(articleURL: self.articleURL, revisionId: Int(changes.newRevisionID))
+            EditAttemptFunnel.shared.logSaveSuccess(pageURL: self.articleURL, revisionId: Int(changes.newRevisionID))
         }
     }
     
     func sectionEditorDidCancelEditing(_ sectionEditor: SectionEditorViewController, navigateToURL url: URL?) {
         dismiss(animated: true) {
             self.navigate(to: url)
-            EditAttemptFunnel.shared.logAbort(articleURL: self.articleURL)
+            EditAttemptFunnel.shared.logAbort(pageURL: self.articleURL)
         }
     }
 

--- a/Wikipedia/Code/ArticleViewController+Editing.swift
+++ b/Wikipedia/Code/ArticleViewController+Editing.swift
@@ -15,6 +15,7 @@ extension ArticleViewController {
         let pageEditorViewController = PageEditorViewController(pageURL: articleURL, sectionID: nil, editFlow: .editorPreviewSave, dataStore: dataStore, articleSelectedInfo: selectedTextEditInfo, delegate: self, theme: theme)
         
         presentEditor(editorViewController: pageEditorViewController)
+        EditAttemptFunnel.shared.logInit(articleURL: articleURL)
     }
     
     func showEditorForSection(with id: Int, selectedTextEditInfo: SelectedTextEditInfo? = nil) {

--- a/Wikipedia/Code/ArticleViewController+Editing.swift
+++ b/Wikipedia/Code/ArticleViewController+Editing.swift
@@ -8,7 +8,6 @@ extension ArticleViewController {
         } else {
             showEditorForSection(with: id, selectedTextEditInfo: selectedTextEditInfo)
         }
-        EditAttemptFunnel.shared.logInit(pageURL: articleURL)
     }
     
     func showEditorForFullSource(selectedTextEditInfo: SelectedTextEditInfo? = nil) {
@@ -20,6 +19,7 @@ extension ArticleViewController {
     
     func showEditorForSection(with id: Int, selectedTextEditInfo: SelectedTextEditInfo? = nil) {
         cancelWIconPopoverDisplay()
+        
         let editorViewController: UIViewController
         if FeatureFlags.needsNativeSourceEditor {
             let pageEditorViewController = PageEditorViewController(pageURL: articleURL, sectionID: id, editFlow: .editorPreviewSave, dataStore: dataStore, articleSelectedInfo: selectedTextEditInfo, delegate: self, theme: theme)
@@ -31,6 +31,7 @@ extension ArticleViewController {
         }
         
         presentEditor(editorViewController: editorViewController)
+        EditAttemptFunnel.shared.logInit(pageURL: articleURL)
     }
     
     func showTitleDescriptionEditor(with descriptionSource: ArticleDescriptionSource) {
@@ -90,6 +91,7 @@ extension ArticleViewController {
     }
     
     func showEditSectionOrTitleDescriptionDialogForSection(with id: Int, descriptionSource: ArticleDescriptionSource, selectedTextEditInfo: SelectedTextEditInfo? = nil) {
+
         let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
         
         let editTitleDescriptionTitle = WMFLocalizedString("description-edit-pencil-title", value: "Edit article description", comment: "Title for button used to show article description editor")
@@ -108,6 +110,8 @@ extension ArticleViewController {
             EditAttemptFunnel.shared.logAbort(pageURL: self.articleURL)
         })
         present(sheet, animated: true)
+        
+        EditAttemptFunnel.shared.logInit(pageURL: articleURL)
     }
 
 }

--- a/Wikipedia/Code/DescriptionEditViewController.swift
+++ b/Wikipedia/Code/DescriptionEditViewController.swift
@@ -207,14 +207,14 @@ protocol DescriptionEditViewControllerDelegate: AnyObject {
 
     @IBAction private func publishDescriptionButton(withSender sender: UIButton) {
         if let articleURL = articleDescriptionController.article.url {
-            EditAttemptFunnel.shared.logSaveIntent(articleURL: articleURL)
+            EditAttemptFunnel.shared.logSaveIntent(pageURL: articleURL)
         }
         save()
     }
 
     @objc func closeButtonPushed(_ : UIBarButtonItem) {
         if let articleURL = articleDescriptionController.article.url {
-            EditAttemptFunnel.shared.logAbort(articleURL: articleURL)
+            EditAttemptFunnel.shared.logAbort(pageURL: articleURL)
         }
         dismiss(animated: true, completion: nil)
     }
@@ -239,7 +239,7 @@ protocol DescriptionEditViewControllerDelegate: AnyObject {
 
 
         if let articleURL = self.articleDescriptionController.article.url {
-            EditAttemptFunnel.shared.logSaveAttempt(articleURL: articleURL)
+            EditAttemptFunnel.shared.logSaveAttempt(pageURL: articleURL)
         }
         
         articleDescriptionController.publishDescription(descriptionToSave) { [weak self] (result) in
@@ -262,7 +262,7 @@ protocol DescriptionEditViewControllerDelegate: AnyObject {
                             revisionID = Int(uintRevisionID)
                         }
                         
-                        EditAttemptFunnel.shared.logSaveSuccess(articleURL: articleURL, revisionId: revisionID)
+                        EditAttemptFunnel.shared.logSaveSuccess(pageURL: articleURL, revisionId: revisionID)
                     }
                     self.dismiss(animated: true) {
                         presentingVC?.wmf_showDescriptionPublishedPanelViewController(theme: self.theme)
@@ -271,7 +271,7 @@ protocol DescriptionEditViewControllerDelegate: AnyObject {
                 case .failure(let error):
                     let nsError = error as NSError
                     if let articleURL = self.articleDescriptionController.article.url {
-                        EditAttemptFunnel.shared.logSaveFailure(articleURL: articleURL)
+                        EditAttemptFunnel.shared.logSaveFailure(pageURL: articleURL)
                     }
                     if let wikidataError = error as? WikidataFetcher.WikidataPublishingError {
                         switch wikidataError {

--- a/Wikipedia/Code/DiffContainerViewController.swift
+++ b/Wikipedia/Code/DiffContainerViewController.swift
@@ -1267,7 +1267,7 @@ extension DiffContainerViewController: DiffToolbarViewDelegate {
         }
 
         if let pageURL = fetchPageURL() {
-            EditAttemptFunnel.shared.logInit(articleURL: pageURL)
+            EditAttemptFunnel.shared.logInit(pageURL: pageURL)
         }
         
         WatchlistFunnel.shared.logDiffToolbarTapUndo(project: wikimediaProject)
@@ -1284,7 +1284,7 @@ extension DiffContainerViewController: DiffToolbarViewDelegate {
         let cancel = UIAlertAction(title: CommonStrings.cancelActionTitle, style: .cancel) { [weak self] (action) in
             WatchlistFunnel.shared.logDiffUndoAlertTapCancel(project: self?.wikimediaProject)
             if let pageURL = self?.fetchPageURL() {
-                EditAttemptFunnel.shared.logAbort(articleURL: pageURL)
+                EditAttemptFunnel.shared.logAbort(pageURL: pageURL)
             }
         }
         
@@ -1319,7 +1319,7 @@ extension DiffContainerViewController: DiffToolbarViewDelegate {
         fakeProgressController.start()
 
         if let pageURL = self.fetchPageURL() {
-            EditAttemptFunnel.shared.logSaveAttempt(articleURL: pageURL)
+            EditAttemptFunnel.shared.logSaveAttempt(pageURL: pageURL)
         }
         WKWatchlistDataController().undo(title: title, revisionID: UInt(revisionID), summary: summary, username: username, project: wkProject) { [weak self] result in
             DispatchQueue.main.async {
@@ -1330,7 +1330,7 @@ extension DiffContainerViewController: DiffToolbarViewDelegate {
 
     func tappedRollback() {
         if let pageURL = fetchPageURL() {
-            EditAttemptFunnel.shared.logInit(articleURL: pageURL)
+            EditAttemptFunnel.shared.logInit(pageURL: pageURL)
         }
         WatchlistFunnel.shared.logDiffToolbarMoreTapRollback(project: wikimediaProject)
         let title = WMFLocalizedString("diff-rollback-alert-title", value: "Rollback edits", comment: "Title of alert when user taps rollback in diff toolbar.")
@@ -1340,7 +1340,7 @@ extension DiffContainerViewController: DiffToolbarViewDelegate {
         let cancel = UIAlertAction(title: CommonStrings.cancelActionTitle, style: .cancel) { [weak self] (action) in
             WatchlistFunnel.shared.logDiffRollbackAlertTapCancel(project: self?.wikimediaProject)
             if let pageURL = self?.fetchPageURL() {
-                EditAttemptFunnel.shared.logAbort(articleURL: pageURL)
+                EditAttemptFunnel.shared.logAbort(pageURL: pageURL)
             }
         }
         let rollback = UIAlertAction(title: CommonStrings.rollback, style: .destructive) { [weak self] (action) in
@@ -1362,7 +1362,7 @@ extension DiffContainerViewController: DiffToolbarViewDelegate {
 
         fakeProgressController.start()
         if let pageURL = self.fetchPageURL() {
-            EditAttemptFunnel.shared.logSaveAttempt(articleURL: pageURL)
+            EditAttemptFunnel.shared.logSaveAttempt(pageURL: pageURL)
         }
 
         WKWatchlistDataController().rollback(title: title, project: wkProject, username: username) { [weak self] result in
@@ -1385,7 +1385,7 @@ extension DiffContainerViewController: DiffToolbarViewDelegate {
             }
             
             if let pageURL = self.fetchPageURL() {
-                    EditAttemptFunnel.shared.logSaveSuccess(articleURL: pageURL, revisionId: result.newRevisionID)
+                    EditAttemptFunnel.shared.logSaveSuccess(pageURL: pageURL, revisionId: result.newRevisionID)
             }
 
             let diffVC = DiffContainerViewController(siteURL: siteURL, theme: theme, fromRevisionID: result.oldRevisionID, toRevisionID: result.newRevisionID, articleTitle: articleTitle, articleSummaryController: diffController.articleSummaryController, authenticationManager: diffController.authenticationManager)
@@ -1412,7 +1412,7 @@ extension DiffContainerViewController: DiffToolbarViewDelegate {
             
         case .failure(let error):
             if let pageURL = self.fetchPageURL() {
-                EditAttemptFunnel.shared.logSaveFailure(articleURL: pageURL)
+                EditAttemptFunnel.shared.logSaveFailure(pageURL: pageURL)
             }
 
             let fallback: (Error) -> Void = { error in

--- a/Wikipedia/Code/EditAttemptFunnel.swift
+++ b/Wikipedia/Code/EditAttemptFunnel.swift
@@ -37,51 +37,51 @@ public final class EditAttemptFunnel {
         case abort = "abort"
     }
 
-    private func logEvent(articleURL: URL, action: EditAction, revisionId: Int? = nil) {
+    private func logEvent(pageURL: URL, action: EditAction, revisionId: Int? = nil) {
         let editorInterface = "wikitext"
         let integrationID = "app-ios"
         let platform = UIDevice.current.userInterfaceIdiom == .pad ? "tablet" : "phone"
 
-        let userId = getUserID(articleURL: articleURL)
+        let userId = getUserID(pageURL: pageURL)
 
-        let event = Event(action: action, editing_session_id: "", editor_interface: editorInterface, integration: integrationID, mw_version: "", platform: platform, user_editcount: 0, user_id: userId, version: 1, page_title: articleURL.wmf_title, page_ns: articleURL.namespace?.rawValue, revision_id: revisionId)
+        let event = Event(action: action, editing_session_id: "", editor_interface: editorInterface, integration: integrationID, mw_version: "", platform: platform, user_editcount: 0, user_id: userId, version: 1, page_title: pageURL.wmf_title, page_ns: pageURL.namespace?.rawValue, revision_id: revisionId)
         
         let container = EventContainer(event: event)
         EventPlatformClient.shared.submit(stream: .editAttempt, event: container, needsMinimal: true)
     }
 
-    func logInit(articleURL: URL) {
-        logEvent(articleURL: articleURL, action: .start)
+    func logInit(pageURL: URL) {
+        logEvent(pageURL: pageURL, action: .start)
     }
 
-    func logSaveIntent(articleURL: URL) {
-        logEvent(articleURL: articleURL, action: .saveIntent)
+    func logSaveIntent(pageURL: URL) {
+        logEvent(pageURL: pageURL, action: .saveIntent)
     }
 
-    func logSaveAttempt(articleURL: URL) {
-        logEvent(articleURL: articleURL, action: .saveAttempt)
+    func logSaveAttempt(pageURL: URL) {
+        logEvent(pageURL: pageURL, action: .saveAttempt)
     }
 
-    func logSaveSuccess(articleURL: URL, revisionId: Int?) {
-        logEvent(articleURL: articleURL, action: .saveSuccess, revisionId: revisionId)
+    func logSaveSuccess(pageURL: URL, revisionId: Int?) {
+        logEvent(pageURL: pageURL, action: .saveSuccess, revisionId: revisionId)
     }
 
-    func logSaveFailure(articleURL: URL) {
-        logEvent(articleURL: articleURL, action: .saveFailure)
+    func logSaveFailure(pageURL: URL) {
+        logEvent(pageURL: pageURL, action: .saveFailure)
     }
 
-    func logAbort(articleURL: URL) {
-        logEvent(articleURL: articleURL, action: .abort)
+    func logAbort(pageURL: URL) {
+        logEvent(pageURL: pageURL, action: .abort)
     }
 
-    fileprivate func getUserID(articleURL: URL) -> Int {
+    fileprivate func getUserID(pageURL: URL) -> Int {
         let isAnon = !MWKDataStore.shared().authenticationManager.isLoggedIn
 
         if isAnon {
             return 0
         } else {
             var userId = 0
-            MWKDataStore.shared().authenticationManager.getLoggedInUser(for: articleURL) { result in
+            MWKDataStore.shared().authenticationManager.getLoggedInUser(for: pageURL) { result in
                 switch result {
                 case .success(let user):
                     userId = user?.userID ?? 0

--- a/Wikipedia/Code/EditPreviewViewController.swift
+++ b/Wikipedia/Code/EditPreviewViewController.swift
@@ -7,7 +7,7 @@ protocol EditPreviewViewControllerDelegate: NSObjectProtocol {
 
 class EditPreviewViewController: ViewController, WMFPreviewAnchorTapAlertDelegate, InternalLinkPreviewing {
     var sectionID: Int?
-    var articleURL: URL
+    var pageURL: URL
     var languageCode: String?
     var wikitext = ""
     var needsNextButton: Bool = true
@@ -36,8 +36,8 @@ class EditPreviewViewController: ViewController, WMFPreviewAnchorTapAlertDelegat
         return tapGR
     }()
 
-    init(articleURL: URL) {
-        self.articleURL = articleURL
+    init(pageURL: URL) {
+        self.pageURL = pageURL
         self.previewWebViewContainer = PreviewWebViewContainer()
         super.init()
 
@@ -49,7 +49,7 @@ class EditPreviewViewController: ViewController, WMFPreviewAnchorTapAlertDelegat
     }
     
     func previewWebViewContainer(_ previewWebViewContainer: PreviewWebViewContainer, didTapLink url: URL) {
-        let isExternal = url.host != articleURL.host
+        let isExternal = url.host != pageURL.host
         if isExternal {
             showExternalLinkInAlert(link: url.absoluteString)
         } else {
@@ -147,7 +147,7 @@ class EditPreviewViewController: ViewController, WMFPreviewAnchorTapAlertDelegat
                     self?.previewWebViewContainer.webView.loadHTMLString(html, baseURL: responseUrl)
                 }
             }
-            try self.fetcher.fetchMobileHTMLFromWikitext(articleURL: self.articleURL, wikitext: self.wikitext, mobileHTMLOutput: .editPreview, completion: completion)
+            try self.fetcher.fetchMobileHTMLFromWikitext(articleURL: self.pageURL, wikitext: self.wikitext, mobileHTMLOutput: .editPreview, completion: completion)
         }
         
         let pcsProductionCompletion: () throws -> Void = { [weak self] in
@@ -156,7 +156,7 @@ class EditPreviewViewController: ViewController, WMFPreviewAnchorTapAlertDelegat
                 return
             }
             
-            let request = try self.fetcher.wikitextToMobileHTMLPreviewRequest(articleURL: self.articleURL, wikitext: self.wikitext, mobileHTMLOutput: .editPreview)
+            let request = try self.fetcher.wikitextToMobileHTMLPreviewRequest(articleURL: self.pageURL, wikitext: self.wikitext, mobileHTMLOutput: .editPreview)
             self.previewWebViewContainer.webView.load(request)
             
             if self.needsSimplifiedFormatToast {
@@ -211,6 +211,10 @@ extension EditPreviewViewController: ReferenceBackLinksViewControllerDelegate, R
     var webView: WKWebView {
         return previewWebViewContainer.webView
     }
+    
+    var articleURL: URL {
+        return pageURL
+    }
 }
 
 extension EditPreviewViewController: UIGestureRecognizerDelegate {
@@ -231,13 +235,13 @@ extension EditPreviewViewController: ArticleWebMessageHandling {
         case .link(let href, _, let title):
             if let title = title, !title.isEmpty {
                 guard
-                    let host = articleURL.host,
+                    let host = pageURL.host,
                     let encodedTitle = title.percentEncodedPageTitleForPathComponents,
-                    let newArticleURL = Configuration.current.articleURLForHost(host, languageVariantCode: articleURL.wmf_languageVariantCode, appending: [encodedTitle]) else {
+                    let newPageURL = Configuration.current.articleURLForHost(host, languageVariantCode: pageURL.wmf_languageVariantCode, appending: [encodedTitle]) else {
                     showInternalLinkInAlert(link: href)
                     break
                 }
-                showInternalLink(url: newArticleURL)
+                showInternalLink(url: newPageURL)
             } else {
                 showExternalLinkInAlert(link: href)
             }

--- a/Wikipedia/Code/EditSaveViewController.swift
+++ b/Wikipedia/Code/EditSaveViewController.swift
@@ -285,7 +285,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
             assertionFailure("Could not get url of section to be edited")
             return
         }
-        EditAttemptFunnel.shared.logSaveAttempt(articleURL: editURL)
+        EditAttemptFunnel.shared.logSaveAttempt(pageURL: editURL)
         
         let section: String?
         if let sectionID {
@@ -328,7 +328,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
         let errorType = WikiTextSectionUploaderErrorType.init(rawValue: nsError.code) ?? .unknown
 
         if let articleURL {
-            EditAttemptFunnel.shared.logSaveFailure(articleURL: articleURL)
+            EditAttemptFunnel.shared.logSaveFailure(pageURL: articleURL)
         }
         
         switch errorType {

--- a/Wikipedia/Code/EditSaveViewController.swift
+++ b/Wikipedia/Code/EditSaveViewController.swift
@@ -32,7 +32,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
     var savedData: SaveData?
 
     var sectionID: Int?
-    var articleURL: URL?
+    var pageURL: URL?
     var languageCode: String?
     var dataStore: MWKDataStore?
     
@@ -177,7 +177,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
         let vc = EditSummaryViewController(nibName: EditSummaryViewController.wmf_classStoryboardName(), bundle: nil)
         vc.delegate = self
         vc.apply(theme: theme)
-        vc.setLanguage(for: articleURL)
+        vc.setLanguage(for: pageURL)
         wmf_add(childController: vc, andConstrainToEdgesOfContainerView: editSummaryVCContainer)
 
         if dataStore?.authenticationManager.isLoggedIn ?? false {
@@ -281,7 +281,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
     private func save() {
         WMFAlertManager.sharedInstance.showAlert(WMFLocalizedString("wikitext-upload-save", value: "Publishing...", comment: "Alert text shown when changes to section wikitext are being published {{Identical|Publishing}}"), sticky: true, dismissPreviousAlerts: true, tapCallBack: nil)
         
-        guard let editURL = articleURL else {
+        guard let editURL = pageURL else {
             assertionFailure("Could not get url of section to be edited")
             return
         }
@@ -320,8 +320,8 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
             notifyDelegate(.failure(RequestError.unexpectedResponse))
             return
         }
-        if let articleURL {
-            EditAttemptFunnel.shared.logSaveSuccess(pageURL: articleURL, revisionId: Int(newRevID))
+        if let pageURL {
+            EditAttemptFunnel.shared.logSaveSuccess(pageURL: pageURL, revisionId: Int(newRevID))
         }
         notifyDelegate(.success(SectionEditorChanges(newRevisionID: newRevID)))
     }
@@ -330,8 +330,8 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
         let nsError = error as NSError
         let errorType = WikiTextSectionUploaderErrorType.init(rawValue: nsError.code) ?? .unknown
 
-        if let articleURL {
-            EditAttemptFunnel.shared.logSaveFailure(pageURL: articleURL)
+        if let pageURL {
+            EditAttemptFunnel.shared.logSaveFailure(pageURL: pageURL)
         }
         
         switch errorType {
@@ -350,7 +350,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
             WMFAlertManager.sharedInstance.dismissAlert() // Hide "Publishing..."
             
             guard let displayError = nsError.userInfo[NSErrorUserInfoDisplayError] as? MediaWikiAPIDisplayError,
-                  let currentTitle = articleURL?.wmf_title else {
+                  let currentTitle = pageURL?.wmf_title else {
                 return
             }
             
@@ -380,7 +380,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
             WMFAlertManager.sharedInstance.dismissAlert() // Hide "Publishing..."
             
             guard let displayError = nsError.userInfo[NSErrorUserInfoDisplayError] as? MediaWikiAPIDisplayError,
-                  let currentTitle = articleURL?.wmf_title else {
+                  let currentTitle = pageURL?.wmf_title else {
                 return
             }
             
@@ -401,7 +401,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
     }
     
     func captchaSiteURL() -> URL {
-        return articleURL?.wmf_site ?? Configuration.current.defaultSiteURL
+        return pageURL?.wmf_site ?? Configuration.current.defaultSiteURL
     }
 
     func captchaReloadPushed(_ sender: AnyObject) {

--- a/Wikipedia/Code/EditSaveViewController.swift
+++ b/Wikipedia/Code/EditSaveViewController.swift
@@ -320,6 +320,9 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
             notifyDelegate(.failure(RequestError.unexpectedResponse))
             return
         }
+        if let articleURL {
+            EditAttemptFunnel.shared.logSaveSuccess(pageURL: articleURL, revisionId: Int(newRevID))
+        }
         notifyDelegate(.success(SectionEditorChanges(newRevisionID: newRevID)))
     }
     

--- a/Wikipedia/Code/PageEditorViewController.swift
+++ b/Wikipedia/Code/PageEditorViewController.swift
@@ -650,12 +650,12 @@ extension PageEditorViewController: SectionEditorNavigationItemControllerDelegat
                 guard let self else {
                     return
                 }
-                self.delegate?.pageEditorDidCancelEditing(self, navigateToURL: nil)
                 EditAttemptFunnel.shared.logAbort(pageURL: pageURL)
+                self.delegate?.pageEditorDidCancelEditing(self, navigateToURL: nil)
             }
         } else {
-            delegate?.pageEditorDidCancelEditing(self, navigateToURL: nil)
             EditAttemptFunnel.shared.logAbort(pageURL: pageURL)
+            delegate?.pageEditorDidCancelEditing(self, navigateToURL: nil)
         }
     }
     
@@ -825,12 +825,12 @@ extension PageEditorViewController: EditNoticesViewControllerDelegate {
                 guard let self else {
                     return
                 }
-                self.delegate?.pageEditorDidCancelEditing(self, navigateToURL: url)
                 EditAttemptFunnel.shared.logAbort(pageURL: pageURL)
+                self.delegate?.pageEditorDidCancelEditing(self, navigateToURL: url)
             }
         } else {
-            delegate?.pageEditorDidCancelEditing(self, navigateToURL: url)
             EditAttemptFunnel.shared.logAbort(pageURL: pageURL)
+            delegate?.pageEditorDidCancelEditing(self, navigateToURL: url)
         }
     }
 }

--- a/Wikipedia/Code/PageEditorViewController.swift
+++ b/Wikipedia/Code/PageEditorViewController.swift
@@ -649,9 +649,11 @@ extension PageEditorViewController: SectionEditorNavigationItemControllerDelegat
                     return
                 }
                 self.delegate?.pageEditorDidCancelEditing(self, navigateToURL: nil)
+                EditAttemptFunnel.shared.logAbort(pageURL: pageURL)
             }
         } else {
             delegate?.pageEditorDidCancelEditing(self, navigateToURL: nil)
+            EditAttemptFunnel.shared.logAbort(pageURL: pageURL)
         }
     }
     
@@ -822,9 +824,11 @@ extension PageEditorViewController: EditNoticesViewControllerDelegate {
                     return
                 }
                 self.delegate?.pageEditorDidCancelEditing(self, navigateToURL: url)
+                EditAttemptFunnel.shared.logAbort(pageURL: pageURL)
             }
         } else {
             delegate?.pageEditorDidCancelEditing(self, navigateToURL: url)
+            EditAttemptFunnel.shared.logAbort(pageURL: pageURL)
         }
     }
 }

--- a/Wikipedia/Code/PageEditorViewController.swift
+++ b/Wikipedia/Code/PageEditorViewController.swift
@@ -637,6 +637,8 @@ extension PageEditorViewController: SectionEditorNavigationItemControllerDelegat
         case .editorPreviewSave:
             showEditPreview(editFlow: editFlow)
         }
+        
+        EditAttemptFunnel.shared.logSaveIntent(pageURL: pageURL)
     }
     
     func sectionEditorNavigationItemController(_ sectionEditorNavigationItemController: SectionEditorNavigationItemController, didTapCloseButton closeButton: UIBarButtonItem) {

--- a/Wikipedia/Code/PageEditorViewController.swift
+++ b/Wikipedia/Code/PageEditorViewController.swift
@@ -508,7 +508,7 @@ final class PageEditorViewController: UIViewController {
     }
 
     private func showEditPreview(editFlow: EditFlow) {
-        let previewVC = EditPreviewViewController(articleURL: pageURL)
+        let previewVC = EditPreviewViewController(pageURL: pageURL)
         previewVC.theme = theme
         previewVC.sectionID = sectionID
         previewVC.languageCode = pageURL.wmf_languageCode
@@ -532,7 +532,7 @@ final class PageEditorViewController: UIViewController {
 
         saveVC.savedData = editConfirmationSavedData
         saveVC.dataStore = dataStore
-        saveVC.articleURL = pageURL
+        saveVC.pageURL = pageURL
         saveVC.sectionID = sectionID
         saveVC.languageCode = pageURL.wmf_languageCode
         saveVC.wikitext = sourceEditor.editedWikitext

--- a/Wikipedia/Code/SectionEditorViewController.swift
+++ b/Wikipedia/Code/SectionEditorViewController.swift
@@ -573,7 +573,7 @@ extension SectionEditorViewController: SectionEditorNavigationItemControllerDele
                 return
             } else if let wikitext = result {
                 if wikitext != self.wikitext {
-                    let vc = EditPreviewViewController(articleURL: self.articleURL)
+                    let vc = EditPreviewViewController(pageURL: self.articleURL)
                     self.inputViewsController.resetFormattingAndStyleSubmenus()
                     self.needsSelectLastSelection = true
                     vc.theme = self.theme
@@ -717,7 +717,7 @@ extension SectionEditorViewController: EditPreviewViewControllerDelegate {
 
         vc.savedData = editConfirmationSavedData
         vc.dataStore = dataStore
-        vc.articleURL = self.articleURL
+        vc.pageURL = self.articleURL
         vc.sectionID = self.sectionID
         vc.languageCode = self.languageCode
         vc.wikitext = editPreviewViewController.wikitext

--- a/Wikipedia/Code/SectionEditorViewController.swift
+++ b/Wikipedia/Code/SectionEditorViewController.swift
@@ -582,7 +582,7 @@ extension SectionEditorViewController: SectionEditorNavigationItemControllerDele
                     vc.wikitext = wikitext
                     vc.delegate = self
                     self.navigationController?.pushViewController(vc, animated: true)
-                    EditAttemptFunnel.shared.logSaveIntent(articleURL: self.articleURL)
+                    EditAttemptFunnel.shared.logSaveIntent(pageURL: self.articleURL)
                 } else {
                     let message = WMFLocalizedString("wikitext-preview-changes-none", value: "No changes were made to be previewed.", comment: "Alert text shown if no changes were made to be previewed.")
                     WMFAlertManager.sharedInstance.showAlert(message, sticky: false, dismissPreviousAlerts: true)

--- a/Wikipedia/Code/TalkPageReplyComposeController.swift
+++ b/Wikipedia/Code/TalkPageReplyComposeController.swift
@@ -392,7 +392,7 @@ class TalkPageReplyComposeController {
     @objc private func tappedPublish() {
 
         if let talkPageURL = commentViewModel?.talkPageURL {
-            EditAttemptFunnel.shared.logSaveIntent(articleURL: talkPageURL)
+            EditAttemptFunnel.shared.logSaveIntent(pageURL: talkPageURL)
         }
         
         guard let commentViewModel = commentViewModel,

--- a/Wikipedia/Code/TalkPageTopicComposeViewController.swift
+++ b/Wikipedia/Code/TalkPageTopicComposeViewController.swift
@@ -283,7 +283,7 @@ class TalkPageTopicComposeViewController: ViewController {
         let alertController = UIAlertController(title: Self.TopicComposeStrings.closeConfirmationTitle, message: nil, preferredStyle: .actionSheet)
         let discardAction = UIAlertAction(title: Self.TopicComposeStrings.closeConfirmationDiscard, style: .destructive) { _ in
             if let talkPageURL = self.viewModel.pageLink {
-                EditAttemptFunnel.shared.logAbort(articleURL: talkPageURL)
+                EditAttemptFunnel.shared.logAbort(pageURL: talkPageURL)
             }
             self.dismiss(animated: true)
         }
@@ -405,7 +405,7 @@ class TalkPageTopicComposeViewController: ViewController {
         
         guard shouldBlockDismissal else {
             if let talkPageURL = viewModel.pageLink {
-                EditAttemptFunnel.shared.logAbort(articleURL: talkPageURL)
+                EditAttemptFunnel.shared.logAbort(pageURL: talkPageURL)
             }
             dismiss(animated: true)
             return
@@ -416,7 +416,7 @@ class TalkPageTopicComposeViewController: ViewController {
     
     @objc private func tappedPublish() {
         if let talkPageURL = viewModel.pageLink {
-            EditAttemptFunnel.shared.logSaveIntent(articleURL: talkPageURL)
+            EditAttemptFunnel.shared.logSaveIntent(pageURL: talkPageURL)
         }
 
         guard let title = titleTextField.text,
@@ -428,7 +428,7 @@ class TalkPageTopicComposeViewController: ViewController {
         
         view.endEditing(true)
         if let talkPageURL = viewModel.pageLink {
-            EditAttemptFunnel.shared.logSaveAttempt(articleURL: talkPageURL)
+            EditAttemptFunnel.shared.logSaveAttempt(pageURL: talkPageURL)
         }
 
         guard let authenticationManager = authenticationManager,

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -426,7 +426,7 @@ class TalkPageViewController: ViewController {
         topicComposeVC.delegate = self
         inputAccessoryViewType = .format
         if let url = viewModel.getTalkPageURL(encoded: false) {
-            EditAttemptFunnel.shared.logInit(articleURL: url)
+            EditAttemptFunnel.shared.logInit(pageURL: url)
         }
         let navVC = UINavigationController(rootViewController: topicComposeVC)
         navVC.modalPresentationStyle = .pageSheet
@@ -479,7 +479,7 @@ class TalkPageViewController: ViewController {
             return
         }
         
-        EditAttemptFunnel.shared.logInit(articleURL: url)
+        EditAttemptFunnel.shared.logInit(pageURL: url)
     }
 
     fileprivate func pushToDesktopWeb() {
@@ -925,7 +925,7 @@ extension TalkPageViewController: TalkPageCellReplyDelegate {
         inputAccessoryViewType = .format
 
         if let url = viewModel.getTalkPageURL(encoded: false) {
-            EditAttemptFunnel.shared.logInit(articleURL: url)
+            EditAttemptFunnel.shared.logInit(pageURL: url)
         }
 
         if !UserDefaults.standard.wmf_userHasOnboardedToContributingToTalkPages {
@@ -947,7 +947,7 @@ extension TalkPageViewController: TalkPageReplyComposeDelegate {
                 UIAccessibility.post(notification: .screenChanged, argument: focusView)
             }
             if let talkPageURL = self.viewModel.getTalkPageURL(encoded: false) {
-                EditAttemptFunnel.shared.logAbort(articleURL: talkPageURL)
+                EditAttemptFunnel.shared.logAbort(pageURL: talkPageURL)
             }
         }
     }
@@ -955,7 +955,7 @@ extension TalkPageViewController: TalkPageReplyComposeDelegate {
     func tappedPublish(text: String, commentViewModel: TalkPageCellCommentViewModel) {
 
         if let talkPageURL = viewModel.getTalkPageURL(encoded: false) {
-            EditAttemptFunnel.shared.logSaveAttempt(articleURL: talkPageURL)
+            EditAttemptFunnel.shared.logSaveAttempt(pageURL: talkPageURL)
         }
 
         let oldCellViewModel = commentViewModel.cellViewModel
@@ -986,7 +986,7 @@ extension TalkPageViewController: TalkPageReplyComposeDelegate {
                         self?.talkPageView.collectionView.reloadData()
                         self?.handleNewTopicOrCommentAlert(isNewTopic: false)
                         if let talkPageURL = self?.viewModel.getTalkPageURL(encoded: false) {
-                            EditAttemptFunnel.shared.logSaveSuccess(articleURL: talkPageURL, revisionId: revID)
+                            EditAttemptFunnel.shared.logSaveSuccess(pageURL: talkPageURL, revisionId: revID)
                         }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                             self?.scrollToNewComment(oldCellViewModel: oldCellViewModel, oldCommentViewModels: oldCommentViewModels)
@@ -994,7 +994,7 @@ extension TalkPageViewController: TalkPageReplyComposeDelegate {
 
                     case .failure:
                         if let talkPageURL = self?.viewModel.getTalkPageURL(encoded: false) {
-                            EditAttemptFunnel.shared.logSaveFailure(articleURL: talkPageURL)
+                            EditAttemptFunnel.shared.logSaveFailure(pageURL: talkPageURL)
                         }
                     }
                 }
@@ -1002,7 +1002,7 @@ extension TalkPageViewController: TalkPageReplyComposeDelegate {
                 DDLogError("Failure publishing reply: \(error)")
                 self.replyComposeController.isLoading = false
                 if let talkPageURL = self.viewModel.getTalkPageURL(encoded: false) {
-                    EditAttemptFunnel.shared.logSaveFailure(articleURL: talkPageURL)
+                    EditAttemptFunnel.shared.logSaveFailure(pageURL: talkPageURL)
                 }
 
                 if (error as NSError).wmf_isNetworkConnectionError() {
@@ -1060,11 +1060,11 @@ extension TalkPageViewController: TalkPageTopicComposeViewControllerDelegate {
                         self?.talkPageView.collectionView.reloadData()
                         self?.scrollToLastTopic()
                         if let viewModel = self?.viewModel, let pageURL = viewModel.getTalkPageURL(encoded: false) {
-                            EditAttemptFunnel.shared.logSaveSuccess(articleURL: pageURL, revisionId: viewModel.latestRevisionID)
+                            EditAttemptFunnel.shared.logSaveSuccess(pageURL: pageURL, revisionId: viewModel.latestRevisionID)
                         }
                     case .failure:
                         if let viewModel = self?.viewModel, let pageURL = viewModel.getTalkPageURL(encoded: false) {
-                            EditAttemptFunnel.shared.logSaveFailure(articleURL: pageURL)
+                            EditAttemptFunnel.shared.logSaveFailure(pageURL: pageURL)
                         }
                     }
                 }
@@ -1074,7 +1074,7 @@ extension TalkPageViewController: TalkPageTopicComposeViewControllerDelegate {
                 composeViewController.setupNavigationBar(isPublishing: false)
 
                 if let viewModel = self?.viewModel, let pageURL = viewModel.getTalkPageURL(encoded: false) {
-                    EditAttemptFunnel.shared.logSaveFailure(articleURL: pageURL)
+                    EditAttemptFunnel.shared.logSaveFailure(pageURL: pageURL)
                 }
                 
                 if (error as NSError).wmf_isNetworkConnectionError() {

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -474,6 +474,12 @@ class TalkPageViewController: ViewController {
         let navigationController = WMFThemeableNavigationController(rootViewController: pageEditorViewController, theme: theme)
         navigationController.modalPresentationStyle = UIModalPresentationStyle.overCurrentContext
         present(navigationController, animated: true)
+        
+        guard let url = viewModel.siteURL.wmf_URL(withTitle: viewModel.pageTitle) else {
+            return
+        }
+        
+        EditAttemptFunnel.shared.logInit(articleURL: url)
     }
 
     fileprivate func pushToDesktopWeb() {


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T355265 (second checkbox)

### Notes
This PR logs EditAttemptStep actions in the new editor flow. I also renamed some minor things away from "article" to "page" in the editor flow, since it no longer serves only articles.

### Test Steps
I have already gone through developer testing of these steps. More details can be seen in the [spec](https://docs.google.com/presentation/d/10M0slX4Pf8KOQDXN9Mlp57WCv_1sltXD0F7ElF75F7o/edit#slide=id.g2b529c45ca6_2_0) if interested. I'm okay with leaning more on QA & Analytics for testing these thoroughly.

1. Confirm when the new editor is presented, you see an `init` action logged in the console.
2. Confirm when you close out of the editor, you see an `abort` action logged in the console.
3. Confirm when tapping next on the editor, you see a `saveIntent` action logged in the console.
4. Confirm when tapping publish on the edit summary view, you see a `saveAttempt` action, followed by a `saveSuccess` action in the console.
5. Confirm when tapping publish on the edit summary and some failure occurs (you can test with no connection / airplane mode), you see a `saveAttempt` action, followed by a `saveFailure` action in the console.
