### PR TITLE
Route thankyou page to in-app web view for deep links

### DIFF
--- a/WMF Framework/Router.swift
+++ b/WMF Framework/Router.swift
@@ -132,6 +132,11 @@ public class Router: NSObject {
                 return nil
             }
             
+            guard let host = url.host,
+                  host != "thankyou.wikipedia.org" else {
+                return nil
+            }
+            
             return WikipediaURLTranslations.isMainpageTitle(title, in: language) ? nil : Destination.article(url)
         case .wikipedia:
             


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T378600

### Notes
This should fix our routing so that our deep links do not route a page to thankyou.wikipedia.org to ArticleViewController.

### Test Steps
1. On device/simulator, run this branch in Xcode. In Safari, load thankyou.wikipedia.org
2. Tap one of the links on the wiki page.
3. The app should open the thank you page on SinglePageWebViewController, and NOT ArticleViewController.

