### PR TITLE
Native Editor - Fix iOS 16 crash

### DIFF
--- a/Components/Sources/ComponentsObjC/WKSourceEditorFormatter.m
+++ b/Components/Sources/ComponentsObjC/WKSourceEditorFormatter.m
@@ -36,6 +36,10 @@ NSString * const WKSourceEditorCustomKeyColorGreen = @"WKSourceEditorKeyColorGre
         return NO;
     }
     
+    if (attributedString.length <= range.location) {
+        return NO;
+    }
+    
     if (attributedString.length < (range.location + range.length)) {
         return NO;
     }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T357138

### Notes
This adds a little bit of extra safety to the formatter range check method to fix a crash I saw in TestFlight.

### Test Steps
1. Open editor on an iOS 16 device (I don't think you need an iPad, but this crash occurred on an iPad).
2. Scroll all the way down to the last line of text. Select text in that last line. Also try to put cursor at the very end. Confirm no crashes occur.

