### PR TITLE
Integrate with Phabricator message bot.

### DIFF
--- a/.github/workflows/post_phab.yml
+++ b/.github/workflows/post_phab.yml
@@ -1,0 +1,24 @@
+name: Post to Phabricator
+
+on:
+  pull_request:
+    types: [opened, closed]
+
+jobs:
+  post_to_phab:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Post to Phabricator when pull request is opened or closed
+      if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'closed') }}
+      env:
+        PR_BODY: ${{ github.event.pull_request.body }}
+      run: |
+        message="${{ github.actor }} ${{ github.event.action }} ${{ github.event.pull_request._links.html.href }}"
+        echo -e "${PR_BODY}" | grep -oEi "^Bug:\s*T[0-9]*" | grep -oEi "T[0-9]*" | while IFS= read -r line; do
+          echo "Processing: $line"
+          curl https://phabricator.wikimedia.org/api/maniphest.edit \
+              -d api.token=${{ secrets.PHAB_BOT_API_KEY }} \
+              -d transactions[0][type]=comment \
+              -d transactions[0][value]="${message}" \
+              -d objectIdentifier=${line}
+        done

--- a/.github/workflows/post_phab.yml
+++ b/.github/workflows/post_phab.yml
@@ -14,7 +14,7 @@ jobs:
         PR_BODY: ${{ github.event.pull_request.body }}
       run: |
         message="${{ github.actor }} ${{ github.event.action }} ${{ github.event.pull_request._links.html.href }}"
-        echo -e "${PR_BODY}" | grep -oEi "^Bug:\s*T[0-9]*" | grep -oEi "T[0-9]*" | while IFS= read -r line; do
+        echo -e "${PR_BODY}" | grep -oEi "(^Bug:\s*T[0-9]+)|(^([*]*phabricator[*]*:[*]*\s*)?https:\/\/phabricator\.wikimedia\.org\/T[0-9]+)" | grep -oEi "T[0-9]+" | while IFS= read -r line; do
           echo "Processing: $line"
           curl https://phabricator.wikimedia.org/api/maniphest.edit \
               -d api.token=${{ secrets.PHAB_BOT_API_KEY }} \


### PR DESCRIPTION
Hey all, I just set this up for Android, and thought I'd suggest it for iOS, too.
This integrates with our Phab bot which should automatically post messages on the corresponding task whenever a pull request is opened or closed.

You can use multiple possible conventions for calling out the Phab task, including:

* The old-style Gerrit callout: `Bug: T...`
* Simply pasting a Phab link on its own line: `https://phabricator.wikimedia.org/T12345`
* New-style convention: `Phabricator: T...`
* The convention for your repo: `**Phabricator:** T...`

(supports multiple tasks (one per line))
(case insensitive)
(optional whitespace between "Bug" and T number)
(no-op if no bugs are mentioned)

Bug: T360680
