### PR TITLE
Profile/Explore nav fixes

### DIFF
--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -28,7 +28,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         navigationBar.shouldTransformUnderBarViewWithBar = true
         navigationBar.isShadowHidingEnabled = true
 
-        //updateNotificationsCenterButton()
+        // updateNotificationsCenterButton()
         updateProfileViewButton()
         updateNavigationBarVisibility()
 
@@ -684,7 +684,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         }
 
         self.theme = theme
-        //updateNotificationsCenterButton()
+        // updateNotificationsCenterButton()
         updateProfileViewButton()
 
         searchBar.apply(theme: theme)

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -28,7 +28,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         navigationBar.shouldTransformUnderBarViewWithBar = true
         navigationBar.isShadowHidingEnabled = true
 
-        updateNotificationsCenterButton()
+        //updateNotificationsCenterButton()
         updateProfileViewButton()
         updateNavigationBarVisibility()
 
@@ -137,21 +137,21 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         }
     }
 
-    @objc func updateNotificationsCenterButton() {
-        if self.dataStore.authenticationManager.authStateIsPermanent {
-            let numberOfUnreadNotifications = try? dataStore.remoteNotificationsController.numberOfUnreadNotifications()
-            let hasUnreadNotifications = numberOfUnreadNotifications?.intValue ?? 0 != 0
-            let bellImage = BarButtonImageStyle.notificationsButtonImage(theme: theme, indicated: hasUnreadNotifications)
-            let notificationsBarButton = UIBarButtonItem(image: bellImage, style: .plain, target: self, action: #selector(userDidTapNotificationsCenter))
-            notificationsBarButton.accessibilityLabel = hasUnreadNotifications ? CommonStrings.notificationsCenterBadgeTitle : CommonStrings.notificationsCenterTitle
-            navigationItem.leftBarButtonItem = notificationsBarButton
-            navigationBar.displayType = .centeredLargeTitle
-        } else {
-            navigationItem.leftBarButtonItem = nil
-            navigationBar.displayType = .largeTitle
-        }
-        navigationBar.updateNavigationItems()
-    }
+//    @objc func updateNotificationsCenterButton() {
+//        if self.dataStore.authenticationManager.authStateIsPermanent {
+//            let numberOfUnreadNotifications = try? dataStore.remoteNotificationsController.numberOfUnreadNotifications()
+//            let hasUnreadNotifications = numberOfUnreadNotifications?.intValue ?? 0 != 0
+//            let bellImage = BarButtonImageStyle.notificationsButtonImage(theme: theme, indicated: hasUnreadNotifications)
+//            let notificationsBarButton = UIBarButtonItem(image: bellImage, style: .plain, target: self, action: #selector(userDidTapNotificationsCenter))
+//            notificationsBarButton.accessibilityLabel = hasUnreadNotifications ? CommonStrings.notificationsCenterBadgeTitle : CommonStrings.notificationsCenterTitle
+//            navigationItem.leftBarButtonItem = notificationsBarButton
+//            navigationBar.displayType = .centeredLargeTitle
+//        } else {
+//            navigationItem.leftBarButtonItem = nil
+//            navigationBar.displayType = .largeTitle
+//        }
+//        navigationBar.updateNavigationItems()
+//    }
 
     @objc public func updateNavigationBarVisibility() {
         navigationBar.isBarHidingEnabled = UIAccessibility.isVoiceOverRunning ? false : true
@@ -684,7 +684,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         }
 
         self.theme = theme
-        updateNotificationsCenterButton()
+        //updateNotificationsCenterButton()
         updateProfileViewButton()
 
         searchBar.apply(theme: theme)

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1469,7 +1469,7 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
 
 - (void)handleExploreCenterBadgeNeedsUpdateNotification {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self.exploreViewController updateNotificationsCenterButton];
+        //[self.exploreViewController updateNotificationsCenterButton];
         [self.exploreViewController updateProfileViewButton];
         [self.settingsViewController configureBarButtonItems];
     });
@@ -2182,7 +2182,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 - (void)userWasLoggedOut:(NSNotification *)note {
     [self showLoggedOutPanelIfNeeded];
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self.exploreViewController updateNotificationsCenterButton];
+        //[self.exploreViewController updateNotificationsCenterButton];
         [self.exploreViewController updateProfileViewButton];
         [self.settingsViewController configureBarButtonItems];
         UIApplication.sharedApplication.applicationIconBadgeNumber = 0;
@@ -2201,7 +2201,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 
 - (void)userWasLoggedIn:(NSNotification *)note {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self.exploreViewController updateNotificationsCenterButton];
