### PR TITLE
Add JS confirm support for Account Vanishing

### DIFF
--- a/Wikipedia/Code/SinglePageWebViewController.swift
+++ b/Wikipedia/Code/SinglePageWebViewController.swift
@@ -61,6 +61,7 @@ class SinglePageWebViewController: ViewController {
     private lazy var webView: WKWebView = {
         let webView = WKWebView(frame: UIScreen.main.bounds, configuration: webViewConfiguration)
         webView.navigationDelegate = self
+        webView.uiDelegate = self
         return webView
     }()
     
@@ -272,5 +273,22 @@ extension SinglePageWebViewController: WKNavigationDelegate {
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         fakeProgressController.finish()
+    }
+}
+
+extension SinglePageWebViewController: WKUIDelegate {
+    func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
+        
+        let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let action1 = UIAlertAction(title: CommonStrings.okTitle, style: .default) { _ in
+            completionHandler(true)
+        }
+        let action2 = UIAlertAction(title: CommonStrings.cancelActionTitle, style: .default) { _ in
+            completionHandler(false)
+        }
+        alertController.addAction(action1)
+        alertController.addAction(action2)
+        
+        present(alertController, animated: true)
     }
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T369628

### Notes
The new account vanishing form will have a confirmation popup before submitting. We need to add extra handling for this to work.

### Test Steps
1. For a test account, go to the new Vanishing form. You should see a native confirmation modal when you submit the form. Tapping OK submits the form, tapping cancel backs out.
