### PR TITLE
Fix flaky Core Data tests

### DIFF
--- a/Test Plans/WMFData.xctestplan
+++ b/Test Plans/WMFData.xctestplan
@@ -9,6 +9,11 @@
     }
   ],
   "defaultOptions" : {
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "-com.apple.CoreData.ConcurrencyDebug 1"
+      }
+    ],
     "language" : "en",
     "region" : "US",
     "testTimeoutsEnabled" : true

--- a/WMFData/Tests/WMFDataTests/WMFCoreDataStoreTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFCoreDataStoreTests.swift
@@ -20,7 +20,7 @@ final class WMFCoreDataStoreTests: XCTestCase {
         try await super.setUp()
     }
 
-    func testCreateAndFetch() throws {
+    func testCreateAndFetch() async throws {
         
         guard let store else {
             throw TestsError.missingStore
@@ -28,26 +28,27 @@ final class WMFCoreDataStoreTests: XCTestCase {
         
         // First save new record
         let backgroundContext = try store.newBackgroundContext
-        let page = try store.create(entityType: CDPage.self, in: backgroundContext)
-        page.title = "Cat"
-        page.namespaceID = 0
-        page.projectID = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)).coreDataIdentifier
-        page.timestamp = Date()
-        
-        try store.saveIfNeeded(moc: backgroundContext)
+        try await backgroundContext.perform {
+            let page = try store.create(entityType: CDPage.self, in: backgroundContext)
+            page.title = "Cat"
+            page.namespaceID = 0
+            page.timestamp = Date()
+            
+            try store.saveIfNeeded(moc: backgroundContext)
 
-        // Then pull from store, confirm values match
-        guard let pulledPage = try store.fetch(entityType: CDPage.self, predicate: nil, fetchLimit: 1, in: backgroundContext)?.first else {
-            throw TestsError.empty
+            // Then pull from store, confirm values match
+            guard let pulledPage = try store.fetch(entityType: CDPage.self, predicate: nil, fetchLimit: 1, in: backgroundContext)?.first else {
+                throw TestsError.empty
+            }
+            
+            XCTAssertEqual(pulledPage.title, "Cat")
+            XCTAssertEqual(pulledPage.namespaceID, 0)
+            XCTAssertEqual(pulledPage.projectID, "wikipedia~en")
+            XCTAssertNotNil(pulledPage.timestamp)
         }
-        
-        XCTAssertEqual(pulledPage.title, "Cat")
-        XCTAssertEqual(pulledPage.namespaceID, 0)
-        XCTAssertEqual(pulledPage.projectID, "wikipedia~en")
-        XCTAssertNotNil(pulledPage.timestamp)
     }
     
-    func testFetchOrCreate() throws {
+    func testFetchOrCreate() async throws {
         
         guard let store else {
             throw TestsError.missingStore
@@ -57,52 +58,54 @@ final class WMFCoreDataStoreTests: XCTestCase {
         let predicate = NSPredicate(format: "projectID == %@ && namespaceID == %@ && title == %@", argumentArray: ["wikipedia~en", 0, "Dog"])
         
         let backgroundContext = try store.newBackgroundContext
-        guard let initialPages = try store.fetch(entityType: CDPage.self, predicate: predicate, fetchLimit: nil, in: backgroundContext) else {
-            throw TestsError.empty
-        }
-        
-        XCTAssertEqual(initialPages.count, 0)
-        
-        // Then fetch or create
-        guard let savedPage = try store.fetchOrCreate(entityType: CDPage.self, predicate: predicate, in: backgroundContext) else {
-            throw TestsError.empty
-        }
+        try await backgroundContext.perform {
+            guard let initialPages = try store.fetch(entityType: CDPage.self, predicate: predicate, fetchLimit: nil, in: backgroundContext) else {
+                throw TestsError.empty
+            }
+            
+            XCTAssertEqual(initialPages.count, 0)
+            
+            // Then fetch or create
+            guard let savedPage = try store.fetchOrCreate(entityType: CDPage.self, predicate: predicate, in: backgroundContext) else {
+                throw TestsError.empty
+            }
 
-        savedPage.title = "Dog"
-        savedPage.namespaceID = 0
-        savedPage.projectID = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)).coreDataIdentifier
-        savedPage.timestamp = Date()
-        
-        try store.saveIfNeeded(moc: backgroundContext)
+            savedPage.title = "Dog"
+            savedPage.namespaceID = 0
+            savedPage.projectID = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)).coreDataIdentifier
+            savedPage.timestamp = Date()
+            
+            try store.saveIfNeeded(moc: backgroundContext)
 
-        // Then pull from store again, confirm only one page saved
-        guard let nextPages = try store.fetch(entityType: CDPage.self, predicate: predicate, fetchLimit: nil, in: backgroundContext) else {
-            throw TestsError.empty
-        }
-        
-        XCTAssertEqual(nextPages.count, 1)
-        
-        // Try saving again, confirm we don't add a duplicate
-        guard let anotherSavedPage = try store.fetchOrCreate(entityType: CDPage.self, predicate: predicate, in: backgroundContext) else {
-            throw TestsError.empty
-        }
+            // Then pull from store again, confirm only one page saved
+            guard let nextPages = try store.fetch(entityType: CDPage.self, predicate: predicate, fetchLimit: nil, in: backgroundContext) else {
+                throw TestsError.empty
+            }
+            
+            XCTAssertEqual(nextPages.count, 1)
+            
+            // Try saving again, confirm we don't add a duplicate
+            guard let anotherSavedPage = try store.fetchOrCreate(entityType: CDPage.self, predicate: predicate, in: backgroundContext) else {
+                throw TestsError.empty
+            }
 
-        anotherSavedPage.title = "Dog"
-        anotherSavedPage.namespaceID = 0
-        anotherSavedPage.projectID = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)).coreDataIdentifier
-        anotherSavedPage.timestamp = Date()
-        
-        try store.saveIfNeeded(moc: backgroundContext)
-        
-        // Then pull from store once more, confirm still only one page saved
-        guard let finalPages = try store.fetch(entityType: CDPage.self, predicate: predicate, fetchLimit: nil, in: backgroundContext) else {
-            throw TestsError.empty
+            anotherSavedPage.title = "Dog"
+            anotherSavedPage.namespaceID = 0
+            anotherSavedPage.projectID = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)).coreDataIdentifier
+            anotherSavedPage.timestamp = Date()
+            
+            try store.saveIfNeeded(moc: backgroundContext)
+            
+            // Then pull from store once more, confirm still only one page saved
+            guard let finalPages = try store.fetch(entityType: CDPage.self, predicate: predicate, fetchLimit: nil, in: backgroundContext) else {
+                throw TestsError.empty
+            }
+            
+            XCTAssertEqual(finalPages.count, 1)
         }
