### PR TITLE
Fix missing wiki_id

### DIFF
--- a/Wikipedia/Code/ImageRecommendationsFunnel.swift
+++ b/Wikipedia/Code/ImageRecommendationsFunnel.swift
@@ -285,6 +285,6 @@ final class ImageRecommendationsFunnel: NSObject {
     }
 
     func logDialogWarningMessageDidDisplay() {
-        logEvent(activeInterface: .recommendedImageToolbar, action: .warning)
+        logEvent(activeInterface: .recommendedImageToolbar, action: .warning, project: project)
     }
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T364049

### Notes
The endpoint was failing without this.

### Test Steps
1. Watch traffic while image recommendations warning goes out, confirm response is 201. 

