### PR TITLE
[YiR] Fix more analytics

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/WMFYearInReviewViewModel.swift
@@ -165,7 +165,11 @@ public class WMFYearInReviewViewModel: ObservableObject {
     }
     
     var slideLoggingID: String {
-        return isFirstSlide ? "start" : slides[currentSlide].loggingID
+        if isFirstSlide {
+            return isUserAuth ? "start_c" : "start"
+        }
+        
+        return slides[currentSlide].loggingID
     }
     
     var isLastSlide: Bool {

--- a/Wikipedia/Code/DonateFunnel.swift
+++ b/Wikipedia/Code/DonateFunnel.swift
@@ -313,8 +313,8 @@ import WMF
     
     // MARK: - Year In Review
     
-    func logProfileDidTapYearInReview(isAnon: Bool) {
-        logEvent(activeInterface: .wikiYiR, action: .startClick, actionData: ["slide": "entry_b_profile", "is_anon": isAnon.description])
+    func logProfileDidTapYearInReview() {
+        logEvent(activeInterface: .wikiYiR, action: .startClick, actionData: ["slide": "entry_b_profile")
     }
     
     func logYearInReviewSlideImpression(slideLoggingID: String) {
@@ -325,8 +325,8 @@ import WMF
         logEvent(activeInterface: .wikiYiR, action: .closeClick, actionData: ["slide": slideLoggingID])
     }
     
-    func logYearInReviewDidTapIntroContinue() {
-        logEvent(activeInterface: .wikiYiR, action: .startClick, actionData: ["slide": "start"])
+    func logYearInReviewDidTapIntroContinue(isEntryC: Bool = false) {
+        logEvent(activeInterface: .wikiYiR, action: .startClick, actionData: ["slide": isEntryC ? "start_c" : "start"])
     }
     
     func logYearInReviewDidTapIntroLearnMore(isEntryC: Bool = false) {
@@ -369,7 +369,7 @@ import WMF
     }
     
     func logYearInReviewLoginPromptDidTapNoThanks() {
-        logEvent(activeInterface: .wikiYiR, action: .rejectClick, actionData: ["slide": "entry_b_profile"])
+        logEvent(activeInterface: .wikiYiR, action: .rejectClick, actionData: ["slide": "new_account_engage"])
     }
     
     func logYearInReviewLoginPromptDidTapNoThanksProfile() {

--- a/Wikipedia/Code/DonateFunnel.swift
+++ b/Wikipedia/Code/DonateFunnel.swift
@@ -314,7 +314,7 @@ import WMF
     // MARK: - Year In Review
     
     func logProfileDidTapYearInReview() {
-        logEvent(activeInterface: .wikiYiR, action: .startClick, actionData: ["slide": "entry_b_profile")
+        logEvent(activeInterface: .wikiYiR, action: .startClick, actionData: ["slide": "entry_b_profile"])
     }
     
     func logYearInReviewSlideImpression(slideLoggingID: String) {
@@ -418,7 +418,7 @@ import WMF
     }
     
     func logYearInReviewDonateSlideLearnMoreWebViewDidTapDonateButton(metricsID: String) {
-        logEvent(activeInterface: .wikiYiR, action: .donateStartClickYir, actionData: ["slide": "about_wikimedia",
+        logEvent(activeInterface: .wikiYiR, action: .donateStartClickYir, actionData: ["slide": "about_wikimedia_base",
                                                                                        "campaign_id": metricsID])
     }
     

--- a/Wikipedia/Code/ProfileCoordinator.swift
+++ b/Wikipedia/Code/ProfileCoordinator.swift
@@ -313,7 +313,7 @@ final class ProfileCoordinator: NSObject, Coordinator, ProfileCoordinatorDelegat
     }
     
     func logYearInReviewTap() {
-        DonateFunnel.shared.logProfileDidTapYearInReview(isAnon: dataStore.authenticationManager.authStateIsPermanent) 
+        DonateFunnel.shared.logProfileDidTapYearInReview()
     }
 }
 

--- a/Wikipedia/Code/YearInReviewCoordinator.swift
+++ b/Wikipedia/Code/YearInReviewCoordinator.swift
@@ -968,7 +968,7 @@ extension YearInReviewCoordinator: WMFYearInReviewLoggingDelegate {
     }
 
     func logYearInReviewIntroDidTapContinue() {
-        DonateFunnel.shared.logYearInReviewDidTapIntroContinue()
+        DonateFunnel.shared.logYearInReviewDidTapIntroContinue(isEntryC: dataStore.authenticationManager.authStateIsPermanent)
     }
 
     func logYearInReviewIntroDidTapLearnMore() {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T381330

### Notes
These are some bugs I found when testing findings in https://phabricator.wikimedia.org/T382972#10446742.

I also removed some unnecessary is_anon data in logProfileDidTapYearInReview. Our library should automatically record is_anon values, so this would just be duplicate data.

### Test Steps
1. Log out of app. Fresh install app. On Explore or Article, trigger feature announcement. Ensure events on announcement match [deck slide](https://docs.google.com/presentation/d/17NO7lrhArvKFB8Sk3eBGeMfhjkaSupyo5zkJTyL-x0Y/edit#slide=id.g31ee0396004_0_70.)
2. Tap Continue. Ensure events on intro slide match [deck slide](https://docs.google.com/presentation/d/17NO7lrhArvKFB8Sk3eBGeMfhjkaSupyo5zkJTyL-x0Y/edit#slide=id.g31ee0396004_0_70).
3. Tap through to last slide. Tap "Learn more about our work". Tap "Donate now" button on web view. Ensure slide value = `about_wikimedia_base`.
4. Close out of web view, tap Finish.
5. Submit survey answer.
6. You should see login prompt. Ensure tapping "No thanks" logs data expected in [deck slide](https://docs.google.com/presentation/d/17NO7lrhArvKFB8Sk3eBGeMfhjkaSupyo5zkJTyL-x0Y/edit#slide=id.g31ee0396004_0_618).
7. Log into app. Delete app and fresh install. On Explore or article, trigger feature announcement. Ensure events on announcement match [deck slide](https://docs.google.com/presentation/d/17NO7lrhArvKFB8Sk3eBGeMfhjkaSupyo5zkJTyL-x0Y/edit#slide=id.g31ee0396004_0_146).
8. Tap Continue. Ensure events on intro slide match [deck slide](https://docs.google.com/presentation/d/17NO7lrhArvKFB8Sk3eBGeMfhjkaSupyo5zkJTyL-x0Y/edit#slide=id.g31ee0396004_0_146).
