### PR TITLE
Fix Core Data threading complaints

### DIFF
--- a/WMF Framework/Remote Notifications/Model/RemoteNotificationsModelController.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotificationsModelController.swift
@@ -113,7 +113,7 @@ final class RemoteNotificationsModelController {
         try FileManager.default.removeItem(at: legecyJournalWalUrl)
     }
     
-    func resetDatabaseAndSharedCache() throws {
+    func resetDatabaseAndSharedCache() {
         
         let batchDeleteBlock: (NSFetchRequest<NSFetchRequestResult>, NSManagedObjectContext) throws -> Void = { [weak self] (fetchRequest, backgroundContext) in
             
@@ -131,21 +131,27 @@ final class RemoteNotificationsModelController {
         }
         
         let backgroundContext = newBackgroundContext()
-        let request: NSFetchRequest<NSFetchRequestResult> = RemoteNotification.fetchRequest()
-        let libraryRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest<NSFetchRequestResult>(entityName: "WMFKeyValue")
-        
-        // batch delete all notification managed objects from Core Data
-        try batchDeleteBlock(request, backgroundContext)
-        
-        // batch delete all library values from Core Data
-        try batchDeleteBlock(libraryRequest, backgroundContext)
-        
-        // remove notifications from shared cache (referenced by the NotificationsService extension)
-        let sharedCache = SharedContainerCache<PushNotificationsCache>.init(fileName: SharedContainerCacheCommonNames.pushNotificationsCache)
-        var cache = sharedCache.loadCache() ?? PushNotificationsCache(settings: .default, notifications: [])
-        cache.notifications = []
-        cache.currentUnreadCount = 0
-        sharedCache.saveCache(cache)
+        backgroundContext.perform {
+            let request: NSFetchRequest<NSFetchRequestResult> = RemoteNotification.fetchRequest()
+            let libraryRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest<NSFetchRequestResult>(entityName: "WMFKeyValue")
+            
+            do {
+                // batch delete all notification managed objects from Core Data
+                try batchDeleteBlock(request, backgroundContext)
+                
+                // batch delete all library values from Core Data
+                try batchDeleteBlock(libraryRequest, backgroundContext)
+                
+                // remove notifications from shared cache (referenced by the NotificationsService extension)
+                let sharedCache = SharedContainerCache<PushNotificationsCache>.init(fileName: SharedContainerCacheCommonNames.pushNotificationsCache)
+                var cache = sharedCache.loadCache() ?? PushNotificationsCache(settings: .default, notifications: [])
+                cache.notifications = []
+                cache.currentUnreadCount = 0
+                sharedCache.saveCache(cache)
+            } catch {
+                DDLogError("Error resetting notifications database: \(error)")
+            }
+        }
     }
     
     func newBackgroundContext() -> NSManagedObjectContext {

--- a/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
@@ -109,7 +109,7 @@ public enum RemoteNotificationsControllerError: LocalizedError {
         do {
             filterState = RemoteNotificationsFilterState(readStatus: .all, offTypes: [], offProjects: [])
             allInboxProjects = []
-            try modelController?.resetDatabaseAndSharedCache()
+            modelController?.resetDatabaseAndSharedCache()
         } catch let error {
             DDLogError("Error resetting notifications database on logout: \(error)")
         }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T375091

### Notes
This fixes a couple of threading complaints thrown when setting the `-com.apple.CoreData.ConcurrencyDebug 1` run argument in the Wikipedia scheme. My hope is that this fixes some of our Core Data crashes that we've been seeing.

### Test Steps
1. Regression test the Suggested Edits card appearance.
2. Go to Notifications, confirm it loads. Log out of the app and log into a different account. Confirm notifications still loads.
