### PR TITLE
Save web donations locally

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonateDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonateDataController.swift
@@ -31,7 +31,7 @@ import Contacts
     @objc(sharedInstance)
     public static let shared = WMFDonateDataController()
     
-    private init(service: WMFService? = WMFDataEnvironment.current.basicService, sharedCacheStore: WMFKeyValueStore? = WMFDataEnvironment.current.sharedCacheStore) {
+    public init(service: WMFService? = WMFDataEnvironment.current.basicService, sharedCacheStore: WMFKeyValueStore? = WMFDataEnvironment.current.sharedCacheStore) {
        self.service = service
         self.sharedCacheStore = sharedCacheStore
    }

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -1389,6 +1389,7 @@
 		834CC34C21075B7600F62818 /* UITabBar+Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834CC34A21075B7600F62818 /* UITabBar+Theme.swift */; };
 		834CC34D21075B7600F62818 /* UITabBar+Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834CC34A21075B7600F62818 /* UITabBar+Theme.swift */; };
 		834F47F42833D91F00F86C80 /* RemoteNotificationFilterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834F47F32833D91F00F86C80 /* RemoteNotificationFilterType.swift */; };
+		835021BA2CD1496E00D0CB5E /* SinglePageWebViewParseDonationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835021B92CD1495900D0CB5E /* SinglePageWebViewParseDonationTests.swift */; };
 		8350FC4C20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8350FC4B20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift */; };
 		8350FC4D20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8350FC4B20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift */; };
 		8350FC4E20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8350FC4B20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift */; };
@@ -3737,6 +3738,7 @@
 		834C269D240D49F400245BE7 /* ReferenceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferenceViewController.swift; sourceTree = "<group>"; };
 		834CC34A21075B7600F62818 /* UITabBar+Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBar+Theme.swift"; sourceTree = "<group>"; };
 		834F47F32833D91F00F86C80 /* RemoteNotificationFilterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationFilterType.swift; sourceTree = "<group>"; };
+		835021B92CD1495900D0CB5E /* SinglePageWebViewParseDonationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinglePageWebViewParseDonationTests.swift; sourceTree = "<group>"; };
 		8350FC4B20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleLocationAuthorizationCollectionViewCell.swift; sourceTree = "<group>"; };
 		83510B0628F4CF6400B6235B /* TalkPageErrorStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageErrorStateView.swift; sourceTree = "<group>"; };
 		8351CE7720D4424100E32FC1 /* CollectionViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewHeader.swift; sourceTree = "<group>"; };
@@ -7899,6 +7901,7 @@
 				67ED8EAF24F99F1900DD5D39 /* Significant Events Tests */,
 				679FA102242E64FC0095F3C6 /* Article Tests */,
 				8330533223F0388E00123141 /* DataStoreTests.swift */,
+				835021B92CD1495900D0CB5E /* SinglePageWebViewParseDonationTests.swift */,
 				D8BDA8C01E71C0760031F4BF /* WMFBlocksKitTests.m */,
 				B39427411E71F79700D3146D /* NSDictionaryBlocksKitTest.m */,
 				B39427421E71F79700D3146D /* NSSetBlocksKitTest.m */,
@@ -10089,6 +10092,7 @@
 				004281C925E6EFC4004945B3 /* LSStubResponseDSL.m in Sources */,
 				004281B225E6EFC4004945B3 /* LSStubRequest.m in Sources */,
 				004281C025E6EFC4004945B3 /* NSString+Matcheable.m in Sources */,
+				835021BA2CD1496E00D0CB5E /* SinglePageWebViewParseDonationTests.swift in Sources */,
 				004281C425E6EFC4004945B3 /* LSRegexMatcher.m in Sources */,
 				004281C225E6EFC4004945B3 /* LSDataMatcher.m in Sources */,
 				004281C625E6EFC4004945B3 /* NSString+Nocilla.m in Sources */,

--- a/Wikipedia/Code/SinglePageWebViewController.swift
+++ b/Wikipedia/Code/SinglePageWebViewController.swift
@@ -218,7 +218,7 @@ class SinglePageWebViewController: ViewController {
             return nil
         }
 
