### PR TITLE
Tweak campaign metric IDs

### DIFF
--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -127,6 +127,6 @@ extension ArticleViewController {
 
 extension WMFFundraisingCampaignConfig.WMFAsset {
     var metricsID: String {
-        return "\(languageCode)\(id)_iOS"
+        return "\(languageCode)\(countryCode)_\(id)_iOS"
     }
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T374169

### Notes
This is a minor tweak to our campaign metrics IDs.

### Test Steps
1. Change device date to October 5th
2. Change device region to France
3. Set WMFLogging.h log level to DDLogLevelAll.
4. Fresh install app, choose French Wiki as primary app language
5. On Explore feed, background, foreground, then pull to refresh to fetch campaigns.
6. Visit an article on French Wikipedia.
7. Confirm you see campaign modal, and you start to see `app_donor_experience` events. Confirm in the payloads you see a campaign ID of `campaign_id:enFR_FR_2024_10_iOS`

