### PR TITLE
[YiR] Only populate after login if app has resumed

### DIFF
--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -2226,14 +2226,13 @@ static NSString *const WMFDidShowOnboarding = @"DidShowOnboarding5.3";
             [self.dataStore.feedContentController updateContentSource:[WMFAnnouncementsContentSource class]
                                                                 force:YES
                                                            completion:nil];
+            [self populateYearInReviewReportFor:WMFYearInReviewDataController.targetYear];
         }
 
         [self.dataStore.feedContentController updateContentSource:[WMFSuggestedEditsContentSource class]
                                                             force:YES
                                                        completion:nil];
     });
-    
-    [self populateYearInReviewReportFor:WMFYearInReviewDataController.targetYear];
 }
 
 - (void)authManagerDidHandlePrimaryLanguageChange:(NSNotification *)note {


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
This fixes a console complaint I started to notice today:

```
Failure populating year in review report: Error Domain=NSCocoaErrorDomain Code=133020 "Could not merge changes." UserInfo={conflictList=(
    "NSMergeConflict (0x6000017d5140) for NSManagedObject (0x60000212cb40) with objectID '0x9c481419d6f2b090 <x-coredata://020B8A47-5DE5-4220-A266-679DB4FEA54B/CDYearInReviewSlide/p1>' with oldVersion = 1 and newVersion = 2 and old object snapshot = {\n    data = \"<null>\";\n    display = 0;\n    evaluated = 0;\n    id = readCount;\n    report = \"0x9c481419d6f2b0a0 <x-coredata://020B8A47-5DE5-4220-A266-679DB4FEA54B/CDYearInReviewReport/p1>\";\n    year = 2024;\n} and new cached row = {\n    data = {length = 1, bytes = 0x30};\n    display = 0;\n    evaluated = 1;\n    id = readCount;\n    report = \"0x9c481419d6f2b0a0 <x-coredata://020B8A47-5DE5-4220-A266-679DB4FEA54B/CDYearInReviewReport/p1>\";\n    year = 2024;\n}"
), NSExceptionOmitCallstacks=true} [WMFAppViewController+Extensions#L626]
```

I think this is caused by my additional call to populate YiR report data after the user logs in (added in https://github.com/wikimedia/wikipedia-ios/pull/5074). When an app launches, it makes the `populateYearInReviewReport` method call twice fairly quickly: Once from `performTasksThatShouldOccurAfterBecomeActiveAndResume` after the app finishes its launch setup code, and again from `userWasLoggedIn`. I think something about this is causing merge conflicts on Core Data (the initial report without editing data attempts to save at the same time as the next report with editing data).

To get around this, I am only calling `populateYearInReviewReport` within `userWasLoggedIn` if the app has already completed its setup.

### Test Steps
1. Ensure you are logged into app for a user with edits from the past year. Delete app, then run again from this branch.
2. Ensure Year in Review entry point appears. Ensure console error does not display.