### PR TITLE
Add filename and recommendation_source to warning action data

### DIFF
--- a/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsBottomSheetViewController.swift
+++ b/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsBottomSheetViewController.swift
@@ -90,7 +90,11 @@ extension WKImageRecommendationsBottomSheetViewController: WKImageRecommendation
             let timeInterval = currentTime.timeIntervalSince(startTime)
             if timeInterval <= 5 {
                 delegate?.imageRecommendationsDidTriggerTimeWarning()
-                loggingDelegate?.logDialogWarningMessageDidDisplay()
+                
+                if let currentRecommendation = viewModel.currentRecommendation {
+                    loggingDelegate?.logDialogWarningMessageDidDisplay(fileName: currentRecommendation.imageData.filename, recommendationSource: currentRecommendation.imageData.source)
+                }
+                
                 return
             }
 

--- a/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsViewController.swift
+++ b/Components/Sources/Components/Components/Suggested Edits/Image Recommendations/WKImageRecommendationsViewController.swift
@@ -33,7 +33,7 @@ public protocol WKImageRecommendationsLoggingDelegate: AnyObject {
     func logRejectSurveyDidTapSubmit(rejectionReasons: [String], otherReason: String?, fileName: String, recommendationSource: String)
     func logEmptyStateDidAppear()
     func logEmptyStateDidTapBack()
-    func logDialogWarningMessageDidDisplay()
+    func logDialogWarningMessageDidDisplay(fileName: String, recommendationSource: String)
 }
 
 fileprivate final class WKImageRecommendationsHostingViewController: WKComponentHostingController<WKImageRecommendationsView> {

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -1430,8 +1430,8 @@ extension ExploreViewController: WKImageRecommendationsLoggingDelegate {
         ImageRecommendationsFunnel.shared.logBottomSheetDidAppear()
     }
 
-    func logDialogWarningMessageDidDisplay() {
-        ImageRecommendationsFunnel.shared.logDialogWarningMessageDidDisplay()
+    func logDialogWarningMessageDidDisplay(fileName: String, recommendationSource: String) {
+        ImageRecommendationsFunnel.shared.logDialogWarningMessageDidDisplay(fileName: fileName, recommendationSource: recommendationSource)
     }
 
     func logBottomSheetDidTapYes() {

--- a/Wikipedia/Code/ImageRecommendationsFunnel.swift
+++ b/Wikipedia/Code/ImageRecommendationsFunnel.swift
@@ -284,7 +284,13 @@ final class ImageRecommendationsFunnel: NSObject {
         logEvent(activeInterface: .editSummaryDialog, action: .saveFailure, actionData: actionData, project: project)
     }
 
-    func logDialogWarningMessageDidDisplay() {
-        logEvent(activeInterface: .recommendedImageToolbar, action: .warning, project: project)
+    func logDialogWarningMessageDidDisplay(fileName: String, recommendationSource: String) {
+        
+        let actionData: [String: String] = [
+            "filename": "\(fileName)",
+            "recommendation_source": "\(recommendationSource)"
+        ]
+        
+        logEvent(activeInterface: .recommendedImageToolbar, action: .warning, actionData: actionData, project: project)
     }
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T364049

### Notes
One more fix needed

### Test Steps
1. Trigger warning. Watch traffic and confirm `action_data` with `filename` and `recommendation_source` is sent.

### Screenshots/Videos

