### PR TITLE
Fix notifications icon bug

### DIFF
--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -118,7 +118,9 @@ extension WMFAppViewController: NotificationsCenterPresentationDelegate {
     public func userDidTapNotificationsCenter(from viewController: UIViewController? = nil) {
         let viewModel = NotificationsCenterViewModel(notificationsController: dataStore.notificationsController, remoteNotificationsController: dataStore.remoteNotificationsController, languageLinkController: self.dataStore.languageLinkController)
         let notificationsCenterViewController = NotificationsCenterViewController(theme: theme, viewModel: viewModel)
-        navigationController?.pushViewController(notificationsCenterViewController, animated: true)
+        if let navigationController = viewController?.navigationController {
+            navigationController.pushViewController(notificationsCenterViewController, animated: true)
+        }
     }
 }
 


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T370965

### Notes
* Fixes bug where the notifications VC was not being pushed when the icon was tapped

### Test Steps
1. Go to the explore feed, tap the notifications icon
2. Verify it pushes the view
3. Turn off the explore feed
4. Tap the notifications icon, and make sure it also works normally