-        let isRecurring = queryDict.keys.contains("recurring")
+        let isRecurring = queryDict["recurring"] == "true" || queryDict.keys.contains("recurring") && queryDict["recurring"] == nil
 
         let donationInfo = DonationInfo(amount: amount, country: country, currency: currency, isRecurring: isRecurring)
 

--- a/Wikipedia/Code/SinglePageWebViewController.swift
+++ b/Wikipedia/Code/SinglePageWebViewController.swift
@@ -2,6 +2,7 @@
 import CocoaLumberjackSwift
 import WMF
 import WMFComponents
+import WMFData
 
 class SinglePageWebViewController: ViewController {
     
@@ -19,7 +20,9 @@ class SinglePageWebViewController: ViewController {
     
     let url: URL
     private let donateConfig: WebViewDonateConfig?
-    
+
+    private let donateDataController = WMFDonateDataController()
+
     var doesUseSimpleNavigationBar: Bool {
         didSet {
             if doesUseSimpleNavigationBar {
@@ -190,13 +193,69 @@ class SinglePageWebViewController: ViewController {
         } else if action.navigationType == .other,
                   actionURL.isThankYouDonationURL {
             didReachThankyouPage = true
+            let parsedDonationInfo = parseThankYouURL(actionURL)
+            saveDonationToLocalHistory(donationInfo: parsedDonationInfo, dataController: donateDataController)
             setupDonationCompleteView()
             donateConfig?.donateLoggingDelegate?.handleDonateLoggingAction(.webViewFormThankYouPageDidAppear)
         }
         
         return true
     }
-    
+
+    func parseThankYouURL(_ url: URL) -> DonationInfo? {
+        guard let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        let queryItems = urlComponents.queryItems ?? []
+        let queryDict = Dictionary(uniqueKeysWithValues: queryItems.compactMap { item in
+            (item.name, item.value)
+        })
+
+        guard let amount = queryDict["amount"],
+              let country = queryDict["country"],
+              let currency = queryDict["currency"] else {
+            return nil
+        }
+
+        let isRecurring = queryDict.keys.contains("recurring")
+
+        let donationInfo = DonationInfo(amount: amount, country: country, currency: currency, isRecurring: isRecurring)
+
+        return donationInfo
+    }
+
+    private func saveDonationToLocalHistory(donationInfo: DonationInfo?, dataController: WMFDonateDataController) {
+        guard let donationInfo,
+        let decimalAmount = Decimal(string: donationInfo.amount ?? String()),
+                let currency = donationInfo.currency else {
+            return
+        }
+        let iso8601Format = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"
+        let date = Date()
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+        dateFormatter.dateFormat = iso8601Format
+        let timestamp = dateFormatter.string(from: date)
+
+        let donationType: WMFDonateLocalHistory.DonationType = donationInfo.isRecurring ? .recurring : .oneTime
+        let donationHistoryEntry = WMFDonateLocalHistory(donationTimestamp: timestamp,
+                                                         donationType: donationType,
+                                                         donationAmount: decimalAmount,
+                                                         currencyCode: currency,
+                                                         isNative: false,
+                                                         isFirstDonation: !userHasLocallySavedDonations(dataController: dataController)
+        )
+        dataController.saveLocalDonationHistory(donationHistoryEntry)
+    }
+
+    private func userHasLocallySavedDonations(dataController: WMFDonateDataController) -> Bool {
+        if let donations = dataController.loadLocalDonationHistory() {
+            return !donations.isEmpty
+        }
+        return false
+    }
+
     @objc func tappedAction(_ sender: UIBarButtonItem) {
         let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: [TUSafariActivity()])
         
@@ -275,4 +334,12 @@ extension SinglePageWebViewController: WKUIDelegate {
         
         present(alertController, animated: true)
     }
+}
+
+
+struct DonationInfo {
+    let amount: String?
+    let country: String?
+    let currency: String?
+    let isRecurring: Bool
 }

--- a/WikipediaUnitTests/Code/SinglePageWebViewParseDonationTests.swift
+++ b/WikipediaUnitTests/Code/SinglePageWebViewParseDonationTests.swift
@@ -5,7 +5,7 @@ import XCTest
 class SinglePageWebViewControllerTests: XCTestCase {
 
     func testParseThankYouURL_WithAllParametersIncludingRecurring() {
-        let urlString = "https://thankyou.wikipedia.org/wiki/Thank_You/en?amount=1.00&country=US&currency=USD&order_id=218642670.1&payment_method=apple&recurring&wmf_medium=WikipediaApp&wmf_source=app_2023_en6C_iOS_control.app.apple&wmf_campaign=iOS"
+        let urlString = "https://thankyou.wikipedia.org/wiki/Thank_You/en?amount=1.00&country=US&currency=USD&order_id=218642670.1&payment_method=apple&recurring=true&wmf_medium=WikipediaApp&wmf_source=app_2023_en6C_iOS_control.app.apple&wmf_campaign=iOS"
         guard let url = URL(string: urlString) else {
             XCTFail("Failed to create URL from string")
             return
@@ -19,11 +19,11 @@ class SinglePageWebViewControllerTests: XCTestCase {
         XCTAssertEqual(result?.amount, "1.00", "Amount should be 1.00")
         XCTAssertEqual(result?.country, "US", "Country should be US")
         XCTAssertEqual(result?.currency, "USD", "Currency should be USD")
-        XCTAssertTrue(((result?.isRecurring) != nil), "isRecurring should be true")
+        XCTAssertTrue(result?.isRecurring ?? false, "isRecurring should be true when recurring=true")
     }
 
     func testParseThankYouURL_WithoutRecurring() {
-        let urlString = "https://thankyou.wikipedia.org/wiki/Thank_You/en?amount=1.00&country=US&currency=USD&order_id=218642670.1&payment_method=apple&wmf_medium=WikipediaApp&wmf_source=app_2023_en6C_iOS_control.app.apple&wmf_campaign=iOS"
+        let urlString = "https://thankyou.wikipedia.org/wiki/Thank_You/en?amount=1.00&country=US&currency=USD&order_id=218642670.1&payment_method=apple&recurring=&wmf_medium=WikipediaApp&wmf_source=app_2023_en6C_iOS_control.app.apple&wmf_campaign=iOS"
         guard let url = URL(string: urlString) else {
             XCTFail("Failed to create URL from string")
             return
@@ -37,8 +37,24 @@ class SinglePageWebViewControllerTests: XCTestCase {
         XCTAssertEqual(result?.amount, "1.00", "Amount should be 1.00")
         XCTAssertEqual(result?.country, "US", "Country should be US")
         XCTAssertEqual(result?.currency, "USD", "Currency should be USD")
-        XCTAssertFalse(((result?.isRecurring) == nil), "isRecurring should be false")
+        XCTAssertFalse(result?.isRecurring ?? false, "isRecurring should be false when recurring parameter is present but empty")
     }
+
+    func testParseThankYouURL_WithRecurringEmptyAndSpecificAmount() {
+            let urlString = "https://thankyou.wikipedia.org/wiki/Thank_You/en?amount=10.00&country=BR&currency=BRL&order_id=220783063.1&payment_method=apple&recurring=&wmf_medium=WikipediaApp&wmf_source=enBR_appmenu_iOS.app.apple&wmf_campaign=iOS"
+            guard let url = URL(string: urlString) else {
+                XCTFail("Failed to create URL from string")
+                return
+            }
+
+            let viewController = SinglePageWebViewController(url: url, theme: Theme.standard)
+            let result = viewController.parseThankYouURL(url)
+
+            XCTAssertEqual(result?.amount, "10.00", "Amount should be 10.00")
+            XCTAssertEqual(result?.country, "BR", "Country should be BR")
+            XCTAssertEqual(result?.currency, "BRL", "Currency should be BRL")
+            XCTAssertFalse(result?.isRecurring ?? false, "isRecurring should be false when recurring is present but empty")
+        }
 
     func testParseThankYouURL_WithMissingParameters() {
         let urlString = "https://thankyou.wikipedia.org/wiki/Thank_You"
@@ -55,6 +71,6 @@ class SinglePageWebViewControllerTests: XCTestCase {
         XCTAssertNil(result?.amount, "Amount should be nil")
         XCTAssertEqual(result?.country, nil, "Country should be nil")
         XCTAssertNil(result?.currency, "Currency should be nil")
-        XCTAssertFalse(((result?.isRecurring) != nil), "isRecurring should be false")
+        XCTAssertFalse(((result?.isRecurring) != nil), "isRecurring should be false when recurring is present but empty")
     }
 }

--- a/WikipediaUnitTests/Code/SinglePageWebViewParseDonationTests.swift
+++ b/WikipediaUnitTests/Code/SinglePageWebViewParseDonationTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+
+@testable import Wikipedia
+
+class SinglePageWebViewControllerTests: XCTestCase {
+
+    func testParseThankYouURL_WithAllParametersIncludingRecurring() {
+        let urlString = "https://thankyou.wikipedia.org/wiki/Thank_You/en?amount=1.00&country=US&currency=USD&order_id=218642670.1&payment_method=apple&recurring&wmf_medium=WikipediaApp&wmf_source=app_2023_en6C_iOS_control.app.apple&wmf_campaign=iOS"
+        guard let url = URL(string: urlString) else {
+            XCTFail("Failed to create URL from string")
+            return
+        }
+
+        let theme = Theme.standard
+        let viewController = SinglePageWebViewController(url: url, theme: theme)
+
+        let result = viewController.parseThankYouURL(url)
+
+        XCTAssertEqual(result?.amount, "1.00", "Amount should be 1.00")
+        XCTAssertEqual(result?.country, "US", "Country should be US")
+        XCTAssertEqual(result?.currency, "USD", "Currency should be USD")
+        XCTAssertTrue(((result?.isRecurring) != nil), "isRecurring should be true")
+    }
+
+    func testParseThankYouURL_WithoutRecurring() {
+        let urlString = "https://thankyou.wikipedia.org/wiki/Thank_You/en?amount=1.00&country=US&currency=USD&order_id=218642670.1&payment_method=apple&wmf_medium=WikipediaApp&wmf_source=app_2023_en6C_iOS_control.app.apple&wmf_campaign=iOS"
+        guard let url = URL(string: urlString) else {
+            XCTFail("Failed to create URL from string")
+            return
+        }
+
+        let theme = Theme.standard
+        let viewController = SinglePageWebViewController(url: url, theme: theme)
+
+        let result = viewController.parseThankYouURL(url)
+
+        XCTAssertEqual(result?.amount, "1.00", "Amount should be 1.00")
+        XCTAssertEqual(result?.country, "US", "Country should be US")
+        XCTAssertEqual(result?.currency, "USD", "Currency should be USD")
+        XCTAssertFalse(((result?.isRecurring) == nil), "isRecurring should be false")
+    }
+
+    func testParseThankYouURL_WithMissingParameters() {
+        let urlString = "https://thankyou.wikipedia.org/wiki/Thank_You"
+        guard let url = URL(string: urlString) else {
+            XCTFail("Failed to create URL from string")
+            return
+        }
+
+        let theme = Theme.standard
+        let viewController = SinglePageWebViewController(url: url, theme: theme)
+
+        let result = viewController.parseThankYouURL(url)
+
+        XCTAssertNil(result?.amount, "Amount should be nil")
+        XCTAssertEqual(result?.country, nil, "Country should be nil")
+        XCTAssertNil(result?.currency, "Currency should be nil")
+        XCTAssertFalse(((result?.isRecurring) != nil), "isRecurring should be false")
+    }
+}


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T376219

### Notes
* This PR adds work to allow us to register web donations by parsing the information on the Thank You page URL
* The Thank You URL contains the info we need to save this donations locally, so we parse this info and save it
* Added some unit tests to verify the parsing

### Test Steps
1. We can rely on the unit tests passing, and have QA do a more thorough test
Alternatively, to manually test: 
2. Go to Settings -> Account -> Delete your local donation history if you have it
3. The button should go away after deleting your history
4. Go to donations, choose "Other payments"
5. On the webview, make a donation
6. Go to Settings -> Account -> You should see the Delete local donation history button again


