### PR TITLE
`MediaListItem`: Use explicit `MediaListItemType` enum over `String` 

### DIFF
--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -1108,7 +1108,7 @@ extension ExploreViewController: WKImageRecommendationsDelegate {
             return
         }
         
-        let item = MediaListItem(title: "File:\(data.filename)", sectionID: 0, type: "image", showInGallery: true, isLeadImage: false, sources: nil)
+        let item = MediaListItem(title: "File:\(data.filename)", sectionID: 0, type: .image, showInGallery: true, isLeadImage: false, sources: nil)
         let mediaList = MediaList(items: [item])
         
         let gallery = MediaListGalleryViewController(articleURL: articleURL, mediaList: mediaList, dataStore: dataStore, initialItem: item, theme: theme)

--- a/Wikipedia/Code/MediaList.swift
+++ b/Wikipedia/Code/MediaList.swift
@@ -13,7 +13,7 @@ public struct MediaListItemSource: Codable {
     }
 }
 
-public enum MediaListItemType: String {
+public enum MediaListItemType: String, Codable {
     case image
     case audio
     case video
@@ -22,7 +22,7 @@ public enum MediaListItemType: String {
 public struct MediaListItem: Codable {
     public let title: String?
     public let sectionID: Int
-    public let type: String
+    public let type: MediaListItemType
     public let showInGallery: Bool
     public let isLeadImage: Bool
     public let sources: [MediaListItemSource]?
@@ -37,7 +37,7 @@ public struct MediaListItem: Codable {
         case audioType
     }
 
-    public init(title: String?, sectionID: Int, type: String, showInGallery: Bool, isLeadImage: Bool, sources: [MediaListItemSource]?, audioType: String? = nil) {
+    public init(title: String?, sectionID: Int, type: MediaListItemType, showInGallery: Bool, isLeadImage: Bool, sources: [MediaListItemSource]?, audioType: String? = nil) {
         self.title = title
         self.sectionID = sectionID
         self.type = type
@@ -48,11 +48,6 @@ public struct MediaListItem: Codable {
     }
 }
 
-extension MediaListItem {
-    public var itemType: MediaListItemType? {
-        return MediaListItemType(rawValue: type)
-    }
-}
 
 public struct MediaList: Codable {
     public let items: [MediaListItem]
@@ -75,7 +70,7 @@ public struct MediaList: Codable {
             MediaListItemSource(urlString: urlString, scale: "1.5x")
         ]
 
-        let mediaListItem = MediaListItem(title: filename, sectionID: 0, type: "image", showInGallery: true, isLeadImage: true, sources: sources, audioType: nil)
+        let mediaListItem = MediaListItem(title: filename, sectionID: 0, type: .image, showInGallery: true, isLeadImage: true, sources: sources, audioType: nil)
         self = MediaList(items: [mediaListItem])
     }
 }

--- a/Wikipedia/Code/MediaListGalleryViewController.swift
+++ b/Wikipedia/Code/MediaListGalleryViewController.swift
@@ -122,7 +122,7 @@ class MediaListItemNYTPhotoWrapper: NSObject, WMFPhoto {
     var imageInfo: MWKImageInfo?
     
     init?(_ mediaListItem: MediaListItem?) {
-        guard let mediaListItem = mediaListItem, mediaListItem.type == "image" else {
+        guard let mediaListItem = mediaListItem, mediaListItem.type == .image else {
             return nil
         }
         self.mediaListItem = mediaListItem


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
From a PR I reviewed yesterday, just noticed this use of strings over the type safe enum. This PR updates that struct to use the enum directly.

### Test Steps
Explore articles with multiple images to confirm the gallery experience hasn't regressed.
