### PR TITLE
Fix Article Web View Link Bug

### DIFF
--- a/Wikipedia/Code/ArticleViewController+FindInPage.swift
+++ b/Wikipedia/Code/ArticleViewController+FindInPage.swift
@@ -71,6 +71,10 @@ extension ArticleViewController {
             self.resignFirstResponder()
             completion?()
         }
+
+        self.findInPage.view?.removeFromSuperview()
+        self.view.layoutSubviews()
+        self.findInPage.view = nil
     }
 
     func resetFindInPage(_ completion: (() -> Void)? = nil) {
@@ -83,7 +87,7 @@ extension ArticleViewController {
             }
         })
     }
-    
+
     func scrollToAndFocusOnFirstFindInPageMatch() {
         findInPage.selectedIndex = -1
         keyboardBarDidTapNext(findInPage.view)


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T378546

### Notes
* When hiding find in page, it's also necessary to set the find in page view as nil. This forces the view to stop being the first responder as it updates the `canBecomeFirstResponder` prop in articleVC to false.
* This allows the webview to take over as first responder instead of the VC

### Test Steps
1. Click find in page in the Article view. 
2. Do to type anything, and tap a link. It should go to the new page
3. Go back, click find in page again. 
4. Type something. In the highlighted state, tap a link. It should work.
5. Return. The toolbar should be active on the view (not sure if this is a bug, it's the behavior as-is in prod)
6. Clear the term. Close the toolbar. Click on a link.
7. Open the toolbar and close it. Click on a link.
8. We can rely on QA for other scenarios.


