### PR TITLE
Fix T385077: Fixes the issue of navigation bar hide on scroll resulting in search content visibility

### DIFF
--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -53,6 +53,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
     
     var topSafeAreaOverlayHeightConstraint: NSLayoutConstraint?
     var topSafeAreaOverlayView: UIView?
+    private var presentingSearchResults: Bool = false
 
     // MARK: - Lifecycle
 
@@ -199,7 +200,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
             searchBarPlaceholder: WMFLocalizedString("search-field-placeholder-text", value: "Search Wikipedia", comment: "Search field placeholder text"),
             showsScopeBar: false, scopeButtonTitles: nil)
         
-        configureNavigationBar(titleConfig: titleConfig, closeButtonConfig: nil, profileButtonConfig: profileButtonConfig, searchBarConfig: searchConfig, hideNavigationBarOnScroll: true)
+        configureNavigationBar(titleConfig: titleConfig, closeButtonConfig: nil, profileButtonConfig: profileButtonConfig, searchBarConfig: searchConfig, hideNavigationBarOnScroll: !presentingSearchResults)
     }
     
     @objc func updateProfileButton() {
@@ -2179,10 +2180,12 @@ extension ExploreViewController: YearInReviewBadgeDelegate {
 extension ExploreViewController: UISearchControllerDelegate {
     
     func willPresentSearchController(_ searchController: UISearchController) {
+        presentingSearchResults.toggle()
         navigationController?.hidesBarsOnSwipe = false
     }
     
     func didDismissSearchController(_ searchController: UISearchController) {
+        presentingSearchResults.toggle()
         navigationController?.hidesBarsOnSwipe = true
     }
 }

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -61,6 +61,8 @@ class SearchViewController: ArticleCollectionViewController, WMFNavigationBarCon
         return try? WMFYearInReviewDataController()
     }
     
+    private var presentingSearchResults: Bool = false
+    
     // MARK: - Funcs
     
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -164,7 +166,7 @@ class SearchViewController: ArticleCollectionViewController, WMFNavigationBarCon
         
         let searchBarConfig = WMFNavigationBarSearchConfig(searchResultsController: nil, searchControllerDelegate: self, searchResultsUpdater: self, searchBarDelegate: self, searchBarPlaceholder: WMFLocalizedString("search-field-placeholder-text", value: "Search Wikipedia", comment: "Search field placeholder text"), showsScopeBar: false, scopeButtonTitles: nil)
         
-        configureNavigationBar(titleConfig: titleConfig, closeButtonConfig: nil, profileButtonConfig: profileButtonConfig, searchBarConfig: searchBarConfig, hideNavigationBarOnScroll: true)
+        configureNavigationBar(titleConfig: titleConfig, closeButtonConfig: nil, profileButtonConfig: profileButtonConfig, searchBarConfig: searchBarConfig, hideNavigationBarOnScroll: !presentingSearchResults)
     }
     
     private func updateProfileButton() {
@@ -648,6 +650,7 @@ extension SearchViewController: UISearchControllerDelegate {
     }
     
     func willPresentSearchController(_ searchController: UISearchController) {
+        presentingSearchResults.toggle()
         needsAnimateLanguageBarMovement = true
         navigationController?.hidesBarsOnSwipe = false
     }
@@ -657,6 +660,7 @@ extension SearchViewController: UISearchControllerDelegate {
     }
     
     func didDismissSearchController(_ searchController: UISearchController) {
+        presentingSearchResults.toggle()
         needsAnimateLanguageBarMovement = false
         navigationController?.hidesBarsOnSwipe = true
     }

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -649,6 +649,7 @@ extension SearchViewController: UISearchControllerDelegate {
     
     func willPresentSearchController(_ searchController: UISearchController) {
         needsAnimateLanguageBarMovement = true
+        navigationController?.hidesBarsOnSwipe = false
     }
     
     func willDismissSearchController(_ searchController: UISearchController) {
@@ -657,6 +658,7 @@ extension SearchViewController: UISearchControllerDelegate {
     
     func didDismissSearchController(_ searchController: UISearchController) {
         needsAnimateLanguageBarMovement = false
+        navigationController?.hidesBarsOnSwipe = true
     }
 }
 

--- a/WikipediaUnitTests/Code/TWNStringsTests.m
+++ b/WikipediaUnitTests/Code/TWNStringsTests.m
@@ -80,6 +80,30 @@
     return twnLprojFiles;
 }
 
++ (NSArray *)twnLFilePaths {
+    static dispatch_once_t onceToken;
+    static NSArray *twnLFilePaths;
+    dispatch_once(&onceToken, ^{
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        NSString *localizationPath = [TWNStringsTests twnLocalizationsDirectory];
+
+        NSArray *lprojDirectories = [[[fileManager contentsOfDirectoryAtPath:localizationPath error:nil] filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"pathExtension='lproj'"]] valueForKey:@"lowercaseString"];
+
+        // Generate full paths of Localizable.strings
+        NSMutableArray *localizationFilePaths = [NSMutableArray array];
+
+        for (NSString *lprojDir in lprojDirectories) {
+            NSString *localizablePath = [localizationPath stringByAppendingPathComponent:[lprojDir stringByAppendingPathComponent:@"Localizable.strings"]];
+
+            if ([fileManager fileExistsAtPath:localizablePath]) {
+                [localizationFilePaths addObject:localizablePath];
+            }
+        }
+        twnLFilePaths = [localizationFilePaths copy];
+    });
+    return twnLFilePaths;
+}
+
 + (NSArray *)iOSLprojFiles {
     static dispatch_once_t onceToken;
     static NSArray *iOSLprojFiles;
@@ -421,6 +445,84 @@
             NSDictionary *translationPluralizableStringsDict = [self getPluralizableStringsDictFromLprogAtPath:[TWNStringsTests.bundleRoot stringByAppendingPathComponent:lprojFileName]];
             for (NSString *key in translationPluralizableStringsDict) {
                 XCTAssertNotNil([enPluralizableStringsDict objectForKey:key], @"\n\n\"%@\" translation containing plurals syntax received for \"%@\" string. The original EN string...\n\thttps://translatewiki.net/w/i.php?title=Wikimedia:Wikipedia-ios-%@/en&action=edit\n...doesn't have (or possibly need) plural syntax - either plural syntax will need to be added to the EN string or the translation...\n\thttps://translatewiki.net/w/i.php?title=Wikimedia:Wikipedia-ios-%@/%@&action=edit\n...will need to be updated to remove plural syntax.\n(Note: after loading the link above you can tap the \"Ask question\" button to pre-fill a Phabricator ticket for asking `i18n` folks for assistance for this string)\n\n", lprojFileName, key, key, key, [lprojFileName stringByReplacingOccurrencesOfString:@".lproj" withString:@""]);
+            }
+        }
+    }
+}
+
+- (void)testLocalizableStringsSingleSemicolonEnd {
+    NSArray *localizationFiles = [TWNStringsTests twnLFilePaths]; // Fetch all Localizable.strings file paths
+
+    XCTAssertTrue(localizationFiles.count > 0, @"No Localizable.strings files found");
+
+    for (NSString *filePath in localizationFiles) {
+        NSError *error = nil;
+        NSString *fileContents = [NSString stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:&error];
+
+        XCTAssertNil(error, @"Error reading file %@: %@", filePath, error.localizedDescription);
+        XCTAssertNotNil(fileContents, @"File contents should not be nil for file %@", filePath);
+
+        // Split file into lines
+        NSArray<NSString *> *lines = [fileContents componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+
+        // Check each line for multiple semicolons at the end
+        for (NSString *line in lines) {
+            if (line.length == 0) {
+                continue; // Skip empty lines
+            }
+
+            // Trim trailing whitespace
+            NSString *trimmedLine = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
+            // Count the number of semicolons at the end
+            NSUInteger semicolonCount = 0;
+            for (NSInteger i = trimmedLine.length - 1; i >= 0; i--) {
+                unichar character = [trimmedLine characterAtIndex:i];
+                if (character == ';') {
+                    semicolonCount++;
+                } else {
+                    break; // Stop counting once a non-semicolon character is found
+                }
+            }
+
+            // Fail if multiple semicolons exist at the end of the line
+            XCTAssertLessThanOrEqual(semicolonCount, 1, @"File %@ has a line with multiple semicolons at the end: %@", filePath, trimmedLine);
+        }
+    }
+}
+
+- (void)testLocalizableStringsMissingSemicolon {
+    NSArray *localizationFiles = [TWNStringsTests twnLFilePaths]; // Fetch all Localizable.strings file paths
+
+    XCTAssertTrue(localizationFiles.count > 0, @"No Localizable.strings files found");
+
+    for (NSString *filePath in localizationFiles) {
+        NSError *error = nil;
+        NSString *fileContents = [NSString stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:&error];
+
+        XCTAssertNil(error, @"Error reading file %@: %@", filePath, error.localizedDescription);
+        XCTAssertNotNil(fileContents, @"File contents should not be nil for file %@", filePath);
+
+        // Split file into lines
+        NSArray<NSString *> *lines = [fileContents componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+
+        // Check each line for missing semicolon at the end
+        for (NSString *line in lines) {
+            if (line.length == 0) {
+                continue; // Skip empty lines
+            }
+
+            // Trim trailing whitespace
+            NSString *trimmedLine = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
+            // Ignore comments (lines starting with "//")
+            if ([trimmedLine hasPrefix:@"//"]) {
+                continue;
+            }
+
+            // Fail if the last character is NOT a semicolon
+            if (![trimmedLine hasSuffix:@";"]) {
+                XCTFail(@"File %@ has a line missing a semicolon at the end: %@", filePath, trimmedLine);
             }
         }
     }


### PR DESCRIPTION
**Phabricator:** 
T385077

### Notes
* The issue was due to the fact that when a search bar is configured via Search View Controller, by default hidesBarsOnSwipe was set to true which was causing the issue of navigation bar hiding on scroll.

### Test Steps
1. Settings > Search > enable Show languages on search
2. Go to search tab, type a search term
3. Scroll down through search results

### Screenshots/Videos
Before Fix:
![Bug1](https://github.com/user-attachments/assets/0dd60295-5065-4bef-a602-0fa89b0a84ed)

After Fix:
![Fix1](https://github.com/user-attachments/assets/5eb85750-1221-4c24-8d3e-f773dde0735e)

