### PR TITLE
[YiR] Add yearID to feature config

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
@@ -5,6 +5,8 @@ public class WMFYearInReviewDataController {
 
     private let coreDataStore: WMFCoreDataStore
     private let developerSettingsDataController: WMFDeveloperSettingsDataControlling
+    
+    public let targetConfigYearID = "2024.1"
 
     public init(coreDataStore: WMFCoreDataStore? = WMFDataEnvironment.current.coreDataStore, developerSettingsDataController: WMFDeveloperSettingsDataControlling = WMFDeveloperSettingsDataController.shared) throws {
         guard let coreDataStore else {
@@ -20,7 +22,8 @@ public class WMFYearInReviewDataController {
             return false
         }
 
-        guard let iosFeatureConfig = developerSettingsDataController.loadFeatureConfig()?.ios.first else {
+        guard let iosFeatureConfig = developerSettingsDataController.loadFeatureConfig()?.ios.first,
+              let yirConfig = iosFeatureConfig.yir(yearID: targetConfigYearID) else {
             return false
         }
 
@@ -29,12 +32,12 @@ public class WMFYearInReviewDataController {
             return false
         }
 
-        let uppercaseConfigCountryCodes = iosFeatureConfig.yir.countryCodes.map { $0.uppercased() }
+        let uppercaseConfigCountryCodes = yirConfig.countryCodes.map { $0.uppercased() }
         guard uppercaseConfigCountryCodes.contains(countryCode.uppercased()) else {
             return false
         }
 
-        let uppercaseConfigPrimaryAppLanguageCodes = iosFeatureConfig.yir.primaryAppLanguageCodes.map { $0.uppercased() }
+        let uppercaseConfigPrimaryAppLanguageCodes = yirConfig.primaryAppLanguageCodes.map { $0.uppercased() }
         guard let languageCode = primaryAppLanguageProject.languageCode,
               uppercaseConfigPrimaryAppLanguageCodes.contains(languageCode.uppercased()) else {
             return false
@@ -246,24 +249,25 @@ public class WMFYearInReviewDataController {
             return false
         }
         
-        guard let iosFeatureConfig = developerSettingsDataController.loadFeatureConfig()?.ios.first else {
+        guard let iosFeatureConfig = developerSettingsDataController.loadFeatureConfig()?.ios.first,
+              let yirConfig = iosFeatureConfig.yir(yearID: targetConfigYearID) else {
             return false
         }
         
         // Check remote feature disable switch
-        guard iosFeatureConfig.yir.isEnabled else {
+        guard yirConfig.isEnabled else {
             return false
         }
         
         
         // Check remote valid country codes
-        let uppercaseConfigCountryCodes = iosFeatureConfig.yir.countryCodes.map { $0.uppercased() }
+        let uppercaseConfigCountryCodes = yirConfig.countryCodes.map { $0.uppercased() }
         guard uppercaseConfigCountryCodes.contains(countryCode.uppercased()) else {
             return false
         }
         
         // Check remote valid primary app language wikis
-        let uppercaseConfigPrimaryAppLanguageCodes = iosFeatureConfig.yir.primaryAppLanguageCodes.map { $0.uppercased() }
+        let uppercaseConfigPrimaryAppLanguageCodes = yirConfig.primaryAppLanguageCodes.map { $0.uppercased() }
         guard let languageCode = primaryAppLanguageProject.languageCode,
               uppercaseConfigPrimaryAppLanguageCodes.contains(languageCode.uppercased()) else {
             return false
@@ -273,14 +277,14 @@ public class WMFYearInReviewDataController {
         
         // TODO: Check persisted slide item here https://phabricator.wikimedia.org/T376041
         // if {read_count persisted slide item}.display == yes {
-            if iosFeatureConfig.yir.personalizedSlides.readCount.isEnabled {
+            if yirConfig.personalizedSlides.readCount.isEnabled {
                 personalizedSlideCount += 1
             }
         // }
         
         // TODO: Check persisted slide item here https://phabricator.wikimedia.org/T376041
         // if {edit_count persisted slide item}.display == yes {
-            if iosFeatureConfig.yir.personalizedSlides.editCount.isEnabled {
+            if yirConfig.personalizedSlides.editCount.isEnabled {
                 personalizedSlideCount += 1
             }
         // }

--- a/WMFData/Sources/WMFData/Models/Developer Settings/WMFFeatureConfigResponse.swift
+++ b/WMFData/Sources/WMFData/Models/Developer Settings/WMFFeatureConfigResponse.swift
@@ -14,6 +14,7 @@ public struct WMFFeatureConfigResponse: Codable {
                 public let isEnabled: Bool
             }
             
+            public let yearID: String
             public let isEnabled: Bool
             public let countryCodes: [String]
             public let primaryAppLanguageCodes: [String]
@@ -24,7 +25,11 @@ public struct WMFFeatureConfigResponse: Codable {
 
         let version: Int
 
-        public let yir: YearInReview
+        public let yir: [YearInReview]
+        
+        public func yir(yearID: String) -> YearInReview? {
+            return yir.first { $0.yearID == yearID }
+        }
     }
     
     public let ios: [IOS]

--- a/WMFData/Sources/WMFDataMocks/Resources/feature-get-config.json
+++ b/WMFData/Sources/WMFDataMocks/Resources/feature-get-config.json
@@ -3,7 +3,8 @@
     "ios": [
         {
             "version": 1,
-            "yir": {
+            "yir": [{
+                "yearID": "2024.1",
                 "isEnabled": true,
                 "countryCodes": [
                     "FR",
@@ -23,7 +24,7 @@
                         "isEnabled": true
                     }
                 }
-            }
+            }]
         }
     ],
     "android": {}

--- a/WMFData/Tests/WMFDataTests/WMFDeveloperSettingsDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFDeveloperSettingsDataControllerTests.swift
@@ -28,19 +28,21 @@ final class WMFDeveloperSettingsDataControllerTests: XCTestCase {
                 return
             }
             
-            guard let config = controller.loadFeatureConfig() else {
+            guard let config = controller.loadFeatureConfig(),
+                  let iosConfig = config.ios.first,
+            let yirConfig = config.ios.first?.yir(yearID: "2024.1") else {
                 XCTFail("Failure loading feature config")
                 return
             }
             
-            XCTAssertEqual(config.ios.first?.version, 1, "Unexpected feature config version")
-            XCTAssertEqual(config.ios.first?.yir.isEnabled, true, "Unexpected feature config yir isEnabled")
-            XCTAssertEqual(config.ios.first?.yir.countryCodes.count, 2, "Unexpected feature config yir countryCodes count")
-            XCTAssertEqual(config.ios.first?.yir.primaryAppLanguageCodes.count, 2, "Unexpected feature config yir primaryAppLanguageCodes count")
-            XCTAssertEqual(config.ios.first?.yir.dataPopulationStartDateString, "2024-01-01T00:00:00Z", "Unexpected feature config yir dataPopulationStartDateString")
-            XCTAssertEqual(config.ios.first?.yir.dataPopulationEndDateString, "2024-11-01T00:00:00Z", "Unexpected feature config yir dataPopulationEndDateString")
-            XCTAssertEqual(config.ios.first?.yir.personalizedSlides.readCount.isEnabled, true, "Unexpected feature config yir personalizedSlides readCount isEnabled flag")
-            XCTAssertEqual(config.ios.first?.yir.personalizedSlides.editCount.isEnabled, true, "Unexpected feature config yir personalizedSlides editCount isEnabled flag")
+            XCTAssertEqual(iosConfig.version, 1, "Unexpected feature config version")
+            XCTAssertEqual(yirConfig.isEnabled, true, "Unexpected feature config yir isEnabled")
+            XCTAssertEqual(yirConfig.countryCodes.count, 2, "Unexpected feature config yir countryCodes count")
+            XCTAssertEqual(yirConfig.primaryAppLanguageCodes.count, 2, "Unexpected feature config yir primaryAppLanguageCodes count")
+            XCTAssertEqual(yirConfig.dataPopulationStartDateString, "2024-01-01T00:00:00Z", "Unexpected feature config yir dataPopulationStartDateString")
+            XCTAssertEqual(yirConfig.dataPopulationEndDateString, "2024-11-01T00:00:00Z", "Unexpected feature config yir dataPopulationEndDateString")
+            XCTAssertEqual(yirConfig.personalizedSlides.readCount.isEnabled, true, "Unexpected feature config yir personalizedSlides readCount isEnabled flag")
+            XCTAssertEqual(yirConfig.personalizedSlides.editCount.isEnabled, true, "Unexpected feature config yir personalizedSlides editCount isEnabled flag")
             
             expectation.fulfill()
         }

--- a/WMFData/Tests/WMFDataTests/WMFYearInReviewDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFYearInReviewDataControllerTests.swift
@@ -133,8 +133,8 @@ final class YearInReviewDataControllerTests: XCTestCase {
         let readCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let editCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let personalizedSlides = WMFFeatureConfigResponse.IOS.YearInReview.PersonalizedSlides(readCount: readCountSlideSettings, editCount: editCountSlideSettings)
-        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(isEnabled: false, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
-        let ios = WMFFeatureConfigResponse.IOS(version: 1, yir: yearInReview)
+        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.1", isEnabled: false, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
+        let ios = WMFFeatureConfigResponse.IOS(version: 1, yir: [yearInReview])
         let config = WMFFeatureConfigResponse(ios: [ios])
         
         // Create mock developer settings data controller
@@ -159,8 +159,8 @@ final class YearInReviewDataControllerTests: XCTestCase {
         let readCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let editCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let personalizedSlides = WMFFeatureConfigResponse.IOS.YearInReview.PersonalizedSlides(readCount: readCountSlideSettings, editCount: editCountSlideSettings)
-        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(isEnabled: true, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
-        let ios = WMFFeatureConfigResponse.IOS(version: 1, yir: yearInReview)
+        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.1", isEnabled: true, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
+        let ios = WMFFeatureConfigResponse.IOS(version: 1, yir: [yearInReview])
         let config = WMFFeatureConfigResponse(ios: [ios])
         
         // Create mock developer settings data controller
@@ -189,8 +189,8 @@ final class YearInReviewDataControllerTests: XCTestCase {
         let readCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let editCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let personalizedSlides = WMFFeatureConfigResponse.IOS.YearInReview.PersonalizedSlides(readCount: readCountSlideSettings, editCount: editCountSlideSettings)
-        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(isEnabled: true, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
-        let ios = WMFFeatureConfigResponse.IOS(version: 1, yir: yearInReview)
+        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.1", isEnabled: true, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
+        let ios = WMFFeatureConfigResponse.IOS(version: 1, yir: [yearInReview])
         let config = WMFFeatureConfigResponse(ios: [ios])
         
         // Create mock developer settings data controller


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T376040

### Notes
This PR adds the discussed `yearID` to our remote config.

### Test Steps
1. Change device simulator region to France.
2. Run this app on the **Staging** scheme, which points to an updated test wiki [config](https://test.wikipedia.org/wiki/MediaWiki:AppsFeatureConfig.json).
3. In onboarding, choose English Wikipedia.
4. In Developer Settings, enable feature flag.
5. Profile entry point should **not** appear.
6. In app Settings, change primary app language to French Wikipedia.
7. Profile entry point should appear.

