### PR TITLE
Diffs: Enable VoiceOver for diff list cells

### DIFF
--- a/Wikipedia/Code/DiffContainerViewController.swift
+++ b/Wikipedia/Code/DiffContainerViewController.swift
@@ -123,7 +123,6 @@ class DiffContainerViewController: ViewController {
         self.needsSetNavDelegate = needsSetNavDelegate
         
         super.init()
-        self.isAccessibilityElement = false
         self.theme = theme
         
         self.containerViewModel.stateHandler = { [weak self] oldState in

--- a/Wikipedia/Code/DiffListChangeCell.swift
+++ b/Wikipedia/Code/DiffListChangeCell.swift
@@ -36,10 +36,6 @@ class DiffListChangeCell: UICollectionViewCell {
     weak var delegate: DiffListChangeCellDelegate?
     
     func update(_ viewModel: DiffListChangeViewModel) {
-
-        textStackView.isAccessibilityElement = false
-        headingLabel.isAccessibilityElement = false
-        
         textLeadingConstraint.constant = viewModel.stackViewPadding.leading
         textTrailingConstraint.constant = viewModel.stackViewPadding.trailing
         textTopConstraint.constant = viewModel.stackViewPadding.top
@@ -180,7 +176,6 @@ private extension DiffListChangeCell {
         for (index, label) in textLabels.enumerated() {
             if let item = newViewModel.items[safeIndex: index] {
                 label.attributedText = item.textAttributedString
-                label.isAccessibilityElement = false
             }
         }
     }

--- a/Wikipedia/Code/DiffListContextCell.swift
+++ b/Wikipedia/Code/DiffListContextCell.swift
@@ -65,13 +65,20 @@ class DiffListContextCell: UICollectionViewCell {
         }
         
         updateContextViews(in: contextItemStackView, newViewModel: viewModel, theme: viewModel.theme)
-        
+
+        if viewModel.isExpanded {
+            accessibilityElements = [headingLabel as Any, expandButton as Any, contextItemStackView as Any]
+        } else {
+            accessibilityElements = [headingLabel as Any, expandButton as Any]
+        }
+
         self.viewModel = viewModel
     }
     
     @IBAction func tappedExpandButton(_ sender: UIButton) {
         if let indexPath = indexPath {
             delegate?.didTapContextExpand(indexPath: indexPath)
+            UIAccessibility.post(notification: .layoutChanged, argument: nil)
         }
     }
 }

--- a/Wikipedia/Code/DiffListContextCell.swift
+++ b/Wikipedia/Code/DiffListContextCell.swift
@@ -27,12 +27,6 @@ class DiffListContextCell: UICollectionViewCell {
     weak var delegate: DiffListContextCellDelegate?
     
     func update(_ viewModel: DiffListContextViewModel, indexPath: IndexPath?) {
-        self.isAccessibilityElement = false
-        contentView.isAccessibilityElement = false
-        headingLabel.isAccessibilityElement = false
-        expandButton.isAccessibilityElement = false
-        contextItemStackView.isAccessibilityElement = false
-        
         if let indexPath = indexPath {
             self.indexPath = indexPath
         }
@@ -139,7 +133,6 @@ private extension DiffListContextCell {
             if let item = newViewModel.items[safeIndex: index] as? DiffListContextItemViewModel,
             let label = subview.subviews.first as? UILabel {
                 label.attributedText = item.textAttributedString
-                label.isAccessibilityElement = false
             }
         }
     }

--- a/Wikipedia/Code/DiffListUneditedCell.swift
+++ b/Wikipedia/Code/DiffListUneditedCell.swift
@@ -19,9 +19,6 @@ class DiffListUneditedCell: UICollectionViewCell {
         textLabel.text = viewModel.text.localizedCapitalized
 
         apply(theme: viewModel.theme)
-
-        textLabel.isAccessibilityElement = false
-        isAccessibilityElement = false
     }
 }
 

--- a/Wikipedia/Code/DiffTransformer.swift
+++ b/Wikipedia/Code/DiffTransformer.swift
@@ -362,7 +362,7 @@ class DiffTransformer {
             
             if contextItems.count > 0 {
                 // package contexts up into context view model, append to result
-                let contextViewModel = DiffListContextViewModel(diffItems: contextItems, isExpanded: false, theme: theme, width: 0, traitCollection: traitCollection, semanticContentAttribute: self.semanticContentAttribute)
+                let contextViewModel = DiffListContextViewModel(diffItems: contextItems, isExpanded: UIAccessibility.isVoiceOverRunning, theme: theme, width: 0, traitCollection: traitCollection, semanticContentAttribute: self.semanticContentAttribute)
                 result.append(contextViewModel)
                 contextItems.removeAll()
             }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T343582 (partially)

### Notes
This PR re-introduces VoiceOver support for diff list cells. It also auto-expands the cells if the user has VoiceOver enabled.

### Test Steps
1. Enable VoiceOver on device
2. Navigate to a diff page change for an article of your choice
3. Confirm (because VoiceOver is on) that the diff list cells start as expanded
4. Confirm navigating elements from top down navigates in order (previously, the collapse/expand button was read out of order)
