### PR TITLE
Fix crash from malformed html in edit notice

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Utility/HTMLUtils.swift
+++ b/WMFComponents/Sources/WMFComponents/Utility/HTMLUtils.swift
@@ -471,12 +471,17 @@ public struct HtmlUtils {
             }
             
             if tagNameString == "/ol" {
-                types.removeLast()
-                indent = indent - 1
-                orderedListCounts.removeLast()
+                
+                if !types.isEmpty && !orderedListCounts.isEmpty { // Prevent crashes from malformed html
+                    types.removeLast()
+                    indent = indent - 1
+                    orderedListCounts.removeLast()
+                }
             } else if tagNameString == "/ul" {
-                types.removeLast()
-                indent = indent - 1
+                if !types.isEmpty { // Prevent crashes from malformed html
+                    types.removeLast()
+                    indent = indent - 1
+                }
             }
             
             if tagNameString == "li" {

--- a/WMFComponents/Tests/WMFComponentsTests/HtmlUtilsTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/HtmlUtilsTests.swift
@@ -19,4 +19,13 @@ final class HtmlUtilsTests: XCTestCase {
         XCTAssertEqual(result, expectedText, "Unexpected result when attempting to strip html and entities.")
     }
 
+    func testMalformedListHtml() throws {
+        
+        let html = "<div class=\"mw-fr-edit-messages\"><div class=\"cdx-message mw-fr-message-box cdx-message--inline cdx-message--notice\"><span class=\"cdx-message__icon\"></span><div class=\"cdx-message__content\"><p><b>Note:</b> Edits to this page from new or unregistered users are subject to review prior to publication (<a href=\"/wiki/Wikipedia:Pending_changes\" title=\"Wikipedia:Pending changes\">help</a>).\n</p><div id=\"mw-fr-logexcerpt\"><ul class=\'mw-logevent-loglines\'>\n<li data-mw-logid=\"166878532\" data-mw-logaction=\"stable/config\" class=\"mw-logline-stable\"> <a href=\"/w/index.php?title=Special:Log&amp;logid=166878532\" title=\"Special:Log\">21:42, 2 January 2025</a> <a href=\"/wiki/User:Ymblanter\" class=\"mw-userlink\" title=\"User:Ymblanter\"><bdi>Ymblanter</bdi></a> configured pending changes settings for <a href=\"/wiki/Josh_Allen\" title=\"Josh Allen\">Josh Allen</a> [Auto-accept: require &quot;autoconfirmed&quot; permission] (expires 21:42, 2 January 2026 (UTC)) <span class=\"comment\">(Persistent <a href=\"/wiki/Wikipedia:Vandalism\" title=\"Wikipedia:Vandalism\">vandalism</a>; requested at <a href=\"/wiki/Wikipedia:RfPP\" class=\"mw-redirect\" title=\"Wikipedia:RfPP\">WP:RfPP</a> (<a href=\"/wiki/Wikipedia:TW\" class=\"mw-redirect\" title=\"Wikipedia:TW\">TW</a>))</span> <span class=\"mw-logevent-actionlink\">(<a href=\"/w/index.php?title=Josh_Allen&amp;action=history&amp;offset=20250102214253\" title=\"Josh Allen\">hist</a>)</span> </li>\n</ul></ul>\n</div></div></div></div>"
+        
+        let largeTraitCollection = UITraitCollection(preferredContentSizeCategory: .large)
+        let styles: HtmlUtils.Styles = HtmlUtils.Styles(font: WMFFont.for(.callout, compatibleWith: largeTraitCollection), boldFont: WMFFont.for(.boldCallout, compatibleWith: largeTraitCollection), italicsFont: WMFFont.for(.italicCallout, compatibleWith: largeTraitCollection), boldItalicsFont: WMFFont.for(.boldItalicCallout, compatibleWith: largeTraitCollection), color: WMFTheme.light.text, linkColor: WMFTheme.light.link, lineSpacing: 3)
+        let attributedString = try HtmlUtils.attributedStringFromHtml(html, styles: styles)
+        XCTAssertNotNil(attributedString, "Test extra unordered list did not cause crash")
+    }
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T384980

### Notes
The edit notice on this article has an extra closing `</ul>` tag, causing it to crash in HtmlUtils. 

### Test Steps
1. Edit article Josh Allen on EN Wikipedia.
2. Confirm edit notice displays and doesn't crash.
