### PR TITLE
Image recommendations - data improvements

### DIFF
--- a/Components/Sources/Components/Components/Onboarding/WKOnboardingViewController.swift
+++ b/Components/Sources/Components/Components/Onboarding/WKOnboardingViewController.swift
@@ -4,9 +4,16 @@ import SwiftUI
 public protocol WKOnboardingViewDelegate: AnyObject {
     func didClickPrimaryButton()
     func didClickSecondaryButton()
+    func willSwipeToDismiss()
 }
 
 public class WKOnboardingViewController: WKCanvasViewController {
+    
+    public weak var delegate: WKOnboardingViewDelegate? {
+        didSet {
+            hostingController.delegate = delegate
+        }
+    }
     
    // MARK: - Properties
 
@@ -23,11 +30,19 @@ public class WKOnboardingViewController: WKCanvasViewController {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-            addComponent(hostingController, pinToEdges: true)
+        addComponent(hostingController, pinToEdges: true)
+        presentationController?.delegate = self
     }
 }
 
-public final class WKOnboardingHostingViewController: WKComponentHostingController<WKOnboardingView>, UIAdaptivePresentationControllerDelegate {
+extension WKOnboardingViewController: UIAdaptivePresentationControllerDelegate {
+    public func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
+        delegate?.willSwipeToDismiss()
+    }
+}
+
+
+public final class WKOnboardingHostingViewController: WKComponentHostingController<WKOnboardingView> {
 
     // MARK: - Properties
 
@@ -47,11 +62,6 @@ public final class WKOnboardingHostingViewController: WKComponentHostingControll
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        presentationController?.delegate = self
     }
 
     func primaryButtonAction() {

--- a/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsView.swift
+++ b/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsView.swift
@@ -57,10 +57,5 @@ struct WKImageRecommendationsView: View {
             }
             .ignoresSafeArea()
         }
-        .onAppear {
-            viewModel.fetchImageRecommendationsIfNeeded {
-
-            }
-        }
     }
 }

