### PR TITLE
[ALT TEXT] Resign text view focus before publishing

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Suggested Edits/Alt Text Experiment/WMFAltTextExperimentModalSheetView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Suggested Edits/Alt Text Experiment/WMFAltTextExperimentModalSheetView.swift
@@ -204,6 +204,8 @@ final class WMFAltTextExperimentModalSheetView: WMFComponentView {
     }
     
     @objc func tappedNext() {
+        textView.resignFirstResponder()
+        
         guard let altText = textView.text,
               !altText.isEmpty else {
             return


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T370232
and https://phabricator.wikimedia.org/T370236

### Notes
This resigns the text view before publishing, so that the next image recommendation can be fully seen.

### Test Steps
1. Fresh install, enable developer settings toggles.
2. Go through image rec flow.
3. Go through alt text flow. Confirm on alt text input view, you can tap "Next" while text view is focused. After publish confirm half sheet modal is dismissed and next image recommendation is visible.

### Screenshots/Videos

