### PR TITLE
Update it to shouldShowDonateButton, logic

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewViewModel.swift
@@ -104,7 +104,11 @@ public class WMFYearInReviewViewModel: ObservableObject {
     }
     
     func handleLearnMore(url: URL) {
-        coordinatorDelegate?.handleYearInReviewAction(.learnMore(url: url, fromPersonalizedDonateSlide: hasPersonalizedDonateSlide))
+        var shouldShowDonate = false
+        if slides.count - 1 == currentSlide && !hasPersonalizedDonateSlide {
+            shouldShowDonate = true
+        }
+        coordinatorDelegate?.handleYearInReviewAction(.learnMore(url: url, shouldShowDonateButton: shouldShowDonate))
         loggingDelegate?.logYearInReviewDonateDidTapLearnMore(slideLoggingID: slideLoggingID)
     }
     

--- a/WMFComponents/Sources/WMFComponents/Coordinator/YearInReviewCoordinatorDelegate.swift
+++ b/WMFComponents/Sources/WMFComponents/Coordinator/YearInReviewCoordinatorDelegate.swift
@@ -9,6 +9,6 @@ public enum YearInReviewCoordinatorAction {
     case share(image: UIImage)
     case dismiss(isLastSlide: Bool)
     case introLearnMore
-    case learnMore(url: URL, fromPersonalizedDonateSlide: Bool)
+    case learnMore(url: URL, shouldShowDonateButton: Bool)
     case info(url: URL)
 }

--- a/Wikipedia/Code/YearInReviewCoordinator.swift
+++ b/Wikipedia/Code/YearInReviewCoordinator.swift
@@ -565,7 +565,7 @@ extension YearInReviewCoordinator: YearInReviewCoordinatorDelegate {
             let url = URL(string: "https://www.mediawiki.org/wiki/Wikimedia_Apps/Team/iOS/Personalized_Wikipedia_Year_in_Review/How_your_data_is_used\(languageCodeSuffix)")
             navigationController.navigate(to: url, useSafari: true)
 
-        case .learnMore(let url, let fromPersonalizedDonateSlide):
+        case .learnMore(let url, let shouldShowDonateButton):
 
             guard let presentedViewController = navigationController.presentedViewController else {
                 DDLogError("Unexpected navigation controller state. Skipping Learn More presentation.")
@@ -575,7 +575,7 @@ extension YearInReviewCoordinator: YearInReviewCoordinatorDelegate {
             let webVC: SinglePageWebViewController
             let slideLoggingID: String
 
-            if !fromPersonalizedDonateSlide {
+            if shouldShowDonateButton {
                 let config = SinglePageWebViewController.YiRLearnMoreConfig(url: url, donateButtonTitle:  WMFLocalizedString("year-in-review-donate-now", value: "Donate now", comment: "Year in review donate now button title. Displayed on top of Learn more in-app web view."))
                 webVC = SinglePageWebViewController(configType: .yirLearnMore(config), theme: theme)
                 slideLoggingID = "about_wikimedia_base"


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T377899

### Notes
* Update logic to determine if webview should show donate button

### Test Steps
1. Fresh install, IT region, EN language
2. Ensure 6+ articles in history, background and foreground app
3. Navigate to year in review
4. Press Learn More on first slide, ensure donate button does not show up in web view
5. Navigate back to YIR, go to the "Wikipedia was edited X times" slide
6. Press "Learn how to participate", ensure no donate button
7. Navigate to the last slide and ensure if you have a donate history, no donate button shows. If you do not have a donate history, we'll want the button to show. 
8. Fake donate history or erase donate history to ensure both of the above work. 

### Screenshots/Videos

