### PR TITLE
Temp accounts - Add notifications center fixes

### DIFF
--- a/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
@@ -1,5 +1,6 @@
 import CocoaLumberjackSwift
 import Foundation
+import WMFData
 
 public enum RemoteNotificationsControllerError: LocalizedError {
     case databaseUnavailable
@@ -128,7 +129,8 @@ public enum RemoteNotificationsControllerError: LocalizedError {
             return
         }
         
-        guard authManager.authStateIsPermanent else {
+        let primaryWikiHasTempAccounts = WMFTempAccountDataController.shared.primaryWikiHasTempAccountsEnabled
+        guard authManager.authStateIsPermanent || (primaryWikiHasTempAccounts && authManager.authStateIsTemporary) else {
             completion?(.failure(RequestError.unauthenticated))
             return
         }
@@ -177,7 +179,8 @@ public enum RemoteNotificationsControllerError: LocalizedError {
             return
         }
         
-        guard authManager.authStateIsPermanent else {
+        let primaryWikiHasTempAccounts = WMFTempAccountDataController.shared.primaryWikiHasTempAccountsEnabled
+        guard authManager.authStateIsPermanent || (primaryWikiHasTempAccounts && authManager.authStateIsTemporary) else {
             completion?(.failure(RequestError.unauthenticated))
             return
         }
@@ -194,7 +197,8 @@ public enum RemoteNotificationsControllerError: LocalizedError {
             return
         }
         
-        guard authManager.authStateIsPermanent else {
+        let primaryWikiHasTempAccounts = WMFTempAccountDataController.shared.primaryWikiHasTempAccountsEnabled
+        guard authManager.authStateIsPermanent || (primaryWikiHasTempAccounts && authManager.authStateIsTemporary) else {
             completion?(.failure(RequestError.unauthenticated))
             return
         }
@@ -205,7 +209,8 @@ public enum RemoteNotificationsControllerError: LocalizedError {
     /// Asks server to mark all notifications as seen for the primary app language
     public func markAllAsSeen(completion: @escaping ((Result<Void, Error>) -> Void)) {
         
-        guard authManager.authStateIsPermanent else {
+        let primaryWikiHasTempAccounts = WMFTempAccountDataController.shared.primaryWikiHasTempAccountsEnabled
+        guard authManager.authStateIsPermanent || (primaryWikiHasTempAccounts && authManager.authStateIsTemporary) else {
             completion(.failure(RequestError.unauthenticated))
             return
         }

--- a/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsController.swift
@@ -346,7 +346,15 @@ public enum RemoteNotificationsControllerError: LocalizedError {
             return false
         }
         
-        let appLanguageProjects =  languageLinkController.preferredLanguages.map { WikimediaProject.wikipedia($0.languageCode, $0.localizedName, $0.languageVariantCode) }
+        let primaryWikiHasTempAccounts = WMFTempAccountDataController.shared.primaryWikiHasTempAccountsEnabled
+        var languages: [MWKLanguageLink] = languageLinkController.preferredLanguages
+        if primaryWikiHasTempAccounts && authManager.authStateIsTemporary,
+           let appLanguage = languageLinkController.appLanguage {
+            languages = [appLanguage]
+        }
+        
+        let appLanguageProjects =  languages.map { WikimediaProject.wikipedia($0.languageCode, $0.localizedName, $0.languageVariantCode) }
+        
         for project in appLanguageProjects {
             if !modelController.isProjectAlreadyImported(project: project) {
                 return false

--- a/WMF Framework/Remote Notifications/RemoteNotificationsOperationsController.swift
+++ b/WMF Framework/Remote Notifications/RemoteNotificationsOperationsController.swift
@@ -1,4 +1,5 @@
 import CocoaLumberjackSwift
+import WMFData
 
 enum RemoteNotificationsOperationsError: LocalizedError {
     case failurePullingAppLanguage
@@ -175,7 +176,7 @@ class RemoteNotificationsOperationsController: NSObject {
         }
     }
  
-    private func secondaryProjects(appLanguage: MWKLanguageLink) -> [WikimediaProject] {
+    private func determineSecondaryProjects(appLanguage: MWKLanguageLink) -> [WikimediaProject] {
         
         let otherLanguages = languageLinkController.preferredLanguages.filter { $0.languageCode != appLanguage.languageCode }
 
@@ -198,7 +199,12 @@ class RemoteNotificationsOperationsController: NSObject {
         }
         
         let appLanguageProject = WikimediaProject.wikipedia(appLanguage.languageCode, appLanguage.localizedName, appLanguage.languageVariantCode)
-        let secondaryProjects = secondaryProjects(appLanguage: appLanguage)
+        
+        // do not fetch secondary projects if auth state is temp account
+        var secondaryProjects: [WikimediaProject] = []
+        if authManager.authStateIsPermanent {
+            secondaryProjects = determineSecondaryProjects(appLanguage: appLanguage)
+        }
         
         // basic operations first - primary language then secondary (languages, commons & wikidata)
         let appLanguageOperation = pagingOperationForProject(appLanguageProject, isAppLanguageProject: true)

--- a/WMFComponents/Sources/WMFComponents/Components/Profile/WMFProfileViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Profile/WMFProfileViewModel.swift
@@ -112,7 +112,7 @@ enum ProfileState {
 
         var needsYiRNotification = false
         if let yearInReviewDependencies {
-            needsYiRNotification = yearInReviewDependencies.dataController.shouldShowYiRNotification(primaryAppLanguageProject: yearInReviewDependencies.primaryAppLanguageProject, isLoggedOut: !isLoggedIn)
+            needsYiRNotification = yearInReviewDependencies.dataController.shouldShowYiRNotification(primaryAppLanguageProject: yearInReviewDependencies.primaryAppLanguageProject, isLoggedOut: !isLoggedIn, isTemporaryAccount: isTemporaryAccount)
         }
 
         if isLoggedIn {

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
@@ -57,7 +57,12 @@ import CoreData
         return (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.seenYearInReviewIntroSlide.rawValue)) ?? YiRNotificationAnnouncementStatus.default
     }
     
-    public func shouldShowYiRNotification(primaryAppLanguageProject: WMFProject?, isLoggedOut: Bool) -> Bool {
+    public func shouldShowYiRNotification(primaryAppLanguageProject: WMFProject?, isLoggedOut: Bool, isTemporaryAccount: Bool) -> Bool {
+        
+        if isTemporaryAccount {
+            return false
+        }
+        
         if isLoggedOut {
             return !hasTappedProfileItem && !hasSeenYiRIntroSlide && shouldShowYearInReviewEntryPoint(countryCode: Locale.current.region?.identifier, primaryAppLanguageProject: primaryAppLanguageProject)
         }

--- a/Wikipedia/Code/UIViewController+ProfileButton.swift
+++ b/Wikipedia/Code/UIViewController+ProfileButton.swift
@@ -5,7 +5,10 @@ extension UIViewController {
     
     func profileButtonConfig(target: Any, action: Selector, dataStore: MWKDataStore, yirDataController: WMFYearInReviewDataController?, leadingBarButtonItem: UIBarButtonItem?, trailingBarButtonItem: UIBarButtonItem?) -> WMFNavigationBarProfileButtonConfig {
         var hasUnreadNotifications: Bool = false
-        if dataStore.authenticationManager.authStateIsPermanent {
+        
+        let isTemporaryAccount = WMFTempAccountDataController.shared.primaryWikiHasTempAccountsEnabled && dataStore.authenticationManager.authStateIsTemporary
+        
+        if dataStore.authenticationManager.authStateIsPermanent || isTemporaryAccount {
             let numberOfUnreadNotifications = try? dataStore.remoteNotificationsController.numberOfUnreadNotifications()
             hasUnreadNotifications = (numberOfUnreadNotifications?.intValue ?? 0) != 0
         } else {
@@ -15,7 +18,7 @@ extension UIViewController {
         var needsYiRNotification = false
         if let yirDataController,  let appLanguage = dataStore.languageLinkController.appLanguage {
             let project = WMFProject.wikipedia(WMFLanguage(languageCode: appLanguage.languageCode, languageVariantCode: appLanguage.languageVariantCode))
-            needsYiRNotification = yirDataController.shouldShowYiRNotification(primaryAppLanguageProject: project, isLoggedOut: !dataStore.authenticationManager.authStateIsPermanent)
+            needsYiRNotification = yirDataController.shouldShowYiRNotification(primaryAppLanguageProject: project, isLoggedOut: !dataStore.authenticationManager.authStateIsPermanent, isTemporaryAccount: isTemporaryAccount)
         }
         // do not override `hasUnreadNotifications` completely
         if needsYiRNotification {

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -598,7 +598,8 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
         [[NSUserDefaults standardUserDefaults] wmf_setShowYirSettingToggle:NO];
     }
 
-    if (_authManager.authStateIsPermanent) {
+    BOOL primaryWikiHasTempAccounts = [[WMFTempAccountDataController shared] primaryWikiHasTempAccountsEnabled];
+    if (_authManager.authStateIsPermanent || (_authManager.authStateIsTemporary && primaryWikiHasTempAccounts)) {
         [items addObject:[WMFSettingsMenuItem itemForType:WMFSettingsMenuItemType_Notifications]];
     }
 


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T361765

### Notes
These were some fixes for notifications center that I found when auditing T361765. There were error messages popping up when in a temp accounts state, due to a lot of those API methods guarding against a permanent account. This opens that back up. A couple of more improvements I made:
- Displaying the push notifications item in Settings, since push notifications should work for temp accounts.
- Removed profile icon badge state for year in review, since temp accounts do not display a year in review line item in profile (for now).

### Test Steps
1. While logged out, make an edit on Test Wiki to spin up a test account.
2. Go to profile > notifications, ensure you see a new notification (editing milestone) instead of an error state.
