### PR TITLE
Use WMFSFSymbolIcon for more button icon 

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Suggested Edits/Image Recommendations/WMFImageRecommendationsViewController.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Suggested Edits/Image Recommendations/WMFImageRecommendationsViewController.swift
@@ -247,7 +247,7 @@ public final class WMFImageRecommendationsViewController: WMFCanvasViewControlle
     }
 
     private func setupOverflowMenu() {
-        let rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), primaryAction: nil, menu: overflowMenu)
+        let rightBarButtonItem = UIBarButtonItem(image: WMFSFSymbolIcon.for(symbol: .ellipsisCircle), primaryAction: nil, menu: overflowMenu)
         navigationItem.rightBarButtonItem = rightBarButtonItem
         rightBarButtonItem.tintColor = theme.link
     }

--- a/Wikipedia/Code/ArticleToolbarController.swift
+++ b/Wikipedia/Code/ArticleToolbarController.swift
@@ -108,9 +108,9 @@ class ArticleToolbarController: Themeable {
         actions.append(UIAction(title: CommonStrings.shortShareTitle, image: UIImage(systemName: "square.and.arrow.up"), handler: { [weak self] _ in self?.share()}))
         
         let menu = UIMenu(title: "", options: .displayInline, children: actions)
-        
-        let moreImage = UIImage(systemName: "ellipsis.circle", withConfiguration: UIImage.SymbolConfiguration(weight: .light))
-        
+
+        let moreImage = WMFSFSymbolIcon.for(symbol: .ellipsisCircle)?.withConfiguration(UIImage.SymbolConfiguration(weight: .light))
+
         let item = IconBarButtonItem(image: moreImage, menu: menu)
 
         item.accessibilityLabel = CommonStrings.moreButton

--- a/Wikipedia/Code/DiffToolbarView.swift
+++ b/Wikipedia/Code/DiffToolbarView.swift
@@ -1,4 +1,4 @@
-import UIKit
+import WMFComponents
 
 protocol DiffToolbarViewDelegate: AnyObject {
     func tappedPrevious()
@@ -163,7 +163,7 @@ class DiffToolbarView: UIView {
         
         let menu = UIMenu(title: "", options: .displayInline, children: actions)
         
-        let item = IconBarButtonItem(title: nil, image: UIImage(systemName: "ellipsis.circle"), primaryAction: nil, menu: menu)
+        let item = IconBarButtonItem(title: nil, image: WMFSFSymbolIcon.for(symbol: .ellipsisCircle), primaryAction: nil, menu: menu)
 
         item.accessibilityLabel = CommonStrings.moreButton
         return item

--- a/Wikipedia/Code/SavedViewController.swift
+++ b/Wikipedia/Code/SavedViewController.swift
@@ -366,7 +366,7 @@ class SavedViewController: ThemeableViewController, WMFNavigationBarConfiguring,
     }
     
     private lazy var moreBarButtonItem: UIBarButtonItem = {
-        let button = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), primaryAction: nil, menu: overflowMenu)
+        let button = UIBarButtonItem(image: WMFSFSymbolIcon.for(symbol: .ellipsisCircle), primaryAction: nil, menu: overflowMenu)
         button.accessibilityLabel = CommonStrings.moreButton
         return button
     }()

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -268,7 +268,7 @@ class TalkPageViewController: ThemeableViewController, WMFNavigationBarConfiguri
     }
     
     private func setupOverflowMenu() {
-        let rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), primaryAction: nil, menu: overflowMenu)
+        let rightBarButtonItem = UIBarButtonItem(image: WMFSFSymbolIcon.for(symbol: .ellipsisCircle), primaryAction: nil, menu: overflowMenu)
         rightBarButtonItem.accessibilityLabel = Self.TalkPageLocalizedStrings.overflowMenuAccessibilityLabel
         navigationItem.rightBarButtonItem = rightBarButtonItem
         rightBarButtonItem.tintColor = theme.colors.link


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T383822#10536600 (comment # 1) 

### Notes
* Now using WMFSFSymbolIcon for more button icon to standardize icon size 
* Also updated in other places - article toolbar, diff toolbar, talk page header button

### Test Steps
1. Run the app, make sure the icon sizes on the saved tab match
2. Check article toolbar, diff toolbar and talk page header buttons
