### PR TITLE
Update alt text percentage and image recs announcement modal

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Alt Text/WMFAltTextDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Alt Text/WMFAltTextDataController.swift
@@ -35,10 +35,8 @@ public final class WMFAltTextDataController {
     private let experimentsDataController: WMFExperimentsDataController
     private let developerSettingsDataController: WMFDeveloperSettingsDataController
     private let userDefaultsStore: WMFKeyValueStore
-    private var experimentPercentage: Int {
-        developerSettingsDataController.alwaysShowAltTextEntryPoint ? 100 : 50
-    }
-    
+    private var experimentPercentage: Int = 100
+
     // MARK: - Public
     
     public init?(experimentStore: WMFKeyValueStore? = WMFDataEnvironment.current.sharedCacheStore, userDefaultsStore: WMFKeyValueStore? = WMFDataEnvironment.current.userDefaultsStore) {

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -987,7 +987,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         imageRecommendationsDataController.hasPresentedFeatureAnnouncementModalAgainForAltTextTargetWikis = true
     }
     
-    // TODO: - Remove after expiry date (4 Oct, 2024)
+    // TODO: - Remove after expiry date (5 Nov, 2024)
     private func presentImageRecommendationsFeatureAnnouncementIfNeeded() {
         
         guard ImageRecommendationsFeatureAnnouncementTimeBox.isAnnouncementActive() else {
@@ -1046,13 +1046,13 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
 }
 
 // MARK: - Image Recommendations Announcement Time-box
-// TODO: - Remove after expiry date (4 Oct, 2024)
+// TODO: - Remove after expiry date (5 Nov, 2024)
 struct ImageRecommendationsFeatureAnnouncementTimeBox {
     static let expiryDate: Date? = {
         var expiryDateComponents = DateComponents()
         expiryDateComponents.year = 2024
-        expiryDateComponents.month = 10
-        expiryDateComponents.day = 4
+        expiryDateComponents.month = 11
+        expiryDateComponents.day = 5
         return Calendar.current.date(from: expiryDateComponents)
     }()
     


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T376229

### Notes
* Updates the alt text experiment percentage to 100
* Updates the Image recs feature announcement card to still display during the alt-text experiment

### Test Steps
1. Fresh install the app with a target language
2. You should see the feature announcement modal
3. Go through either image recs or the edit flow in an eligible article
4. If you saw the alt text prompt in either, do the other task: you should not see the prompt again
5. Fresh install the app again, until you're sorted into control in any task (alt text or regular edit). 
6. Try the other task. You should see the alt text prompt.

