### PR TITLE
[YiR] Fixed saved articles slide crash

### DIFF
--- a/ContinueReadingWidget/Info.plist
+++ b/ContinueReadingWidget/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.6.3</string>
+	<string>7.6.4</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/NotificationServiceExtension/Info.plist
+++ b/NotificationServiceExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.6.3</string>
+	<string>7.6.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>

--- a/WMF Framework/Info.plist
+++ b/WMF Framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.6.3</string>
+	<string>7.6.4</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSPrincipalClass</key>

--- a/Widgets/Info.plist
+++ b/Widgets/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.6.3</string>
+	<string>7.6.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>

--- a/Wikipedia Stickers/Info.plist
+++ b/Wikipedia Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.6.3</string>
+	<string>7.6.4</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/Wikipedia/Experimental-Info.plist
+++ b/Wikipedia/Experimental-Info.plist
@@ -24,7 +24,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.6.3</string>
+	<string>7.6.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Wikipedia/Local-Info.plist
+++ b/Wikipedia/Local-Info.plist
@@ -28,7 +28,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.6.3</string>
+	<string>7.6.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Wikipedia/Staging-Info.plist
+++ b/Wikipedia/Staging-Info.plist
@@ -24,7 +24,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.6.3</string>
+	<string>7.6.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Wikipedia/Wikipedia-Info.plist
+++ b/Wikipedia/Wikipedia-Info.plist
@@ -24,7 +24,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.6.3</string>
+	<string>7.6.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/WikipediaUnitTests/Info.plist
+++ b/WikipediaUnitTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.6.3</string>
+	<string>7.6.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T384051

### Notes
This PR asks Core Data only for articles with a populated displayTitle when determining the saved slide article titles.

### Test Steps
1. Check out `releases/7.6.2` tag. Set scheme region to a country that did NOT qualify to see YiR V1. Run in simulator. Save and visit several articles.
2. Open simulator directory from Terminal by grabbing the directory written out at the top of the console log after "Simulator container directory:"

```
open /Users/tonisevener/Library/Developer/...etc
```

3. Open Wikipedia.sqlite file with Liya.
4. At the bottom, paste this command to get the list of saved articles:

```
SELECT * FROM `ZWMFARTICLE` WHERE `ZSAVEDDATE` IS NOT NULL
```

5. Make a note of a few ZDISPLAYTITLE values that you see in the database, then run a command like this that clears out all titles _except_ those three:

```
UPDATE `ZWMFARTICLE` SET `ZDISPLAYTITLE` = null WHERE `ZDISPLAYTITLE` NOT IN ('Dallas', 'MrBeast', 'Catherine the Great')
```

6. Run command from step 4 again to confirm most `ZDISPLAYTITLE` values were cleared out, and the 3 you kept still have a `ZDISPLAYTITLE`.

7. Switch to this PR branch. Temporarily return `Date()` in `dataPopulationEndDate` in the WMFFeatureConfigResponse.swift file. This allows the saved articles in step 1 to be considered for data population.
8. Temporarily set `WMFRemoteAppConfigCheckInterval = 1` at the top of WMFAppViewController.m. This forces the config to fetch on the next run.
9. Run the app. Confirm app does not crash, you see the year in review feature and the saved articles slide appears with the article titles you kept in step  5 populated.