--- a/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsViewController.swift
+++ b/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsViewController.swift
@@ -135,7 +135,7 @@ public final class WKImageRecommendationsViewController: WKCanvasViewController 
     }
 
     private func bindViewModel() {
-        viewModel.$loading
+        viewModel.$debouncedLoading
             .receive(on: RunLoop.main)
             .sink { [weak self] isLoading in
                 if !isLoading {

--- a/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsViewController.swift
+++ b/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsViewController.swift
@@ -139,7 +139,9 @@ public final class WKImageRecommendationsViewController: WKCanvasViewController 
             .receive(on: RunLoop.main)
             .sink { [weak self] isLoading in
                 if !isLoading {
-                    self?.presentModalView()
+                    if self?.viewModel.currentRecommendation != nil {
+                        self?.presentModalView()
+                    }
                 }
             }
             .store(in: &cancellables)

--- a/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsViewModel.swift
+++ b/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsViewModel.swift
@@ -102,7 +102,6 @@ public final class WKImageRecommendationsViewModel: ObservableObject {
     let localizedStrings: LocalizedStrings
     
     private(set) var imageRecommendations: [ImageRecommendation] = []
-    private var recommendationData: [WKImageRecommendation.Page] = []
     @Published var currentRecommendation: ImageRecommendation?
     @Published var loading: Bool = true
     @Published var debouncedLoading: Bool = true
@@ -147,7 +146,6 @@ public final class WKImageRecommendationsViewModel: ObservableObject {
             switch result {
             case .success(let pages):
                 DispatchQueue.main.async {
-                    self.recommendationData = pages
                     let imageDataArray = self.getFirstImageData(for: pages)
 
                     for page in pages {
@@ -190,7 +188,9 @@ public final class WKImageRecommendationsViewModel: ObservableObject {
             return
         }
         
-        imageRecommendations.removeFirst()
+        let removedPage = imageRecommendations.removeFirst()
+        growthTasksDataController.remove(pageId: removedPage.pageId, from: project)
+        
         guard let nextRecommendation = imageRecommendations.first else {
             growthTasksDataController.reset(for: project)
             fetchImageRecommendationsIfNeeded {

--- a/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsViewModel.swift
+++ b/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsViewModel.swift
@@ -120,7 +120,7 @@ public final class WKImageRecommendationsViewModel: ObservableObject {
         self.articleSummaryDataController = WKArticleSummaryDataController()
         
         $loading
-            .debounce(for: .seconds(0.3), scheduler: DispatchQueue.main)
+            .debounce(for: .seconds(0.1), scheduler: DispatchQueue.main)
                     .sink(receiveValue: { [weak self] t in
                         self?.debouncedLoading = t
                     })

--- a/WKData/Sources/WKData/Data Controllers/Shared/WKArticleSummaryDataController.swift
+++ b/WKData/Sources/WKData/Data Controllers/Shared/WKArticleSummaryDataController.swift
@@ -15,7 +15,7 @@ public final class WKArticleSummaryDataController {
         }
 
         guard !title.isEmpty,
-              let url = URL.wikimediaRestAPIURL(project: project, additionalPathComponents: ["page", "summary", title]) else {
+              let url = URL.wikimediaRestAPIURL(project: project, additionalPathComponents: ["page", "summary", title.spacesToUnderscores]) else {
             completion(.failure(WKDataControllerError.failureCreatingRequestURL))
             return
         }

--- a/WKData/Sources/WKData/Data Controllers/WKGrowthTasks/WKGrowthTasksDataController.swift
+++ b/WKData/Sources/WKData/Data Controllers/WKGrowthTasks/WKGrowthTasksDataController.swift
@@ -13,6 +13,14 @@ import Foundation
 
     // MARK: GET Methods
     
+    public func remove(pageId: Int, from project: WKProject) {
+        guard let recommendations = Self.currentImageRecommendations[project] else {
+            return
+        }
+        
+        Self.currentImageRecommendations[project] = recommendations.filter { $0.pageid != pageId }
+    }
+    
     public func reset(for project: WKProject) {
         Self.currentImageRecommendations[project] = []
     }

--- a/WKData/Sources/WKData/Data Controllers/WKGrowthTasks/WKGrowthTasksDataController.swift
+++ b/WKData/Sources/WKData/Data Controllers/WKGrowthTasks/WKGrowthTasksDataController.swift
@@ -4,12 +4,18 @@ import Foundation
 
     private var service = WKDataEnvironment.current.mediaWikiService
     let project: WKProject
+    
+    private static var currentImageRecommendations: [WKProject: [WKImageRecommendation.Page]] = [:]
 
     public init (project: WKProject) {
         self.project = project
     }
 
     // MARK: GET Methods
+    
+    public func reset(for project: WKProject) {
+        Self.currentImageRecommendations[project] = []
+    }
 
     public func getImageRecommendationsCombined(completion: @escaping (Result<[WKImageRecommendation.Page], Error>) -> Void) {
         guard let service else {
@@ -17,7 +23,11 @@ import Foundation
             return
         }
         
-        var recommendationsPerPage: [WKImageRecommendation.Page] = []
+        if let currentRecommendations = Self.currentImageRecommendations[project],
+           !currentRecommendations.isEmpty {
+            completion(.success(currentRecommendations))
+            return
+        }
 
         let parameters: [String: Any] = [ "action": "query",
                            "generator": "search",
@@ -39,12 +49,16 @@ import Foundation
         }
 
         let request = WKMediaWikiServiceRequest(url: url, method: .GET, parameters: parameters)
-        service.performDecodableGET(request: request) { (result: Result<WKImageRecommendationAPIResponse, Error>) in
+        service.performDecodableGET(request: request) { [weak self] (result: Result<WKImageRecommendationAPIResponse, Error>) in
+            
+            guard let self else {
+                return
+            }
+            
             switch result {
             case .success(let response):
-                print(response)
-                recommendationsPerPage.append(contentsOf: self.getImageSuggestions(from: response))
-                completion(.success(recommendationsPerPage))
+                Self.currentImageRecommendations[project, default: []].append(contentsOf: self.getImageSuggestions(from: response))
+                completion(.success(Self.currentImageRecommendations[project] ?? []))
             case .failure(let error):
                 print(error)
                 completion(.failure(error))

--- a/WKData/Sources/WKData/Extensions/String+Extensions.swift
+++ b/WKData/Sources/WKData/Extensions/String+Extensions.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public extension String {
+    var spacesToUnderscores: String {
+        return self.replacingOccurrences(of: " ", with: "_")
+    }
+    
+    var underscoresToSpaces: String {
+        return self.replacingOccurrences(of: "_", with: " ")
+    }
+}

--- a/Wikipedia/Code/ViewControllerRouter.swift
+++ b/Wikipedia/Code/ViewControllerRouter.swift
@@ -363,6 +363,7 @@ class ViewControllerRouter: NSObject {
 }
 
 extension ViewControllerRouter: WKOnboardingViewDelegate {
+    
     func didClickPrimaryButton() {
         
         let targetNavigationController = watchlistTargetNavigationController()
@@ -390,5 +391,9 @@ extension ViewControllerRouter: WKOnboardingViewDelegate {
                 self?.appViewController.navigate(to: url)
             }
         }
+    }
+    
+    func willSwipeToDismiss() {
+        
     }
 }


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
This PR contains some improvements to image recommendations data fetching.

1. The explore feed card already fetched image recommendations, because it needs that data to know whether or not to display. However, when we pushed on image recommendations, it fetched a whole new set. It's wasteful to do it twice, especially since this call seems to take a while to load. Now I am caching the image recommendations within the data controller.
2. At the end of the cycle, I am attempting to fetch more image recommendations. This matches Android.
3. I added underscores to the article summary title before fetching. Without them, the article summary call redirected to another endpoint with underscores.
4. The faster initial call caused onboarding to intercept the half sheet modal. The last commit fixes that.

### Test Steps
1. Fresh install on Staging. Tap Explore feed card.
2. Dismiss onboarding. Confirm image recommendations appear after dismissal.
3. Tap Not Sure until the end. Confirm you see a loading state after exhausting recommendations, and then new recommendations load.
