### PR TITLE
[YiR] Show survey for users that reached second slide

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewView.swift
@@ -79,6 +79,9 @@ public struct WMFYearInReviewView: View {
             .onChange(of: viewModel.currentSlide) { newSlide in
                 // Logs slide impressions and next taps
                 viewModel.logYearInReviewSlideDidAppear()
+                if newSlide == 1 {
+                    viewModel.hasSeenTwoSlides = true
+                }
             }
             .toolbar {
                 if !viewModel.isFirstSlide {

--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewViewModel.swift
@@ -24,7 +24,8 @@ public class WMFYearInReviewViewModel: ObservableObject {
     weak var coordinatorDelegate: YearInReviewCoordinatorDelegate?
     weak var badgeDelegate: YearInReviewBadgeDelegate?
     private(set) weak var loggingDelegate: WMFYearInReviewLoggingDelegate?
-        
+    var hasSeenTwoSlides: Bool = false
+
     @Published public var isLoading: Bool = false
 
     public init(isFirstSlide: Bool = true, localizedStrings: LocalizedStrings, slides: [YearInReviewSlideContent], shareLink: String, hashtag: String, hasPersonalizedDonateSlide: Bool, coordinatorDelegate: YearInReviewCoordinatorDelegate?, loggingDelegate: WMFYearInReviewLoggingDelegate, badgeDelegate: YearInReviewBadgeDelegate?) {
@@ -44,8 +45,8 @@ public class WMFYearInReviewViewModel: ObservableObject {
     }
     
     public func nextSlide() {
-        if isLastSlide {
-            coordinatorDelegate?.handleYearInReviewAction(.dismiss(isLastSlide: true))
+        if hasSeenTwoSlides {
+            coordinatorDelegate?.handleYearInReviewAction(.dismiss(hasSeenTwoSlides: true))
         } else {
             currentSlide = (currentSlide + 1) % slides.count
         }
@@ -85,7 +86,7 @@ public class WMFYearInReviewViewModel: ObservableObject {
     }
     
     func handleDone() {
-        coordinatorDelegate?.handleYearInReviewAction(.dismiss(isLastSlide: isLastSlide))
+        coordinatorDelegate?.handleYearInReviewAction(.dismiss(hasSeenTwoSlides: hasSeenTwoSlides))
     }
     
     func handleDonate(sourceRect: CGRect) {

--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewViewModel.swift
@@ -45,7 +45,7 @@ public class WMFYearInReviewViewModel: ObservableObject {
     }
     
     public func nextSlide() {
-        if hasSeenTwoSlides {
+        if isLastSlide {
             coordinatorDelegate?.handleYearInReviewAction(.dismiss(hasSeenTwoSlides: true))
         } else {
             currentSlide = (currentSlide + 1) % slides.count

--- a/WMFComponents/Sources/WMFComponents/Coordinator/YearInReviewCoordinatorDelegate.swift
+++ b/WMFComponents/Sources/WMFComponents/Coordinator/YearInReviewCoordinatorDelegate.swift
@@ -7,7 +7,7 @@ public protocol YearInReviewCoordinatorDelegate: AnyObject {
 public enum YearInReviewCoordinatorAction {
     case donate(sourceRect: CGRect)
     case share(image: UIImage)
-    case dismiss(isLastSlide: Bool)
+    case dismiss(hasSeenTwoSlides: Bool)
     case introLearnMore
     case learnMore(url: URL, shouldShowDonateButton: Bool)
     case info(url: URL)

--- a/Wikipedia/Code/YearInReviewCoordinator.swift
+++ b/Wikipedia/Code/YearInReviewCoordinator.swift
@@ -700,12 +700,12 @@ extension YearInReviewCoordinator: YearInReviewCoordinatorDelegate {
 
                 visibleVC.present(activityController, animated: true, completion: nil)
             }
-        case .dismiss(let isLastSlide):
+        case .dismiss(let hasSeenTwoSlides):
             (self.navigationController as? RootNavigationController)?.turnOffForcePortrait()
             navigationController.dismiss(animated: true, completion: { [weak self] in
                 guard let self else { return }
 
-                guard isLastSlide else { return }
+                guard hasSeenTwoSlides else { return }
 
                 self.presentSurveyIfNeeded()
             })


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T380433

### Notes
* Adds a local flag to indicate if the user reached the second slide
* User is then eligible to see the survey
* Survey display logic remains as-is, is not shown again if user already seen
* We're checking for the slide of index 1, which the second item in the in 0-based array it's stored

### Test Steps
1. Fresh install the app, go to YiR
2. Go to the second slide, return to the first
3. Leave YiR
4. You should see the survey
5. Fresh install the app again, go to YiR
6. Go to the last slide, tap finish
7. You should see the survey
8. Fresh install the app again, go to YiR
9. Leave YiR at any point from the 2nd slide, you should see the survey
10. Enter and leave YiR, the survey should no be displayed


