### PR TITLE
Update HtmlUtils to handle apostrophes and ampersands regression bugs

### DIFF
--- a/Components/Sources/Components/Utility/HTMLUtils.swift
+++ b/Components/Sources/Components/Utility/HTMLUtils.swift
@@ -644,7 +644,7 @@ public struct HtmlUtils {
                 replaceText = ">"
             case "&lt;":
                 replaceText = "<"
-            case "&apos;":
+            case "&apos;", "&#039;":
                 replaceText = "'"
             case "&quot;":
                 replaceText = "\""

--- a/Components/Sources/Components/Utility/HTMLUtils.swift
+++ b/Components/Sources/Components/Utility/HTMLUtils.swift
@@ -405,7 +405,7 @@ public struct HtmlUtils {
 
     public static func stringFromHTML(_ string: String) throws -> String {
         let regex = try htmlTagRegex()
-        let cleanString = regex.stringByReplacingMatches(in: string, options: [], range: string.fullNSRange, withTemplate: "")
+        let cleanString = regex.stringByReplacingMatches(in: string, options: [], range: string.fullNSRange, withTemplate: "").replacingOccurrences(of: "&amp;", with: "&")
         return cleanString
     }
 

--- a/Components/Sources/Components/Utility/HTMLUtils.swift
+++ b/Components/Sources/Components/Utility/HTMLUtils.swift
@@ -402,11 +402,15 @@ public struct HtmlUtils {
         }
     }
 
-
     public static func stringFromHTML(_ string: String) throws -> String {
         let regex = try htmlTagRegex()
-        let cleanString = regex.stringByReplacingMatches(in: string, options: [], range: string.fullNSRange, withTemplate: "").replacingOccurrences(of: "&amp;", with: "&")
-        return cleanString
+        let cleanString = regex.stringByReplacingMatches(in: string, options: [], range: string.fullNSRange, withTemplate: "")
+        let entityReplaceData = try entityReplaceData(html: cleanString)
+            let mutableCleanString = NSMutableString(string: cleanString)
+            for data in entityReplaceData {
+                mutableCleanString.replaceCharacters(in: data.range, with: data.replaceText)
+            }
+            return mutableCleanString as String
     }
 
     // MARK: - Shared - Private

--- a/Widgets/Widgets/FeaturedArticleWidget.swift
+++ b/Widgets/Widgets/FeaturedArticleWidget.swift
@@ -40,9 +40,9 @@ struct FeaturedArticleEntry: TimelineEntry {
 		return content?.languageCode
 	}
 
-	var title: String {
-		return (content?.displayTitle as NSString?)?.wmf_stringByRemovingHTML() ?? ""
-	}
+    var title: String {
+        return content?.displayTitle.removingHTML ?? ""
+    }
 
 	var description: String {
 		return content?.description ?? ""


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T371148 & https://phabricator.wikimedia.org/T371149

### Notes
* This PR updates the HtmlUtils to search for another HTML apostrophe tag and to handle HTML tags for characters better when stripping HTML from strings

### Test Steps
1. Run the app, find an article on the explore feed that has an apostrophe on the title. It should display correctly
2. Go to the top read widget (or any place that uses the removingHTML String extension)
3. Confirm it handles & correctly (and other tags like <>, etc, etc) 

