### PR TITLE
Final fr metric tweaks

### DIFF
--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -23,7 +23,9 @@ extension ArticleViewController {
             }
 
             if !isOptedIn {
-                DonateFunnel.shared.logHiddenBanner(metricsID: activeCampaignAsset.metricsID)
+                if let project {
+                    DonateFunnel.shared.logHiddenBanner(project: project, metricsID: activeCampaignAsset.metricsID)
+                }
             }
 
             guard isOptedIn else {

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -76,7 +76,7 @@ extension ArticleViewController {
             
             if shouldShowMaybeLater {
                 dataController.markAssetAsMaybeLater(asset: asset, currentDate: Date())
-                self.donateDidSetMaybeLater()
+                self.donateDidSetMaybeLater(metricsID: asset.metricsID)
             } else {
                 DonateFunnel.shared.logFundraisingCampaignModalDidTapAlreadyDonated(project: project, metricsID: asset.metricsID)
                 self.donateAlreadyDonated()
@@ -89,7 +89,7 @@ extension ArticleViewController {
             dataController.markAssetAsPermanentlyHidden(asset: asset)
             
         }, footerLinkAction: { url in
-            DonateFunnel.shared.logFundraisingCampaignModalDidTapDonorPolicy(project: project)
+            DonateFunnel.shared.logFundraisingCampaignModalDidTapDonorPolicy(project: project, metricsID: asset.metricsID)
             self.navigate(to: url, useSafari: true)
         }, traceableDismissHandler: { action in
             
@@ -100,14 +100,14 @@ extension ArticleViewController {
         }, showMaybeLater: shouldShowMaybeLater)
     }
 
-    func donateDidSetMaybeLater() {
+    func donateDidSetMaybeLater(metricsID: String) {
         
         let project = WikimediaProject(siteURL: articleURL)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             let title = WMFLocalizedString("donate-later-title", value: "We will remind you again tomorrow.", comment: "Title for toast shown when user clicks remind me later on fundraising banner")
 
             if let project {
-                DonateFunnel.shared.logArticleDidSeeReminderToast(project: project)
+                DonateFunnel.shared.logArticleDidSeeReminderToast(project: project, metricsID: metricsID)
             }
             
             WMFAlertManager.sharedInstance.showBottomAlertWithMessage(title, subtitle: nil, image: UIImage.init(systemName: "checkmark.circle.fill"), type: .custom, customTypeName: "watchlist-add-remove-success", duration: -1, dismissPreviousAlerts: true)

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -1310,7 +1310,7 @@ private extension ArticleViewController {
     }
     
     @objc func userDidTapProfile() {
-        guard let navigationController, let languageCode = articleURL.wmf_languageCode,
+        guard let navigationController, let languageCode = dataStore.languageLinkController.appLanguage?.languageCode,
         let metricsID = DonateCoordinator.metricsID(for: .articleProfile(articleURL), languageCode: languageCode),
         let project else { return }
         

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -1310,9 +1310,10 @@ private extension ArticleViewController {
     }
     
     @objc func userDidTapProfile() {
-        guard let navigationController else { return }
+        guard let navigationController, let languageCode = articleURL.wmf_languageCode,
+        let metricsID = DonateCoordinator.metricsID(for: .articleProfile, languageCode: languageCode) else { return }
         
-        DonateFunnel.shared.logArticleProfile()
+        DonateFunnel.shared.logArticleProfile(metricsID: metricsID)
         let coordinator = ProfileCoordinator(navigationController: navigationController, theme: theme, dataStore: dataStore, donateSouce: .articleProfile, logoutDelegate: self, sourcePage: ProfileCoordinatorSource.article)
         self.profileCoordinator = coordinator
         coordinator.start()

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -1311,10 +1311,11 @@ private extension ArticleViewController {
     
     @objc func userDidTapProfile() {
         guard let navigationController, let languageCode = articleURL.wmf_languageCode,
-        let metricsID = DonateCoordinator.metricsID(for: .articleProfile, languageCode: languageCode) else { return }
+        let metricsID = DonateCoordinator.metricsID(for: .articleProfile(articleURL), languageCode: languageCode),
+        let project else { return }
         
-        DonateFunnel.shared.logArticleProfile(metricsID: metricsID)
-        let coordinator = ProfileCoordinator(navigationController: navigationController, theme: theme, dataStore: dataStore, donateSouce: .articleProfile, logoutDelegate: self, sourcePage: ProfileCoordinatorSource.article)
+        DonateFunnel.shared.logArticleProfile(project: project, metricsID: metricsID)
+        let coordinator = ProfileCoordinator(navigationController: navigationController, theme: theme, dataStore: dataStore, donateSouce: .articleProfile(articleURL), logoutDelegate: self, sourcePage: ProfileCoordinatorSource.article)
         self.profileCoordinator = coordinator
         coordinator.start()
     }

--- a/Wikipedia/Code/DonateCoordinator.swift
+++ b/Wikipedia/Code/DonateCoordinator.swift
@@ -47,18 +47,8 @@ class DonateCoordinator: Coordinator {
         return languageCode
     }()
     
-    private lazy var metricsID: String? = {
-        switch source {
-        case .articleCampaignModal(_, let metricsID, _):
-            return metricsID
-        case .articleProfile, .exploreProfile, .settingsProfile:
-            guard let languageCode = self.languageCode,
-                  let countryCode = Locale.current.region?.identifier else {
-                return nil
-            }
-            
-            return "\(languageCode)\(countryCode)_appmenu_iOS"
-        }
+    private(set) lazy var metricsID: String? = {
+        return Self.metricsID(for: source, languageCode: languageCode)
     }()
     
     private var webViewURL: URL? {
@@ -89,6 +79,20 @@ class DonateCoordinator: Coordinator {
         self.dataStore = dataStore
         self.theme = theme
         self.setLoadingBlock = setLoadingBlock
+    }
+    
+    static func metricsID(for donateSource: Source, languageCode: String?) -> String? {
+        switch donateSource {
+        case .articleCampaignModal(_, let metricsID, _):
+            return metricsID
+        case .articleProfile, .exploreProfile, .settingsProfile:
+            guard let languageCode,
+                  let countryCode = Locale.current.region?.identifier else {
+                return nil
+            }
+            
+            return "\(languageCode)\(countryCode)_appmenu_iOS"
+        }
     }
     
     func start() {

--- a/Wikipedia/Code/DonateCoordinator.swift
+++ b/Wikipedia/Code/DonateCoordinator.swift
@@ -3,6 +3,14 @@ import PassKit
 import WMFComponents
 import WMFData
 
+
+// Helper class to access donate coordinator logic from Obj-c
+@objc class WMFDonateCoordinatorWrapper: NSObject {
+    @objc static func metricsIDForSettingsProfileDonateSource(languageCode: String?) -> String? {
+        return DonateCoordinator.metricsID(for: .settingsProfile, languageCode: languageCode)
+    }
+}
+
 class DonateCoordinator: Coordinator {
     
     // MARK: Nested Types

--- a/Wikipedia/Code/DonateCoordinator.swift
+++ b/Wikipedia/Code/DonateCoordinator.swift
@@ -50,17 +50,21 @@ class DonateCoordinator: Coordinator {
     
     private var webViewURL: URL? {
         
-        var urlString = "https://donate.wikimedia.org/?utm_medium=WikipediaApp&utm_campaign=iOS&utm_source=appmenu&uselang=<langcode>"
+        // Start with settings (appmenu) url
+        var urlString = "https://donate.wikimedia.org/?utm_medium=WikipediaApp&utm_campaign=iOS&utm_source=<langcode><countrycode>_appmenu_iOS&uselang=<langcode>"
         
-        if case .articleCampaignModal(_, _, let articleCampaignDonateURL) = source {
-            urlString = articleCampaignDonateURL.absoluteString
-        }
-        
-        guard let languageCode = dataStore.languageLinkController.appLanguage?.languageCode else {
+        guard let languageCode = dataStore.languageLinkController.appLanguage?.languageCode,
+              let countryCode = Locale.current.region?.identifier else {
             return nil
         }
         
         urlString = urlString.replacingOccurrences(of: "<langcode>", with: languageCode)
+        urlString = urlString.replacingOccurrences(of: "<countrycode>", with: countryCode)
+        
+        // Replace with article campaign url if needed
+        if case .articleCampaignModal(_, _, let articleCampaignDonateURL) = source {
+            urlString = articleCampaignDonateURL.absoluteString
+        }
         
         let appVersion = Bundle.main.wmf_debugVersion()
         return URL(string: urlString)?.appendingAppVersion(appVersion: appVersion)

--- a/Wikipedia/Code/DonateCoordinator.swift
+++ b/Wikipedia/Code/DonateCoordinator.swift
@@ -76,7 +76,7 @@ class DonateCoordinator: Coordinator {
         if case .articleCampaignModal(_, _, let articleCampaignDonateURL) = source {
             urlString = articleCampaignDonateURL.absoluteString
         } else {
-            urlString = "https://donate.wikimedia.org/?utm_medium=WikipediaApp&utm_campaign=iOS&utm_source=\(metricsID)&uselang=<langcode>"
+            urlString = "https://donate.wikimedia.org/?wmf_medium=WikipediaApp&wmf_campaign=iOS&wmf_source=\(metricsID)&uselang=<langcode>"
             urlString = urlString.replacingOccurrences(of: "<langcode>", with: languageCode)
         }
         

--- a/Wikipedia/Code/DonateCoordinator.swift
+++ b/Wikipedia/Code/DonateCoordinator.swift
@@ -569,16 +569,16 @@ extension DonateCoordinator: WMFDonateLoggingDelegate {
         
         switch source {
         case .exploreProfile:
-            print("TODO: Logging")
+            DonateFunnel.shared.logExploreProfileDidSeeApplePayDonateSuccessToast(metricsID: metricsID)
         case .articleProfile:
-            print("TODO: Logging")
+            if let wikimediaProject = self.wikimediaProject {
+                DonateFunnel.shared.logArticleProfileDidSeeApplePayDonateSuccessToast(project: wikimediaProject, metricsID: metricsID)
+            }
         case .settingsProfile:
-            print("TODO: Logging")
-            // This is the old donate logging from WMFSettingsViewController.m cell
-            // DonateFunnel.shared.logSettingDidSeeApplePayDonateSuccessToast()
+            DonateFunnel.shared.logExploreOptOutProfileDidSeeApplePayDonateSuccessToast(metricsID: metricsID)
         case .articleCampaignModal:
             if let wikimediaProject = self.wikimediaProject {
-                DonateFunnel.shared.logArticleDidSeeApplePayDonateSuccessToast(project: wikimediaProject, metricsID: metricsID)
+                DonateFunnel.shared.logArticleCampaignDidSeeApplePayDonateSuccessToast(project: wikimediaProject, metricsID: metricsID)
             }
         }
     }
@@ -674,9 +674,17 @@ extension DonateCoordinator: WMFDonateLoggingDelegate {
                     return
                 }
                 
-                DonateFunnel.shared.logArticleDidSeeApplePayDonateSuccessToast(project: wikimediaProject, metricsID: metricsID)
-            case .articleProfile, .exploreProfile, .settingsProfile:
-                print("TODO: Logging")
+                DonateFunnel.shared.logArticleCampaignDidSeeApplePayDonateSuccessToast(project: wikimediaProject, metricsID: metricsID)
+            case .articleProfile:
+                guard let wikimediaProject else {
+                    return
+                }
+                
+                DonateFunnel.shared.logArticleProfileDidSeeApplePayDonateSuccessToast(project: wikimediaProject, metricsID: metricsID)
+            case .exploreProfile:
+                DonateFunnel.shared.logExploreProfileDidSeeApplePayDonateSuccessToast(metricsID: metricsID)
+            case .settingsProfile:
+                DonateFunnel.shared.logExploreOptOutProfileDidSeeApplePayDonateSuccessToast(metricsID: metricsID)
             }
         }
     }

--- a/Wikipedia/Code/DonateCoordinator.swift
+++ b/Wikipedia/Code/DonateCoordinator.swift
@@ -135,11 +135,11 @@ class DonateCoordinator: Coordinator {
                 DonateFunnel.shared.logArticleProfileDonateCancel()
             case .settingsProfile:
                 DonateFunnel.shared.logExploreOptOutProfileDonateCancel()
-            case .articleCampaignModal:
+            case .articleCampaignModal(_, let metricsID, _):
                guard let project = self.wikimediaProject else {
                    return
                }
-                DonateFunnel.shared.logArticleDidTapCancel(project: project)
+                DonateFunnel.shared.logArticleDidTapCancel(project: project, metricsID: metricsID)
             }
         }))
         
@@ -154,11 +154,11 @@ class DonateCoordinator: Coordinator {
                 DonateFunnel.shared.logArticleProfileDonateApplePay()
             case .settingsProfile:
                 DonateFunnel.shared.logExploreOptOutProfileDonateApplePay()
-            case .articleCampaignModal:
+            case .articleCampaignModal(_, let metricsID, _):
                 guard let project = wikimediaProject else {
                    return
                }
-               DonateFunnel.shared.logArticleDidTapDonateWithApplePay(project: project)
+                DonateFunnel.shared.logArticleDidTapDonateWithApplePay(project: project, metricsID: metricsID)
             }
             self.navigationController.dismiss(animated: true, completion: {
                 self.pushToNativeDonateForm(donateViewModel: donateViewModel)
@@ -177,11 +177,11 @@ class DonateCoordinator: Coordinator {
                 DonateFunnel.shared.logArticleProfileDonateWebPay()
             case .settingsProfile:
                 DonateFunnel.shared.logExploreOptOutProfileDonateWebPay()
-            case .articleCampaignModal:
+            case .articleCampaignModal(_, let metricsID, _):
                 guard let project = wikimediaProject else {
                     return
                 }
-                DonateFunnel.shared.logArticleDidTapOtherPaymentMethod(project: project)
+                DonateFunnel.shared.logArticleDidTapOtherPaymentMethod(project: project, metricsID: metricsID)
             }
             self.navigationController.dismiss(animated: true, completion: {
                 self.pushToOtherPaymentMethod()
@@ -445,7 +445,7 @@ extension DonateCoordinator: WMFDonateLoggingDelegate {
     
 
     private func logNativeFormDidAppear() {
-        DonateFunnel.shared.logDonateFormNativeApplePayImpression(project: wikimediaProject)
+        DonateFunnel.shared.logDonateFormNativeApplePayImpression(project: wikimediaProject, metricsID: metricsID)
     }
     
     private func logNativeFormDidTriggerError(error: any Error) {
@@ -456,13 +456,13 @@ extension DonateCoordinator: WMFDonateLoggingDelegate {
         if let viewModelError = error as? WMFDonateViewModel.Error {
             switch viewModelError {
             case .invalidToken:
-                DonateFunnel.shared.logDonateFormNativeApplePaySubmissionError(errorReason: errorReason, errorCode: errorCode, orderID: nil, project: wikimediaProject)
+                DonateFunnel.shared.logDonateFormNativeApplePaySubmissionError(errorReason: errorReason, errorCode: errorCode, orderID: nil, project: wikimediaProject, metricsID: metricsID)
             case .missingDonorInfo:
-                DonateFunnel.shared.logDonateFormNativeApplePaySubmissionError(errorReason: errorReason, errorCode: errorCode, orderID: nil, project: wikimediaProject)
+                DonateFunnel.shared.logDonateFormNativeApplePaySubmissionError(errorReason: errorReason, errorCode: errorCode, orderID: nil, project: wikimediaProject, metricsID: metricsID)
             case .validationAmountMinimum:
-                DonateFunnel.shared.logDonateFormNativeApplePayEntryError(project: wikimediaProject)
+                DonateFunnel.shared.logDonateFormNativeApplePayEntryError(project: wikimediaProject, metricsID: metricsID)
             case .validationAmountMaximum:
-                DonateFunnel.shared.logDonateFormNativeApplePayEntryError(project: wikimediaProject)
+                DonateFunnel.shared.logDonateFormNativeApplePayEntryError(project: wikimediaProject, metricsID: metricsID)
             }
             return
         }
@@ -470,24 +470,24 @@ extension DonateCoordinator: WMFDonateLoggingDelegate {
         if let donateDataControllerError = error as? WMFDonateDataControllerError {
             switch donateDataControllerError {
             case .paymentsWikiResponseError(let reason, let orderID):
-                DonateFunnel.shared.logDonateFormNativeApplePaySubmissionError(errorReason: reason, errorCode: errorCode, orderID: orderID, project: wikimediaProject)
+                DonateFunnel.shared.logDonateFormNativeApplePaySubmissionError(errorReason: reason, errorCode: errorCode, orderID: orderID, project: wikimediaProject, metricsID: metricsID)
             }
             return
         }
         
-        DonateFunnel.shared.logDonateFormNativeApplePaySubmissionError(errorReason: errorReason, errorCode: errorCode, orderID: nil, project: wikimediaProject)
+        DonateFunnel.shared.logDonateFormNativeApplePaySubmissionError(errorReason: errorReason, errorCode: errorCode, orderID: nil, project: wikimediaProject, metricsID: metricsID)
     }
     
     private func logNativeFormDidTapAmountPresetButton() {
-        DonateFunnel.shared.logDonateFormNativeApplePayDidTapAmountPresetButton(project: wikimediaProject)
+        DonateFunnel.shared.logDonateFormNativeApplePayDidTapAmountPresetButton(project: wikimediaProject, metricsID: metricsID)
     }
     
     private func logNativeFormDidEnterAmountInTextfield() {
-        DonateFunnel.shared.logDonateFormNativeApplePayDidEnterAmountInTextfield(project: wikimediaProject)
+        DonateFunnel.shared.logDonateFormNativeApplePayDidEnterAmountInTextfield(project: wikimediaProject, metricsID: metricsID)
     }
     
     private func logNativeFormDidTapApplePayButton(transactionFeeIsSelected: Bool, recurringMonthlyIsSelected: Bool, emailOptInIsSelected: NSNumber?) {
-        DonateFunnel.shared.logDonateFormNativeApplePayDidTapApplePayButton(transactionFeeIsSelected: transactionFeeIsSelected, recurringMonthlyIsSelected: recurringMonthlyIsSelected, emailOptInIsSelected: emailOptInIsSelected?.boolValue, project: wikimediaProject)
+        DonateFunnel.shared.logDonateFormNativeApplePayDidTapApplePayButton(transactionFeeIsSelected: transactionFeeIsSelected, recurringMonthlyIsSelected: recurringMonthlyIsSelected, emailOptInIsSelected: emailOptInIsSelected?.boolValue, project: wikimediaProject, metricsID: metricsID)
     }
     
     private func logNativeFormDidAuthorizeApplePayPaymentSheet(amount: Decimal, presetIsSelected: Bool, recurringMonthlyIsSelected: Bool, donorEmail: String?, metricsID: String?) {
@@ -504,31 +504,31 @@ extension DonateCoordinator: WMFDonateLoggingDelegate {
             print("TODO: Logging")
             // This is the old donate logging from WMFSettingsViewController.m cell
             // DonateFunnel.shared.logSettingDidSeeApplePayDonateSuccessToast()
-        case .articleCampaignModal:
+        case .articleCampaignModal(_, let metricsID, _):
             if let wikimediaProject = self.wikimediaProject {
-                DonateFunnel.shared.logArticleDidSeeApplePayDonateSuccessToast(project: wikimediaProject)
+                DonateFunnel.shared.logArticleDidSeeApplePayDonateSuccessToast(project: wikimediaProject, metricsID: metricsID)
             }
         }
     }
     
     private func logNativeFormDidTapProblemsDonating() {
-        DonateFunnel.shared.logDonateFormNativeApplePayDidTapProblemsDonatingLink(project: wikimediaProject)
+        DonateFunnel.shared.logDonateFormNativeApplePayDidTapProblemsDonatingLink(project: wikimediaProject, metricsID: metricsID)
     }
     
     private func logNativeFormDidTapOtherWaysToGive() {
-        DonateFunnel.shared.logDonateFormNativeApplePayDidTapOtherWaysToGiveLink(project: wikimediaProject)
+        DonateFunnel.shared.logDonateFormNativeApplePayDidTapOtherWaysToGiveLink(project: wikimediaProject, metricsID: metricsID)
     }
     
     private func logNativeFormDidTapFAQ() {
-        DonateFunnel.shared.logDonateFormNativeApplePayDidTapFAQLink(project: wikimediaProject)
+        DonateFunnel.shared.logDonateFormNativeApplePayDidTapFAQLink(project: wikimediaProject, metricsID: metricsID)
     }
     
     private func logNativeFormDidTapTaxInfo() {
-        DonateFunnel.shared.logDonateFormNativeApplePayDidTapTaxInfoLink(project: wikimediaProject)
+        DonateFunnel.shared.logDonateFormNativeApplePayDidTapTaxInfoLink(project: wikimediaProject, metricsID: metricsID)
     }
     
     private func logWebViewFormDidAppear() {
-        DonateFunnel.shared.logDonateFormInAppWebViewImpression(project: wikimediaProject)
+        DonateFunnel.shared.logDonateFormInAppWebViewImpression(project: wikimediaProject, metricsID: metricsID)
     }
     
     private func logWebViewFormThankYouPageDidAppear() {
@@ -542,7 +542,7 @@ extension DonateCoordinator: WMFDonateLoggingDelegate {
     private func logWebViewFormThankYouDidTapReturn() {
         if case .articleCampaignModal = source,
         let wikimediaProject {
-            DonateFunnel.shared.logDonateFormInAppWebViewDidTapArticleReturnButton(project: wikimediaProject)
+            DonateFunnel.shared.logDonateFormInAppWebViewDidTapArticleReturnButton(project: wikimediaProject, metricsID: metricsID)
         } else {
             DonateFunnel.shared.logDonateFormInAppWebViewDidTapReturnButton()
         }
@@ -556,7 +556,7 @@ extension DonateCoordinator: WMFDonateLoggingDelegate {
             }
             
             if let wikimediaProject {
-                DonateFunnel.shared.logArticleDidSeeApplePayDonateSuccessToast(project: wikimediaProject)
+                DonateFunnel.shared.logArticleDidSeeApplePayDonateSuccessToast(project: wikimediaProject, metricsID: metricsID)
             } else {
                 // This is the old donate logging from WMFSettingsViewController.m cell
                 // DonateFunnel.shared.logSettingDidSeeApplePayDonateSuccessToast()

--- a/Wikipedia/Code/DonateFunnel.swift
+++ b/Wikipedia/Code/DonateFunnel.swift
@@ -87,205 +87,97 @@ import WMF
         EventPlatformClient.shared.submit(stream: .appDonorExperience, event: event)
     }
     
-    func logSettingsDidTapSettingsIcon() {
-        logEvent(activeInterface: .setting, action: .settingClick)
+    func logFundraisingCampaignModalImpression(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleBanner, action: .impression, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    @objc func logSettingsDidTapDonateCell() {
-        logEvent(activeInterface: .setting, action: .donateStartClick)
+    func logFundraisingCampaignModalDidTapClose(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleBanner, action: .closeClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logFundraisingCampaignModalImpression(project: WikimediaProject, metricsID: String?) {
-        
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = [:]
-            actionData?["campaign_id"] = metricsID
-        }
-        
-        logEvent(activeInterface: .articleBanner, action: .impression, actionData: actionData, project: project)
+    func logFundraisingCampaignModalDidTapDonate(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleBanner, action: .donateClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logFundraisingCampaignModalDidTapClose(project: WikimediaProject, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = [:]
-            actionData?["campaign_id"] = metricsID
-        }
-        
-        logEvent(activeInterface: .articleBanner, action: .closeClick, actionData: actionData, project: project)
+    func logFundraisingCampaignModalDidTapMaybeLater(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleBanner, action: .laterClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logFundraisingCampaignModalDidTapDonate(project: WikimediaProject, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .articleBanner, action: .donateClick, actionData: actionData, project: project)
+    func logFundraisingCampaignModalDidTapAlreadyDonated(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleBanner, action: .alreadyDonatedClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logFundraisingCampaignModalDidTapMaybeLater(project: WikimediaProject, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .articleBanner, action: .laterClick, actionData: actionData, project: project)
+    func logFundraisingCampaignModalDidTapDonorPolicy(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleBanner, action: .donorPolicyClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logFundraisingCampaignModalDidTapAlreadyDonated(project: WikimediaProject, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .articleBanner, action: .alreadyDonatedClick, actionData: actionData, project: project)
+    func logArticleDidSeeReminderToast(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .article, action: .reminderToast, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logFundraisingCampaignModalDidTapDonorPolicy(project: WikimediaProject) {
-        logEvent(activeInterface: .articleBanner, action: .donorPolicyClick, project: project)
+    func logArticleDidTapDonateWithApplePay(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleBanner, action: .applePayClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logArticleDidSeeReminderToast(project: WikimediaProject) {
-        logEvent(activeInterface: .article, action: .reminderToast, project: project)
+    func logArticleDidTapOtherPaymentMethod(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleBanner, action: .webPayClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logSettingDidTapApplePay() {
-        logEvent(activeInterface: .setting, action: .applePayClick)
+    func logArticleDidTapCancel(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleBanner, action: .cancelClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logSettingDidTapOtherPaymentMethod() {
-        logEvent(activeInterface: .setting, action: .webPayClick)
+    func logDonateFormNativeApplePayImpression(project: WikimediaProject?, metricsID: String) {
+        logEvent(activeInterface: .applePayInitiated, action: .impression, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logSettingDidTapCancel() {
-        logEvent(activeInterface: .setting, action: .cancelClick)
+    func logDonateFormNativeApplePayEntryError(project: WikimediaProject?, metricsID: String) {
+        logEvent(activeInterface: .applePay, action: .entryError, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logArticleDidTapDonateWithApplePay(project: WikimediaProject, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .articleBanner, action: .applePayClick, actionData: actionData, project: project)
+    func logDonateFormNativeApplePayDidTapAmountPresetButton(project: WikimediaProject?, metricsID: String) {
+        logEvent(activeInterface: .applePay, action: .amountSelected, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logArticleDidTapOtherPaymentMethod(project: WikimediaProject, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .articleBanner, action: .webPayClick, actionData: actionData, project: project)
+    func logDonateFormNativeApplePayDidEnterAmountInTextfield(project: WikimediaProject?, metricsID: String) {
+        logEvent(activeInterface: .applePay, action: .amountEntered, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logArticleDidTapCancel(project: WikimediaProject, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .articleBanner, action: .cancelClick, actionData: actionData, project: project)
-    }
-    
-    func logDonateFormNativeApplePayImpression(project: WikimediaProject?, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .applePayInitiated, action: .impression, actionData: actionData, project: project)
-    }
-    
-    func logDonateFormNativeApplePayEntryError(project: WikimediaProject?, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .applePay, action: .entryError, actionData: actionData, project: project)
-    }
-    
-    func logDonateFormNativeApplePayDidTapAmountPresetButton(project: WikimediaProject?, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .applePay, action: .amountSelected, actionData: actionData, project: project)
-    }
-    
-    func logDonateFormNativeApplePayDidEnterAmountInTextfield(project: WikimediaProject?, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .applePay, action: .amountEntered, actionData: actionData, project: project)
-    }
-    
-    func logDonateFormNativeApplePayDidTapApplePayButton(transactionFeeIsSelected: Bool, recurringMonthlyIsSelected: Bool, emailOptInIsSelected: Bool?, project: WikimediaProject?, metricsID: String?) {
+    func logDonateFormNativeApplePayDidTapApplePayButton(transactionFeeIsSelected: Bool, recurringMonthlyIsSelected: Bool, emailOptInIsSelected: Bool?, project: WikimediaProject?, metricsID: String) {
         var actionData = ["add_transaction": String(transactionFeeIsSelected),
-                          "recurring": String(recurringMonthlyIsSelected)]
+                          "recurring": String(recurringMonthlyIsSelected),
+                          "campaign_id": metricsID]
         
         if let emailOptInIsSelected {
             actionData["email_subscribe"] = String(emailOptInIsSelected)
         }
         
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
         logEvent(activeInterface: .applePay, action: .donateConfirmClick, actionData: actionData, project: project)
     }
     
-    func logDonateFormNativeApplePayDidTapProblemsDonatingLink(project: WikimediaProject?, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .applePay, action: .reportProblemClick, actionData: actionData, project: project)
+    func logDonateFormNativeApplePayDidTapProblemsDonatingLink(project: WikimediaProject?, metricsID: String) {
+        logEvent(activeInterface: .applePay, action: .reportProblemClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logDonateFormNativeApplePayDidTapOtherWaysToGiveLink(project: WikimediaProject?, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .applePay, action: .otherGiveClick, actionData: actionData, project: project)
+    func logDonateFormNativeApplePayDidTapOtherWaysToGiveLink(project: WikimediaProject?, metricsID: String) {
+        logEvent(activeInterface: .applePay, action: .otherGiveClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logDonateFormNativeApplePayDidTapFAQLink(project: WikimediaProject?, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .applePay, action: .faqClick, actionData: actionData, project: project)
+    func logDonateFormNativeApplePayDidTapFAQLink(project: WikimediaProject?, metricsID: String) {
+        logEvent(activeInterface: .applePay, action: .faqClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logDonateFormNativeApplePayDidTapTaxInfoLink(project: WikimediaProject?, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .applePay, action: .taxInfoClick, actionData: actionData, project: project)
+    func logDonateFormNativeApplePayDidTapTaxInfoLink(project: WikimediaProject?, metricsID: String) {
+        logEvent(activeInterface: .applePay, action: .taxInfoClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logDonateFormNativeApplePayDidAuthorizeApplePay(amount: Decimal, presetIsSelected: Bool, recurringMonthlyIsSelected: Bool, metricsID: String?, donorEmail: String?, project: WikimediaProject?) {
+    func logDonateFormNativeApplePayDidAuthorizeApplePay(amount: Decimal, presetIsSelected: Bool, recurringMonthlyIsSelected: Bool, metricsID: String, donorEmail: String?, project: WikimediaProject?) {
         var actionData = ["preset_selected": String(presetIsSelected),
                           "donation_amount": (amount as NSNumber).stringValue,
                           "recurring": String(recurringMonthlyIsSelected),
-                          "pay_method": "applepay"]
-        if let metricsID {
-            actionData["campaign_id"] = metricsID
-        }
-        
+                          "pay_method": "applepay",
+                          "campaign_id": metricsID]
+
         if let donorEmail {
             actionData["email"] = donorEmail
         }
@@ -293,8 +185,8 @@ import WMF
         logEvent(activeInterface: .applePayProcessed, action: .applePayUIConfirm, actionData: actionData, project: project)
     }
     
-    func logDonateFormNativeApplePaySubmissionError(errorReason: String?, errorCode: String?, orderID: String?, project: WikimediaProject?, metricsID: String?) {
-        var actionData: [String: String] = [:]
+    func logDonateFormNativeApplePaySubmissionError(errorReason: String?, errorCode: String?, orderID: String?, project: WikimediaProject?, metricsID: String) {
+        var actionData: [String: String] = ["campaign_id": metricsID]
         
         if let errorReason {
             actionData["error_reason"] = "'\(errorReason)'"
@@ -308,124 +200,90 @@ import WMF
             actionData["order_id"] = orderID
         }
         
-        if let metricsID {
-            actionData["campaign_id"] = metricsID
-        }
-        
         logEvent(activeInterface: .applePay, action: .submissionError, actionData: actionData, project: project)
     }
     
-    func logSettingDidSeeApplePayDonateSuccessToast() {
-        logEvent(activeInterface: .setting, action: .successToastSetting)
+    func logArticleDidSeeApplePayDonateSuccessToast(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .article, action: .successToastArticle, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logArticleDidSeeApplePayDonateSuccessToast(project: WikimediaProject, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .article, action: .successToastArticle, actionData: actionData, project: project)
+    func logDonateFormInAppWebViewImpression(project: WikimediaProject?, metricsID: String) {
+        logEvent(activeInterface: .webPayInitiated, action: .impression, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logDonateFormInAppWebViewImpression(project: WikimediaProject?, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .webPayInitiated, action: .impression, actionData: actionData, project: project)
+    func logDonateFormInAppWebViewThankYouImpression(project: WikimediaProject?, metricsID: String) {
+        logEvent(activeInterface: .webPayProcessed, action: .impression, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logDonateFormInAppWebViewThankYouImpression(project: WikimediaProject?, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = [:]
-            actionData?["campaign_id"] = metricsID
-        }
-        logEvent(activeInterface: .webPayProcessed, action: .impression, actionData: actionData, project: project)
+    func logDonateFormInAppWebViewDidTapArticleReturnButton(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .webPayProcessed, action: .articleReturnClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logDonateFormInAppWebViewDidTapArticleReturnButton(project: WikimediaProject, metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = ["campaign_id": metricsID]
-        }
-        
-        logEvent(activeInterface: .webPayProcessed, action: .articleReturnClick, actionData: actionData, project: project)
-    }
-    
-    func logDonateFormInAppWebViewDidTapReturnButton() {
-        logEvent(activeInterface: .webPayProcessed, action: .returnClick)
+    func logDonateFormInAppWebViewDidTapReturnButton(metricsID: String) {
+        logEvent(activeInterface: .webPayProcessed, action: .returnClick, actionData: ["campaign_id": metricsID])
     }
 
-    func logHiddenBanner(metricsID: String?) {
-        var actionData: [String: String]?
-        if let metricsID {
-            actionData = [:]
-            actionData?["campaign_id"] = metricsID
-        }
-
-        logEvent(activeInterface: .articleBanner, action: .impressionSuppressed, actionData: actionData)
+    func logHiddenBanner(metricsID: String) {
+        logEvent(activeInterface: .articleBanner, action: .impressionSuppressed, actionData: ["campaign_id": metricsID])
     }
     
-    func logArticleProfile() {
-        logEvent(activeInterface: .articleProfile, action: .profileClick)
+    func logArticleProfile(metricsID: String) {
+        logEvent(activeInterface: .articleProfile, action: .profileClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logArticleProfileDonate() {
-        logEvent(activeInterface: .articleProfile, action: .donateStartClick)
+    func logArticleProfileDonate(metricsID: String) {
+        logEvent(activeInterface: .articleProfile, action: .donateStartClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logExploreProfile() {
-        logEvent(activeInterface: .exploreProfile, action: .profileClick)
+    func logExploreProfile(metricsID: String) {
+        logEvent(activeInterface: .exploreProfile, action: .profileClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logExploreProfileDonate() {
-        logEvent(activeInterface: .exploreProfile, action: .donateStartClick)
+    func logExploreProfileDonate(metricsID: String) {
+        logEvent(activeInterface: .exploreProfile, action: .donateStartClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logOptOutExploreProfileDonate() {
-        logEvent(activeInterface: .exploreOptOut, action: .donateStartClick)
+    func logOptOutExploreProfileDonate(metricsID: String) {
+        logEvent(activeInterface: .exploreOptOut, action: .donateStartClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logArticleProfileDonateCancel() {
-        logEvent(activeInterface: .articleProfile, action: .cancelClick)
+    func logArticleProfileDonateCancel(metricsID: String) {
+        logEvent(activeInterface: .articleProfile, action: .cancelClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logExploreProfileDonateCancel() {
-        logEvent(activeInterface: .exploreProfile, action: .cancelClick)
+    func logExploreProfileDonateCancel(metricsID: String) {
+        logEvent(activeInterface: .exploreProfile, action: .cancelClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logExploreOptOutProfileDonateCancel() {
-        logEvent(activeInterface: .exploreOptOut, action: .cancelClick)
+    func logExploreOptOutProfileDonateCancel(metricsID: String) {
+        logEvent(activeInterface: .exploreOptOut, action: .cancelClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logExploreProfileDonateApplePay() {
-        logEvent(activeInterface: .exploreProfile, action: .applePayClick)
+    func logExploreProfileDonateApplePay(metricsID: String) {
+        logEvent(activeInterface: .exploreProfile, action: .applePayClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logArticleProfileDonateApplePay() {
-        logEvent(activeInterface: .articleProfile, action: .applePayClick)
+    func logArticleProfileDonateApplePay(metricsID: String) {
+        logEvent(activeInterface: .articleProfile, action: .applePayClick, actionData: ["campaign_id": metricsID])
     }
 
-    func logExploreOptOutProfileDonateApplePay() {
-        logEvent(activeInterface: .exploreOptOut, action: .applePayClick)
+    func logExploreOptOutProfileDonateApplePay(metricsID: String) {
+        logEvent(activeInterface: .exploreOptOut, action: .applePayClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logExploreProfileDonateWebPay() {
-        logEvent(activeInterface: .exploreProfile, action: .webPayClick)
+    func logExploreProfileDonateWebPay(metricsID: String) {
+        logEvent(activeInterface: .exploreProfile, action: .webPayClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logArticleProfileDonateWebPay() {
-        logEvent(activeInterface: .articleProfile, action: .webPayClick)
+    func logArticleProfileDonateWebPay(metricsID: String) {
+        logEvent(activeInterface: .articleProfile, action: .webPayClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logExploreOptOutProfileDonateWebPay() {
-        logEvent(activeInterface: .exploreOptOut, action: .applePayClick)
+    func logExploreOptOutProfileDonateWebPay(metricsID: String) {
+        logEvent(activeInterface: .exploreOptOut, action: .applePayClick, actionData: ["campaign_id": metricsID])
     }
     
-    @objc func logExploreOptOutProfileClick() {
-        logEvent(activeInterface: .exploreOptOut, action: . profileClick)
+    @objc func logExploreOptOutProfileClick(metricsID: String) {
+        logEvent(activeInterface: .exploreOptOut, action: . profileClick, actionData: ["campaign_id": metricsID])
     }
 }

--- a/Wikipedia/Code/DonateFunnel.swift
+++ b/Wikipedia/Code/DonateFunnel.swift
@@ -223,15 +223,15 @@ import WMF
         logEvent(activeInterface: .webPayProcessed, action: .returnClick, actionData: ["campaign_id": metricsID])
     }
 
-    func logHiddenBanner(metricsID: String) {
+    func logHiddenBanner(project: WikimediaProject, metricsID: String) {
         logEvent(activeInterface: .articleBanner, action: .impressionSuppressed, actionData: ["campaign_id": metricsID])
     }
     
-    func logArticleProfile(metricsID: String) {
-        logEvent(activeInterface: .articleProfile, action: .profileClick, actionData: ["campaign_id": metricsID])
+    func logArticleProfile(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleProfile, action: .profileClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
-    func logArticleProfileDonate(metricsID: String) {
+    func logArticleProfileDonate(project: WikimediaProject, metricsID: String) {
         logEvent(activeInterface: .articleProfile, action: .donateStartClick, actionData: ["campaign_id": metricsID])
     }
     
@@ -247,8 +247,8 @@ import WMF
         logEvent(activeInterface: .exploreOptOut, action: .donateStartClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logArticleProfileDonateCancel(metricsID: String) {
-        logEvent(activeInterface: .articleProfile, action: .cancelClick, actionData: ["campaign_id": metricsID])
+    func logArticleProfileDonateCancel(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleProfile, action: .cancelClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
     func logExploreProfileDonateCancel(metricsID: String) {
@@ -263,8 +263,8 @@ import WMF
         logEvent(activeInterface: .exploreProfile, action: .applePayClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logArticleProfileDonateApplePay(metricsID: String) {
-        logEvent(activeInterface: .articleProfile, action: .applePayClick, actionData: ["campaign_id": metricsID])
+    func logArticleProfileDonateApplePay(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleProfile, action: .applePayClick, actionData: ["campaign_id": metricsID], project: project)
     }
 
     func logExploreOptOutProfileDonateApplePay(metricsID: String) {
@@ -275,8 +275,8 @@ import WMF
         logEvent(activeInterface: .exploreProfile, action: .webPayClick, actionData: ["campaign_id": metricsID])
     }
     
-    func logArticleProfileDonateWebPay(metricsID: String) {
-        logEvent(activeInterface: .articleProfile, action: .webPayClick, actionData: ["campaign_id": metricsID])
+    func logArticleProfileDonateWebPay(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleProfile, action: .webPayClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
     func logExploreOptOutProfileDonateWebPay(metricsID: String) {

--- a/Wikipedia/Code/DonateFunnel.swift
+++ b/Wikipedia/Code/DonateFunnel.swift
@@ -45,6 +45,7 @@ import WMF
         case applePayUIConfirm = "applepay_ui_confirm"
         case successToastSetting = "success_toast_setting"
         case successToastArticle = "success_toast_article"
+        case successToastProfile = "success_toast_profile"
         case articleReturnClick = "article_return_click"
         case returnClick = "return_click"
         case profileClick = "profile_click"
@@ -203,8 +204,20 @@ import WMF
         logEvent(activeInterface: .applePay, action: .submissionError, actionData: actionData, project: project)
     }
     
-    func logArticleDidSeeApplePayDonateSuccessToast(project: WikimediaProject, metricsID: String) {
+    func logArticleCampaignDidSeeApplePayDonateSuccessToast(project: WikimediaProject, metricsID: String) {
         logEvent(activeInterface: .article, action: .successToastArticle, actionData: ["campaign_id": metricsID], project: project)
+    }
+    
+    func logArticleProfileDidSeeApplePayDonateSuccessToast(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .articleProfile, action: .successToastProfile, actionData: ["campaign_id": metricsID], project: project)
+    }
+    
+    func logExploreProfileDidSeeApplePayDonateSuccessToast(metricsID: String) {
+        logEvent(activeInterface: .exploreProfile, action: .successToastProfile, actionData: ["campaign_id": metricsID])
+    }
+    
+    func logExploreOptOutProfileDidSeeApplePayDonateSuccessToast(metricsID: String) {
+        logEvent(activeInterface: .exploreOptOut, action: .successToastProfile, actionData: ["campaign_id": metricsID])
     }
     
     func logDonateFormInAppWebViewImpression(project: WikimediaProject?, metricsID: String) {

--- a/Wikipedia/Code/DonateFunnel.swift
+++ b/Wikipedia/Code/DonateFunnel.swift
@@ -245,7 +245,7 @@ import WMF
     }
     
     func logArticleProfileDonate(project: WikimediaProject, metricsID: String) {
-        logEvent(activeInterface: .articleProfile, action: .donateStartClick, actionData: ["campaign_id": metricsID])
+        logEvent(activeInterface: .articleProfile, action: .donateStartClick, actionData: ["campaign_id": metricsID], project: project)
     }
     
     func logExploreProfile(metricsID: String) {

--- a/Wikipedia/Code/DonateFunnel.swift
+++ b/Wikipedia/Code/DonateFunnel.swift
@@ -163,35 +163,70 @@ import WMF
         logEvent(activeInterface: .setting, action: .cancelClick)
     }
     
-    func logArticleDidTapDonateWithApplePay(project: WikimediaProject) {
-        logEvent(activeInterface: .articleBanner, action: .applePayClick, project: project)
+    func logArticleDidTapDonateWithApplePay(project: WikimediaProject, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .articleBanner, action: .applePayClick, actionData: actionData, project: project)
     }
     
-    func logArticleDidTapOtherPaymentMethod(project: WikimediaProject) {
-        logEvent(activeInterface: .articleBanner, action: .webPayClick, project: project)
+    func logArticleDidTapOtherPaymentMethod(project: WikimediaProject, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .articleBanner, action: .webPayClick, actionData: actionData, project: project)
     }
     
-    func logArticleDidTapCancel(project: WikimediaProject) {
-        logEvent(activeInterface: .articleBanner, action: .cancelClick, project: project)
+    func logArticleDidTapCancel(project: WikimediaProject, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .articleBanner, action: .cancelClick, actionData: actionData, project: project)
     }
     
-    func logDonateFormNativeApplePayImpression(project: WikimediaProject?) {
-        logEvent(activeInterface: .applePayInitiated, action: .impression, project: project)
+    func logDonateFormNativeApplePayImpression(project: WikimediaProject?, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .applePayInitiated, action: .impression, actionData: actionData, project: project)
     }
     
-    func logDonateFormNativeApplePayEntryError(project: WikimediaProject?) {
-        logEvent(activeInterface: .applePay, action: .entryError, project: project)
+    func logDonateFormNativeApplePayEntryError(project: WikimediaProject?, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .applePay, action: .entryError, actionData: actionData, project: project)
     }
     
-    func logDonateFormNativeApplePayDidTapAmountPresetButton(project: WikimediaProject?) {
-        logEvent(activeInterface: .applePay, action: .amountSelected, project: project)
+    func logDonateFormNativeApplePayDidTapAmountPresetButton(project: WikimediaProject?, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .applePay, action: .amountSelected, actionData: actionData, project: project)
     }
     
-    func logDonateFormNativeApplePayDidEnterAmountInTextfield(project: WikimediaProject?) {
-        logEvent(activeInterface: .applePay, action: .amountEntered, project: project)
+    func logDonateFormNativeApplePayDidEnterAmountInTextfield(project: WikimediaProject?, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .applePay, action: .amountEntered, actionData: actionData, project: project)
     }
     
-    func logDonateFormNativeApplePayDidTapApplePayButton(transactionFeeIsSelected: Bool, recurringMonthlyIsSelected: Bool, emailOptInIsSelected: Bool?, project: WikimediaProject?) {
+    func logDonateFormNativeApplePayDidTapApplePayButton(transactionFeeIsSelected: Bool, recurringMonthlyIsSelected: Bool, emailOptInIsSelected: Bool?, project: WikimediaProject?, metricsID: String?) {
         var actionData = ["add_transaction": String(transactionFeeIsSelected),
                           "recurring": String(recurringMonthlyIsSelected)]
         
@@ -199,23 +234,47 @@ import WMF
             actionData["email_subscribe"] = String(emailOptInIsSelected)
         }
         
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
         logEvent(activeInterface: .applePay, action: .donateConfirmClick, actionData: actionData, project: project)
     }
     
-    func logDonateFormNativeApplePayDidTapProblemsDonatingLink(project: WikimediaProject?) {
-        logEvent(activeInterface: .applePay, action: .reportProblemClick, project: project)
+    func logDonateFormNativeApplePayDidTapProblemsDonatingLink(project: WikimediaProject?, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .applePay, action: .reportProblemClick, actionData: actionData, project: project)
     }
     
-    func logDonateFormNativeApplePayDidTapOtherWaysToGiveLink(project: WikimediaProject?) {
-        logEvent(activeInterface: .applePay, action: .otherGiveClick, project: project)
+    func logDonateFormNativeApplePayDidTapOtherWaysToGiveLink(project: WikimediaProject?, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .applePay, action: .otherGiveClick, actionData: actionData, project: project)
     }
     
-    func logDonateFormNativeApplePayDidTapFAQLink(project: WikimediaProject?) {
-        logEvent(activeInterface: .applePay, action: .faqClick, project: project)
+    func logDonateFormNativeApplePayDidTapFAQLink(project: WikimediaProject?, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .applePay, action: .faqClick, actionData: actionData, project: project)
     }
     
-    func logDonateFormNativeApplePayDidTapTaxInfoLink(project: WikimediaProject?) {
-        logEvent(activeInterface: .applePay, action: .taxInfoClick, project: project)
+    func logDonateFormNativeApplePayDidTapTaxInfoLink(project: WikimediaProject?, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .applePay, action: .taxInfoClick, actionData: actionData, project: project)
     }
     
     func logDonateFormNativeApplePayDidAuthorizeApplePay(amount: Decimal, presetIsSelected: Bool, recurringMonthlyIsSelected: Bool, metricsID: String?, donorEmail: String?, project: WikimediaProject?) {
@@ -234,7 +293,7 @@ import WMF
         logEvent(activeInterface: .applePayProcessed, action: .applePayUIConfirm, actionData: actionData, project: project)
     }
     
-    func logDonateFormNativeApplePaySubmissionError(errorReason: String?, errorCode: String?, orderID: String?, project: WikimediaProject?) {
+    func logDonateFormNativeApplePaySubmissionError(errorReason: String?, errorCode: String?, orderID: String?, project: WikimediaProject?, metricsID: String?) {
         var actionData: [String: String] = [:]
         
         if let errorReason {
@@ -249,6 +308,10 @@ import WMF
             actionData["order_id"] = orderID
         }
         
+        if let metricsID {
+            actionData["campaign_id"] = metricsID
+        }
+        
         logEvent(activeInterface: .applePay, action: .submissionError, actionData: actionData, project: project)
     }
     
@@ -256,12 +319,22 @@ import WMF
         logEvent(activeInterface: .setting, action: .successToastSetting)
     }
     
-    func logArticleDidSeeApplePayDonateSuccessToast(project: WikimediaProject) {
-        logEvent(activeInterface: .article, action: .successToastArticle, project: project)
+    func logArticleDidSeeApplePayDonateSuccessToast(project: WikimediaProject, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .article, action: .successToastArticle, actionData: actionData, project: project)
     }
     
-    func logDonateFormInAppWebViewImpression(project: WikimediaProject?) {
-        logEvent(activeInterface: .webPayInitiated, action: .impression, project: project)
+    func logDonateFormInAppWebViewImpression(project: WikimediaProject?, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .webPayInitiated, action: .impression, actionData: actionData, project: project)
     }
     
     func logDonateFormInAppWebViewThankYouImpression(project: WikimediaProject?, metricsID: String?) {
@@ -273,8 +346,13 @@ import WMF
         logEvent(activeInterface: .webPayProcessed, action: .impression, actionData: actionData, project: project)
     }
     
-    func logDonateFormInAppWebViewDidTapArticleReturnButton(project: WikimediaProject) {
-        logEvent(activeInterface: .webPayProcessed, action: .articleReturnClick, project: project)
+    func logDonateFormInAppWebViewDidTapArticleReturnButton(project: WikimediaProject, metricsID: String?) {
+        var actionData: [String: String]?
+        if let metricsID {
+            actionData = ["campaign_id": metricsID]
+        }
+        
+        logEvent(activeInterface: .webPayProcessed, action: .articleReturnClick, actionData: actionData, project: project)
     }
     
     func logDonateFormInAppWebViewDidTapReturnButton() {

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -208,7 +208,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         
         guard let navigationController = self.navigationController,
               let languageCode = dataStore.languageLinkController.appLanguage?.languageCode,
-            let metricsID = DonateCoordinator.metricsID(for: .articleProfile, languageCode: languageCode) else {
+        let metricsID = DonateCoordinator.metricsID(for: .exploreProfile, languageCode: languageCode) else {
             return
         }
         

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -205,10 +205,14 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
     }()
 
     @objc func userDidTapProfile() {
-        DonateFunnel.shared.logExploreProfile()
-        guard let navigationController = self.navigationController else {
+        
+        guard let navigationController = self.navigationController,
+              let languageCode = dataStore.languageLinkController.appLanguage?.languageCode,
+            let metricsID = DonateCoordinator.metricsID(for: .articleProfile, languageCode: languageCode) else {
             return
         }
+        
+        DonateFunnel.shared.logExploreProfile(metricsID: metricsID)
         
         let coordinator = ProfileCoordinator(navigationController: navigationController, theme: theme, dataStore: dataStore, donateSouce: .exploreProfile, logoutDelegate: self, sourcePage: ProfileCoordinatorSource.explore)
 

--- a/Wikipedia/Code/ProfileCoordinator.swift
+++ b/Wikipedia/Code/ProfileCoordinator.swift
@@ -216,13 +216,18 @@ final class ProfileCoordinator: NSObject, Coordinator, ProfileCoordinatorDelegat
     }
     
     func logDonateTap() {
+        
+        guard let metricsID = DonateCoordinator.metricsID(for: donateSouce, languageCode: dataStore.languageLinkController.appLanguage?.languageCode) else {
+            return
+        }
+        
         switch sourcePage {
         case .exploreOptOut:
-            DonateFunnel.shared.logOptOutExploreProfileDonate()
+            DonateFunnel.shared.logOptOutExploreProfileDonate(metricsID: metricsID)
         case .explore:
-            DonateFunnel.shared.logExploreProfileDonate()
+            DonateFunnel.shared.logExploreProfileDonate(metricsID: metricsID)
         case .article:
-            DonateFunnel.shared.logArticleProfileDonate()
+            DonateFunnel.shared.logArticleProfileDonate(metricsID: metricsID)
         }
     }
 }

--- a/Wikipedia/Code/ProfileCoordinator.swift
+++ b/Wikipedia/Code/ProfileCoordinator.swift
@@ -227,7 +227,19 @@ final class ProfileCoordinator: NSObject, Coordinator, ProfileCoordinatorDelegat
         case .explore:
             DonateFunnel.shared.logExploreProfileDonate(metricsID: metricsID)
         case .article:
-            DonateFunnel.shared.logArticleProfileDonate(metricsID: metricsID)
+            
+            switch donateSouce {
+            case .articleProfile(let articleURL):
+                
+                guard let siteURL = articleURL.wmf_site,
+                      let project = WikimediaProject(siteURL: siteURL) else {
+                    return
+                }
+                
+                DonateFunnel.shared.logArticleProfileDonate(project: project, metricsID: metricsID)
+            default:
+                return
+            }
         }
     }
 }

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -280,7 +280,7 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
             break;
         }
         case WMFSettingsMenuItemType_Support: {
-            [[WMFDonateFunnel shared] logSettingsDidTapDonateCell];
+            //[[WMFDonateFunnel shared] logSettingsDidTapDonateCell];
 
             if ([cell isKindOfClass:[WMFSettingsTableViewCell class]]) {
                 WMFSettingsTableViewCell *settingsCell = (WMFSettingsTableViewCell *)cell;
@@ -654,7 +654,13 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
 
 - (void)userDidTapProfile {
     WMFProfileCoordinator *profileCoordinator = [WMFProfileCoordinator profileCoordinatorForSettingsProfileButtonWithNavigationController:self.navigationController theme:self.theme dataStore:self.dataStore logoutDelegate:self sourcePage:ProfileCoordinatorSourceExploreOptOut];
-    [[WMFDonateFunnel shared] logExploreOptOutProfileClick];
+    
+    NSString *metricsID = [WMFDonateCoordinatorWrapper metricsIDForSettingsProfileDonateSourceWithLanguageCode:self.dataStore.languageLinkController.appLanguage.languageCode];
+    
+    if (metricsID) {
+        [[WMFDonateFunnel shared] logExploreOptOutProfileClickWithMetricsID:metricsID];
+    }
+    
     self.profileCoordinator = profileCoordinator;
     [profileCoordinator start];
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T374169

### Notes
This PR is a sweep to make our logging more consistent when donating from either the new profile donate button or an article campaign modal donate button. These inconsistencies existed before we moved the Settings donate button to the profile menu. In general, the changes applied are:

1. It was determined that we should pass an `action_data: campaign_id` value of `{primaryAppLanguageCode}{countryCode}_appmenu_iOS` for all donation events going through profile. The DonateFunnel methods have all been updated to take in a required metricsID.
2. We also want to pass this ID into the web url when choosing "Other payment method" under a "wmf_source" url parameter, and pass this ID when submitting the native payment under the "banner" parameter.
3. When donating through an article campaign modal, some events to DonateFunnel were missing a campaign ID. I added that as well.
4. When donating through the _article_ profile, we want to ensure a `wiki_id` value representing the article wiki is sent in the event payload. We were already doing this with the campaign modal flow, but now I'm sending it with the article profile donation flow. Via code, this looks like passing in a WikimediaProject into the DonateFunnel calls. That project eventually becomes the `wiki_id` value in the funnel class.
5. There were some TODOs still leftover in the DonateCoordinator, that were missing events in the deck. These are the "success toast displayed" events. I have added these for the new profile donation flows.

### Test Steps
I recommend this be kept strictly to code review, because it's so tedious to test. I documented how it's looking through multiple flows here - https://phabricator.wikimedia.org/T374169#10183391. The pieces in this comment that shows this is working are:

1.  campaign_id is now sent in every payload. The ones coming through the profile flows have the word `appmenu` within them.
2. There's now a `success_toast_profile` event when going through a profile donate flow.
3. When going through an article profile flow, we now see that there's a `wiki_id` key in the payloads.
