### PR TITLE
Fix deep links

### DIFF
--- a/Wikipedia/Code/AppDelegate.swift
+++ b/Wikipedia/Code/AppDelegate.swift
@@ -43,10 +43,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         updateDynamicIconShortcutItems()
     }
-    
-    func application(_ application: UIApplication, willContinueUserActivityWithType userActivityType: String) -> Bool {
-        return true
-    }
 
     // MARK: UISceneSession Lifecycle
 

--- a/Wikipedia/Code/NavigationStateController.swift
+++ b/Wikipedia/Code/NavigationStateController.swift
@@ -25,12 +25,14 @@ final class NavigationStateController: NSObject {
         }
         
         guard let articleViewController = visibleArticleViewController(for: selectedNavigationController) else {
+            moc.navigationState = nil
             return
         }
         
         let info = Info(articleKey: articleViewController.articleURL.wmf_databaseKey)
         
         guard let stateToPersist = NavigationState.ViewController(kind: .article, presentation: .push, info: info) else {
+            moc.navigationState = nil
             return
         }
         

--- a/Wikipedia/Code/SceneDelegate.swift
+++ b/Wikipedia/Code/SceneDelegate.swift
@@ -36,7 +36,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // scene(_ scene: UIScene, continue userActivity: NSUserActivity) and
         // scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)
         // windowScene(_ windowScene: UIWindowScene, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void)
-        // are not called upon cold launch, so we need to handle them explicitly here.
+        // are not called upon terminated state, so we need to handle them explicitly here.
         if let userActivity = connectionOptions.userActivities.first {
             processUserActivity(userActivity)
         } else if !connectionOptions.urlContexts.isEmpty {

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -384,9 +384,7 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
 #pragma mark - Notifications
 
 - (void)appWillEnterForegroundWithNotification:(NSNotification *)note {
-    // Don't access anything that can't be accessed in the background without starting a background task. For example, don't use anything in the shared app container like all of the Core Data persistent stores
-    self.unprocessedUserActivity = nil;
-    self.unprocessedShortcutItem = nil;
+
 }
 
 // When the user launches from a terminated state, resume might not finish before didBecomeActive, so these tasks are held until both items complete

--- a/docs/url_schemes.md
+++ b/docs/url_schemes.md
@@ -6,9 +6,9 @@ The URL scheme is `wikipedia://`. The following URLs are currently handled:
 | ------------------ | ---------------------------------------- | ---------------------------------------- |
 | Article            | wikipedia://[site]/wiki/[page_id]        | wikipedia://en.wikipedia.org/wiki/Red    |
 |                    | https://[[site]/wiki/[page_id]           | https://en.wikipedia.org/wiki/Red        |
-| Content            | wikipedia://content                      |                                          |
+| Content            | wikipedia://content                      | wikipedia://content/on-this-day/wikipedia.org/en/2024/08/15                                         |
 | Explore            | wikipedia://explore                      |                                          |
 | History            | wikipedia://history                      |                                          |
-| Places             | wikipedia://places[?WMFArticleURL=]      |                                          |
+| Places             | wikipedia://places[?WMFArticleURL=]      | wikipedia://places/?WMFArticleURL=https://en.wikipedia.org/wiki/Dallas
+                                         |
 | Saved pages        | wikipedia://saved                        |                                          |
-| Search             | wikipedia://[site]/w/index.php?search=[query] | wikipedia://en.wikipedia.org/w/index.php?search=dog |


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T371983

### Notes
This PR should fix the deep link regressions when launching from a terminated state. Note I tested the deep link documentation and updated it with more concrete examples. I also deleted a deep link format `wikipedia://en.wikipedia.org/w/index.php?search=dog` from the documentation. I think this one has likely been broken for a while because it didn't work on 7.5.5 either.

### Test Steps
1. Go to an article in the app from the Explore feed.
2. Background the app, then terminate.
3. Tap the app icon again, confirm that state restoration still works and you land on the article you were reading. Terminate app again from article.
4. Go to Safari, search for an article, then tap result to deep link into app.
5. Confirm app correctly displays deep linked article. Tap back to show Explore. Terminate app. Relaunch from home screen.
6. Confirm app correctly shows Explore feed.

You can also test home icon shortcuts and the older "wikipedia://" format in Safari (search `wikipedia://history` in Safari, tap open in Wikipedia).
