### PR TITLE
[YiR] Fix sharing bugs

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewShareableSlideView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewShareableSlideView.swift
@@ -14,6 +14,10 @@ struct WMFYearInReviewShareableSlideView: View {
     var slideTitle: String
     var slideSubtitle: String
     var hashtag: String
+    
+    private func subtitleAttributedString() -> AttributedString {
+        return (try? AttributedString(markdown: slideSubtitle)) ?? AttributedString(slideSubtitle)
+    }
 
     var body: some View {
         GeometryReader { geometry in
@@ -34,8 +38,6 @@ struct WMFYearInReviewShareableSlideView: View {
 
                         if let imageOverlay {
                             Image(imageOverlay, bundle: .module)
-                                .padding(.horizontal, 100)
-                                .padding(.vertical, 50)
                         }
 
                         if let overlayText = textOverlay {
@@ -49,13 +51,13 @@ struct WMFYearInReviewShareableSlideView: View {
                         Text(slideTitle)
                             .font(Font(WMFFont.for(.boldTitle1, compatibleWith: UITraitCollection(preferredContentSizeCategory: .medium))))
                             .foregroundStyle(Color(uiColor: theme.text))
-                        Text(slideSubtitle)
+                        Text(subtitleAttributedString())
                             .font(Font(WMFFont.for(.title3, compatibleWith: UITraitCollection(preferredContentSizeCategory: .medium))))
                             .foregroundStyle(Color(uiColor: theme.text))
+                            .accentColor(Color(uiColor: theme.link))
                     }
                     .padding(28)
                 }
-
 
                 Spacer(minLength: 10)
 

--- a/Wikipedia/Code/YearInReviewCoordinator.swift
+++ b/Wikipedia/Code/YearInReviewCoordinator.swift
@@ -621,7 +621,21 @@ class YiRShareActivityContentProvider: UIActivityItemProvider, @unchecked Sendab
     }
 
     override var item: Any {
-        return YiRShareActivityContentProvider.messageRepresentation(text: text, appStoreURL: appStoreURL, hashtag: hashtag)
+        return  YiRShareActivityContentProvider.messageRepresentation(text: text, appStoreURL: appStoreURL, hashtag: hashtag)
+    }
+    
+    override func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        switch activityType {
+        case .postToFacebook:
+            return nil
+        default:
+            if let activityType,
+               activityType.rawValue.contains("instagram") {
+                return nil
+            }
+            
+            return item
+        }
     }
 
     override func activityViewController(_ activityViewController: UIActivityViewController, subjectForActivityType activityType: UIActivity.ActivityType?) -> String {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T376300

### Notes
This PR fixes some issues with the sharing view:

1. Facebook and Instagram sharing is fixed. We're only sharing the image - it seems like having both text and image caused issues.
2. Fixed cropping issues on the last donate slide
3. Fixed markdown display in share view subtitle.

Note: I have noticed the subtitle truncates. I'm not sure if this was introduced by this PR or not, but Product has said this is ok for V1.

### Test Steps
1. Check to see if you can share to Facebook and Instagram (can lean on QA for this).
2. Check that last donate slide sharing looks good (gradient crop and learn more url).
