### PR TITLE
Present announcement on app foreground

### DIFF
--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -42,6 +42,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         NotificationCenter.default.addObserver(self, selector: #selector(pushNotificationBannerDidDisplayInForeground(_:)), name: .pushNotificationBannerDidDisplayInForeground, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(viewContextDidReset(_:)), name: NSNotification.Name.WMFViewContextDidReset, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(databaseHousekeeperDidComplete), name: .databaseHousekeeperDidComplete, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(applicationDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
     
     @objc var isGranularUpdatingEnabled: Bool = true {
@@ -1165,6 +1166,11 @@ extension ExploreViewController {
         dataStore.remoteNotificationsController.loadNotifications(force: true)
     }
 
+    @objc func applicationDidBecomeActive() {
+        if !UIAccessibility.isVoiceOverRunning {
+            presentImageRecommendationsFeatureAnnouncementIfNeeded()
+        }
+    }
 }
 
 extension ExploreViewController: WKImageRecommendationsDelegate {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T358894#9762158

### Notes
Adds presenting of feature announcement on app foreground.

### Test Steps
1. Fresh install app.
2. Dismiss any initial modals that present on Explore
3. When suggested edits card appears, background app.
4. Foreground app
5. Confirm feature announcement modal appears.
6. Terminate app
7. Relaunch app.
8. Confirm you cannot trigger feature announcement again.

### Screenshots/Videos

