### PR TITLE
T373126: Fix picture of the day not being shown

### DIFF
--- a/Wikipedia/Code/RootNavigationController.swift
+++ b/Wikipedia/Code/RootNavigationController.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-/// Root view controller for the entire app. Handles splash screen presentation.
 @objc(WMFRootNavigationController)
 class RootNavigationController: WMFThemeableNavigationController {
 

--- a/Wikipedia/Code/SplashScreenViewController.swift
+++ b/Wikipedia/Code/SplashScreenViewController.swift
@@ -29,26 +29,9 @@ class SplashScreenViewController: ThemeableViewController {
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(showLoadingAnimation), object: nil)
     }
     
-    /// Ensure we show the busy animation for some minimum amount of time, otherwise the transition can be jarring
-    @objc func ensureMinimumShowDuration(completion: @escaping () -> Void) {
-        guard loadingAnimationShowTime != 0 else {
-            completion()
-            return
-        }
-        let now = CFAbsoluteTimeGetCurrent()
-        let busyAnimationVisibleTimeInterval = now - loadingAnimationShowTime
-        guard busyAnimationVisibleTimeInterval < SplashScreenViewController.minimumBusyAnimationVisibleTimeInterval else {
-            completion()
-            return
-        }
-        let delay = SplashScreenViewController.minimumBusyAnimationVisibleTimeInterval - busyAnimationVisibleTimeInterval
-        dispatchOnMainQueueAfterDelayInSeconds(delay, completion)
-    }
-    
     // MARK: Constants
     
     static let maximumNonInteractiveTimeInterval: TimeInterval = 4
-    static let minimumBusyAnimationVisibleTimeInterval: TimeInterval = 0.6
     static let crossFadeAnimationDuration: TimeInterval = 0.3
     
     // MARK: Splash View

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -63,7 +63,7 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
 @property (nonatomic, strong, readonly) WMFPlacesViewController *placesViewController;
 @property (nonatomic, strong, readonly) WMFHistoryViewController *recentArticlesViewController;
 
-@property (nonatomic, strong, readonly) WMFSplashScreenViewController *splashScreenViewController;
+@property (nonatomic, strong) WMFSplashScreenViewController *splashScreenViewController;
 
 @property (nonatomic, strong) WMFSavedArticlesFetcher *savedArticlesFetcher;
 
