### PR TITLE
[YiR] Ungroup accessibility elements

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewView.swift
@@ -169,7 +169,7 @@ public struct WMFYearInReviewView: View {
                 viewModel.coordinatorDelegate?.handleYearInReviewAction(.introLearnMore)
             }
 
-        }.accessibilityElement(children: .contain)
+        }
     }
 
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T378129

### Notes
* Reverts https://github.com/wikimedia/wikipedia-ios/pull/5139
* QA revealed some issues caused by this change that I can't reproduce at this moment (per [this video](https://drive.google.com/file/d/1PysXhVdWBEmajmMaMUQo-Eoap5rL3xJE/view?usp=drive_link)), so I'm reverting this change to mitigate a worse scenario for this release

### Test Steps
1. With VoiceOver on, go to the first YiR slide
2. Make sure you can access all the buttons. The Learn More button might not work (this is [acceptable](https://phabricator.wikimedia.org/T378129#10450410))
3. Make sure you can click on "Get Started"


