### PR TITLE
[YiR] Update donate button displaying logic on saved articles slide

### DIFF
--- a/Wikipedia/Code/YearInReviewCoordinator.swift
+++ b/Wikipedia/Code/YearInReviewCoordinator.swift
@@ -639,7 +639,7 @@ final class YearInReviewCoordinator: NSObject, Coordinator {
                             subtitle: personalizedSaveCountSlideSubtitle(saveCount: count, articleNames: savedSlideData.articleTitles),
                             loggingID: "save_count_custom",
                             infoURL: aboutYIRURL,
-                            hideDonateButton: false)
+                            hideDonateButton: shoudlHideDonateButton())
                     }
                 }
             case .mostReadDay:


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T378842

### Notes
* Fixes the logic on the saved articles slide, it was set to true

### Test Steps
1. Run the app with the region set to a country where YiR displays, but we can't fundraise (Finland works)
2. Make sure the donate button doesn't appear on YiR
3. Run the app in a region where we fundraise
4. The donate button display logic should be the default

