### PR TITLE
Fix automatic trait collection assignment in WMFComponents

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Environment/WMFAppEnvironment.swift
+++ b/WMFComponents/Sources/WMFComponents/Environment/WMFAppEnvironment.swift
@@ -15,7 +15,7 @@ public final class WMFAppEnvironment: ObservableObject {
 
 	// MARK: - Update
 
-	public func set(theme newTheme: WMFTheme? = nil, articleAndEditorTextSize newArticleAndEditorTextSize: UIContentSizeCategory? = nil,  traitCollection newTraitCollection: UITraitCollection? = nil) {
+	public func set(theme newTheme: WMFTheme? = nil, articleAndEditorTextSize newArticleAndEditorTextSize: UIContentSizeCategory? = nil, traitCollection newTraitCollection: UITraitCollection? = nil) {
 		theme = newTheme ?? theme
         articleAndEditorTextSize = newArticleAndEditorTextSize ?? articleAndEditorTextSize
 		traitCollection = newTraitCollection ?? traitCollection

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1908,7 +1908,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
     if (self.theme != theme || [self appEnvironmentTraitCollectionIsDifferentThanTraitCollection:traitCollection]) {
         [self applyTheme:theme];
         [self.settingsViewController loadSections];
-        [self updateAppEnvironmentWithTheme:theme traitCollection:self.navigationController.traitCollection];
+        [self updateAppEnvironmentWithTheme:theme traitCollection:self.traitCollection];
     }
 }
 


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
This broke in https://github.com/wikimedia/wikipedia-ios/pull/4876. In that PR, we changed the UITabBarController from being embedded within a UINavigationController to instead be the root view controller of the window and containing UINavigationControllers within each of its 5 tabs. In short, calling `self.navigationController.traitCollection` within WMFAppViewController.m is no longer valid (it will return nil), because our app view controller (UITabBarController subclass) no longer has a parent navigation controller.

Now we are looking at the tab bar controller's trait collection directly. This pulls the correct new trait collection (which holds the dynamic type size), and assigns it to the WMFComponents' traitCollection property that all the components reference. This will fix the dynamic type bug in Profile.

### Test Steps
1. Open Profile from Explore
2. Background app and change dynamic type in iOS Settings
3. Go back to the app and confirm headline font changes.
