### PR TITLE
Fix warnings and logs

### DIFF
--- a/Components/Sources/Components/Components/Shared/Buttons/WKButton.swift
+++ b/Components/Sources/Components/Components/Shared/Buttons/WKButton.swift
@@ -1,3 +1,0 @@
-import UIKit
-
-public class WKButton: UIButton {}

--- a/Components/Sources/Components/Components/Shared/Buttons/WKSmallMenuButton.swift
+++ b/Components/Sources/Components/Components/Shared/Buttons/WKSmallMenuButton.swift
@@ -52,10 +52,14 @@ public class WKSmallMenuButton: WKComponentView {
 
     // MARK: - UI Elements
 
-    private lazy var button: WKButton = {
-        let button = WKButton(type: .custom)
+    private lazy var button: UIButton = {
+        let buttonConfig = createButtonConfig()
+        
+        let button = UIButton(configuration: buttonConfig, primaryAction: nil)
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.showsMenuAsPrimaryAction = true
         button.addTarget(self, action: #selector(userDidTap), for: .touchDown)
+        button.menu = generateMenu()
         return button
     }()
 
@@ -73,7 +77,8 @@ public class WKSmallMenuButton: WKComponentView {
 
     public func updateTitle(_ title: String?) {
         configuration.title = title
-        configure()
+        let buttonConfig = createButtonConfig()
+        button.configuration = buttonConfig
     }
 
 	// MARK: - Setup
@@ -90,34 +95,6 @@ public class WKSmallMenuButton: WKComponentView {
             button.topAnchor.constraint(equalTo: topAnchor),
             button.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
-
-        button.showsMenuAsPrimaryAction = true
-
-        configure()
-    }
-
-    private func configure() {
-        button.menu = generateMenu()
-        button.backgroundColor = theme[keyPath: configuration.primaryColor].withAlphaComponent(0.15)
-        button.tintColor = theme[keyPath: configuration.primaryColor]
-        button.setTitleColor(theme[keyPath: configuration.primaryColor], for: .normal)
-        button.titleLabel?.font = WKFont.for(.boldFootnote)
-        button.setTitle(configuration.title, for: .normal)
-        button.setImage(configuration.image, for: .normal)
-
-        button.adjustsImageSizeForAccessibilityContentSizeCategory = true
-        button.adjustsImageWhenHighlighted = false
-
-        button.layer.cornerRadius = 8
-        button.layer.cornerCurve = .continuous
-
-        if effectiveUserInterfaceLayoutDirection == .leftToRight {
-            button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 4, bottom: 0, right: -8)
-            button.contentEdgeInsets = UIEdgeInsets(top: 6, left: 8, bottom: 8, right: 16)
-        } else {
-            button.titleEdgeInsets = UIEdgeInsets(top: 0, left: -8, bottom: 0, right: 4)
-            button.contentEdgeInsets = UIEdgeInsets(top: 6, left: 16, bottom: 8, right: 8)
-        }
     }
 
     private func generateMenu() -> UIMenu {
@@ -132,13 +109,37 @@ public class WKSmallMenuButton: WKComponentView {
 
         return UIMenu(children: actions)
     }
+    
+    private func createButtonConfig() -> UIButton.Configuration {
+        
+        var buttonConfig = UIButton.Configuration.filled()
+        buttonConfig.image = configuration.image
+        buttonConfig.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 13)
+        buttonConfig.imagePadding = 8
+        buttonConfig.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
+
+        var container = AttributeContainer()
+        container.font = WKFont.for(.boldFootnote)
+        container.foregroundColor = theme[keyPath: configuration.primaryColor]
+        if let title = configuration.title {
+            buttonConfig.attributedTitle = AttributedString(title, attributes: container)
+        }
+
+        buttonConfig.baseForegroundColor = theme[keyPath: configuration.primaryColor]
+        buttonConfig.background.backgroundColor = theme[keyPath: configuration.primaryColor].withAlphaComponent(0.15)
+        
+        buttonConfig.background.cornerRadius = 8
+        buttonConfig.image = configuration.image
+        
+        return buttonConfig
+    }
 
     // MARK: - Button Actions
 
     private func userDidTapMenuItem(_ item: MenuItem) {
         delegate?.wkMenuButton(self, didTapMenuItem: item)
     }
-
+    
     @objc private func userDidTap() {
         delegate?.wkMenuButtonDidTap(self)
     }
@@ -146,6 +147,7 @@ public class WKSmallMenuButton: WKComponentView {
     // MARK: - Component Conformance
 
     public override func appEnvironmentDidChange() {
-        configure()
+        let buttonConfig = createButtonConfig()
+        button.configuration = buttonConfig
     }
 }

--- a/Components/Sources/Components/Components/Shared/Buttons/WKSmallMenuButton.swift
+++ b/Components/Sources/Components/Components/Shared/Buttons/WKSmallMenuButton.swift
@@ -114,8 +114,8 @@ public class WKSmallMenuButton: WKComponentView {
         
         var buttonConfig = UIButton.Configuration.filled()
         buttonConfig.image = configuration.image
-        buttonConfig.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 13)
-        buttonConfig.imagePadding = 8
+        buttonConfig.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: UIFontMetrics.default.scaledValue(for: 13))
+        buttonConfig.imagePadding = 6
         buttonConfig.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
 
         var container = AttributeContainer()

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ When reading logs, note that the log levels are shortened to emoji.
 - 💬 Debug
 - ℹ️ Info
 - ⚠️ Warning
-- 🚨 Error 
+- 🚨 Error
+
+ The app only writes Warning and Error messages to the console for both Debug and Release mode. If you need to log all messages temporarily during troubleshooting, update [this level](https://github.com/wikimedia/wikipedia-ios/blob/main/Wikipedia/Code/WMFLogging.h#L6) to DDLogLevelAll.  
 
 ### Testing
 The **Wikipedia** scheme is configured to execute the project's iOS unit tests, which can be run using the `Cmd+U` hotkey or the **Product → Test** menu bar action. In order for the tests to pass, the test device's language and region must be set to `en-US` in Settings → General → Language & Region. There is a [ticket filed](https://phabricator.wikimedia.org/T259859) to update the tests to pass regardless of language and region.

--- a/WMF Framework/Event Platform/EventPlatformClient.swift
+++ b/WMF Framework/Event Platform/EventPlatformClient.swift
@@ -362,7 +362,6 @@ import CocoaLumberjackSwift
 
         let events = storageManager.popAll()
         if events.count == 0 {
-//            DDLogDebug("EPC: Nothing to send.")
             completion?()
             return
         }
@@ -595,7 +594,7 @@ import CocoaLumberjackSwift
         let userDefaults = UserDefaults.standard
 
         guard let appInstallID = userDefaults.wmf_appInstallId else {
-            DDLogWarn("EPC: App install ID is unset. This shouldn't happen.")
+            DDLogError("EPC: App install ID is unset. This shouldn't happen.")
             return
         }
         
@@ -704,7 +703,7 @@ private extension EventPlatformClient {
         let request = dataStore.session.request(with: url, method: .post, bodyData: body, bodyEncoding: .json)
         let task = dataStore.session.dataTask(with: request, completionHandler: { (_, response, error) in
             let fail: (PostEventError) -> Void = { error in
-                DDLogDebug("EPC: An error occurred sending the request: \(error)")
+                DDLogError("EPC: An error occurred sending the request: \(error)")
                 completion(.failure(error))
             }
             if let error = error {

--- a/WMF Framework/Event Platform/SamplingController.swift
+++ b/WMF Framework/Event Platform/SamplingController.swift
@@ -66,13 +66,13 @@ class SamplingController: NSObject {
         let appInstallID = UserDefaults.standard.wmf_appInstallId
 
         guard identifierType == sessionIdentifierType || identifierType == deviceIdentifierType else {
-            DDLogDebug("EPC: Logged to stream which is not configured for sampling based on \(sessionIdentifierType) or \(deviceIdentifierType) identifier")
+            DDLogWarn("EPC: Logged to stream which is not configured for sampling based on \(sessionIdentifierType) or \(deviceIdentifierType) identifier")
             cacheSamplingForStream(stream, inSample: false)
             return false
         }
 
         guard let identifier = identifierType == sessionIdentifierType ? delegate?.sessionID : appInstallID else {
-            DDLogError("EPC: Missing token for determining in- vs out-of-sample. Falling back to out-of-sample.")
+            DDLogWarn("EPC: Missing token for determining in- vs out-of-sample. Falling back to out-of-sample.")
             cacheSamplingForStream(stream, inSample: false)
             return false
         }

--- a/WMF Framework/Event Platform/StorageManager.swift
+++ b/WMF Framework/Event Platform/StorageManager.swift
@@ -100,21 +100,21 @@ public class StorageManager: NSObject {
         perform { moc in
             do {
                 guard let psc = moc.persistentStoreCoordinator else {
-                    DDLogWarn("EPC: Error getting persistent store coordinator")
+                    DDLogError("EPC: Error getting persistent store coordinator")
                     return
                 }
                 guard let moid = psc.managedObjectID(forURIRepresentation: event.managedObjectURI) else {
-                    DDLogWarn("EPC: Error getting managed object ID for URI \(event.managedObjectURI)")
+                    DDLogError("EPC: Error getting managed object ID for URI \(event.managedObjectURI)")
                     return
                 }
                 guard let record = try moc.existingObject(with: moid) as? EPEventRecord else {
-                    DDLogWarn("EPC: Tried to mark managed object \(moid) as purgeable, but it was not found")
+                    DDLogError("EPC: Tried to mark managed object \(moid) as purgeable, but it was not found")
                     return
                 }
                 record.purgeable = true
                 self.save(moc)
             } catch let error {
-                DDLogError(error.localizedDescription)
+                DDLogError("\(error.localizedDescription)")
             }
 
         }
@@ -148,7 +148,7 @@ public class StorageManager: NSObject {
                 }
 
                 if count > 0 {
-                    DDLogInfo("EPC StorageManager: Pruned \(count) events")
+                    DDLogDebug("EPC StorageManager: Pruned \(count) events")
                 }
 
             } catch let error {

--- a/WMF Framework/Event Platform/StorageManager.swift
+++ b/WMF Framework/Event Platform/StorageManager.swift
@@ -90,7 +90,7 @@ public class StorageManager: NSObject {
                     DDLogDebug("EPC: Found \(count) events awaiting submission")
                 }
             } catch let error {
-                DDLogError(error.localizedDescription)
+                DDLogError("\(error.localizedDescription)")
             }
         }
         return events

--- a/WMF Framework/ImageCacheController.swift
+++ b/WMF Framework/ImageCacheController.swift
@@ -111,7 +111,6 @@ public final class ImageCacheController: CacheController {
                 }
                 
                 self.dataCompletionManager.complete(uniqueKey, enumerator: { (completion) in
-                    // DDLogDebug("complete: \(url) \(token)")
                     switch result {
                     case .success(let result):
                         completion.success(result.data, result.response)

--- a/WMF Framework/LocationManager.swift
+++ b/WMF Framework/LocationManager.swift
@@ -61,7 +61,7 @@ final public class LocationManager: NSObject {
         
         guard authorizationStatus != .notDetermined else {
             authorize(success: startMonitoringLocation)
-            DDLogVerbose("LocationManager - skip monitoring location because status is \(authorizationStatus.rawValue).")
+            DDLogDebug("LocationManager - skip monitoring location because status is \(authorizationStatus.rawValue).")
             return
         }
 
@@ -130,7 +130,7 @@ final public class LocationManager: NSObject {
     private func authorize(success: (() -> Void)? = nil) {
         authorizedCompletion = success
         locationManager.requestWhenInUseAuthorization()
-        DDLogInfo("LocationManager - requesting authorization to access location when in use.")
+        DDLogDebug("LocationManager - requesting authorization to access location when in use.")
     }
 
     // MARK: - Heading
@@ -178,7 +178,7 @@ extension LocationManager: CLLocationManagerDelegate {
 
         self.location = location
         delegate?.locationManager?(self, didUpdate: location)
-        DDLogVerbose("LocationManager - did update location: \(location).")
+        DDLogDebug("LocationManager - did update location: \(location).")
     }
 
     public func locationManager(_ manager: CLLocationManager, didUpdateHeading heading: CLHeading) {
@@ -186,12 +186,12 @@ extension LocationManager: CLLocationManagerDelegate {
 
         self.heading = heading
         delegate?.locationManager?(self, didUpdate: heading)
-        DDLogVerbose("LocationManager - did update heading: \(heading).")
+        DDLogDebug("LocationManager - did update heading: \(heading).")
     }
 
     public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         guard isUpdating else {
-            DDLogVerbose("LocationManager - suppressing error received after call to stop monitoring location: \(error)")
+            DDLogDebug("LocationManager - suppressing error received after call to stop monitoring location: \(error)")
             return
         }
 
@@ -208,7 +208,7 @@ extension LocationManager: CLLocationManagerDelegate {
     
     public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         let status = manager.authorizationStatus
-        DDLogInfo("LocationManager - did change authorization status \(status.rawValue).")
+        DDLogDebug("LocationManager - did change authorization status \(status.rawValue).")
         delegate?.locationManager?(self, didUpdateAuthorized: status.isAuthorized)
 
         if status.isAuthorized {

--- a/WMF Framework/NavigationBar.swift
+++ b/WMF Framework/NavigationBar.swift
@@ -534,7 +534,6 @@ public class NavigationBar: SetupView, FakeProgressReceiving, FakeProgressDelega
         }
         
         setNeedsLayout()
-        // DDLogDebug("nb: \(navigationBarPercentHidden) ev: \(extendedViewPercentHidden)")
         let applyChanges = {
             let changes = {
                 if shadowAlpha >= 0 {

--- a/WMF Framework/ReadingListsAPIController.swift
+++ b/WMF Framework/ReadingListsAPIController.swift
@@ -168,11 +168,11 @@ public class ReadingListsAPIController: Fetcher {
                         self.untrack(taskFor: identifier)
                     }
                     if let apiErrorType = result?["title"] as? String, let apiError = APIReadingListError(rawValue: apiErrorType), apiError != .alreadySetUp {
-                        DDLogDebug("RLAPI FAILED: \(method.stringValue) \(path) \(apiError)")
+                        DDLogError("RLAPI FAILED: \(method.stringValue) \(path) \(apiError)")
                     } else {
                         #if DEBUG
                         if let error = error {
-                            DDLogDebug("RLAPI FAILED: \(method.stringValue) \(path) \(error)")
+                            DDLogError("RLAPI FAILED: \(method.stringValue) \(path) \(error)")
                         } else {
                             DDLogDebug("RLAPI: \(method.stringValue) \(path)")
                         }

--- a/Wikipedia.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Wikipedia.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,17 +5,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
       "state" : {
-        "revision" : "0188d31089b5881a269e01777be74c7316924346",
-        "version" : "3.8.0"
+        "revision" : "4b8714a7fb84d42393314ce897127b3939885ec3",
+        "version" : "3.8.5"
       }
     },
     {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
+      "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "532d8b529501fb73a2455b179e0bbb6d49b652ed",
-        "version" : "1.5.3"
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     }
   ],

--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/Experimental.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/Experimental.xcscheme
@@ -34,6 +34,7 @@
       buildConfiguration = "ExperimentalDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disablePerformanceAntipatternChecker = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/Staging.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/Staging.xcscheme
@@ -34,6 +34,7 @@
       buildConfiguration = "StagingDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disablePerformanceAntipatternChecker = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
@@ -96,6 +96,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disablePerformanceAntipatternChecker = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Wikipedia/Code/AppDelegate.m
+++ b/Wikipedia/Code/AppDelegate.m
@@ -147,7 +147,7 @@ static NSString *const WMFBackgroundDatabaseHousekeeperTaskIdentifier = @"org.wi
 }
 
 - (void)application:(UIApplication *)application didFailToContinueUserActivityWithType:(NSString *)userActivityType error:(NSError *)error {
-    DDLogDebug(@"didFailToContinueUserActivityWithType: %@ error: %@", userActivityType, error);
+    DDLogWarn(@"didFailToContinueUserActivityWithType: %@ error: %@", userActivityType, error);
 }
 
 - (void)application:(UIApplication *)application didUpdateUserActivity:(NSUserActivity *)userActivity {

--- a/Wikipedia/Code/AppDelegate.m
+++ b/Wikipedia/Code/AppDelegate.m
@@ -242,7 +242,7 @@ static NSString *const WMFBackgroundDatabaseHousekeeperTaskIdentifier = @"org.wi
     appRefreshTask.earliestBeginDate = [NSDate dateWithTimeIntervalSinceNow:WMFBackgroundFetchInterval];
     NSError *taskSubmitError = nil;
     if (![[BGTaskScheduler sharedScheduler] submitTaskRequest:appRefreshTask error:&taskSubmitError]) {
-        DDLogError(@"Unable to schedule background task: %@", taskSubmitError);
+        DDLogWarn(@"Unable to schedule background task. This is expected if this is simulator: %@", taskSubmitError);
     }
 }
 
@@ -251,7 +251,7 @@ static NSString *const WMFBackgroundDatabaseHousekeeperTaskIdentifier = @"org.wi
     databaseHousekeeperTask.earliestBeginDate = nil; // Docs indicate nil = no start delay.
     NSError *taskSubmitError = nil;
     if (![[BGTaskScheduler sharedScheduler] submitTaskRequest:databaseHousekeeperTask error:&taskSubmitError]) {
-        DDLogError(@"Unable to schedule background task: %@", taskSubmitError);
+        DDLogWarn(@"Unable to schedule background task. This is expected if this is simulator: %@", taskSubmitError);
     }
 }
 

--- a/Wikipedia/Code/Article as a Living Document/ArticleAsLivingDocController.swift
+++ b/Wikipedia/Code/Article as a Living Document/ArticleAsLivingDocController.swift
@@ -223,7 +223,7 @@ class ArticleAsLivingDocController: NSObject {
                     self.failedLastInitialFetch = true
                 }
                 self.surveyLinkState = .inExperimentFailureLoadingEvents
-                DDLogDebug("Failure getting article as living doc view models: \(error)")
+                DDLogError("Failure getting article as living doc view models: \(error)")
             }
         }
         
@@ -235,7 +235,7 @@ class ArticleAsLivingDocController: NSObject {
                 switch result {
                 case .failure(let error):
                     self.articleAsLivingDocEditMetrics = nil
-                    DDLogDebug("Error fetching edit metrics for article as a living document: \(error)")
+                    DDLogError("Error fetching edit metrics for article as a living document: \(error)")
                 case .success(let timeseriesOfEditCounts):
                     self.articleAsLivingDocEditMetrics = timeseriesOfEditCounts
                 }
@@ -479,7 +479,7 @@ class ArticleAsLivingDocController: NSObject {
 
             switch result {
             case .failure(let error):
-                DDLogDebug("Failure fetching next significant events page \(error)")
+                DDLogError("Failure fetching next significant events page \(error)")
             case .success(let articleAsLivingDocViewModel):
                 self.articleAsLivingDocViewModel = articleAsLivingDocViewModel
             }

--- a/Wikipedia/Code/ArticleViewController+Editing.swift
+++ b/Wikipedia/Code/ArticleViewController+Editing.swift
@@ -154,7 +154,7 @@ extension ArticleViewController: ShortDescriptionControllerDelegate {
         webView.evaluateJavaScript(javascript) { (result, error) in
             DispatchQueue.main.async {
                 if let error = error {
-                    DDLogDebug("Failure in articleHtmlTitleDescription: \(error)")
+                    DDLogWarn("Failure in articleHtmlTitleDescription: \(error)")
                     completion(nil)
                     return
                 }
@@ -199,7 +199,7 @@ extension ArticleViewController: ShortDescriptionControllerDelegate {
         webView.evaluateJavaScript(javascript) { (result, error) in
             DispatchQueue.main.async {
                 if let error = error {
-                    DDLogDebug("Failure in injectNewDescriptionIntoArticleContent: \(error)")
+                    DDLogWarn("Failure in injectNewDescriptionIntoArticleContent: \(error)")
                     completion(.failure(error))
                     return
                 }
@@ -258,7 +258,7 @@ extension ArticleViewController: DescriptionEditViewControllerDelegate {
 
             switch injectResult {
             case .failure(let error):
-                DDLogError("Failure injecting new description into article content, refreshing instead: \(error)")
+                DDLogWarn("Failure injecting new description into article content, refreshing instead: \(error)")
                 self.waitForNewContentAndRefresh(result.newRevisionID)
             case .success:
                 break

--- a/Wikipedia/Code/ArticleViewController+TableOfContents.swift
+++ b/Wikipedia/Code/ArticleViewController+TableOfContents.swift
@@ -8,7 +8,7 @@ extension ArticleViewController : ArticleTableOfContentsDisplayControllerDelegat
                 let sectionId = info["id"] as? Int,
                 let anchor = info["anchor"] as? String
             else {
-                DDLogError("Error getting first on screen section: \(String(describing: error))")
+                DDLogWarn("Error getting first on screen section: \(String(describing: error))")
                 completion(-1, "")
                 return
             }

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -166,7 +166,7 @@ class ArticleViewController: ViewController, HintPresenting {
     func loadLeadImage(with leadImageURL: URL) {
         leadImageHeightConstraint.constant = leadImageHeight
         leadImageView.wmf_setImage(with: leadImageURL, detectFaces: true, onGPU: true, failure: { (error) in
-            DDLogError("Error loading lead image: \(error)")
+            DDLogWarn("Error loading lead image: \(error)")
         }) {
             self.updateLeadImageMargins()
             self.updateArticleMargins()
@@ -506,7 +506,7 @@ class ArticleViewController: ViewController, HintPresenting {
                 case .success(let itemKeys):
                     DDLogDebug("successfully synced \(itemKeys.count) resources")
                 case .failure(let error):
-                    DDLogDebug("failed to synced resources for \(groupKey): \(error)")
+                    DDLogError("failed to synced resources for \(groupKey): \(error)")
                 }
             }
         }

--- a/Wikipedia/Code/ArticleWebMessagingController.swift
+++ b/Wikipedia/Code/ArticleWebMessagingController.swift
@@ -74,7 +74,7 @@ class ArticleWebMessagingController: NSObject {
         }
         webView?.evaluateJavaScript("pcs.c1.Footer.add(\(parametersJS))", completionHandler: { (result, error) in
             if let error = error {
-                DDLogError("Error adding footer: \(error)")
+                DDLogWarn("Error adding footer: \(error)")
             }
         })
     }
@@ -134,7 +134,7 @@ class ArticleWebMessagingController: NSObject {
         }
         webView.evaluateJavaScript("pcs.c1.Page.prepareForScrollToAnchor(`\(anchor.sanitizedForJavaScriptTemplateLiterals)`, {highlight: \(highlight ? "true" : "false")})") { (result, error) in
             if let error = error {
-                DDLogError("Error attempting to scroll to anchor: \(anchor) \(error)")
+                DDLogWarn("Error attempting to scroll to anchor: \(anchor) \(error)")
                 completion(.failure(error))
             } else {
                 completion(.success(()))
@@ -486,20 +486,20 @@ extension ArticleWebMessagingController {
         webView?.evaluateJavaScript(javascript) { (result, error) in
             DispatchQueue.main.async {
                 if let error = error {
-                    DDLogDebug("Failure in removeSkeletonArticleAsLivingDocContent: \(error)")
+                    DDLogWarn("Failure in removeSkeletonArticleAsLivingDocContent: \(error)")
                     completion?(false)
                     return
                 }
                 
                 if let boolResult = result as? Bool {
                     if !boolResult {
-                        DDLogDebug("Failure in removeSkeletonArticleAsLivingDocContent")
+                        DDLogWarn("Failure in removeSkeletonArticleAsLivingDocContent")
                     }
                     completion?(boolResult)
                     return
                 }
                 
-                DDLogDebug("Failure in removeSkeletonArticleAsLivingDocContent")
+                DDLogWarn("Failure in removeSkeletonArticleAsLivingDocContent")
                 completion?(false)
             }
         }
@@ -525,20 +525,20 @@ extension ArticleWebMessagingController {
         webView?.evaluateJavaScript(javascript) { (result, error) in
             DispatchQueue.main.async {
                 if let error = error {
-                    DDLogDebug("Failure in injectSkeletonArticleAsLivingDocContent: \(error)")
+                    DDLogWarn("Failure in injectSkeletonArticleAsLivingDocContent: \(error)")
                     completion?(false)
                     return
                 }
                 
                 if let boolResult = result as? Bool {
                     if !boolResult {
-                        DDLogDebug("Failure in injectSkeletonArticleAsLivingDocContent")
+                        DDLogWarn("Failure in injectSkeletonArticleAsLivingDocContent")
                     }
                     completion?(boolResult)
                     return
                 }
                 
-                DDLogDebug("Failure in injectSkeletonArticleAsLivingDocContent")
+                DDLogWarn("Failure in injectSkeletonArticleAsLivingDocContent")
                 completion?(false)
             }
         }
@@ -659,20 +659,20 @@ extension ArticleWebMessagingController {
         webView?.evaluateJavaScript(finalInjectJS) { (result, error) in
             DispatchQueue.main.async {
                 if let error = error {
-                    DDLogDebug("Failure in injectArticleAsLivingDocContent: \(error)")
+                    DDLogWarn("Failure in injectArticleAsLivingDocContent: \(error)")
                     completion?(false)
                     return
                 }
                 
                 if let boolResult = result as? Bool {
                     if !boolResult {
-                        DDLogDebug("Failure in injectArticleAsLivingDocContent")
+                        DDLogWarn("Failure in injectArticleAsLivingDocContent")
                     }
                     completion?(boolResult)
                     return
                 }
                 
-                DDLogDebug("Failure in injectArticleAsLivingDocContent")
+                DDLogWarn("Failure in injectArticleAsLivingDocContent")
                 completion?(false)
             }
         }
@@ -703,12 +703,12 @@ extension ArticleWebMessagingController {
         """
         webView?.evaluateJavaScript(javascript) { (success, error) in
             if let error = error {
-                DDLogDebug("Failure in customUpdateMargins: \(error)")
+                DDLogWarn("Failure in customUpdateMargins: \(error)")
             }
             
             if let success = success as? Bool,
                success == false {
-                DDLogDebug("Failure in customUpdateMargins")
+                DDLogWarn("Failure in customUpdateMargins")
             }
         }
     }

--- a/Wikipedia/Code/DiffHeaderView.swift
+++ b/Wikipedia/Code/DiffHeaderView.swift
@@ -68,7 +68,7 @@ final class DiffHeaderView: SetupView {
 
         if let leadImageURL = viewModel?.imageURL {
             imageView.wmf_setImage(with: leadImageURL, detectFaces: true, onGPU: true, failure: { (error) in
-                DDLogError("Failure loading diff header image: \(error)")
+                DDLogWarn("Failure loading diff header image: \(error)")
             }, success: { [weak self] in
                 self?.imageView.isHidden = false
             })

--- a/Wikipedia/Code/EditorViewController.swift
+++ b/Wikipedia/Code/EditorViewController.swift
@@ -887,7 +887,7 @@ extension EditorViewController: EditLinkViewControllerDelegate {
     }
     
     func editLinkViewController(_ editLinkViewController: EditLinkViewController, didFailToExtractArticleTitleFromArticleURL articleURL: URL) {
-        DDLogError("Failed to extract article title from \(pageURL)")
+        DDLogWarn("Failed to extract article title from \(pageURL)")
         dismiss(animated: true)
     }
     

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -150,7 +150,7 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
     NSError *unarchiveError = nil;
     NSMutableDictionary *infoDictionary = [[self unarchivedDictionaryFromFileURL:infoDictionaryURL error:&unarchiveError] mutableCopy] ?: [NSMutableDictionary new];
     if (unarchiveError) {
-        DDLogError(@"Error unarchiving shared info dictionary: %@", unarchiveError);
+        DDLogDebug(@"Error unarchiving shared info dictionary, possibly because this is a fresh install and it doesn't exist yet: %@", unarchiveError);
     }
 
     BOOL needsWrite = false;

--- a/Wikipedia/Code/PlacesViewController.swift
+++ b/Wikipedia/Code/PlacesViewController.swift
@@ -660,7 +660,7 @@ class PlacesViewController: ViewController, UISearchBarDelegate, ArticlePopoverV
     
     func showDidYouMeanButton(search: PlaceSearch) {
         guard let description = search.localizedDescription else {
-            DDLogError("Could not show Did You Mean button = no description for search:\n\(search)")
+            DDLogWarn("Could not show Did You Mean button = no description for search:\n\(search)")
             return
         }
         
@@ -699,7 +699,7 @@ class PlacesViewController: ViewController, UISearchBarDelegate, ArticlePopoverV
         }
         
         wikidataFetcher.wikidataBoundingRegion(forArticleURL: articleURL, failure: { (error) in
-            DDLogError("Error fetching bounding region from Wikidata: \(error)")
+            DDLogWarn("Error fetching bounding region from Wikidata: \(error)")
             fail()
         }, success: { (region) in
             DispatchQueue.main.async {
@@ -820,7 +820,7 @@ class PlacesViewController: ViewController, UISearchBarDelegate, ArticlePopoverV
         }
         
         guard let search = self.didYouMeanSearch else {
-            DDLogError("Did You Mean search is unset")
+            DDLogWarn("Did You Mean search is unset")
             return
         }
         SearchFunnel.shared.logSearchDidYouMean(source: "places")

--- a/Wikipedia/Code/SavedArticlesFetcher.swift
+++ b/Wikipedia/Code/SavedArticlesFetcher.swift
@@ -198,7 +198,7 @@ private extension SavedArticlesFetcher {
                 DispatchQueue.main.async {
                     switch groupResult {
                     case .success(let itemKeys):
-                        DDLogInfo("Successfully saved all items for \(articleKey), itemKeyCount: \(itemKeys.count)")
+                        DDLogDebug("Successfully saved all items for \(articleKey), itemKeyCount: \(itemKeys.count)")
                         self.didFetchArticle(with: articleObjectID)
                         self.spotlightManager.addToIndex(url: articleURL as NSURL)
                         self.updateCountOfFetchesInProcess()
@@ -250,7 +250,7 @@ private extension SavedArticlesFetcher {
                     DispatchQueue.main.async {
                         switch groupResult {
                         case .success:
-                            DDLogInfo("Successfully removed all items for \(articleKey)")
+                            DDLogDebug("Successfully removed all items for \(articleKey)")
                             self.spotlightManager.removeFromIndex(url: articleURL as NSURL)
                         case .failure(let error):
                             DDLogError("Failed removing items for \(articleKey): \(error)")

--- a/Wikipedia/Code/ShiftingTopView.swift
+++ b/Wikipedia/Code/ShiftingTopView.swift
@@ -26,7 +26,7 @@ class ShiftingTopView: SetupView {
         super.layoutSubviews()
 
         if stackView == nil {
-            DDLogError("Missing stackView assignment in ShiftingSubview, which could potentially cause incorrect content inset/padding calculations.")
+            DDLogWarn("Missing stackView assignment in ShiftingSubview, which could potentially cause incorrect content inset/padding calculations.")
         }
         stackView?.calculateTotalHeight()
     }

--- a/Wikipedia/Code/SinglePageWebViewController.swift
+++ b/Wikipedia/Code/SinglePageWebViewController.swift
@@ -259,13 +259,13 @@ extension SinglePageWebViewController: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        DDLogError("Error loading single page - did fail provisional navigation: \(error)")
+        DDLogWarn("Error loading single page - did fail provisional navigation: \(error)")
         WMFAlertManager.sharedInstance.showErrorAlert(error as NSError, sticky: false, dismissPreviousAlerts: true)
         fakeProgressController.finish()
     }
     
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        DDLogError("Error loading single page: \(error)")
+        DDLogWarn("Error loading single page: \(error)")
         WMFAlertManager.sharedInstance.showErrorAlert(error as NSError, sticky: false, dismissPreviousAlerts: false)
         fakeProgressController.finish()
     }

--- a/Wikipedia/Code/TableOfContentsAnimator.swift
+++ b/Wikipedia/Code/TableOfContentsAnimator.swift
@@ -273,7 +273,7 @@ class TableOfContentsAnimator: UIPercentDrivenInteractiveTransition, UIViewContr
             let transitionProgress = max(min(translation.x * tocMultiplier / self.presentedViewController!.view.bounds.maxX, 0.99), 0.01)
         
             self.update(transitionProgress)
-            DDLogVerbose("TOC transition progress: \(transitionProgress)")
+            DDLogDebug("TOC transition progress: \(transitionProgress)")
         case .ended:
             self.isInteractive = false
             let velocityRequiredToPresent = -gesture.view!.bounds.width * tocMultiplier

--- a/Wikipedia/Code/TalkPageHeaderView.swift
+++ b/Wikipedia/Code/TalkPageHeaderView.swift
@@ -326,7 +326,7 @@ final class TalkPageHeaderView: SetupView {
         
         if let leadImageURL = viewModel.leadImageURL {
             imageView.wmf_setImage(with: leadImageURL, detectFaces: true, onGPU: true, failure: { (error) in
-                DDLogError("Failure loading talk page header image: \(error)")
+                DDLogWarn("Failure loading talk page header image: \(error)")
             }, success: { [weak self] in
                 self?.imageView.isHidden = false
             })

--- a/Wikipedia/Code/TalkPageTopicComposeViewController+TalkPageFormattingToolbar.swift
+++ b/Wikipedia/Code/TalkPageTopicComposeViewController+TalkPageFormattingToolbar.swift
@@ -64,7 +64,7 @@ extension TalkPageTopicComposeViewController: EditLinkViewControllerDelegate {
     }
 
     func editLinkViewController(_ editLinkViewController: EditLinkViewController, didFailToExtractArticleTitleFromArticleURL articleURL: URL) {
-        DDLogError("Failed to extract article title from \(articleURL)")
+        DDLogWarn("Failed to extract article title from \(articleURL)")
         dismiss(animated: true)
     }
 

--- a/Wikipedia/Code/TalkPageViewController+TalkPageFormattingToolbar.swift
+++ b/Wikipedia/Code/TalkPageViewController+TalkPageFormattingToolbar.swift
@@ -72,7 +72,7 @@ extension TalkPageViewController: EditLinkViewControllerDelegate {
     }
 
     func editLinkViewController(_ editLinkViewController: EditLinkViewController, didFailToExtractArticleTitleFromArticleURL articleURL: URL) {
-        DDLogError("Failed to extract article title from \(articleURL)")
+        DDLogWarn("Failed to extract article title from \(articleURL)")
         dismiss(animated: true)
     }
 

--- a/Wikipedia/Code/TalkPageViewModel.swift
+++ b/Wikipedia/Code/TalkPageViewModel.swift
@@ -211,12 +211,12 @@ final class TalkPageViewModel {
         for topic in cleanTopics {
             
             guard let topicTitleHtml = topic.html else {
-                DDLogWarn("Missing topic title. Skipping topic.")
+                DDLogDebug("Missing topic title. Skipping topic.")
                 continue
             }
             
             guard let topicName = topic.name else {
-                DDLogError("Unable to parse topic name")
+                DDLogWarn("Unable to parse topic name")
                 continue
             }
             
@@ -231,14 +231,14 @@ final class TalkPageViewModel {
             
             // Parse through topic replies and set up comment view models
             guard let firstReply = topic.replies.first else {
-                DDLogWarn("Unable to parse lead comment. Skipping topic.")
+                DDLogDebug("Unable to parse lead comment. Skipping topic.")
                 continue
             }
             
             let firstReplyHtml = firstReply.html
             
             guard let leadCommentViewModel = TalkPageCellCommentViewModel(commentId: firstReply.id, html: firstReplyHtml, author: firstReply.author, authorTalkPageURL: "", timestamp: firstReply.timestamp, replyDepth: firstReply.level, talkPageURL: getTalkPageURL(encoded: false)) else {
-                DDLogWarn("Unable to parse lead comment. Skipping topic.")
+                DDLogDebug("Unable to parse lead comment. Skipping topic.")
                 continue
             }
             

--- a/Wikipedia/Code/WKWebView+EditSelectionJavascript.swift
+++ b/Wikipedia/Code/WKWebView+EditSelectionJavascript.swift
@@ -11,7 +11,7 @@ extension WKWebView {
             let isSelectedTextInTitleDescription = dictionary["isSelectedTextInTitleDescription"] as? Bool,
             let sectionID = dictionary["sectionID"] as? Int
             else {
-                DDLogError("Error converting dictionary to SelectedTextEditInfo")
+                DDLogWarn("Error converting dictionary to SelectedTextEditInfo")
                 return nil
         }
         let descriptionSource: ArticleDescriptionSource?
@@ -34,14 +34,14 @@ extension WKWebView {
                     let resultDict = result as? [String: Any],
                     let selectedTextEditInfo = self?.selectedTextEditInfo(from: resultDict)
                 else {
-                    DDLogError("Error handling 'getSelectedTextEditInfo()' dictionary response")
+                    DDLogWarn("Error handling 'getSelectedTextEditInfo()' dictionary response")
                     return
                 }
                 
                 completionHandler(selectedTextEditInfo, nil)
                 return
             }
-            DDLogError("Error when evaluating javascript on fetch and transform: \(error)")
+            DDLogWarn("Error when evaluating javascript on fetch and transform: \(error)")
         }
     }
 }

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1348,7 +1348,7 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
         articleVC.initialSetupCompletion = ^{
             NSDate *end = [NSDate date];
             NSTimeInterval articleLoadTime = [end timeIntervalSinceDate:start];
-            DDLogInfo(@"article load time = %f", articleLoadTime);
+            DDLogDebug(@"article load time = %f", articleLoadTime);
         };
     }
 #endif
@@ -1897,7 +1897,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
     NSString *name = [@[NSStringFromClass([workerController class]), identifier] componentsJoinedByString:@"-"];
     UIBackgroundTaskIdentifier backgroundTaskIdentifier = [UIApplication.sharedApplication beginBackgroundTaskWithName:name
                                                                                                      expirationHandler:^{
-                                                                                                         DDLogWarn(@"Ending background task with name: %@", name);
+                                                                                                         DDLogDebug(@"Ending background task with name: %@", name);
                                                                                                          [workerController cancelWorkWithIdentifier:identifier];
                                                                                                          [self endBackgroundTaskWithWorkerController:workerController identifier:identifier];
                                                                                                      }];

--- a/Wikipedia/Code/WMFAuthenticationManager.swift
+++ b/Wikipedia/Code/WMFAuthenticationManager.swift
@@ -139,7 +139,7 @@ import CocoaLumberjackSwift
                 DDLogDebug("User \(result.name) is already logged in.")
                 self.session.cloneCentralAuthCookies()
             case .failure(let error):
-                DDLogDebug("loginWithSavedCredentials failed with error \(error).")
+                DDLogError("loginWithSavedCredentials failed with error \(error).")
             }
             DispatchQueue.main.async {
                 completion(loginResult)
@@ -277,7 +277,7 @@ import CocoaLumberjackSwift
                 DispatchQueue.main.async {
                     if let error = error {
                         // ...but if "action=logout" fails we *still* want to clear local login settings, which still effectively logs the user out.
-                        DDLogDebug("Failed to log out, delete login tokens and other browser cookies: \(error)")
+                        DDLogError("Failed to log out, delete login tokens and other browser cookies: \(error)")
                         self.resetLocalUserLoginSettings()
                         completion()
                         postDidLogOutNotification()
@@ -309,7 +309,7 @@ extension WMFAuthenticationManager {
         let completion: AuthenticationResultHandler = { loginResult in
             switch loginResult {
             case .failure(let error):
-                DDLogDebug("\n\nloginWithSavedCredentials failed with error \(error).\n\n")
+                DDLogError("\n\nloginWithSavedCredentials failed with error \(error).\n\n")
                 self.logout(initiatedBy: initiatedBy)
             default:
                 break

--- a/Wikipedia/Code/WMFCurrentlyLoggedInUserFetcher.swift
+++ b/Wikipedia/Code/WMFCurrentlyLoggedInUserFetcher.swift
@@ -62,7 +62,7 @@ public class WMFCurrentlyLoggedInUserFetcher: Fetcher {
             let editCount = userinfo["editcount"] as? UInt64 ?? 0
             
             var isBlocked = false
-            if let blockID = userinfo["blockid"] as? UInt64 {
+            if userinfo["blockid"] is UInt64 {
                 let blockPartial = (userinfo["blockpartial"] as? Bool ?? false)
                 if !blockPartial {
                     isBlocked = true

--- a/Wikipedia/Code/WMFFeedContentFetcher.m
+++ b/Wikipedia/Code/WMFFeedContentFetcher.m
@@ -66,7 +66,7 @@ static const NSInteger WMFFeedContentFetcherMinimumMaxAge = 18000; // 5 minutes
                                                                       options:NSRegularExpressionCaseInsensitive
                                                                         error:&error];
         if (error) {
-            DDLogError(@"Error creating cache control regex: %@", error);
+            DDLogWarn(@"Error creating cache control regex: %@", error);
         }
     });
     return cacheControlRegex;

--- a/Wikipedia/Code/WMFImageGalleryViewController.m
+++ b/Wikipedia/Code/WMFImageGalleryViewController.m
@@ -273,7 +273,7 @@ NS_ASSUME_NONNULL_BEGIN
             [self wmf_navigateToURL:imageInfo.filePageURL.wmf_urlByPrependingSchemeIfSchemeless];
         } else {
             // There should always be a file page URL, but log an error anyway
-            DDLogError(@"No license URL or file page URL for %@", imageInfo);
+            DDLogWarn(@"No license URL or file page URL for %@", imageInfo);
         }
     };
     caption.infoTapCallback = ^{

--- a/Wikipedia/Code/WMFImageURLParsing.m
+++ b/Wikipedia/Code/WMFImageURLParsing.m
@@ -30,7 +30,7 @@ NSString *WMFParseImageNameFromSourceURL(NSString *sourceURL) __attribute__((ove
     }
     NSArray *pathComponents = [sourceURL componentsSeparatedByString:@"/"];
     if (pathComponents.count < 2) {
-        DDLogWarn(@"Unable to parse source URL with too few path components: %@", pathComponents);
+        DDLogError(@"Unable to parse source URL with too few path components: %@", pathComponents);
         return nil;
     }
 

--- a/Wikipedia/Code/WMFLogging.h
+++ b/Wikipedia/Code/WMFLogging.h
@@ -1,9 +1,9 @@
 @import CocoaLumberjack;
 
-// Log level defaults to DEBUG in debug mode, and WARN in release.
 #if DEBUG
 
-static const DDLogLevel ddLogLevel = DDLogLevelDebug;
+// Change to DDLogLevelAll to enable all logging
+static const DDLogLevel ddLogLevel = DDLogLevelWarning;
 
 #else
 

--- a/Wikipedia/Code/WMFRandomDiceButton.m
+++ b/Wikipedia/Code/WMFRandomDiceButton.m
@@ -52,7 +52,7 @@
     NSString *diceJS = [NSString stringWithContentsOfURL:diceJSURL encoding:NSUTF8StringEncoding error:nil];
     [self.webView evaluateJavaScript:diceJS
                    completionHandler:^(id _Nullable obj, NSError *_Nullable error) {
-                       DDLogError(@"%@", error);
+                       DDLogWarn(@"%@", error);
                    }];
 }
 

--- a/Wikipedia/Code/WMFSearchFetcher.m
+++ b/Wikipedia/Code/WMFSearchFetcher.m
@@ -35,7 +35,7 @@ NSUInteger const WMFMaxSearchResultLimit = 24;
     }
 
     if (resultLimit > WMFMaxSearchResultLimit) {
-        DDLogError(@"Illegal attempt to request %lu articles, limiting to %lu.",
+        DDLogWarn(@"Illegal attempt to request %lu articles, limiting to %lu.",
                    (unsigned long)resultLimit, (unsigned long)WMFMaxSearchResultLimit);
         resultLimit = WMFMaxSearchResultLimit;
     }
@@ -149,7 +149,7 @@ NSUInteger const WMFMaxSearchResultLimit = 24;
         return;
     }
     if (resultLimit > WMFMaxSearchResultLimit) {
-        DDLogError(@"Illegal attempt to request %lu articles, limiting to %lu.",
+        DDLogWarn(@"Illegal attempt to request %lu articles, limiting to %lu.",
                    (unsigned long)resultLimit, (unsigned long)WMFMaxSearchResultLimit);
         resultLimit = WMFMaxSearchResultLimit;
     }

--- a/Wikipedia/Code/WMFWelcomeAnalyticsAnimationView.swift
+++ b/Wikipedia/Code/WMFWelcomeAnalyticsAnimationView.swift
@@ -33,16 +33,7 @@ open class WMFWelcomeAnalyticsAnimationView : WMFWelcomeAnimationView {
         removeExistingSubviewsAndSublayers()
         addSubview(phoneImgView)
         addSubview(chartImgView)
-        /*
-        isUserInteractionEnabled = true
-        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTapGestureRecognizer(_:))))
-         */
     }
-    /*
-    @objc func handleTapGestureRecognizer(_ gestureRecognizer: UITapGestureRecognizer) {
-        DDLogDebug("chartImgView anchorPoint \(gestureRecognizer.location(in: self).wmf_normalizeUsingSize(frame.size))")
-    }
-    */
     override open func beginAnimations() {
         super.beginAnimations()
         CATransaction.begin()

--- a/Wikipedia/Code/WMFWelcomeAnimationBackgroundView.swift
+++ b/Wikipedia/Code/WMFWelcomeAnimationBackgroundView.swift
@@ -45,33 +45,7 @@ open class WMFWelcomeAnimationBackgroundView: WMFWelcomeAnimationView {
             // Denormalize unitSize using a scalar (NOT a CGSize - so aspect ratio remains constant)
             imageViewAndModel.imageView.frame.size = imageViewAndModel.model.unitSize.wmf_denormalizeUsingReference(frame.size.width)
         }
-        /*
-         isUserInteractionEnabled = true
-         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTapGestureRecognizer(_:))))
-         */
     }
-    /*
-     @objc func handleTapGestureRecognizer(_ gestureRecognizer: UITapGestureRecognizer) {
-         // print unit coords for easy re-positioning
-         let point = gestureRecognizer.location(in: self)
-         let unitDestination = CGPoint(x: (point.x - (bounds.size.width * 0.5)) / bounds.size.width, y: (point.y - (bounds.size.height * 0.5)) / bounds.size.height)
-         DDLogDebug("unitDestination \(unitDestination)")
-     
-         // preview the item at the tap location
-         let imageViewAndModel = imageViewsAndModels![0] // <-- Adjust to pick which image is being tweaked.
-         imageViewAndModel.imageView.layer.removeAllAnimations()
-         let dest = unitDestination.wmf_denormalizeUsingSize(frame.size)
-         let tx = CATransform3DMakeAffineTransform(CGAffineTransform(translationX: dest.x, y: dest.y))
-         imageViewAndModel.imageView.layer.transform = tx
-         imageViewAndModel.imageView.layer.opacity = 1.0
-     
-         guard let image = imageViewAndModel.imageView.image else {
-             return
-         }
-         let imageUnitSize = CGSize(width: image.size.width / bounds.size.width, height: image.size.height / bounds.size.width) // "bounds.size.width" for both cases is deliberate here
-         DDLogDebug("unitSize \(imageUnitSize)")
-     }
-    */
     override open func beginAnimations() {
         super.beginAnimations()
         CATransaction.begin()

--- a/Wikipedia/Code/WMFWelcomeExplorationAnimationView.swift
+++ b/Wikipedia/Code/WMFWelcomeExplorationAnimationView.swift
@@ -33,17 +33,7 @@ open class WMFWelcomeExplorationAnimationView : WMFWelcomeAnimationView {
         removeExistingSubviewsAndSublayers()
         addSubview(baseImgView)
         addSubview(tubeImgView)
-        /*
-        isUserInteractionEnabled = true
-        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTapGestureRecognizer(_:))))
-        */
     }
-
-    /*
-    @objc func handleTapGestureRecognizer(_ gestureRecognizer: UITapGestureRecognizer) {
-        DDLogDebug("tubeImgView anchorPoint \(gestureRecognizer.location(in: self).wmf_normalizeUsingSize(frame.size))")
-    }
-    */
     
     override open func beginAnimations() {
         super.beginAnimations()


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T369871

### Notes
These are some tweaks to improve our logging and fix easy project warnings.

### Test Steps
1. Observe user buttons on diff view, confirm no regressions occurred.
2. Confirm there are fewer Cocoalumberjack logs in the console.
3. Temporarily change debug level to all [here](https://github.com/wikimedia/wikipedia-ios/blob/main/Wikipedia/Code/WMFLogging.h#L6).
4. Confirm Cocoalumberjack debug console logs return. 
