### PR TITLE
[ALT TEXT] Add additional action data when sending group assignment event

### DIFF
--- a/Wikipedia/Code/ArticleViewController+Editing.swift
+++ b/Wikipedia/Code/ArticleViewController+Editing.swift
@@ -296,7 +296,11 @@ extension ArticleViewController: EditorViewControllerDelegate {
         
         do {
             try dataController.assignArticleEditorExperiment(isLoggedIn: isLoggedIn, project: project)
-            EditInteractionFunnel.shared.logAltTextDidAssignArticleEditorGroup(project: WikimediaProject(wmfProject: project))
+            
+            if let user = dataStore.authenticationManager.getLoggedInUserCache(for: articleURL) {
+                EditInteractionFunnel.shared.logAltTextDidAssignArticleEditorGroup(username:user.name, userEditCount: user.editCount, articleTitle: articleTitle, image: filename, registrationDate: user.registrationDateString, project: WikimediaProject(wmfProject: project))
+            }
+            
         } catch let error {
             DDLogWarn("Error assigning alt text article editor experiment: \(error)")
         }

--- a/Wikipedia/Code/EditInteractionFunnel.swift
+++ b/Wikipedia/Code/EditInteractionFunnel.swift
@@ -277,13 +277,20 @@ final class EditInteractionFunnel {
     
     // MARK: Alt-Text-Experiment
     
-    func logAltTextDidAssignImageRecsGroup(project: WikimediaProject) {
-        
+    func logAltTextDidAssignImageRecsGroup(username: String, userEditCount: UInt64, articleTitle: String, image: String, registrationDate: String?, project: WikimediaProject) {
         guard let group = WMFAltTextDataController.shared?.assignedAltTextImageRecommendationsGroupForLogging() else {
             return
         }
         
-        var actionData: [String: String] = [:]
+        var actionData = ["article_title": articleTitle,
+                          "image": image,
+                          "username": username,
+                          "event_user_revision_count": String(userEditCount)]
+        
+        if let registrationDate {
+            actionData["user_create_date"] = registrationDate
+        }
+        
         switch group {
         case "A":
             actionData["exp_b_group"] = "a"
@@ -296,13 +303,21 @@ final class EditInteractionFunnel {
         logEvent(activeInterface: .altTextEditingOnboarding, action: .groupAssignment, actionData: actionData, project: project)
     }
     
-    func logAltTextDidAssignArticleEditorGroup(project: WikimediaProject) {
+    func logAltTextDidAssignArticleEditorGroup(username: String, userEditCount: UInt64, articleTitle: String, image: String, registrationDate: String?, project: WikimediaProject) {
         
         guard let group = WMFAltTextDataController.shared?.assignedAltTextArticleEditorGroupForLogging() else {
             return
         }
         
-        var actionData: [String: String] = [:]
+        var actionData = ["article_title": articleTitle,
+                          "image": image,
+                          "username": username,
+                          "event_user_revision_count": String(userEditCount)]
+        
+        if let registrationDate {
+            actionData["user_create_date"] = registrationDate
+        }
+        
         switch group {
         case "C":
             actionData["exp_c_group"] = "c"

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -1536,13 +1536,16 @@ extension ExploreViewController: WMFImageRecommendationsLoggingDelegate {
     
     func logAltTextExperimentDidAssignGroup() {
         
-        guard let imageRecommendationsViewModel else {
+        guard let imageRecommendationsViewModel,
+              let lastRecommendation = imageRecommendationsViewModel.lastRecommendation,
+           let siteURL = dataStore.languageLinkController.appLanguage?.siteURL,
+           let user = dataStore.authenticationManager.getLoggedInUserCache(for: siteURL) else {
             return
         }
         
         let project = WikimediaProject(wmfProject: imageRecommendationsViewModel.project)
         
-        EditInteractionFunnel.shared.logAltTextDidAssignImageRecsGroup(project: project)
+        EditInteractionFunnel.shared.logAltTextDidAssignImageRecsGroup(username:user.name, userEditCount: user.editCount, articleTitle: lastRecommendation.title, image: lastRecommendation.imageData.filename, registrationDate: user.registrationDateString, project: WikimediaProject(wmfProject: imageRecommendationsViewModel.project))
     }
 
     func logOnboardingDidTapPrimaryButton() {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T373558

### Notes
This PR adds additional action data when the group assignment event is called.

### Test Steps
1. Set `DDLogLevelAll` in [WMFLogging.h](https://github.com/wikimedia/wikipedia-ios/blob/main/Wikipedia/Code/WMFLogging.h#L6).
2. Fresh install app. Submit an image recommendation (it is fine if "do not post" feature flag is on here). Inspect console for group assignment event. Confirm additional action data is added.
3. Fresh install app again. Change an article with a valid image on Test Wiki.  Inspect console for group assignment event. Confirm additional action data is added.

