### PR TITLE
Use new yearID for YiR V2

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
@@ -7,7 +7,7 @@ import CoreData
     private let userDefaultsStore: WMFKeyValueStore?
     private let developerSettingsDataController: WMFDeveloperSettingsDataControlling
 
-    public let targetConfigYearID = "2024.1"
+    public let targetConfigYearID = "2024.2"
     @objc public static let targetYear = 2024
     public static let appShareLink = "https://apps.apple.com/app/apple-store/id324715238?pt=208305&ct=yir_2024_share&mt=8"
 

--- a/WMFData/Sources/WMFDataMocks/Resources/feature-get-config.json
+++ b/WMFData/Sources/WMFDataMocks/Resources/feature-get-config.json
@@ -3,31 +3,101 @@
     "ios": [
         {
             "version": 1,
-            "yir": [{
-                "yearID": "2024.1",
-                "isEnabled": true,
-                "countryCodes": [
-                    "FR",
-                    "IT"
-                ],
-                "primaryAppLanguageCodes": [
-                    "fr",
-                    "it"
-                ],
-                "dataPopulationStartDateString": "2024-01-01T00:00:00Z",
-                "dataPopulationEndDateString": "2024-11-01T00:00:00Z",
-                "personalizedSlides": {
-                    "readCount": {
-                        "isEnabled": true
-                    },
-                    "editCount": {
-                        "isEnabled": true
-                    },
-                    "donateCount": {
-                        "isEnabled": true
+            "yir": [
+                {
+                    "yearID": "2024.1",
+                    "isEnabled": true,
+                    "countryCodes": [
+                        "MX",
+                        "IT"
+                    ],
+                    "primaryAppLanguageCodes": [
+                        "es",
+                        "it",
+                        "en"
+                    ],
+                    "dataPopulationStartDateString": "2024-01-01T00:00:00Z",
+                    "dataPopulationEndDateString": "2024-12-31T23:59:59Z",
+                    "personalizedSlides": {
+                        "readCount": {
+                            "isEnabled": true
+                        },
+                        "editCount": {
+                            "isEnabled": true
+                        },
+                        "donateCount": {
+                            "isEnabled": true
+                        }
                     }
+                },
+                {
+                    "yearID": "2024.2",
+                    "isEnabled": true,
+                    "countryCodes": [
+                        "IT",
+                        "MX"
+                    ],
+                    "primaryAppLanguageCodes": [
+                        "es",
+                        "it",
+                        "en"
+                    ],
+                    "dataPopulationStartDateString": "2024-01-01T00:00:00Z",
+                    "dataPopulationEndDateString": "2024-12-31T23:59:59Z",
+                    "personalizedSlides": {
+                        "readCount": {
+                            "isEnabled": true
+                        },
+                        "editCount": {
+                            "isEnabled": true
+                        },
+                        "mostReadDay": {
+                            "isEnabled": true
+                        },
+                        "saveCount": {
+                            "isEnabled": true
+                        },
+                        "viewCount": {
+                            "isEnabled": true
+                        },
+                        "donateCount": {
+                            "isEnabled": true
+                        }
+                    },
+                    "hideDonateCountryCodes": [
+                        "AE",
+                        "AF",
+                        "AX",
+                        "BY",
+                        "CD",
+                        "CI",
+                        "CU",
+                        "FI",
+                        "ID",
+                        "IQ",
+                        "IR",
+                        "KP",
+                        "KR",
+                        "LB",
+                        "LY",
+                        "MM",
+                        "PY",
+                        "RU",
+                        "SA",
+                        "SD",
+                        "SO",
+                        "SS",
+                        "SY",
+                        "TM",
+                        "TR",
+                        "UA",
+                        "UZ",
+                        "XK",
+                        "YE",
+                        "ZW"
+                    ]
                 }
-            }]
+            ]
         }
     ],
     "android": {}

--- a/WMFData/Tests/WMFDataTests/WMFDeveloperSettingsDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFDeveloperSettingsDataControllerTests.swift
@@ -30,7 +30,7 @@ final class WMFDeveloperSettingsDataControllerTests: XCTestCase {
             
             guard let config = controller.loadFeatureConfig(),
                   let iosConfig = config.ios.first,
-            let yirConfig = config.ios.first?.yir(yearID: "2024.1") else {
+            let yirConfig = config.ios.first?.yir(yearID: "2024.2") else {
                 XCTFail("Failure loading feature config")
                 return
             }
@@ -38,9 +38,9 @@ final class WMFDeveloperSettingsDataControllerTests: XCTestCase {
             XCTAssertEqual(iosConfig.version, 1, "Unexpected feature config version")
             XCTAssertEqual(yirConfig.isEnabled, true, "Unexpected feature config yir isEnabled")
             XCTAssertEqual(yirConfig.countryCodes.count, 2, "Unexpected feature config yir countryCodes count")
-            XCTAssertEqual(yirConfig.primaryAppLanguageCodes.count, 2, "Unexpected feature config yir primaryAppLanguageCodes count")
+            XCTAssertEqual(yirConfig.primaryAppLanguageCodes.count, 3, "Unexpected feature config yir primaryAppLanguageCodes count")
             XCTAssertEqual(yirConfig.dataPopulationStartDateString, "2024-01-01T00:00:00Z", "Unexpected feature config yir dataPopulationStartDateString")
-            XCTAssertEqual(yirConfig.dataPopulationEndDateString, "2024-11-01T00:00:00Z", "Unexpected feature config yir dataPopulationEndDateString")
+            XCTAssertEqual(yirConfig.dataPopulationEndDateString, "2024-12-31T23:59:59Z", "Unexpected feature config yir dataPopulationEndDateString")
             XCTAssertEqual(yirConfig.personalizedSlides.readCount.isEnabled, true, "Unexpected feature config yir personalizedSlides readCount isEnabled flag")
             XCTAssertEqual(yirConfig.personalizedSlides.editCount.isEnabled, true, "Unexpected feature config yir personalizedSlides editCount isEnabled flag")
             

--- a/WMFData/Tests/WMFDataTests/WMFYearInReviewDataControllerCreateOrRetrieveTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFYearInReviewDataControllerCreateOrRetrieveTests.swift
@@ -13,7 +13,7 @@ fileprivate class WMFMockYearInReviewDataController: WMFYearInReviewDataControll
         let editCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let donateCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let personalizedSlides = WMFFeatureConfigResponse.IOS.YearInReview.PersonalizedSlides(readCount: readCountSlideSettings, editCount: editCountSlideSettings, donateCount: donateCountSlideSettings)
-        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.1", isEnabled: false, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
+        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.2", isEnabled: false, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
         let ios = WMFFeatureConfigResponse.IOS(version: 1, yir: [yearInReview])
         let config = WMFFeatureConfigResponse(ios: [ios])
         let developerSettingsDataController = WMFMockDeveloperSettingsDataController(featureConfig: config)

--- a/WMFData/Tests/WMFDataTests/WMFYearInReviewDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFYearInReviewDataControllerTests.swift
@@ -191,7 +191,7 @@ final class WMFYearInReviewDataControllerTests: XCTestCase {
         let editCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let donateCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let personalizedSlides = WMFFeatureConfigResponse.IOS.YearInReview.PersonalizedSlides(readCount: readCountSlideSettings, editCount: editCountSlideSettings, donateCount: donateCountSlideSettings)
-        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.1", isEnabled: false, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
+        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.2", isEnabled: false, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
         let ios = WMFFeatureConfigResponse.IOS(version: 1, yir: [yearInReview])
         let config = WMFFeatureConfigResponse(ios: [ios])
         
@@ -218,7 +218,7 @@ final class WMFYearInReviewDataControllerTests: XCTestCase {
         let editCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let donateCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let personalizedSlides = WMFFeatureConfigResponse.IOS.YearInReview.PersonalizedSlides(readCount: readCountSlideSettings, editCount: editCountSlideSettings, donateCount: donateCountSlideSettings)
-        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.1", isEnabled: true, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
+        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.2", isEnabled: true, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
         let ios = WMFFeatureConfigResponse.IOS(version: 1, yir: [yearInReview])
         let config = WMFFeatureConfigResponse(ios: [ios])
         
@@ -255,7 +255,7 @@ final class WMFYearInReviewDataControllerTests: XCTestCase {
         let editCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let donateCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let personalizedSlides = WMFFeatureConfigResponse.IOS.YearInReview.PersonalizedSlides(readCount: readCountSlideSettings, editCount: editCountSlideSettings, donateCount: donateCountSlideSettings)
-        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.1", isEnabled: true, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
+        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.2", isEnabled: true, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
         let ios = WMFFeatureConfigResponse.IOS(version: 1, yir: [yearInReview])
         let config = WMFFeatureConfigResponse(ios: [ios])
         
@@ -292,7 +292,7 @@ final class WMFYearInReviewDataControllerTests: XCTestCase {
         let editCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: false)
         let donateCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let personalizedSlides = WMFFeatureConfigResponse.IOS.YearInReview.PersonalizedSlides(readCount: readCountSlideSettings, editCount: editCountSlideSettings, donateCount: donateCountSlideSettings)
-        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.1", isEnabled: true, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
+        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.2", isEnabled: true, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
         let ios = WMFFeatureConfigResponse.IOS(version: 1, yir: [yearInReview])
         let config = WMFFeatureConfigResponse(ios: [ios])
 
@@ -325,7 +325,7 @@ final class WMFYearInReviewDataControllerTests: XCTestCase {
         let editCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: false)
         let donateCountSlideSettings = WMFFeatureConfigResponse.IOS.YearInReview.SlideSettings(isEnabled: true)
         let personalizedSlides = WMFFeatureConfigResponse.IOS.YearInReview.PersonalizedSlides(readCount: readCountSlideSettings, editCount: editCountSlideSettings, donateCount: donateCountSlideSettings)
-        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.1", isEnabled: true, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
+        let yearInReview = WMFFeatureConfigResponse.IOS.YearInReview(yearID: "2024.2", isEnabled: true, countryCodes: ["FR", "IT"], primaryAppLanguageCodes: ["fr", "it"], dataPopulationStartDateString: "2024-01-01T00:00:00Z", dataPopulationEndDateString: "2024-11-01T00:00:00Z", personalizedSlides: personalizedSlides)
         let ios = WMFFeatureConfigResponse.IOS(version: 1, yir: [yearInReview])
         let config = WMFFeatureConfigResponse(ios: [ios])
 


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
This bumps our year ID to match our new [config](https://donate.wikimedia.org/wiki/MediaWiki:AppsFeatureConfig.json) object.

### Test Steps
1. Ensure Year in Review displays as before.

