### PR TITLE
[YiR] Show YiR after creating account through Profile

### DIFF
--- a/Wikipedia/Code/LoginCoordinator.swift
+++ b/Wikipedia/Code/LoginCoordinator.swift
@@ -7,6 +7,7 @@ final class LoginCoordinator: Coordinator {
     var navigationController: UINavigationController
     
     var loginSuccessCompletion: (() -> Void)?
+    var createAccountSuccessCustomDismissBlock: (() -> Void)?
 
     // MARK: Properties
 
@@ -24,6 +25,7 @@ final class LoginCoordinator: Coordinator {
             loginVC.apply(theme: theme)
             let loginNavVC = WMFThemeableNavigationController(rootViewController: loginVC, theme: theme)
             loginVC.loginSuccessCompletion = loginSuccessCompletion
+            loginVC.createAccountSuccessCustomDismissBlock = createAccountSuccessCustomDismissBlock
             
             if let presentedVC = navigationController.presentedViewController {
                 presentedVC.present(loginNavVC, animated: true)

--- a/Wikipedia/Code/ProfileCoordinator.swift
+++ b/Wikipedia/Code/ProfileCoordinator.swift
@@ -201,6 +201,12 @@ final class ProfileCoordinator: NSObject, Coordinator, ProfileCoordinatorDelegat
                     self.showYearInReview()
                 }
             }
+            
+            loginCoordinator.createAccountSuccessCustomDismissBlock = {
+                self.dismissProfile {
+                    self.showYearInReview()
+                }
+            }
 
             loginCoordinator.start()
         }

--- a/Wikipedia/Code/WMFAccountCreationViewController.swift
+++ b/Wikipedia/Code/WMFAccountCreationViewController.swift
@@ -21,6 +21,8 @@ class WMFAccountCreationViewController: WMFScrollViewController, WMFCaptchaViewC
 
     @IBOutlet fileprivate weak var scrollContainer: UIView!
     
+    public var createAccountSuccessCustomDismissBlock: (() -> Void)?
+    
     // SINGLETONTODO
     let dataStore = MWKDataStore.shared()
     
@@ -227,10 +229,16 @@ class WMFAccountCreationViewController: WMFScrollViewController, WMFCaptchaViewC
                 } else {
                     assertionFailure("startDate is nil; startDate is required to calculate timeElapsed")
                 }
-                let presenter = self.presentingViewController
-                self.dismiss(animated: true, completion: {
-                    presenter?.wmf_showEnableReadingListSyncPanel(theme: self.theme, oncePerLogin: true)
-                })
+                
+                if let customDismissBlock = self.createAccountSuccessCustomDismissBlock {
+                    customDismissBlock()
+                } else {
+                    let presenter = self.presentingViewController
+                    self.dismiss(animated: true, completion: {
+                        presenter?.wmf_showEnableReadingListSyncPanel(theme: self.theme, oncePerLogin: true)
+                    })
+                }
+                
             case .failure(let error):
                 self.setViewControllerUserInteraction(enabled: true)
                 self.enableProgressiveButtonIfNecessary()

--- a/Wikipedia/Code/WMFLoginViewController.swift
+++ b/Wikipedia/Code/WMFLoginViewController.swift
@@ -17,6 +17,7 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
     @IBOutlet weak var scrollContainer: UIView!
     
     public var loginSuccessCompletion: (() -> Void)?
+    public var createAccountSuccessCustomDismissBlock: (() -> Void)?
     public var loginDismissedCompletion: (() -> Void)?
 
     private var startDate: Date? // to calculate time elapsed between login start and login success
@@ -269,6 +270,7 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
             return
         }
         createAcctVC.category = category
+        createAcctVC.createAccountSuccessCustomDismissBlock = createAccountSuccessCustomDismissBlock
         createAcctVC.apply(theme: theme)
         LoginFunnel.shared.logCreateAccountAttempt(category: category)
         dismiss(animated: true, completion: {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T379794

### Notes
Fixes an issue found in https://phabricator.wikimedia.org/T379794#10428455. After creating an account, there was no completion block assigned to navigate to Year in Review. This PR adds the completion handler (similar to how Login is working).

### Test Steps
1. Launch app while logged out.
2. Tap YiR in Profile.
3. Tap "Join Wikipedia / Log in"
4. Tap "Join Wikipedia"
5. Create a new account. Year in Review should present after successfully creating an account.