-        
-        XCTAssertEqual(finalPages.count, 1)
     }
     
-    func testFetchGrouped() throws {
+    func testFetchGrouped() async throws {
         
         guard let store else {
             throw TestsError.missingStore
@@ -110,28 +113,30 @@ final class WMFCoreDataStoreTests: XCTestCase {
         
         // First save new records
         let backgroundContext = try store.newBackgroundContext
-        let page = try store.create(entityType: CDPage.self, in: backgroundContext)
-        page.title = "Cat"
-        page.namespaceID = 0
-        page.projectID = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)).coreDataIdentifier
-        page.timestamp = Date()
-        
-        let pageView1 = try store.create(entityType: CDPageView.self, in: backgroundContext)
-        pageView1.timestamp = Date.init(timeIntervalSinceNow: -(60*60))
-        pageView1.page = page
-        
-        let pageView2 = try store.create(entityType: CDPageView.self, in: backgroundContext)
-        pageView2.timestamp = Date()
-        pageView2.page = page
-        
-        try store.saveIfNeeded(moc: backgroundContext)
-        
-        // Then fetch grouped and compare counts
-        let pageViews = try store.fetchGrouped(entityType: CDPageView.self, predicate: nil, propertyToCount: "page", propertiesToGroupBy: ["page"], propertiesToFetch: ["page"], in: backgroundContext)
-        XCTAssertEqual(pageViews.count, 1)
-        let pageViewsDict = pageViews[0]
-        XCTAssertEqual(pageViewsDict["page"] as? NSManagedObjectID, page.objectID)
-        XCTAssertEqual(pageViewsDict["count"] as? Int, 2)
+        try await backgroundContext.perform {
+            let page = try store.create(entityType: CDPage.self, in: backgroundContext)
+            page.title = "Cat"
+            page.namespaceID = 0
+            page.projectID = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)).coreDataIdentifier
+            page.timestamp = Date()
+            
+            let pageView1 = try store.create(entityType: CDPageView.self, in: backgroundContext)
+            pageView1.timestamp = Date.init(timeIntervalSinceNow: -(60*60))
+            pageView1.page = page
+            
+            let pageView2 = try store.create(entityType: CDPageView.self, in: backgroundContext)
+            pageView2.timestamp = Date()
+            pageView2.page = page
+            
+            try store.saveIfNeeded(moc: backgroundContext)
+            
+            // Then fetch grouped and compare counts
+            let pageViews = try store.fetchGrouped(entityType: CDPageView.self, predicate: nil, propertyToCount: "page", propertiesToGroupBy: ["page"], propertiesToFetch: ["page"], in: backgroundContext)
+            XCTAssertEqual(pageViews.count, 1)
+            let pageViewsDict = pageViews[0]
+            XCTAssertEqual(pageViewsDict["page"] as? NSManagedObjectID, page.objectID)
+            XCTAssertEqual(pageViewsDict["count"] as? Int, 2)
+        }
     }
     
     func testDatabaseHousekeeping() async throws {
@@ -144,64 +149,68 @@ final class WMFCoreDataStoreTests: XCTestCase {
         
         // First save new records
         let backgroundContext = try store.newBackgroundContext
-        let catPage = try store.create(entityType: CDPage.self, in: backgroundContext)
-        catPage.title = "Cat"
-        catPage.namespaceID = 0
-        catPage.projectID = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)).coreDataIdentifier
-        catPage.timestamp = Date(timeIntervalSinceNow: -(60*60))
-        
-        let catPageView1 = try store.create(entityType: CDPageView.self, in: backgroundContext)
-        catPageView1.timestamp = Date(timeIntervalSinceNow: -(60*60))
-        catPageView1.page = catPage
-        
-        let catPageView2 = try store.create(entityType: CDPageView.self, in: backgroundContext)
-        catPageView2.timestamp = Date()
-        catPageView2.page = catPage
-        
-        let dogPage = try store.create(entityType: CDPage.self, in: backgroundContext)
-        dogPage.title = "Dog"
-        dogPage.namespaceID = 0
-        dogPage.projectID = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)).coreDataIdentifier
-        dogPage.timestamp = Date(timeIntervalSinceNow: -(overTwoYearsAgoInSeconds + 20))
-        
-        let dogPageView1 = try store.create(entityType: CDPageView.self, in: backgroundContext)
-        dogPageView1.timestamp = Date(timeIntervalSinceNow: -(overTwoYearsAgoInSeconds + 20))
-        dogPageView1.page = dogPage
-        
-        let dogPageView2 = try store.create(entityType: CDPageView.self, in: backgroundContext)
-        dogPageView2.timestamp = Date(timeIntervalSinceNow: -(overTwoYearsAgoInSeconds))
-        dogPageView2.page = dogPage
-        
-        try store.saveIfNeeded(moc: backgroundContext)
-        
-        // Confirm counts
-        guard let pages = try store.fetch(entityType: CDPage.self, predicate: nil, fetchLimit: nil, in: backgroundContext) else {
-            throw TestsError.empty
+        try backgroundContext.performAndWait {
+            let catPage = try store.create(entityType: CDPage.self, in: backgroundContext)
+            catPage.title = "Cat"
+            catPage.namespaceID = 0
+            catPage.projectID = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)).coreDataIdentifier
+            catPage.timestamp = Date(timeIntervalSinceNow: -(60*60))
+            
+            let catPageView1 = try store.create(entityType: CDPageView.self, in: backgroundContext)
+            catPageView1.timestamp = Date(timeIntervalSinceNow: -(60*60))
+            catPageView1.page = catPage
+            
+            let catPageView2 = try store.create(entityType: CDPageView.self, in: backgroundContext)
+            catPageView2.timestamp = Date()
+            catPageView2.page = catPage
+            
+            let dogPage = try store.create(entityType: CDPage.self, in: backgroundContext)
+            dogPage.title = "Dog"
+            dogPage.namespaceID = 0
+            dogPage.projectID = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)).coreDataIdentifier
+            dogPage.timestamp = Date(timeIntervalSinceNow: -(overTwoYearsAgoInSeconds + 20))
+            
+            let dogPageView1 = try store.create(entityType: CDPageView.self, in: backgroundContext)
+            dogPageView1.timestamp = Date(timeIntervalSinceNow: -(overTwoYearsAgoInSeconds + 20))
+            dogPageView1.page = dogPage
+            
+            let dogPageView2 = try store.create(entityType: CDPageView.self, in: backgroundContext)
+            dogPageView2.timestamp = Date(timeIntervalSinceNow: -(overTwoYearsAgoInSeconds))
+            dogPageView2.page = dogPage
+            
+            try store.saveIfNeeded(moc: backgroundContext)
+            
+            // Confirm counts
+            guard let pages = try store.fetch(entityType: CDPage.self, predicate: nil, fetchLimit: nil, in: backgroundContext) else {
+                throw TestsError.empty
+            }
+            
+            XCTAssertEqual(pages.count, 2)
+            
+            guard let pageViews = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: backgroundContext) else {
+                throw TestsError.empty
+            }
+            
+            XCTAssertEqual(pageViews.count, 4)
         }