@@ -1578,7 +1578,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 #pragma mark - Splash
 
 - (void)showSplashView {
-    if (_splashScreenViewController) {
+    if (self.splashScreenViewController) {
         return;
     }
     WMFSplashScreenViewController *vc = [[WMFSplashScreenViewController alloc] initWithNibName:nil bundle:nil];
@@ -1586,23 +1586,23 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
     [vc applyTheme:self.theme];
     [self.view wmf_addSubviewWithConstraintsToEdges:vc.view];
     [vc endAppearanceTransition];
-    _splashScreenViewController = vc;
+    self.splashScreenViewController = vc;
 }
 
 - (void)hideSplashView {
-    WMFSplashScreenViewController *vc = _splashScreenViewController;
+    WMFSplashScreenViewController *vc = self.splashScreenViewController;
     if (!vc) {
         return;
     }
     [vc beginAppearanceTransition:NO animated:NO];
     [vc.view removeFromSuperview];
     [vc endAppearanceTransition];
-    _splashScreenViewController = nil;
+    self.splashScreenViewController = nil;
 }
 
 - (void)triggerMigratingAnimation {
-    if (_splashScreenViewController) {
-        [_splashScreenViewController triggerMigratingAnimation];
+    if (self.splashScreenViewController) {
+        [self.splashScreenViewController triggerMigratingAnimation];
     }
 }
 

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1583,6 +1583,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
     }
     WMFSplashScreenViewController *vc = [[WMFSplashScreenViewController alloc] initWithNibName:nil bundle:nil];
     [vc beginAppearanceTransition:YES animated:NO];
+    [vc applyTheme:self.theme];
     [self.view wmf_addSubviewWithConstraintsToEdges:vc.view];
     [vc endAppearanceTransition];
     _splashScreenViewController = vc;

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -63,6 +63,8 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
 @property (nonatomic, strong, readonly) WMFPlacesViewController *placesViewController;
 @property (nonatomic, strong, readonly) WMFHistoryViewController *recentArticlesViewController;
 
+@property (nonatomic, strong, readonly) WMFSplashScreenViewController *splashScreenViewController;
+
 @property (nonatomic, strong) WMFSavedArticlesFetcher *savedArticlesFetcher;
 
 @property (nonatomic, strong, readwrite) MWKDataStore *dataStore;
@@ -1576,22 +1578,30 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 #pragma mark - Splash
 
 - (void)showSplashView {
+    if (_splashScreenViewController) {
+        return;
+    }
     WMFSplashScreenViewController *vc = [[WMFSplashScreenViewController alloc] initWithNibName:nil bundle:nil];
-    [vc applyTheme:self.theme];
-    vc.modalPresentationStyle = UIModalPresentationOverFullScreen;
-    [self presentViewController:vc animated:NO completion:NULL];
+    [vc beginAppearanceTransition:YES animated:NO];
+    [self.view wmf_addSubviewWithConstraintsToEdges:vc.view];
+    [vc endAppearanceTransition];
+    _splashScreenViewController = vc;
 }
 
 - (void)hideSplashView {
-    if ([self.presentedViewController isKindOfClass:[WMFSplashScreenViewController class]]) {
-        [self dismissViewControllerAnimated:NO completion:nil];
+    WMFSplashScreenViewController *vc = _splashScreenViewController;
+    if (!vc) {
+        return;
     }
+    [vc beginAppearanceTransition:NO animated:NO];
+    [vc.view removeFromSuperview];
+    [vc endAppearanceTransition];
+    _splashScreenViewController = nil;
 }
 
 - (void)triggerMigratingAnimation {
-    if ([self.presentedViewController isKindOfClass:[WMFSplashScreenViewController class]]) {
-        WMFSplashScreenViewController *splashVC = (WMFSplashScreenViewController *)self.presentedViewController;
-        [splashVC triggerMigratingAnimation];
+    if (_splashScreenViewController) {
+        [_splashScreenViewController triggerMigratingAnimation];
     }
 }
 


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T373126

This is a suggestion to fix the "picture of the day" image not being presented when the user deep-links to the app by tapping on the widget, when the app is in a backgrounded state.

The issue seems to have been introduced in [this PR](https://github.com/wikimedia/wikipedia-ios/pull/4876).  As the `presentViewController` API was now used to display the image from `WMFAppViewController`, the system was trying to display two controllers at once:

- the photo gallery
- the splash screen (which is shown as the user deep-links into the app via `appViewController.showSplashView()`)

The issue is not present when opening the app from a terminated state because the splash screen is not shown manually in that case.

The fix suggested here is to avoid presenting the splash screen with the `presentViewController` API and go back to using `add/remove subview`, like it was done before in `SplashScreenViewController`. This way the splash screen can't interfere with other controllers.

### Notes

- Although there is a call to `dismissPresentedViewControllers` before presenting the gallery, it's executed asynchronously, so the conflict still occurs. A completion block could be added to ensure dismissing is finished, but it seemed less elegant as a fix
- It looks like [the PR mentioned above](https://github.com/wikimedia/wikipedia-ios/pull/4876) removed animation for dismissing the splash screen. Assuming this was intentional, I went ahead and removed some dead code which was ensuring the smoother transition

### Test Steps
- Add the picture of the day widget and tap it to open the app, the picture should be displayed
- Make sure the splash screen works as before
- Make sure migration splash screen/animation works as before

### Screenshots/Videos

Without the fix, the following is logged:

<img width="455" alt="Screenshot 2024-09-11 at 16 04 32" src="https://github.com/user-attachments/assets/abd64e1c-eaea-4aad-8f95-85d80bcd9b7e">
