### PR TITLE
Image recommendations - search field when opening image link fixed

### DIFF
--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -1203,6 +1203,7 @@ extension ExploreViewController: WKImageRecommendationsDelegate {
     func imageRecommendationsUserDidTapImageLink(commonsURL: URL) {
         navigate(to: commonsURL, useSafari: false)
         ImageRecommendationsFunnel.shared.logCommonsWebViewDidAppear()
+        navigationController?.setNavigationBarHidden(true, animated: false)
     }
 
     func imageRecommendationsUserDidTapInsertImage(viewModel: WKImageRecommendationsViewModel, title: String, with imageData: WKImageRecommendationsViewModel.WKImageRecommendationData) {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T363942

### Notes
* [Here](https://github.com/wikimedia/wikipedia-ios/blob/08f5693881a6d0fac23e649643f673a3fb4e724e/Components/Sources/Components/Components/Suggested%20Edits/Image%20Recommendations/WKImageRecommendationsViewController.swift#L134) we are setting the navigation bar to be visible for the controller, but we were missing toggling it back when opening an image link.

### Test Steps
1. Toggle [this boolean](https://github.com/wikimedia/wikipedia-ios/blob/08f5693881a6d0fac23e649643f673a3fb4e724e/WMF%20Framework/FeatureFlags.swift#L24) for being able to get offered the image recommendations feature
2. Log-in
3. Tap on the "Add an image" card
4. Tap on the image link
5. Tap on the search navigation bar icon

### Screenshots/Videos

| Before | After |
| ------ | ----- |
| ![before](https://github.com/wikimedia/wikipedia-ios/assets/34898507/db42d969-3764-444c-bce2-b0dcb44917ce) | ![after](https://github.com/wikimedia/wikipedia-ios/assets/34898507/eb4708a3-7215-4bd8-a8a7-9a070e5f9819) |




