### PR TITLE
Remove underscores and html strings from add image details view

### DIFF
--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -1213,7 +1213,11 @@ extension ExploreViewController: WKImageRecommendationsDelegate {
         
         if let imageURL = URL(string: imageData.descriptionURL),
            let thumbURL = URL(string: imageData.thumbUrl) {
-            let searchResult = InsertMediaSearchResult(fileTitle: "File:\(imageData.filename)", displayTitle: imageData.filename, thumbnailURL: thumbURL, imageDescription: imageData.description,  filePageURL: imageURL)
+            
+            let fileName = imageData.filename.normalizedPageTitle ?? imageData.filename
+            let imageDescription = imageData.description?.removingHTML
+            let searchResult = InsertMediaSearchResult(fileTitle: "File:\(imageData.filename)", displayTitle: fileName, thumbnailURL: thumbURL, imageDescription: imageDescription,  filePageURL: imageURL)
+            
             let insertMediaViewController = InsertMediaSettingsViewController(image: image, searchResult: searchResult, fromImageRecommendations: true, delegate: self, imageRecLoggingDelegate: self, theme: theme)
             self.imageRecommendationsViewModel = viewModel
             navigationController?.pushViewController(insertMediaViewController, animated: true)

--- a/Wikipedia/Code/InsertMediaSettingsViewController.swift
+++ b/Wikipedia/Code/InsertMediaSettingsViewController.swift
@@ -151,7 +151,7 @@ final class InsertMediaSettingsViewController: ViewController {
     private lazy var imageView: InsertMediaSettingsImageView = {
         let imageView = InsertMediaSettingsImageView.wmf_viewFromClassNib()!
         imageView.image = image
-        imageView.imageDescription = searchResult.imageDescription
+        imageView.imageDescription = searchResult.imageDescription ?? searchResult.imageInfo?.imageDescription
         imageView.title = searchResult.displayTitle
         imageView.titleURL = imageTitle
         imageView.titleAction = { [weak self] url in


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T363944

### Notes
Removes underscores and html tags from image information before showing "Add image details" view. Also ensure the image description is displayed from the editor flow.

### Test Steps
1. Go to "Add image details" view in recommendations flow.
2. Confirm image title and description does not show underscores or html tags.
3. From editor flow, tap image wizard. Tap through until you reach the "Media settings" view. Confirm image description shows beneath image url.

