### PR TITLE
Fundraising cleanup - use metricsID consistently

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Donate Form/WMFDonateViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Donate Form/WMFDonateViewModel.swift
@@ -169,7 +169,6 @@ public final class WMFDonateViewModel: NSObject, ObservableObject {
     private let languageCode: String
     
     private let merchantID: String
-    private let bannerID: String?
     private let metricsID: String?
     private let appVersion: String?
     
@@ -192,7 +191,7 @@ public final class WMFDonateViewModel: NSObject, ObservableObject {
     
     // MARK: - Lifecycle
     
-    public init?(localizedStrings: LocalizedStrings, donateConfig: WMFDonateConfig, paymentMethods: WMFPaymentMethods, countryCode: String, currencyCode: String, languageCode: String, merchantID: String, bannerID: String?, metricsID: String?, appVersion: String?, delegate: WMFDonateDelegate?, loggingDelegate: WMFDonateLoggingDelegate?) {
+    public init?(localizedStrings: LocalizedStrings, donateConfig: WMFDonateConfig, paymentMethods: WMFPaymentMethods, countryCode: String, currencyCode: String, languageCode: String, merchantID: String, metricsID: String?, appVersion: String?, delegate: WMFDonateDelegate?, loggingDelegate: WMFDonateLoggingDelegate?) {
         self.localizedStrings = localizedStrings
         self.donateConfig = donateConfig
         self.paymentMethods = paymentMethods
@@ -200,7 +199,6 @@ public final class WMFDonateViewModel: NSObject, ObservableObject {
         self.currencyCode = currencyCode
         self.languageCode = languageCode
         self.merchantID = merchantID
-        self.bannerID = bannerID
         self.metricsID = metricsID
         self.appVersion = appVersion
         self.delegate = delegate
@@ -492,7 +490,7 @@ extension WMFDonateViewModel: PKPaymentAuthorizationControllerDelegate {
         let paymentNetwork = payment.token.paymentMethod.network?.rawValue
         
         let dataController = WMFDonateDataController.shared
-        dataController.submitPayment(amount: finalAmount, countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, paymentToken: paymentToken, paymentNetwork: paymentNetwork, donorNameComponents: donorNameComponents, recurring: recurring, donorEmail: donorEmail, donorAddressComponents: donorAddressComponents, emailOptIn: emailOptIn, transactionFee: transactionFeeOptInViewModel.isSelected, bannerID: bannerID, appVersion: appVersion) { [weak self] result in
+        dataController.submitPayment(amount: finalAmount, countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, paymentToken: paymentToken, paymentNetwork: paymentNetwork, donorNameComponents: donorNameComponents, recurring: recurring, donorEmail: donorEmail, donorAddressComponents: donorAddressComponents, emailOptIn: emailOptIn, transactionFee: transactionFeeOptInViewModel.isSelected, metricsID: metricsID, appVersion: appVersion) { [weak self] result in
             
             guard let self else {
                 return

--- a/WMFComponents/Tests/WMFComponentsTests/WMFDonateViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFDonateViewModelTests.swift
@@ -37,7 +37,7 @@ final class WMFDonateViewModelTests: XCTestCase {
             return
         }
         
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD",  languageCode: "EN", merchantID: merchantID, bannerID: "app_2023_enNL_iOS_control", metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
+        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD",  languageCode: "EN", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
             XCTFail("View model failed to instantiate")
             return
         }
@@ -95,7 +95,7 @@ final class WMFDonateViewModelTests: XCTestCase {
             return
         }
         
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("UYU"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "UY", currencyCode: "UYU", languageCode: "ES", merchantID: merchantID, bannerID: "app_2023_enNL_iOS_control", metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
+        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("UYU"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "UY", currencyCode: "UYU", languageCode: "ES", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
             XCTFail("View model failed to instantiate")
             return
         }
@@ -153,7 +153,7 @@ final class WMFDonateViewModelTests: XCTestCase {
             return
         }
         
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, bannerID: "app_2023_enNL_iOS_control", metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
+        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
             XCTFail("View model failed to instantiate")
             return
         }
@@ -186,7 +186,7 @@ final class WMFDonateViewModelTests: XCTestCase {
             return
         }
         
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, bannerID: "app_2023_enNL_iOS_control", metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
+        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
             XCTFail("View model failed to instantiate")
             return
         }
@@ -221,7 +221,7 @@ final class WMFDonateViewModelTests: XCTestCase {
             return
         }
         
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, bannerID: "app_2023_enNL_iOS_control", metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
+        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
             XCTFail("View model failed to instantiate")
             return
         }
@@ -257,7 +257,7 @@ final class WMFDonateViewModelTests: XCTestCase {
             return
         }
         
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, bannerID: "app_2023_enNL_iOS_control", metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
+        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
             XCTFail("View model failed to instantiate")
             return
         }
@@ -282,7 +282,7 @@ final class WMFDonateViewModelTests: XCTestCase {
             return
         }
         
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, bannerID: "app_2023_enNL_iOS_control", metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
+        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", delegate: nil, loggingDelegate: nil) else {
             XCTFail("View model failed to instantiate")
             return
         }

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonateDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonateDataController.swift
@@ -158,7 +158,7 @@ import Contacts
         }
     }
     
-    public func submitPayment(amount: Decimal, countryCode: String, currencyCode: String, languageCode: String, paymentToken: String, paymentNetwork: String?, donorNameComponents: PersonNameComponents, recurring: Bool, donorEmail: String, donorAddressComponents: CNPostalAddress, emailOptIn: Bool?, transactionFee: Bool, bannerID: String?, appVersion: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+    public func submitPayment(amount: Decimal, countryCode: String, currencyCode: String, languageCode: String, paymentToken: String, paymentNetwork: String?, donorNameComponents: PersonNameComponents, recurring: Bool, donorEmail: String, donorAddressComponents: CNPostalAddress, emailOptIn: Bool?, transactionFee: Bool, metricsID: String?, appVersion: String?, completion: @escaping (Result<Void, Error>) -> Void) {
         
         guard let donatePaymentSubmissionURL = URL.donatePaymentSubmissionURL() else {
             completion(.failure(WMFDataControllerError.failureCreatingRequestURL))
@@ -201,8 +201,8 @@ import Contacts
             parameters["payment_network"] = paymentNetwork
         }
         
-        if let bannerID {
-            parameters["banner"] = bannerID
+        if let metricsID {
+            parameters["banner"] = metricsID
         }
         
         if let appVersion {

--- a/WMFData/Tests/WMFDataTests/WMFDonateDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFDonateDataControllerTests.swift
@@ -63,7 +63,7 @@ final class WMFDonateDataControllerTests: XCTestCase {
         let nameComponents = PersonNameComponents()
         let addressComponents = CNPostalAddress()
         
-        controller.submitPayment(amount: 3, countryCode: "US", currencyCode: "USD", languageCode: "EN", paymentToken: "fake-token", paymentNetwork: "Discover", donorNameComponents: nameComponents, recurring: true, donorEmail: "wikimediaTester1@gmail.com", donorAddressComponents: addressComponents, emailOptIn: nil, transactionFee: false, bannerID: "app_2023_enNL_iOS_control", appVersion: "7.4.3") { result in
+        controller.submitPayment(amount: 3, countryCode: "US", currencyCode: "USD", languageCode: "EN", paymentToken: "fake-token", paymentNetwork: "Discover", donorNameComponents: nameComponents, recurring: true, donorEmail: "wikimediaTester1@gmail.com", donorAddressComponents: addressComponents, emailOptIn: nil, transactionFee: false, metricsID: "enUS_2024_09_iOS", appVersion: "7.4.3") { result in
             switch result {
             case .success:
                 break
@@ -174,7 +174,7 @@ final class WMFDonateDataControllerTests: XCTestCase {
         let nameComponents = PersonNameComponents()
         let addressComponents = CNPostalAddress()
         
-        controller.submitPayment(amount: 3, countryCode: "US", currencyCode: "USD", languageCode: "EN", paymentToken: "fake-token", paymentNetwork: "Discover", donorNameComponents: nameComponents, recurring: true, donorEmail: "wikimediaTester1@gmail.com", donorAddressComponents: addressComponents, emailOptIn: nil, transactionFee: false, bannerID: "app_2023_enNL_iOS_control", appVersion: "7.4.3") { result in
+        controller.submitPayment(amount: 3, countryCode: "US", currencyCode: "USD", languageCode: "EN", paymentToken: "fake-token", paymentNetwork: "Discover", donorNameComponents: nameComponents, recurring: true, donorEmail: "wikimediaTester1@gmail.com", donorAddressComponents: addressComponents, emailOptIn: nil, transactionFee: false, metricsID: "enUS_2024_09_iOS", appVersion: "7.4.3") { result in
             switch result {
             case .success:
                 XCTFail("Expected submitPayment to fail")

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -23,7 +23,7 @@ extension ArticleViewController {
             }
 
             if !isOptedIn {
-                DonateFunnel.shared.logHiddenBanner(campaignID: activeCampaignAsset.metricsID)
+                DonateFunnel.shared.logHiddenBanner(metricsID: activeCampaignAsset.metricsID)
             }
 
             guard isOptedIn else {
@@ -44,25 +44,25 @@ extension ArticleViewController {
         
         wmf_showFundraisingAnnouncement(theme: theme, asset: asset, primaryButtonTapHandler: { button, _ in
             
-            DonateFunnel.shared.logFundraisingCampaignModalDidTapDonate(project: project, campaignID: asset.utmSource)
+            DonateFunnel.shared.logFundraisingCampaignModalDidTapDonate(project: project, metricsID: asset.metricsID)
             self.pushToDonateForm(asset: asset, sourceView: button)
             dataController.markAssetAsPermanentlyHidden(asset: asset)
             
         }, secondaryButtonTapHandler: { _, _ in
-            DonateFunnel.shared.logFundraisingCampaignModalDidTapMaybeLater(project: project, campaignID: asset.utmSource)
+            DonateFunnel.shared.logFundraisingCampaignModalDidTapMaybeLater(project: project, metricsID: asset.metricsID)
             
             
             if shouldShowMaybeLater {
                 dataController.markAssetAsMaybeLater(asset: asset, currentDate: Date())
                 self.donateDidSetMaybeLater()
             } else {
-                DonateFunnel.shared.logFundraisingCampaignModalDidTapAlreadyDonated(project: project, campaignID: asset.utmSource)
+                DonateFunnel.shared.logFundraisingCampaignModalDidTapAlreadyDonated(project: project, metricsID: asset.metricsID)
                 self.donateAlreadyDonated()
                 dataController.markAssetAsPermanentlyHidden(asset: asset)
             }
             
         }, optionalButtonTapHandler: { _, _ in
-            DonateFunnel.shared.logFundraisingCampaignModalDidTapAlreadyDonated(project: project, campaignID: asset.utmSource)
+            DonateFunnel.shared.logFundraisingCampaignModalDidTapAlreadyDonated(project: project, metricsID: asset.metricsID)
             self.donateAlreadyDonated()
             dataController.markAssetAsPermanentlyHidden(asset: asset)
             
@@ -72,7 +72,7 @@ extension ArticleViewController {
         }, traceableDismissHandler: { action in
             
             if action == .tappedClose {
-                DonateFunnel.shared.logFundraisingCampaignModalDidTapClose(project: project, campaignID: asset.utmSource)
+                DonateFunnel.shared.logFundraisingCampaignModalDidTapClose(project: project, metricsID: asset.metricsID)
                 dataController.markAssetAsPermanentlyHidden(asset: asset)
             }
         }, showMaybeLater: shouldShowMaybeLater)
@@ -81,15 +81,14 @@ extension ArticleViewController {
     private func pushToDonateForm(asset: WMFFundraisingCampaignConfig.WMFAsset, sourceView: UIView?) {
         let firstAction = asset.actions[0]
         
-        let utmSource = asset.utmSource
         let metricsID = asset.metricsID
 
         let appVersion = Bundle.main.wmf_debugVersion()
         let donateURL = firstAction.url?.appendingAppVersion(appVersion: appVersion)
 
-        if canOfferNativeDonateForm(countryCode: asset.countryCode, currencyCode: asset.currencyCode, languageCode: asset.languageCode, bannerID: utmSource, metricsID: metricsID, appVersion: appVersion),
+        if canOfferNativeDonateForm(countryCode: asset.countryCode, currencyCode: asset.currencyCode, languageCode: asset.languageCode, metricsID: metricsID, appVersion: appVersion),
            let donateURL = donateURL {
-            presentNewDonorExperiencePaymentMethodActionSheet(donateSource: .articleCampaignModal, countryCode: asset.countryCode, currencyCode: asset.currencyCode, languageCode: asset.languageCode, donateURL: donateURL, bannerID: utmSource, metricsID: metricsID, appVersion: appVersion, articleURL: articleURL, sourceView: sourceView, loggingDelegate: self)
+            presentNewDonorExperiencePaymentMethodActionSheet(donateSource: .articleCampaignModal, countryCode: asset.countryCode, currencyCode: asset.currencyCode, languageCode: asset.languageCode, donateURL: donateURL, metricsID: metricsID, appVersion: appVersion, articleURL: articleURL, sourceView: sourceView, loggingDelegate: self)
         } else {
             self.navigate(to: donateURL, userInfo: [
                 RoutingUserInfoKeys.campaignArticleURL: articleURL as Any,
@@ -229,27 +228,6 @@ extension ArticleViewController: WMFDonateLoggingDelegate {
 }
 
 extension WMFFundraisingCampaignConfig.WMFAsset {
-    
-    var utmSource: String? {
-        
-        guard actions.count > 0 else {
-            return nil
-        }
-        
-        let firstAction = actions[0]
-        var utmSource: String? = nil
-        if let donateURL = firstAction.url,
-           let queryItems = URLComponents(url: donateURL, resolvingAgainstBaseURL: false)?.queryItems {
-            for queryItem in queryItems {
-                if queryItem.name == "utm_source" {
-                    utmSource = queryItem.value
-                }
-            }
-        }
-        
-        return utmSource
-    }
-    
     var metricsID: String {
         return "\(languageCode)\(id)_iOS"
     }

--- a/Wikipedia/Code/DonateFunnel.swift
+++ b/Wikipedia/Code/DonateFunnel.swift
@@ -102,38 +102,38 @@ import WMF
         logEvent(activeInterface: .articleBanner, action: .impression, actionData: actionData, project: project)
     }
     
-    func logFundraisingCampaignModalDidTapClose(project: WikimediaProject, campaignID: String?) {
+    func logFundraisingCampaignModalDidTapClose(project: WikimediaProject, metricsID: String?) {
         var actionData: [String: String]?
-        if let campaignID {
+        if let metricsID {
             actionData = [:]
-            actionData?["campaign_id"] = campaignID
+            actionData?["campaign_id"] = metricsID
         }
         
         logEvent(activeInterface: .articleBanner, action: .closeClick, actionData: actionData, project: project)
     }
     
-    func logFundraisingCampaignModalDidTapDonate(project: WikimediaProject, campaignID: String?) {
+    func logFundraisingCampaignModalDidTapDonate(project: WikimediaProject, metricsID: String?) {
         var actionData: [String: String]?
-        if let campaignID {
-            actionData = ["campaign_id": campaignID]
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
         }
         
         logEvent(activeInterface: .articleBanner, action: .donateClick, actionData: actionData, project: project)
     }
     
-    func logFundraisingCampaignModalDidTapMaybeLater(project: WikimediaProject, campaignID: String?) {
+    func logFundraisingCampaignModalDidTapMaybeLater(project: WikimediaProject, metricsID: String?) {
         var actionData: [String: String]?
-        if let campaignID {
-            actionData = ["campaign_id": campaignID]
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
         }
         
         logEvent(activeInterface: .articleBanner, action: .laterClick, actionData: actionData, project: project)
     }
     
-    func logFundraisingCampaignModalDidTapAlreadyDonated(project: WikimediaProject, campaignID: String?) {
+    func logFundraisingCampaignModalDidTapAlreadyDonated(project: WikimediaProject, metricsID: String?) {
         var actionData: [String: String]?
-        if let campaignID {
-            actionData = ["campaign_id": campaignID]
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
         }
         
         logEvent(activeInterface: .articleBanner, action: .alreadyDonatedClick, actionData: actionData, project: project)
@@ -277,11 +277,11 @@ import WMF
         logEvent(activeInterface: .webPayProcessed, action: .returnClick)
     }
 
-    func logHiddenBanner(campaignID: String?) {
+    func logHiddenBanner(metricsID: String?) {
         var actionData: [String: String]?
-        if let campaignID {
+        if let metricsID {
             actionData = [:]
-            actionData?["campaign_id"] = campaignID
+            actionData?["campaign_id"] = metricsID
         }
 
         logEvent(activeInterface: .articleBanner, action: .impressionSuppressed, actionData: actionData)

--- a/Wikipedia/Code/UIViewController+DonateHelpers.swift
+++ b/Wikipedia/Code/UIViewController+DonateHelpers.swift
@@ -11,7 +11,7 @@ import PassKit
 
 @objc extension UIViewController {
     
-    func canOfferNativeDonateForm(countryCode: String, currencyCode: String, languageCode: String, bannerID: String?, metricsID: String?, appVersion: String?) -> Bool {
+    func canOfferNativeDonateForm(countryCode: String, currencyCode: String, languageCode: String, metricsID: String?, appVersion: String?) -> Bool {
         let donateDataController = WMFDonateDataController.shared
         let donateData = donateDataController.loadConfigs()
         
@@ -23,10 +23,10 @@ import PassKit
             return false
         }
         
-        return nativeDonateFormViewModel(countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, bannerID: bannerID, metricsID: metricsID, appVersion: appVersion, loggingDelegate: nil) != nil
+        return nativeDonateFormViewModel(countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, metricsID: metricsID, appVersion: appVersion, loggingDelegate: nil) != nil
     }
     
-    private func nativeDonateFormViewModel(countryCode: String, currencyCode: String, languageCode: String, bannerID: String?, metricsID: String?, appVersion: String?, loggingDelegate: WMFDonateLoggingDelegate?) -> WMFDonateViewModel? {
+    private func nativeDonateFormViewModel(countryCode: String, currencyCode: String, languageCode: String, metricsID: String?, appVersion: String?, loggingDelegate: WMFDonateLoggingDelegate?) -> WMFDonateViewModel? {
         
         let donateDataController = WMFDonateDataController.shared
         let donateData = donateDataController.loadConfigs()
@@ -111,16 +111,16 @@ import PassKit
             return nil
         }
         
-        guard let viewModel = WMFDonateViewModel(localizedStrings: localizedStrings, donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, merchantID: merchantID, bannerID: bannerID, metricsID: metricsID, appVersion: appVersion, delegate: delegate, loggingDelegate: loggingDelegate) else {
+        guard let viewModel = WMFDonateViewModel(localizedStrings: localizedStrings, donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, merchantID: merchantID, metricsID: metricsID, appVersion: appVersion, delegate: delegate, loggingDelegate: loggingDelegate) else {
             return nil
         }
         
         return viewModel
     }
     
-    func pushToNativeDonateForm(countryCode: String, currencyCode: String, languageCode: String, bannerID: String?, metricsID: String?, appVersion: String?, loggingDelegate: WMFDonateLoggingDelegate?) {
+    func pushToNativeDonateForm(countryCode: String, currencyCode: String, languageCode: String, metricsID: String?, appVersion: String?, loggingDelegate: WMFDonateLoggingDelegate?) {
         
-        guard let viewModel = nativeDonateFormViewModel(countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, bannerID: bannerID, metricsID: metricsID, appVersion: appVersion, loggingDelegate: loggingDelegate) else {
+        guard let viewModel = nativeDonateFormViewModel(countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, metricsID: metricsID, appVersion: appVersion, loggingDelegate: loggingDelegate) else {
             return
         }
         
@@ -132,7 +132,7 @@ import PassKit
         navigationController?.pushViewController(donateViewController, animated: true)
     }
     
-    @objc func presentNewDonorExperiencePaymentMethodActionSheet(donateSource: DonateSource, countryCode: String, currencyCode: String, languageCode: String, donateURL: URL, bannerID: String?, metricsID: String?, appVersion: String?, articleURL: URL?, sourceView: UIView?, loggingDelegate: WMFDonateLoggingDelegate?) {
+    @objc func presentNewDonorExperiencePaymentMethodActionSheet(donateSource: DonateSource, countryCode: String, currencyCode: String, languageCode: String, donateURL: URL, metricsID: String?, appVersion: String?, articleURL: URL?, sourceView: UIView?, loggingDelegate: WMFDonateLoggingDelegate?) {
         
         let wikimediaProject: WikimediaProject?
         if let articleURL {
@@ -171,10 +171,10 @@ import PassKit
             
             if donateSource == .articleCampaignModal {
                 self.dismiss(animated: true) {
-                    self.pushToNativeDonateForm(countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, bannerID: bannerID, metricsID: metricsID, appVersion: appVersion, loggingDelegate: loggingDelegate)
+                    self.pushToNativeDonateForm(countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, metricsID: metricsID, appVersion: appVersion, loggingDelegate: loggingDelegate)
                 }
             } else {
-                self.pushToNativeDonateForm(countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, bannerID: bannerID, metricsID: metricsID, appVersion: appVersion, loggingDelegate: loggingDelegate)
+                self.pushToNativeDonateForm(countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, metricsID: metricsID, appVersion: appVersion, loggingDelegate: loggingDelegate)
             }
         })
         alert.addAction(applePayAction)

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -478,8 +478,8 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
             NSString *currencyCode = [[NSLocale currentLocale] currencyCode];
             NSString *languageCode = MWKDataStore.shared.languageLinkController.appLanguage.languageCode;
             NSString *appVersion = [[NSBundle mainBundle] wmf_debugVersion];
-            if ([self canOfferNativeDonateFormWithCountryCode:countryCode currencyCode:currencyCode languageCode:languageCode bannerID:nil metricsID:nil appVersion: appVersion]) {
-                [self presentNewDonorExperiencePaymentMethodActionSheetWithDonateSource: DonateSourceSettings countryCode:countryCode currencyCode:currencyCode languageCode:languageCode donateURL:self.donationURL bannerID:nil metricsID:nil appVersion: appVersion articleURL:nil sourceView: settingsCell loggingDelegate:self];
+            if ([self canOfferNativeDonateFormWithCountryCode:countryCode currencyCode:currencyCode languageCode:languageCode metricsID:nil appVersion: appVersion]) {
+                [self presentNewDonorExperiencePaymentMethodActionSheetWithDonateSource: DonateSourceSettings countryCode:countryCode currencyCode:currencyCode languageCode:languageCode donateURL:self.donationURL metricsID:nil appVersion: appVersion articleURL:nil sourceView: settingsCell loggingDelegate:self];
             } else {
                 // New experience pushing to in-app browser
                 [self wmf_navigateToURL:[self donationURL] useSafari:NO];


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T367360

### Notes
This is partially a follow-on to https://github.com/wikimedia/wikipedia-ios/pull/4848. In that PR we updated the campaign identifier for fundraising events sent via MEP, using a new identifier called `metricsID`. There were several spots still sending the old format, so those have been updated.

We also now want to send this same identifier format to the `submitPayment` endpoint under the "banner" parameter. This removes our dependence on the `utm_source` parameter from the campaign config (see linked Phabricator task).

### Test Steps
Since there's no active campaign going, there's not an easy way to confirm this. I suggest we lean on data validation for testing this one.