### PR TITLE
Image Recs - Allow any license for pageimages

### DIFF
--- a/WKData/Sources/WKData/Data Controllers/WKGrowthTasks/WKGrowthTasksDataController.swift
+++ b/WKData/Sources/WKData/Data Controllers/WKGrowthTasks/WKGrowthTasksDataController.swift
@@ -43,6 +43,7 @@ import Foundation
                            "gsrnamespace": 0,
                            "gsrsort": "random",
                            "prop": "growthimagesuggestiondata|revisions|pageimages",
+                           "pilicense": "any",
                            "rvprop": "ids|timestamp|flags|comment|user|content",
                            "rvslots": "main",
                            "rvsection": 0,


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T371055

### Notes
This parameter might allow us to strip out more articles from the image recommendations pool that already have an image.

### Test Steps
1. Add a breakpoint [here](https://github.com/wikimedia/wikipedia-ios/blob/main/WKData/Sources/WKData/Data%20Controllers/WKGrowthTasks/WKGrowthTasksDataController.swift#L84).
2. Run the app and go to the image recommendations flow. Confirm that we still are able to see some recommendations. If breakpoint is hit, that may be a sign that we are stripping out more invalid recommendations.
