### PR TITLE
Fix T385077: Fixes the issue of navigation bar hide on scroll resulting in search content visibility

### DIFF
--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -649,6 +649,7 @@ extension SearchViewController: UISearchControllerDelegate {
     
     func willPresentSearchController(_ searchController: UISearchController) {
         needsAnimateLanguageBarMovement = true
+        navigationController?.hidesBarsOnSwipe = false
     }
     
     func willDismissSearchController(_ searchController: UISearchController) {
@@ -657,6 +658,7 @@ extension SearchViewController: UISearchControllerDelegate {
     
     func didDismissSearchController(_ searchController: UISearchController) {
         needsAnimateLanguageBarMovement = false
+        navigationController?.hidesBarsOnSwipe = true
     }
 }
 


### PR DESCRIPTION
**Phabricator:** 
[T385077](https://phabricator.wikimedia.org/T385077)

### Notes
* The issue was due to the fact that when a search bar is configured via Search View Controller, by default hidesBarsOnSwipe was set to true which was causing the issue of navigation bar hiding on scroll. 

### Test Steps
1. Settings > Search > enable Show languages on search
2. Go to search tab, type a search term
3. Scroll down through search results

### Screenshots/Videos
Before Fix:
![Bug1](https://github.com/user-attachments/assets/8d16999e-e9c4-42e0-9432-3fcc4f3418ec)

After Fix:
![Fix1](https://github.com/user-attachments/assets/899bd192-0757-47c0-8aac-eaec58bcf822)

