### PR TITLE
[YiR] Show X button on native donate form modal

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Donate Form/WMFDonateViewController.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Donate Form/WMFDonateViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 public final class WMFDonateViewController: WMFCanvasViewController {
     
@@ -24,6 +25,16 @@ public final class WMFDonateViewController: WMFCanvasViewController {
         super.viewDidLoad()
         self.title = viewModel.localizedStrings.title
         addComponent(hostingViewController, pinToEdges: true)
+        
+        if navigationController?.viewControllers.first === self {
+            let image = WMFSFSymbolIcon.for(symbol: .close)
+            let closeButton = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(closeButtonTapped(_:)))
+            navigationItem.leftBarButtonItem = closeButton
+        }
+    }
+    
+    @objc func closeButtonTapped(_ sender: UIButton) {
+        dismiss(animated: true)
     }
     
     public override func viewWillAppear(_ animated: Bool) {

--- a/Wikipedia/Code/DonateCoordinator.swift
+++ b/Wikipedia/Code/DonateCoordinator.swift
@@ -379,7 +379,8 @@ class DonateCoordinator: Coordinator {
                 return
             }
             
-            let newNavigationController = WMFThemeableNavigationController(rootViewController: donateViewController)
+            let newNavigationController = WMFThemeableNavigationController(rootViewController: donateViewController, theme: theme)
+            newNavigationController.modalPresentationStyle = .pageSheet
             presentedViewController.present(newNavigationController, animated: true)
         }
         
@@ -412,7 +413,7 @@ class DonateCoordinator: Coordinator {
                 return
             }
             
-            let newNavigationController = WMFThemeableNavigationController(rootViewController: webVC)
+            let newNavigationController = WMFThemeableNavigationController(rootViewController: webVC, theme: theme)
             newNavigationController.modalPresentationStyle = .formSheet
             presentedViewController.present(newNavigationController, animated: true)
         }

--- a/Wikipedia/Code/SinglePageWebViewController.swift
+++ b/Wikipedia/Code/SinglePageWebViewController.swift
@@ -194,7 +194,8 @@ class SinglePageWebViewController: ViewController {
         navigationController?.setNavigationBarHidden(true, animated: false)
         
         if navigationController?.viewControllers.first === self {
-            let closeButton = UIBarButtonItem.wmf_buttonType(WMFButtonType.X, target: self, action: #selector(closeButtonTapped(_:)))
+            let image = WMFSFSymbolIcon.for(symbol: .close)
+            let closeButton = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(closeButtonTapped(_:)))
             navigationItem.leftBarButtonItem = closeButton
         }
         


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T376046

### Notes
This addresses QA feedback in https://phabricator.wikimedia.org/T376046#10320900. I am adding an SFSymbol close button on the native donate form when it is displayed as a modal. I also decided to update the in-app web view close button to match.

### Test Steps
1. Tap Donate button in Year in Review slide
2. Choose Apple Pay.
3. Confirm Close button appears in nav bar. Confirm tapping closes the donate form.

### Screenshots
![screenshot](https://github.com/user-attachments/assets/b9530482-a279-4e9b-916d-79a423371696)


