### PR TITLE
Hide floating tab bar on iPad when scrolling

### DIFF
--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -1367,6 +1367,16 @@ class ArticleViewController: ThemeableViewController, HintPresenting, UIScrollVi
         updateTableOfContentsHighlightIfNecessary()
 
         calculateNavigationBarHiddenState(scrollView: webView.scrollView)
+
+        if #available(iOS 18.0, *) {
+            let velocity = scrollView.panGestureRecognizer.velocity(in: scrollView).y
+
+            if velocity < 0 { // Scrolling down
+                tabBarController?.setTabBarHidden(true, animated: true)
+            } else if velocity > 0 { // Scrolling up
+                tabBarController?.setTabBarHidden(false, animated: true)
+            }
+        }
     }
     
     func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {

--- a/Wikipedia/Code/ColumnarCollectionViewController.swift
+++ b/Wikipedia/Code/ColumnarCollectionViewController.swift
@@ -385,7 +385,7 @@ class ColumnarCollectionViewController: ThemeableViewController, ColumnarCollect
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         _maxViewed = max(_maxViewed, percentViewed)
-        if #available(iOS 18.0, *) {
+        if UIDevice.current.userInterfaceIdiom == .pad, #available(iOS 18.0, *) {
             let velocity = scrollView.panGestureRecognizer.velocity(in: scrollView).y
             if velocity < 0 { // Scrolling down
                 tabBarController?.setTabBarHidden(true, animated: true)

--- a/Wikipedia/Code/ColumnarCollectionViewController.swift
+++ b/Wikipedia/Code/ColumnarCollectionViewController.swift
@@ -385,6 +385,14 @@ class ColumnarCollectionViewController: ThemeableViewController, ColumnarCollect
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         _maxViewed = max(_maxViewed, percentViewed)
+        if #available(iOS 18.0, *) {
+            let velocity = scrollView.panGestureRecognizer.velocity(in: scrollView).y
+            if velocity < 0 { // Scrolling down
+                tabBarController?.setTabBarHidden(true, animated: true)
+            } else if velocity > 0 { // Scrolling up
+                tabBarController?.setTabBarHidden(false, animated: true)
+            }
+        }
     }
 
     // MARK: - CollectionViewFooterDelegate


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T383759

### Notes
* Works on current UIKit implementation

### Test Steps
1. Scroll up and down on Article View, Explore, Saved, Search and History.
2. Make sure it behaves as expected
3. Check if iPhone is not affected


