### PR TITLE
[YiR] Fix YiR feature announcement login state bug

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
@@ -157,6 +157,12 @@ import CoreData
               uppercaseConfigPrimaryAppLanguageCodes.contains(languageCode.uppercased()) else {
             return false
         }
+        
+        // Check persisted year in review report exists.
+        guard let yirReport = try? fetchYearInReviewReport(forYear: Self.targetYear) else {
+            return false
+        }
+        
         return true
     }
 

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -400,9 +400,6 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
     [self checkRemoteAppConfigIfNecessary];
     [self.periodicWorkerController start];
     [self.savedArticlesFetcher start];
-
-    [self populateYearInReviewReportFor:WMFYearInReviewDataController.targetYear];
-    
 }
 
 - (void)performTasksThatShouldOccurAfterAnnouncementsUpdated {
@@ -992,6 +989,9 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
     [resumeAndAnnouncementsCompleteGroup enter];
     [self.dataStore.authenticationManager
         attemptLoginWithCompletion:^{
+        
+            [self populateYearInReviewReportFor:WMFYearInReviewDataController.targetYear];
+        
             [self checkRemoteAppConfigIfNecessary];
             if (!self.reachabilityNotifier) {
                 @weakify(self);


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T380802

### Notes
I think these tweaks might help us see the personalized feature announcement for logged in users. The year in review report was generated as soon as the app was launched or foregrounded. In some cases this has occurred before the app tried to get the user's login state, so there was a race condition where the report was generated and displayed the feature announcement, before the user was automatically logged into the app.

So now I am delaying the report population until the initial automatic login has attempted in AppViewController [here](https://github.com/wikimedia/wikipedia-ios/compare/fix-yir-login-state-bugs?expand=1#diff-53892ba35877905bfabb1572472302074e7251ac44ee8ac623d2b0be877d4953R994). This code will be run whether the user successfully logs in automatically or not and a report will be created.

I also added back in the check for a report before we show the year in review entry points [here](https://github.com/wikimedia/wikipedia-ios/compare/fix-yir-login-state-bugs?expand=1#diff-1c01e90351b11ab077c5dff447720470dad032889b5206d5e9c5e4a69065649cR161). I deleted it back in [this PR](https://github.com/wikimedia/wikipedia-ios/pull/5085/files#diff-1c01e90351b11ab077c5dff447720470dad032889b5206d5e9c5e4a69065649cL158), but I think we still want to check for the existence of a report, indicating that we have at least tried to populate their data. We just no longer need to check the personalized slide count > 1 logic.

### Test Steps
1. Log into the app on simulator. Uninstall the app in simulator, then run this branch in Xcode.
2. When the app launches and you tap through onboarding, the app will then automatically log in. Do something to trigger a feature announcement after a bit (go to ArticleViewController, or leave the Explore tab, then come back to Explore). You should see the personalized version of the feature announcement.

