### PR TITLE
Watchlist navigation bugs

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Buttons/WMFSmallMenuButtonDelegate.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Buttons/WMFSmallMenuButtonDelegate.swift
@@ -3,8 +3,7 @@ import UIKit
 public protocol WMFSmallMenuButtonDelegate: AnyObject {
     func wmfMenuButton(_ sender: WMFSmallMenuButton, didTapMenuItem item: WMFSmallMenuButton.MenuItem)
     func wmfMenuButtonDidTap(_ sender: WMFSmallMenuButton)
-
-	func wmfSwiftUIMenuButtonUserDidTap(configuration: WMFSmallMenuButton.Configuration, item: WMFSmallMenuButton.MenuItem?)
+    func wmfSwiftUIMenuButtonUserDidTap(configuration: WMFSmallMenuButton.Configuration, item: WMFSmallMenuButton.MenuItem?)
     func wmfSwiftUIMenuButtonUserDidTapAccessibility(configuration: WMFSmallMenuButton.Configuration, item: WMFSmallMenuButton.MenuItem?)
 }
 

--- a/WMFComponents/Sources/WMFComponents/Components/Watchlist/WKWatchlistViewController.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Watchlist/WKWatchlistViewController.swift
@@ -51,7 +51,7 @@ public final class WMFWatchlistViewController: WMFCanvasViewController {
             self.articleTitleMetadataKey = articleTitleMetadaKey
 		}
 
-		func WMFSwiftUIMenuButtonUserDidTap(configuration: WMFSmallMenuButton.Configuration, item: WMFSmallMenuButton.MenuItem?) {
+		func wmfSwiftUIMenuButtonUserDidTap(configuration: WMFSmallMenuButton.Configuration, item: WMFSmallMenuButton.MenuItem?) {
             guard let username = configuration.title, let tappedTitle = item?.title,
                     let wmfProject = configuration.metadata[wmfProjectMetadataKey] as? WMFProject,
                   let revisionID = configuration.metadata[revisionIDMetadataKey] as? UInt,
@@ -84,7 +84,7 @@ public final class WMFWatchlistViewController: WMFCanvasViewController {
             }
 		}
 
-        func WMFSwiftUIMenuButtonUserDidTapAccessibility(configuration: WMFSmallMenuButton.Configuration, item: WMFSmallMenuButton.MenuItem?) {
+        func wmfSwiftUIMenuButtonUserDidTapAccessibility(configuration: WMFSmallMenuButton.Configuration, item: WMFSmallMenuButton.MenuItem?) {
             guard let username = configuration.title, let tappedTitle = item?.title,
                     let wmfProject = configuration.metadata[wmfProjectMetadataKey] as? WMFProject,
                   let revisionID = configuration.metadata[revisionIDMetadataKey] as? UInt,

--- a/Wikipedia/Code/ViewControllerRouter.swift
+++ b/Wikipedia/Code/ViewControllerRouter.swift
@@ -226,7 +226,7 @@ class ViewControllerRouter: NSObject {
     }
     
     private func watchlistTargetNavigationController() -> UINavigationController? {
-        var targetNavigationController = appViewController.navigationController
+        var targetNavigationController: UINavigationController? = appViewController.currentTabNavigationController
         if let presentedNavigationController = appViewController.presentedViewController as? UINavigationController,
            presentedNavigationController.viewControllers[0] is WMFSettingsViewController {
             targetNavigationController = presentedNavigationController


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T374035 & https://phabricator.wikimedia.org/T373965

### Notes
* This PR fixes two watchlist-related bugs: 
 1. Unable to navigate to the watchlist from the toasts after adding an article.
 2. Unable to navigate to the user submenus from the watchlist cell

### Test Steps
1. Go to an article, add it to your watchlist
2. Click on the "Go to Watchlist" button on the toast
3. You should be able to navigate to the watchlist
4. On the watchlist view, click on the user button
5. Make sure you can navigate to all the options
6. Go to Watchlist from settings 
7. Make sure you can repeat items 4 and 5