-        
-        XCTAssertEqual(pages.count, 2)
-        
-        guard let pageViews = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: backgroundContext) else {
-            throw TestsError.empty
-        }
-        
-        XCTAssertEqual(pageViews.count, 4)
         
         // Clean up via database housekeeper
         try await store.performDatabaseHousekeeping()
         
-        backgroundContext.refreshAllObjects()
-        
-        guard let newPages = try store.fetch(entityType: CDPage.self, predicate: nil, fetchLimit: nil, in: backgroundContext) else {
-            throw TestsError.empty
+        try await backgroundContext.perform {
+            backgroundContext.refreshAllObjects()
+            
+            guard let newPages = try store.fetch(entityType: CDPage.self, predicate: nil, fetchLimit: nil, in: backgroundContext) else {
+                throw TestsError.empty
+            }
+
+            XCTAssertEqual(newPages.count, 1)
+
+            guard let newPageViews = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: backgroundContext) else {
+                throw TestsError.empty
+            }
+
+            XCTAssertEqual(newPageViews.count, 2)
         }
-        
-        XCTAssertEqual(newPages.count, 1)
-        
-        guard let newPageViews = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: backgroundContext) else {
-            throw TestsError.empty
-        }
-        
-        XCTAssertEqual(newPageViews.count, 2)
     }
 }

