### PR TITLE
Fix Core Data threading complaints + Auth suggested edits card appearance

### DIFF
--- a/WMF Framework/Remote Notifications/Model/RemoteNotificationsModelController.swift
+++ b/WMF Framework/Remote Notifications/Model/RemoteNotificationsModelController.swift
@@ -113,7 +113,7 @@ final class RemoteNotificationsModelController {
         try FileManager.default.removeItem(at: legecyJournalWalUrl)
     }
     
-    func resetDatabaseAndSharedCache() throws {
+    func resetDatabaseAndSharedCache() {
         
         let batchDeleteBlock: (NSFetchRequest<NSFetchRequestResult>, NSManagedObjectContext) throws -> Void = { [weak self] (fetchRequest, backgroundContext) in
             
@@ -131,21 +131,27 @@ final class RemoteNotificationsModelController {
         }
         
         let backgroundContext = newBackgroundContext()
-        let request: NSFetchRequest<NSFetchRequestResult> = RemoteNotification.fetchRequest()
-        let libraryRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest<NSFetchRequestResult>(entityName: "WMFKeyValue")
-        
-        // batch delete all notification managed objects from Core Data
-        try batchDeleteBlock(request, backgroundContext)
-        
-        // batch delete all library values from Core Data
-        try batchDeleteBlock(libraryRequest, backgroundContext)
-        
-        // remove notifications from shared cache (referenced by the NotificationsService extension)
-        let sharedCache = SharedContainerCache<PushNotificationsCache>.init(fileName: SharedContainerCacheCommonNames.pushNotificationsCache)
-        var cache = sharedCache.loadCache() ?? PushNotificationsCache(settings: .default, notifications: [])
-        cache.notifications = []
-        cache.currentUnreadCount = 0
-        sharedCache.saveCache(cache)
+        backgroundContext.perform {
+            let request: NSFetchRequest<NSFetchRequestResult> = RemoteNotification.fetchRequest()
+            let libraryRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest<NSFetchRequestResult>(entityName: "WMFKeyValue")
+            
+            do {
+                // batch delete all notification managed objects from Core Data
+                try batchDeleteBlock(request, backgroundContext)
+                
+                // batch delete all library values from Core Data
+                try batchDeleteBlock(libraryRequest, backgroundContext)
+                
+                // remove notifications from shared cache (referenced by the NotificationsService extension)
+                let sharedCache = SharedContainerCache<PushNotificationsCache>.init(fileName: SharedContainerCacheCommonNames.pushNotificationsCache)
+                var cache = sharedCache.loadCache() ?? PushNotificationsCache(settings: .default, notifications: [])
+                cache.notifications = []
+                cache.currentUnreadCount = 0
+                sharedCache.saveCache(cache)
+            } catch {
+                DDLogError("Error resetting notifications database: \(error)")
+            }
+        }
     }
     
     func newBackgroundContext() -> NSManagedObjectContext {

--- a/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
@@ -109,7 +109,7 @@ public enum RemoteNotificationsControllerError: LocalizedError {
         do {
             filterState = RemoteNotificationsFilterState(readStatus: .all, offTypes: [], offProjects: [])
             allInboxProjects = []
-            try modelController?.resetDatabaseAndSharedCache()
+            modelController?.resetDatabaseAndSharedCache()
         } catch let error {
             DDLogError("Error resetting notifications database on logout: \(error)")
         }

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -218,6 +218,11 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
                                                object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(authManagerDidHandlePrimaryLanguageChange:)
+                                                 name:[WMFAuthenticationManager didHandlePrimaryLanguageChange]
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleExploreCenterBadgeNeedsUpdateNotification)
                                                  name:NSNotification.notificationsCenterBadgeNeedsUpdate
                                                object:nil];
@@ -2213,6 +2218,16 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
         [self.dataStore.feedContentController updateContentSource:[WMFSuggestedEditsContentSource class]
                                                             force:YES
                                                        completion:nil];
+    });
+}
+
+- (void)authManagerDidHandlePrimaryLanguageChange:(NSNotification *)note {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self.isResumeComplete) {
+            [self.dataStore.feedContentController updateContentSource:[WMFSuggestedEditsContentSource class]
+                                                                force:YES
+                                                           completion:nil];
+        }
     });
 }
 

--- a/Wikipedia/Code/WMFAuthenticationManager.swift
+++ b/Wikipedia/Code/WMFAuthenticationManager.swift
@@ -50,6 +50,7 @@ import CocoaLumberjackSwift
     
     @objc public static let didLogOutNotification = Notification.Name("WMFAuthenticationManagerDidLogOut")
     @objc public static let didLogInNotification = Notification.Name("WMFAuthenticationManagerDidLogIn")
+    @objc public static let didHandlePrimaryLanguageChange = Notification.Name("WMFAuthenticationManagerDidHandlePrimaryLanguageChange")
     
     @objc weak var delegate: WMFAuthenticationManagerDelegate?
     
@@ -61,10 +62,11 @@ import CocoaLumberjackSwift
     @objc public required init(session: Session, configuration: Configuration) {
         accountLoginLogoutFetcher = WMFAccountLoginLogoutFetcher(session: session, configuration: configuration)
         currentUserFetcher = WMFCurrentUserFetcher(session: session, configuration: configuration)
+        super.init()
+        NotificationCenter.default.addObserver(self, selector: #selector(appLanguageDidChange(_:)), name: NSNotification.Name.WMFAppLanguageDidChange, object: nil)
     }
     
     // MARK: Public
-    
     
     /// Pulls a current user from cache, according to the siteURL we want to check against.
     /// Current user cache is populated via a call to https://www.mediawiki.org/wiki/API:Userinfo.
@@ -367,6 +369,32 @@ import CocoaLumberjackSwift
         set {
             UserDefaults.standard.isUserUnawareOfLogout = newValue
         }
+    }
+    
+    // MARK: NSNotifications
+    
+    @objc private func appLanguageDidChange(_ notification: Notification) {
+        guard let siteURL = loginSiteURL else {
+            return
+        }
+        
+        // App Language has changed. Fetch current user again to refresh currentUserCache.
+        
+        guard let langController = notification.object, let appLanguage = (langController as AnyObject).appLanguage else {
+            assertionFailure("Could not extract app language from WMFAppLanguageDidChangeNotification")
+            return
+        }
+        
+        self.currentUserFetcher.fetch(siteURL: siteURL, success: { user in
+            DispatchQueue.main.async {
+                if let host = siteURL.host {
+                    self.currentUserCache[host] = user
+                    NotificationCenter.default.post(name: WMFAuthenticationManager.didHandlePrimaryLanguageChange, object: nil)
+                }
+            }
+        }, failure: { error in
+            DDLogError("Failure refreshing currentUserCache after app language change: \(error)")
+        })
     }
     
     // MARK: Private


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T375091

### Notes
This is a repeat PR of https://github.com/wikimedia/wikipedia-ios/pull/4974 with the PR feedback addressed.

### Test Steps
1. Regression test the Suggested Edits card appearance.
2. Go to Notifications, confirm it loads. Log out of the app and log into a different account. Confirm notifications still loads.

af85b00528d61ce4bfe2ceee2709ce70069c59ca - this commit fixes the regression found in the PR feedback on https://github.com/wikimedia/wikipedia-ios/pull/4974. Now when changing the app primary language, the authentication manager will fetch the user's information against their app primary language and cache it. Then the Explore feed will refresh and re-evaluate the suggested edits card visibility.