### PR TITLE
Fix blank language variant name in watchlist filters

### DIFF
--- a/Wikipedia/Code/WikimediaProject.swift
+++ b/Wikipedia/Code/WikimediaProject.swift
@@ -113,14 +113,16 @@ public enum WikimediaProject: Hashable {
             return nil
         }
         
+        let languageVariantCode = canonicalSiteURL.wmf_languageVariantCode
+        
         let recognizedLanguage = languageLinkController?.allLanguages.first { languageLink in
-            languageLink.languageCode == languageCode
+            languageLink.languageCode == languageCode && languageLink.languageVariantCode == languageVariantCode
         }
         
         let localizedLanguageName = recognizedLanguage?.localizedName ?? ""
         
         if siteURLString.contains(Configuration.current.defaultSiteDomain) {
-            self = .wikipedia(languageCode, localizedLanguageName, nil)
+            self = .wikipedia(languageCode, localizedLanguageName, languageVariantCode)
         } else if siteURLString.contains(Configuration.Domain.wikiquote) {
             self = .wikiquote(languageCode, localizedLanguageName)
         } else if siteURLString.contains(Configuration.Domain.wikibooks) {


### PR DESCRIPTION
**Phabricator:**
https://phabricator.wikimedia.org/T357370

### Notes
This PR fixes the blank language variant name issue in Watchlist Filters.

### Test Steps
1. Confirm language variant names appear in Watchlist Filters.
2. Confirm Watchlist filters correctly by language.
