### PR TITLE
Add .mailmap file w/ entries for bvibber name update

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+# See: https://git-scm.com/docs/git-shortlog#_mapping_authors
+#
+Brooke Vibber <bvibber@wikimedia.org>
+Brooke Vibber <bvibber@wikimedia.org> <brion@wikimedia.org>
+Brooke Vibber <bvibber@wikimedia.org> <brion@pobox.com>


### PR DESCRIPTION
Fixes name on my old commits. :)

**Phabricator:** n/a

### Notes
* adds a .mailmap file to the repo which normalizes name and email address of distant past commits by bvibber

### Test Steps
1. git log | grep ibber

### Screenshots/Videos

n/a