### PR TITLE
Fix Apple Pay form state refresh bug

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Donate Form/WMFDonateViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Donate Form/WMFDonateViewModel.swift
@@ -65,10 +65,7 @@ public final class WMFDonateViewModel: NSObject, ObservableObject {
         }
     }
     
-    public final class AmountButtonViewModel: ObservableObject, Equatable, Identifiable {
-        public static func == (lhs: WMFDonateViewModel.AmountButtonViewModel, rhs: WMFDonateViewModel.AmountButtonViewModel) -> Bool {
-            return lhs.amount == rhs.amount
-        }
+    public final class AmountButtonViewModel: ObservableObject, Identifiable {
         
         @Published var amount: Decimal
         @Published var isSelected: Bool = false
@@ -341,7 +338,7 @@ public final class WMFDonateViewModel: NSObject, ObservableObject {
 
         // Deselect other buttons
         for loopButtonViewModel in buttonViewModels {
-            if loopButtonViewModel != buttonViewModel {
+            if loopButtonViewModel.amount != buttonViewModel.amount {
                 loopButtonViewModel.isSelected = false
             }
         }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T365043

### Notes
Something about Identifiable caused Apple Pay form issues on the more recent builds. We weren't using it heavily, so I deleted the conformance and checked the amount directly for deselecting the button state.

### Test Steps
1. Run app in iOS 18 simulator from Xcode 16.
2. Confirm Apple Pay form works as expected.

