### PR TITLE
Image Recommendations - Fix assert failure for ZH Wiki

### DIFF
--- a/WMF Framework/WMFContentGroup+Extensions.h
+++ b/WMF Framework/WMFContentGroup+Extensions.h
@@ -80,7 +80,7 @@ typedef NS_ENUM(int16_t, WMFContentGroupUndoType) {
 + (nullable NSURL *)notificationContentGroupURLWithLanguageVariantCode:(NSString *)languageVariantCode;
 + (nullable NSURL *)themeContentGroupURLWithLanguageVariantCode:(NSString *)languageVariantCode;
 + (nullable NSURL *)readingListContentGroupURLWithLanguageVariantCode:(NSString *)languageVariantCode;
-+ (nullable NSURL *)suggestedEditsURL;
++ (nullable NSURL *)suggestedEditsURLForSiteURL:(NSURL *)siteURL;
 
 - (BOOL)isForLocalDate:(NSDate *)date;           //date is a date in the user's time zone
 @property (nonatomic, readonly) BOOL isForToday; //is for today in the user's time zone

--- a/WMF Framework/WMFContentGroup+Extensions.m
+++ b/WMF Framework/WMFContentGroup+Extensions.m
@@ -85,7 +85,7 @@
         case WMFContentGroupKindAnnouncement:
             URL = [WMFContentGroup announcementURLForSiteURL:self.siteURL identifier:[(WMFAnnouncement *)self.contentPreview identifier]];
         case WMFContentGroupKindSuggestedEdits:
-            URL = [WMFContentGroup suggestedEditsURL];
+            URL = [WMFContentGroup suggestedEditsURLForSiteURL:self.siteURL];
         default:
             break;
     }
@@ -524,8 +524,10 @@
     return URL;
 }
 
-+ (nullable NSURL *)suggestedEditsURL {
-    return [[self baseURL] URLByAppendingPathComponent:@"suggested-edits"];
++ (nullable NSURL *)suggestedEditsURLForSiteURL:(NSURL *)siteURL {
+    NSURL *URL = [[self baseURL] URLByAppendingPathComponent:@"suggested-edits"];
+    URL.wmf_languageVariantCode = siteURL.wmf_languageVariantCode;
+    return URL;
 }
 
 - (BOOL)isForLocalDate:(NSDate *)date {

--- a/Wikipedia/Code/WMFSuggestedEditsContentSource.m
+++ b/Wikipedia/Code/WMFSuggestedEditsContentSource.m
@@ -57,7 +57,7 @@
             if (currentUser) {
                 if ((currentUser.editCount > 50 && !currentUser.isBlocked && hasImageRecommendations) || WMFFeatureFlags.forceImageRecommendationsExploreCard) {
 
-                    NSURL *URL = [WMFContentGroup suggestedEditsURL];
+                    NSURL *URL = [WMFContentGroup suggestedEditsURLForSiteURL:appLanguageSiteURL];
 
                     [moc fetchOrCreateGroupForURL:URL ofKind:WMFContentGroupKindSuggestedEdits forDate:[NSDate date] withSiteURL:appLanguageSiteURL associatedContent:nil customizationBlock:nil];
                 }


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
I noticed this assert failure when testing something unrelated in ZH Wiki.

### Test Steps
1. Fresh install experimental app.
2. Set primary language to a ZH Wiki variant in onboarding
3. Wait until the app logs the user in and tries to insert the suggested edits card.
4. Confirm card is successfully inserted without triggering assert, and you can tap on it to get into the feature.
