### PR TITLE
Fix T385397: Fixes the issue of navigation bar hiding on tab switch resulting in content visiblity under navigatoin bar in Explore tab.

### DIFF
--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -53,6 +53,8 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
     
     var topSafeAreaOverlayHeightConstraint: NSLayoutConstraint?
     var topSafeAreaOverlayView: UIView?
+    
+    private var presentingSearchResults: Bool = false
 
     // MARK: - Lifecycle
 
@@ -199,7 +201,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
             searchBarPlaceholder: WMFLocalizedString("search-field-placeholder-text", value: "Search Wikipedia", comment: "Search field placeholder text"),
             showsScopeBar: false, scopeButtonTitles: nil)
         
-        configureNavigationBar(titleConfig: titleConfig, closeButtonConfig: nil, profileButtonConfig: profileButtonConfig, searchBarConfig: searchConfig, hideNavigationBarOnScroll: true)
+        configureNavigationBar(titleConfig: titleConfig, closeButtonConfig: nil, profileButtonConfig: profileButtonConfig, searchBarConfig: searchConfig, hideNavigationBarOnScroll: !presentingSearchResults)
     }
     
     @objc func updateProfileButton() {
@@ -2179,10 +2181,12 @@ extension ExploreViewController: YearInReviewBadgeDelegate {
 extension ExploreViewController: UISearchControllerDelegate {
     
     func willPresentSearchController(_ searchController: UISearchController) {
+        presentingSearchResults = true
         navigationController?.hidesBarsOnSwipe = false
     }
     
     func didDismissSearchController(_ searchController: UISearchController) {
+        presentingSearchResults = false
         navigationController?.hidesBarsOnSwipe = true
     }
 }


### PR DESCRIPTION
**Phabricator:** 
T385397

### Notes
*  The issue arises when viewing search results in the Explore tab, switching to another tab, returning to the Explore tab, and then scrolling through the search results. During this process, the navigation bar scrolls along with the search results.

### Test Steps
1.  In explore tab, search for anything. (Optional you can have languages added but not required)
2. Scroll search results and observe search bar doesn't hide (Expected behavior)
3. Keeping search results in explore tab, Switch to any other tab and then switch back to explore tab.
4. Scroll search results and observe

### Screenshots/Videos
Before Fix:
![Bug2](https://github.com/user-attachments/assets/8145174c-dab1-4322-bed7-d58071f2de96)

After Fix:
![Fix2](https://github.com/user-attachments/assets/8c100e2d-3ba2-448d-95b8-c4f60259c1d8)


