### PR TITLE
[YiR] Remove toolbar appearance change

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewView.swift
@@ -10,14 +10,6 @@ public struct WMFYearInReviewView: View {
 
     public init(viewModel: WMFYearInReviewViewModel) {
         self.viewModel = viewModel
-        let toolbarAppearance = UIToolbarAppearance()
-        toolbarAppearance.configureWithOpaqueBackground()
-        toolbarAppearance.backgroundColor = theme.midBackground
-        toolbarAppearance.shadowColor = .clear
-
-        UIToolbar.appearance().standardAppearance = toolbarAppearance
-        UIToolbar.appearance().compactAppearance = toolbarAppearance
-
     }
 
     let configuration = WMFSmallButton.Configuration(style: .quiet, trailingIcon: nil)
@@ -88,7 +80,6 @@ public struct WMFYearInReviewView: View {
                 // Logs slide impressions and next taps
                 viewModel.logYearInReviewSlideDidAppear()
             }
-            .toolbarColorScheme(theme.preferredColorScheme)
             .toolbar {
                 if !viewModel.isFirstSlide {
                     ToolbarItem(placement: .bottomBar) {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T379779

### Notes
Minor revert to some [design review feedback](https://phabricator.wikimedia.org/T378507#10297255) to fix the navigation bar theming bugs. Per product, it is acceptable to have the white toolbar on Sepia as a quick fix. We will look into a deeper fix (perhaps by avoiding .toolbar altogether) for V2.

### Test Steps
1. Open YiR slide.
2. Dismiss YiR, go to Settings, change theme.
3. Confirm navigation bars in the app still look good.
4. Confirm article toolbar in the app still looks good.

