### PR TITLE
Edit summary - Capture watchlist toggle state in logging

### DIFF
--- a/Wikipedia/Code/EditInteractionFunnel.swift
+++ b/Wikipedia/Code/EditInteractionFunnel.swift
@@ -178,10 +178,11 @@ final class EditInteractionFunnel {
         logEvent(activeInterface: .articleEditPreview, action: .previewNext, project: project)
     }
     
-    func logArticleEditSummaryDidTapPublish(summaryAdded: Bool, minorEdit: Bool, project: WikimediaProject) {
+    func logArticleEditSummaryDidTapPublish(summaryAdded: Bool, minorEdit: Bool, watchlistAdded: Bool, project: WikimediaProject) {
         
         let actionData = ["summary_added": String(summaryAdded),
-                          "minor_edit": String(minorEdit)]
+                          "minor_edit": String(minorEdit),
+                          "watchlist_added": String(watchlistAdded)]
         
         logEvent(activeInterface: .articleEditSummary, action: .saveAttempt, actionData: actionData, project: project)
     }

--- a/Wikipedia/Code/EditSaveViewController.swift
+++ b/Wikipedia/Code/EditSaveViewController.swift
@@ -367,8 +367,7 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
             
         }
         
-        let isWatchlist = addToWatchlistToggle.isOn
-        imageRecLoggingDelegate?.logEditSaveViewControllerDidTapPublish(minorEditEnabled: isMinor, watchlistEnabled: isWatchlist)
+        imageRecLoggingDelegate?.logEditSaveViewControllerDidTapPublish(minorEditEnabled: isMinor, watchlistEnabled: isWatched)
         
         EditAttemptFunnel.shared.logSaveAttempt(pageURL: editURL)
         

--- a/Wikipedia/Code/EditSaveViewController.swift
+++ b/Wikipedia/Code/EditSaveViewController.swift
@@ -16,7 +16,7 @@ protocol EditSaveViewControllerDelegate: NSObjectProtocol {
 
 protocol EditSaveViewControllerPageEditorLoggingDelegate: AnyObject {
     func logEditSaveViewControllerDidTapShowWebPreview()
-    func logEditSaveViewControllerDidTapPublish(source: PageEditorViewController.Source, summaryAdded: Bool, isMinor: Bool, project: WikimediaProject)
+    func logEditSaveViewControllerDidTapPublish(source: PageEditorViewController.Source, summaryAdded: Bool, isMinor: Bool, isWatched: Bool, project: WikimediaProject)
     func logEditSaveViewControllerPublishSuccess(source: PageEditorViewController.Source, revisionID: UInt64, project: WikimediaProject)
     func logEditSaveViewControllerPublishFailed(source: PageEditorViewController.Source, problemSource: EditInteractionFunnel.ProblemSource?, project: WikimediaProject)
     func logEditSaveViewControllerDidTapBlockedMessageLink(source: PageEditorViewController.Source, project: WikimediaProject)
@@ -356,13 +356,14 @@ class EditSaveViewController: WMFScrollViewController, Themeable, UITextFieldDel
         }
         
         let isMinor = minorEditToggle.isOn
+        let isWatched = addToWatchlistToggle.isOn
         
         if let source,
            let pageURL,
         let project = WikimediaProject(siteURL: pageURL) {
             let summaryAdded = !summaryText.isEmpty
             
-            pageEditorLoggingDelegate?.logEditSaveViewControllerDidTapPublish(source: source, summaryAdded: summaryAdded, isMinor: isMinor, project: project)
+            pageEditorLoggingDelegate?.logEditSaveViewControllerDidTapPublish(source: source, summaryAdded: summaryAdded, isMinor: isMinor, isWatched: isWatched, project: project)
             
         }
         

--- a/Wikipedia/Code/PageEditorViewController.swift
+++ b/Wikipedia/Code/PageEditorViewController.swift
@@ -970,10 +970,10 @@ extension PageEditorViewController: EditSaveViewControllerDelegate {
 // MARK: - EditSaveViewControllerPageEditorLoggingDelegate
 
 extension PageEditorViewController: EditSaveViewControllerPageEditorLoggingDelegate {
-    func logEditSaveViewControllerDidTapPublish(source: Source, summaryAdded: Bool, isMinor: Bool, project: WikimediaProject) {
+    func logEditSaveViewControllerDidTapPublish(source: Source, summaryAdded: Bool, isMinor: Bool, isWatched: Bool, project: WikimediaProject) {
         switch source {
         case .article:
-            EditInteractionFunnel.shared.logArticleEditSummaryDidTapPublish(summaryAdded: summaryAdded, minorEdit: isMinor, project: project)
+            EditInteractionFunnel.shared.logArticleEditSummaryDidTapPublish(summaryAdded: summaryAdded, minorEdit: isMinor, watchlistAdded: isWatched, project: project)
         case .talk:
             EditInteractionFunnel.shared.logTalkEditSummaryDidTapPublish(summaryAdded: summaryAdded, minorEdit: isMinor, project: project)
         }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T354219#9765698

### Notes


### Test Steps
1. On Test Wiki, edit and publish an article. Toggle on watchlist when publishing.
2. Confirm you see an event logged in the console with `active_interface` = `article_edit_summary`, `action` = `save_attempt`, and `action_data` contains `watchlist_added: true`.