### PR TITLE
Image recommendations - activate feature flag

### DIFF
--- a/WMF Framework/FeatureFlags.swift
+++ b/WMF Framework/FeatureFlags.swift
@@ -11,30 +11,17 @@ public struct FeatureFlags {
     }
     
     public static var needsImageRecommendations: Bool {
-        
-    #if WMF_STAGING || WMF_EXPERIMENTAL
         return true
-    #else
-        return false
-    #endif
     }
     
     public static var needsImageRecommendationsSuppressPosting: Bool {
-        #if WMF_EXPERIMENTAL
-            return true
-        #else
-            return false
-        #endif
+        return false
     }
 
     // Bypasses card display conditional (50+ edits on primary app wiki, not blocked, wiki has recommendations)
     // This allows for easier design review on Experimental app
     public static var forceImageRecommendationsExploreCard: Bool {
-        #if WMF_EXPERIMENTAL
-            return true
-        #else
-            return false
-        #endif
+        return false
     }
 }
 


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
* This PR activates the image recommendations feature flag and disables the ones used for testing. 
* Following the pattern for the previous flags, I'm not removing but disabling `needsImageRecommendationsSuppressPosting` and `forceImageRecommendationsExploreCard` as they can be handy to test in the future. 

### Test Steps
1. Run the app on the main target on an account with less than 50 edits
2. The explore feed card should not appear
3. Fresh install the app, log into an account with 50+ edits
4. The new feature modal and explore feed card should appear