--- a/WMFData/Tests/WMFDataTests/WMFPageViewsDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFPageViewsDataControllerTests.swift
@@ -56,16 +56,18 @@ final class WMFPageViewsDataControllerTests: XCTestCase {
         try await dataController.addPageView(title: "Cat", namespaceID: 0, project: enProject)
         
         // Fetch, confirm page view was added
-        let results = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
-        XCTAssertNotNil(results)
-        XCTAssertEqual(results!.count, 1)
-        XCTAssertNotNil(results![0].page)
-        XCTAssertNotNil(results![0].timestamp)
-        XCTAssertNotNil(results![0].page)
-        XCTAssertEqual(results![0].page!.title, "Cat")
-        XCTAssertEqual(results![0].page!.namespaceID, 0)
-        XCTAssertEqual(results![0].page!.projectID, "wikipedia~en")
-        XCTAssertNotNil(results![0].page?.timestamp)
+        try await store.viewContext.perform {
+            let results = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
+            XCTAssertNotNil(results)
+            XCTAssertEqual(results!.count, 1)
+            XCTAssertNotNil(results![0].page)
+            XCTAssertNotNil(results![0].timestamp)
+            XCTAssertNotNil(results![0].page)
+            XCTAssertEqual(results![0].page!.title, "Cat")
+            XCTAssertEqual(results![0].page!.namespaceID, 0)
+            XCTAssertEqual(results![0].page!.projectID, "wikipedia~en")
+            XCTAssertNotNil(results![0].page?.timestamp)
+        }
     }
     
     func testDeletePageView() async throws {
@@ -82,17 +84,21 @@ final class WMFPageViewsDataControllerTests: XCTestCase {
         try await dataController.addPageView(title: "Cat", namespaceID: 0, project: enProject)
         
         // Fetch, confirm page view was added
-        let addedResults = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
-        XCTAssertNotNil(addedResults)
-        XCTAssertEqual(addedResults!.count, 1)
+        try store.viewContext.performAndWait {
+            let addedResults = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
+            XCTAssertNotNil(addedResults)
+            XCTAssertEqual(addedResults!.count, 1)
+        }
         
         // Then delete page view
         try await dataController.deletePageView(title: "Cat", namespaceID: 0, project: enProject)
         
         // Fetch, confirm page view was deleted
-        let deletedResults = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
-        XCTAssertNotNil(deletedResults)
-        XCTAssertEqual(deletedResults!.count, 0)
+        try await store.viewContext.perform {
+            let deletedResults = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
+            XCTAssertNotNil(deletedResults)
+            XCTAssertEqual(deletedResults!.count, 0)
+        }
     }
     
     func testDeleteAllPageViews() async throws {
@@ -109,17 +115,21 @@ final class WMFPageViewsDataControllerTests: XCTestCase {
         try await dataController.addPageView(title: "Cat", namespaceID: 0, project: enProject)
         
         // Fetch, confirm page view was added
-        let addedResults = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
-        XCTAssertNotNil(addedResults)
-        XCTAssertEqual(addedResults!.count, 1)
+        try store.viewContext.performAndWait {
+            let addedResults = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
+            XCTAssertNotNil(addedResults)
+            XCTAssertEqual(addedResults!.count, 1)
+        }
         
         // Then delete page view
         try await dataController.deleteAllPageViews()
         
         // Fetch, confirm page view was deleted
-        let deletedResults = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
-        XCTAssertNotNil(deletedResults)
-        XCTAssertEqual(deletedResults!.count, 0)
+        try await store.viewContext.perform {
+            let deletedResults = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
+            XCTAssertNotNil(deletedResults)
+            XCTAssertEqual(deletedResults!.count, 0)
+        }
     }
     
     func testImportPageViews() async throws {
@@ -140,14 +150,17 @@ final class WMFPageViewsDataControllerTests: XCTestCase {
         try await dataController.importPageViews(requests: importRequests)
         
         // Fetch, confirm page views were added
-        let pageViews = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
-        XCTAssertNotNil(pageViews)
-        XCTAssertEqual(pageViews!.count, 2)
         
-        // Fetch, confirm pages were added
-        let pages = try store.fetch(entityType: CDPage.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
-        XCTAssertNotNil(pages)
-        XCTAssertEqual(pages!.count, 2)
+        try await store.viewContext.perform {
+            let pageViews = try store.fetch(entityType: CDPageView.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
+            XCTAssertNotNil(pageViews)
+            XCTAssertEqual(pageViews!.count, 2)
+            
+            // Fetch, confirm pages were added
+            let pages = try store.fetch(entityType: CDPage.self, predicate: nil, fetchLimit: nil, in: store.viewContext)
+            XCTAssertNotNil(pages)
+            XCTAssertEqual(pages!.count, 2)
+        }
     }
     
     func testFetchPageViewCounts() async throws {

--- a/WMFData/Tests/WMFDataTests/WMFYearInReviewDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFYearInReviewDataControllerTests.swift
@@ -57,10 +57,12 @@ final class WMFYearInReviewDataControllerTests: XCTestCase {
 
         try await dataController.createNewYearInReviewReport(year: 2023, slides: [slide1, slide2])
 
-        let reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
-        XCTAssertEqual(reports!.count, 1)
-        XCTAssertEqual(reports![0].year, 2023)
-        XCTAssertEqual(reports![0].slides!.count, 2)
+        try await store.viewContext.perform {
+            let reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
+            XCTAssertEqual(reports!.count, 1)
+            XCTAssertEqual(reports![0].year, 2023)
+            XCTAssertEqual(reports![0].slides!.count, 2)
+        }
     }
 
     func testSaveYearInReviewReport() async throws {
@@ -78,11 +80,13 @@ final class WMFYearInReviewDataControllerTests: XCTestCase {
 
         try await dataController.saveYearInReviewReport(report)
 
-        let reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
+        try await store.viewContext.perform {
+            let reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
 
-        XCTAssertEqual(reports!.count, 1)
-        XCTAssertEqual(reports![0].year, 2024)
-        XCTAssertEqual(reports![0].slides!.count, 1)
+            XCTAssertEqual(reports!.count, 1)
+            XCTAssertEqual(reports![0].year, 2024)
+            XCTAssertEqual(reports![0].slides!.count, 1)
+        }
     }
 
     func testFetchYearInReviewReports() async throws {
@@ -101,10 +105,12 @@ final class WMFYearInReviewDataControllerTests: XCTestCase {
 
         try await dataController.saveYearInReviewReport(report)
 
-        let reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
-        XCTAssertEqual(reports!.count, 1)
-        XCTAssertEqual(reports![0].year, 2024)
-        XCTAssertEqual(reports![0].slides!.count, 2)
+        try await store.viewContext.perform {
+            let reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
+            XCTAssertEqual(reports!.count, 1)
+            XCTAssertEqual(reports![0].year, 2024)
+            XCTAssertEqual(reports![0].slides!.count, 2)
+        }
     }
 
     func testFetchYearInReviewReportForYear() async throws {
@@ -150,13 +156,18 @@ final class WMFYearInReviewDataControllerTests: XCTestCase {
         let slide = WMFYearInReviewSlide(year: 2021, id: .readCount,  evaluated: true, display: true, data: nil)
         try await dataController.createNewYearInReviewReport(year: 2021, slides: [slide])
 
-        var reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
-        XCTAssertEqual(reports!.count, 1)
+        var reports: [CDYearInReviewReport]?
+        try store.viewContext.performAndWait {
+            reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
+            XCTAssertEqual(reports!.count, 1)
+        }
 
         try await dataController.deleteYearInReviewReport(year: 2021)
 
-        reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
-        XCTAssertEqual(reports!.count, 0)
+        try await store.viewContext.perform {
+            reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
+            XCTAssertEqual(reports!.count, 0)
+        }
     }
 
     func testDeleteAllYearInReviewReports() async throws {
@@ -175,13 +186,20 @@ final class WMFYearInReviewDataControllerTests: XCTestCase {
         try await dataController.createNewYearInReviewReport(year: 2024, slides: [slide1])
         try await dataController.createNewYearInReviewReport(year: 2023, slides: [slide2])
 
-        var reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
-        XCTAssertEqual(reports!.count, 1)
+        var reports: [CDYearInReviewReport]?
+        try store.viewContext.performAndWait {
+            reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
+            XCTAssertEqual(reports!.count, 1)
+        }
+
 
         try await dataController.deleteAllYearInReviewReports()
 
-        reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
-        XCTAssertEqual(reports!.count, 0)
+        try await store.viewContext.perform {
+            reports = try store.fetch(entityType: CDYearInReviewReport.self, predicate: nil, fetchLimit: 1, in: store.viewContext)
+            XCTAssertEqual(reports!.count, 0)
+        }
+
     }
     
     func testYearInReviewEntryPointFeatureDisabled() throws {


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
I added the `-com.apple.CoreData.ConcurrencyDebug 1` launch argument to the WMFData test plan, which will cause crashes when we are incorrectly handling concurrency through Core Data. Then I wrapped up crash areas in `perform` and `performAndWait` calls.

This should hopefully fix some of our flaky WMFData tests.

### Test Steps
1. Ensure WMFData unit tests pass
