### PR TITLE
Delete YiR saved articles slides upon logout

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
@@ -1040,7 +1040,9 @@ import CoreData
                 for slide in slides {
 
                     guard slide.id == WMFYearInReviewPersonalizedSlideID.editCount.rawValue ||
-                            slide.id == WMFYearInReviewPersonalizedSlideID.viewCount.rawValue else {
+                            slide.id == WMFYearInReviewPersonalizedSlideID.viewCount.rawValue ||
+                            slide.id == WMFYearInReviewPersonalizedSlideID.saveCount.rawValue
+                    else {
                         continue
                     }
 


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T378135

### Notes
* Removes personalized saved slides in `deleteAllYearInReviewReports()` 

### Test Steps
1. Login with one account, trigger YiR report
2. Verify personalized saved articles slide
3. Log out, on the dialog, click 'Delete saved slides from device' 
4. Log in with another account, and trigger YiR report (I had to toggle the YiR setting to populate my personalized slides) 
5. Go to YiR, verify saved slide count and titles displays correctly
