### PR TITLE
[YiR] Clear out edit data upon logout, populate data upon login and settings toggle

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
@@ -721,10 +721,10 @@ import CoreData
                     continue
                 }
                 
-                innerLoop: for slide in slides {
+                for slide in slides {
                     
                     guard slide.id == WMFYearInReviewPersonalizedSlideID.editCount.rawValue else {
-                        break innerLoop
+                        continue
                     }
                     
                     slide.data = nil

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
@@ -8,6 +8,8 @@ import CoreData
     private let developerSettingsDataController: WMFDeveloperSettingsDataControlling
 
     public let targetConfigYearID = "2024.1"
+    @objc public static let targetYear = 2024
+    public static let appShareLink = "https://apps.apple.com/app/apple-store/id324715238?pt=208305&ct=yir_2024_share&mt=8"
 
     private let service = WMFDataEnvironment.current.mediaWikiService
 
@@ -153,7 +155,7 @@ import CoreData
         }
         
         // Check persisted year in review report. Year in Review entry point should display if one or more personalized slides are set to display and slide is not disabled in remote config
-        guard let yirReport = try? fetchYearInReviewReport(forYear: 2024) else {
+        guard let yirReport = try? fetchYearInReviewReport(forYear: Self.targetYear) else {
             return false
         }
         

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -627,6 +627,17 @@ extension WMFAppViewController {
             }
         }
     }
+    
+    @objc func deleteYearInReviewPersonalizedEditingData() {
+        Task {
+            do {
+                let yirDataController = try WMFYearInReviewDataController()
+                try await yirDataController.deleteAllPersonalizedEditingData()
+            } catch {
+                DDLogError("Failure deleting personalized editing data from year in review: \(error)")
+            }
+        }
+    }
 }
 
 // MARK: WMFComponents App Environment Helpers

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -16,6 +16,8 @@
 #import "Wikipedia-Swift.h"
 #import "EXTScope.h"
 
+@import WMFData;
+
 /**
  *  Enums for each tab in the main tab bar.
  */
@@ -398,7 +400,7 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
     [self checkRemoteAppConfigIfNecessary];
     [self.periodicWorkerController start];
     [self.savedArticlesFetcher start];
-    [self populateYearInReviewReportFor:2024];
+    [self populateYearInReviewReportFor:WMFYearInReviewDataController.targetYear];
 }
 
 - (void)performTasksThatShouldOccurAfterAnnouncementsUpdated {
@@ -2210,6 +2212,8 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
                                                             force:YES
                                                        completion:nil];
     });
+    
+    [self deleteYearInReviewPersonalizedEditingData];
 }
 
 - (void)userWasLoggedIn:(NSNotification *)note {

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -2232,6 +2232,8 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
                                                             force:YES
                                                        completion:nil];
     });
+    
+    [self populateYearInReviewReportFor:WMFYearInReviewDataController.targetYear];
 }
 
 - (void)authManagerDidHandlePrimaryLanguageChange:(NSNotification *)note {

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -500,7 +500,7 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
 #pragma mark - Year in Review
 
 - (void)showYearInReview {
-    WMFYearInReviewSettingsViewController *yearInReviewSettingsVC = [[WMFYearInReviewSettingsViewController alloc] initWithTheme:self.theme];
+    WMFYearInReviewSettingsViewController *yearInReviewSettingsVC = [[WMFYearInReviewSettingsViewController alloc] initWithDataStore:self.dataStore theme:self.theme];
     [self.navigationController pushViewController:yearInReviewSettingsVC animated:YES];
 }
 

--- a/Wikipedia/Code/YearInReviewCoordinator.swift
+++ b/Wikipedia/Code/YearInReviewCoordinator.swift
@@ -221,7 +221,7 @@ final class YearInReviewCoordinator: NSObject, Coordinator {
     private func getPersonalizedSlides() -> PersonalizedSlides {
         
         guard let dataController = try? WMFYearInReviewDataController(),
-              let report = try? dataController.fetchYearInReviewReport(forYear: 2024) else {
+              let report = try? dataController.fetchYearInReviewReport(forYear: WMFYearInReviewDataController.targetYear) else {
             return PersonalizedSlides(readCount: nil, editCount: nil, donateCount: nil)
         }
         
@@ -386,7 +386,7 @@ final class YearInReviewCoordinator: NSObject, Coordinator {
            usernameTitle: CommonStrings.userTitle
        )
        
-       let appShareLink = "https://apps.apple.com/app/apple-store/id324715238?pt=208305&ct=yir_2024_share&mt=8"
+        let appShareLink = WMFYearInReviewDataController.appShareLink
        let hashtag = "#WikipediaYearInReview"
 
         let viewModel = WMFYearInReviewViewModel(localizedStrings: localizedStrings, slides: slides, username: dataStore.authenticationManager.authStatePermanentUsername, shareLink: appShareLink, hashtag: hashtag, hasPersonalizedDonateSlide: hasPersonalizedDonateSlide, coordinatorDelegate: self, loggingDelegate: self, badgeDelegate: badgeDelegate)


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T378135

### Notes
This PR clears out the user's YiR editing data upon logout, so that if they log in with a different username they will not see the old edit count slide.

I also did some cleanup with data population, so that we don't have to background / foreground as often. I am now also populating data upon login and whenever the YiR settings toggle is turned on.

### Test Steps
1. Log into an account with editing data. Confirm you see account reflected in Year in Review.
2. Log out.
3. Log into another account with a different edit count. Confirm you see new count in Year in Review.
4. Go to app Settings, turn off year in review. Confirm entry point disappears. Go back to settings and turn year in review back on. Confirm entry point comes back without needing to background/foreground.

