### PR TITLE
Fix bolding of italicized titles in search

### DIFF
--- a/WMF Framework/NSMutableAttributedString+Mutations.swift
+++ b/WMF Framework/NSMutableAttributedString+Mutations.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-extension NSMutableAttributedString {
-    /// Applies a bold font to the first portion of the string that matches the given string
+extension String {
+    private enum Tags {
+        static let boldStart = "<b>"
+        static let boldEnd = "</b>"
+    }
+    /// Applies a bold tag to the first portion of the string that matches the given string
     /// - Parameter matchingString: the string to search for and bold
-    /// - Parameter textStyle: The text style to use for the bolded string
-    /// - Parameter weight: The font weight to use for the bolded string
-    /// - Parameter traitCollection: The trait collection used for generating the font
-    public func applyBoldFont(to matchingString: String, textStyle: DynamicTextStyle, weight: UIFont.Weight = .semibold, matching traitCollection: UITraitCollection) {
+    public mutating func applyBoldTag(to matchingString: String) {
         // NSString and NSRange are used here for better compatability with NSAttributedString
-        let range = (string as NSString).range(of: matchingString, options: .caseInsensitive)
-        guard range.location != NSNotFound else {
+        guard let range = range(of: matchingString, options: .caseInsensitive) else {
             return
         }
-        let boldFont = UIFont.wmf_font(textStyle.with(weight: weight), compatibleWithTraitCollection: traitCollection)
-        addAttribute(.font, value: boldFont, range: range)
+        insert(contentsOf: Tags.boldStart, at: range.lowerBound)
+        insert(contentsOf: Tags.boldEnd, at: index(range.upperBound, offsetBy: Tags.boldStart.count))
     }
 }

--- a/WMF Framework/UIFont+WMFDynamicType.swift
+++ b/WMF Framework/UIFont+WMFDynamicType.swift
@@ -143,10 +143,9 @@ public extension UIFont {
     }
     
     func with(traits: UIFontDescriptor.SymbolicTraits) -> UIFont {
-        guard let descriptor = self.fontDescriptor.withSymbolicTraits(traits) else {
+        guard let descriptor = fontDescriptor.withSymbolicTraits(fontDescriptor.symbolicTraits.union(traits)) else {
             return self
         }
-        
         return UIFont(descriptor: descriptor, size: 0)
     }
 }

--- a/Wikipedia/Code/ArticleCollectionViewCell.swift
+++ b/Wikipedia/Code/ArticleCollectionViewCell.swift
@@ -16,11 +16,11 @@ open class ArticleCollectionViewCell: CollectionViewCell, SwipeableCell, BatchEd
     private var _titleBoldedString: String? = nil
     
     private func updateTitleLabel() {
-        if let titleHTML = _titleHTML {
-            let attributedTitle = titleHTML.byAttributingHTML(with: titleTextStyle, matching: traitCollection)
+        if var titleHTML = _titleHTML {
             if let boldString = _titleBoldedString {
-                attributedTitle.applyBoldFont(to: boldString, textStyle: titleTextStyle, matching: traitCollection)
+                titleHTML.applyBoldTag(to: boldString)
             }
+            let attributedTitle = titleHTML.byAttributingHTML(with: titleTextStyle, matching: traitCollection)
             titleLabel.attributedText = attributedTitle
         } else {
             let titleFont = UIFont.wmf_font(titleTextStyle, compatibleWithTraitCollection: traitCollection)


### PR DESCRIPTION

### Test Steps
1. Search for an article with an italicized title, using a term in that title

Expected: Search term is bold and italic
Actual: Search term is just bold

### Screenshots/Videos
Before:
<img src=https://github.com/wikimedia/wikipedia-ios/assets/741327/8db3d79d-4da5-498f-8a66-0f73002c4aad width=393>

After:
<img src=https://github.com/wikimedia/wikipedia-ios/assets/741327/29aa2587-90f6-44dc-b2a2-16ea28349406 width=393>

