### PR TITLE
Restore image recs edit summary comment

### DIFF
--- a/WKData/Sources/WKData/Models/Shared/WKEditSummaryTag.swift
+++ b/WKData/Sources/WKData/Models/Shared/WKEditSummaryTag.swift
@@ -12,4 +12,5 @@ public enum WKEditSummaryTag: String {
     case diffRollback = "#diff-rollback"
     case talkReply = "#talk-reply"
     case talkTopic = "#talk-topic"
+    case suggestedEditsAddImageTop = "#app-image-add-top"
 }

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -1276,6 +1276,7 @@ extension ExploreViewController: EditPreviewViewControllerDelegate {
         saveVC.wikitext = editPreviewViewController.wikitext
         saveVC.cannedSummaryTypes = [.addedImage, .addedImageAndCaption]
         saveVC.needsSuppressPosting = FeatureFlags.needsImageRecommendationsSuppressPosting
+        saveVC.editSummaryTag = .suggestedEditsAddImageTop
 
         saveVC.delegate = self
         saveVC.imageRecLoggingDelegate = self

--- a/Wikipedia/Code/ImageRecommendationsFunnel.swift
+++ b/Wikipedia/Code/ImageRecommendationsFunnel.swift
@@ -224,7 +224,7 @@ final class ImageRecommendationsFunnel: NSObject {
     
     func logSaveChangesPublishSuccess(timeSpent: Int?, revisionID: Int, captionAdded: Bool, altTextAdded: Bool, summaryAdded: Bool) {
         var actionData = ["revision_id": "\(revisionID)",
-                          "capion_add": "\(captionAdded)",
+                          "caption_add": "\(captionAdded)",
                           "alt_text_add": "\(altTextAdded)",
                           "summary_add": "\(summaryAdded)"]
         if let timeSpent {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T366639

### Notes
This adds the edit summary comment back into the image recommendations flow.

### Test Steps
1. Complete the image recommendations flow. Look at revision history after publishing and confirm `#app-image-add-top` is added to the end of the edit summary.