+        //[self.exploreViewController updateNotificationsCenterButton];
         [self.exploreViewController updateProfileViewButton];
         [self.settingsViewController configureBarButtonItems];
 

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -142,7 +142,6 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
     }
 #endif
 
-
     [self applyTheme:self.theme];
 
     [self updateAppEnvironmentWithTheme:self.theme traitCollection:self.traitCollection];
@@ -386,7 +385,6 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
 #pragma mark - Notifications
 
 - (void)appWillEnterForegroundWithNotification:(NSNotification *)note {
-
 }
 
 // When the user launches from a terminated state, resume might not finish before didBecomeActive, so these tasks are held until both items complete
@@ -875,14 +873,13 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
     //    };
 
     self.migrationActive = YES;
-    
+
     MWKDataStore *dataStore = self.dataStore; // Triggers init
     [dataStore finishSetup:^{
-        
         if ([dataStore needsMigration]) {
             [self triggerMigratingAnimation];
         }
-        
+
         [dataStore
             performLibraryUpdates:^{
                 dispatch_async(dispatch_get_main_queue(), ^{
@@ -952,12 +949,12 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
                                                              with:self.theme
                                                        completion:^{
                                                            [self hideSplashView];
-                
-                                                            NSError *saveError = nil;
-                                                            if (![self.dataStore save:&saveError]) {
-                                                                DDLogError(@"Error saving dataStore: %@", saveError);
-                                                            }
-                
+
+                                                           NSError *saveError = nil;
+                                                           if (![self.dataStore save:&saveError]) {
+                                                               DDLogError(@"Error saving dataStore: %@", saveError);
+                                                           }
+
                                                            done();
                                                        }];
         } else if ([self shouldShowExploreScreenOnLaunch]) {
@@ -1473,6 +1470,7 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
 - (void)handleExploreCenterBadgeNeedsUpdateNotification {
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.exploreViewController updateNotificationsCenterButton];
+        [self.exploreViewController updateProfileViewButton];
         [self.settingsViewController configureBarButtonItems];
     });
 }
@@ -1866,7 +1864,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 
     self.view.backgroundColor = theme.colors.baseBackground;
     self.view.tintColor = theme.colors.link;
-    
+
     // Ensures theming happens after main UI is loaded
     if (self.viewControllers.count > 0) {
         [self.settingsViewController applyTheme:theme];
@@ -1890,8 +1888,6 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 
         [self setNeedsStatusBarAppearanceUpdate];
     }
-
-    
 }
 
 - (void)updateAppThemeIfNecessary {
@@ -2149,7 +2145,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 
 #pragma mark - Remote Notifications
 
-- (void)setRemoteNotificationRegistrationStatusWithDeviceToken: (NSData * _Nullable )deviceToken error: (NSError * _Nullable)error {
+- (void)setRemoteNotificationRegistrationStatusWithDeviceToken:(NSData *_Nullable)deviceToken error:(NSError *_Nullable)error {
     [self.notificationsController setRemoteNotificationRegistrationStatusWithDeviceToken:deviceToken error:error];
 }
 
@@ -2187,6 +2183,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
     [self showLoggedOutPanelIfNeeded];
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.exploreViewController updateNotificationsCenterButton];
+        [self.exploreViewController updateProfileViewButton];
         [self.settingsViewController configureBarButtonItems];
         UIApplication.sharedApplication.applicationIconBadgeNumber = 0;
 
@@ -2205,6 +2202,7 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
 - (void)userWasLoggedIn:(NSNotification *)note {
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.exploreViewController updateNotificationsCenterButton];
+        [self.exploreViewController updateProfileViewButton];
         [self.settingsViewController configureBarButtonItems];
 
         if (self.isResumeComplete) {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T374162

### Notes
These were a couple of bugs that I noticed when testing profile:

1. The profile icon badge isn't always in sync with having unread notifications. When I change a read state in Notifications Center, the bell icon will show a badge, but the profile icon does not. I found a few more places in the codebase where the Explore bell icon update was called. I made sure to call the profile update method in the same place.
2. According to task description, we should hide the notifications center bell icon. I commented the icon out in this PR. I'd rather not fully deleting the code just yet until we're sure we won't have to bring it back as a part of https://phabricator.wikimedia.org/T374161 (A/B test control experience).

Note that some of this diff includes automatic linter changes.

### Test Steps
1. Confirm notifications bell icon is hidden.
2. We can't really test the badge update until our Notifications Center navigation is in place.

### Screenshots/Videos
Video of bug:

https://github.com/user-attachments/assets/879261b5-355c-4bb5-8241-f7f245d828db