### PR TITLE
Remove extraneous character from Localizable strings file

### DIFF
--- a/Wikipedia/Localizations/ja.lproj/Localizable.strings
+++ b/Wikipedia/Localizations/ja.lproj/Localizable.strings
@@ -1228,7 +1228,7 @@
 // Fuzzy
 "year-in-review-base-edits-subtitle" = "今年、ウィキペディアは1分あたり平均$1回編集されました。記事は信頼できる情報源を使用して共同で作成、改訂されています。私達は皆、共有すべき知識を持っています。[参加方法をご覧ください]($2)。";;
 // Fuzzy
-"year-in-review-base-edits-title" = "ウィキペディアは1分あたり$1回編集されました";;
+"year-in-review-base-edits-title" = "ウィキペディアは1分あたり$1回編集されました";
 // Fuzzy
 "year-in-review-base-reading-subtitle" = "今年、ウィキペディアには、活発に使用されている$2以上の言語で$1万件以上の記事が掲載されていました。 あなたは何百万人もの人々に加わり、知識を広げ、多様なトピックを探求しました。";
 "year-in-review-base-reading-title" = "ウィキペディアは300以上の言語で利用可能でした。";


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
* The double semicolons were causing the file format handler to crash during sync to translatewiki.net

### Test Steps
1. Make sure the project compiles


