### PR TITLE
Fix: Visual issues in Saved Articles tab

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Utility/HTMLUtils.swift
+++ b/WMFComponents/Sources/WMFComponents/Utility/HTMLUtils.swift
@@ -83,6 +83,7 @@ public struct HtmlUtils {
         let attributedString = NSMutableAttributedString(string: html)
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = styles.lineSpacing
+        paragraphStyle.lineBreakMode = styles.lineBreakMode
         let attributes: [NSAttributedString.Key : Any] = [
             .font: styles.font,
             .foregroundColor: styles.color,

--- a/WMFComponents/Sources/WMFComponents/Utility/HTMLUtils.swift
+++ b/WMFComponents/Sources/WMFComponents/Utility/HTMLUtils.swift
@@ -16,8 +16,9 @@ public struct HtmlUtils {
         let strongColor: UIColor?
         let lineSpacing: CGFloat
         let listIndent: String
-        
-        public init(font: UIFont, boldFont: UIFont, italicsFont: UIFont, boldItalicsFont: UIFont, color: UIColor, linkColor: UIColor?, strongColor: UIColor? = nil, lineSpacing: CGFloat, listIndent: String = HtmlUtils.defaultListIndent) {
+        let lineBreakMode: NSLineBreakMode
+
+        public init(font: UIFont, boldFont: UIFont, italicsFont: UIFont, boldItalicsFont: UIFont, color: UIColor, linkColor: UIColor?, strongColor: UIColor? = nil, lineSpacing: CGFloat, listIndent: String = HtmlUtils.defaultListIndent, lineBreakMode: NSLineBreakMode = .byWordWrapping) {
             self.font = font
             self.boldFont = boldFont
             self.italicsFont = italicsFont
@@ -27,6 +28,7 @@ public struct HtmlUtils {
             self.strongColor = strongColor
             self.lineSpacing = lineSpacing
             self.listIndent = listIndent
+            self.lineBreakMode = lineBreakMode
         }
     }
     

--- a/Wikipedia/Code/SavedArticlesCollectionViewCell.swift
+++ b/Wikipedia/Code/SavedArticlesCollectionViewCell.swift
@@ -124,7 +124,7 @@ class SavedArticlesCollectionViewCell: ArticleCollectionViewCell {
     }
     
     override func updateStyles() {
-        styles = HtmlUtils.Styles(font: WMFFont.for(.boldCallout, compatibleWith: traitCollection), boldFont: WMFFont.for(.boldCallout, compatibleWith: traitCollection), italicsFont: WMFFont.for(.italicCallout, compatibleWith: traitCollection), boldItalicsFont: WMFFont.for(.boldItalicCallout, compatibleWith: traitCollection), color: theme.colors.primaryText, linkColor: theme.colors.link, lineSpacing: 1)
+        styles = HtmlUtils.Styles(font: WMFFont.for(.boldCallout, compatibleWith: traitCollection), boldFont: WMFFont.for(.boldCallout, compatibleWith: traitCollection), italicsFont: WMFFont.for(.italicCallout, compatibleWith: traitCollection), boldItalicsFont: WMFFont.for(.boldItalicCallout, compatibleWith: traitCollection), color: theme.colors.primaryText, linkColor: theme.colors.link, lineSpacing: 1, lineBreakMode: .byTruncatingTail)
     }
     
     private var collectionViewAvailableWidth: CGFloat = 0

--- a/Wikipedia/Code/SavedArticlesCollectionViewCell.swift
+++ b/Wikipedia/Code/SavedArticlesCollectionViewCell.swift
@@ -124,7 +124,7 @@ class SavedArticlesCollectionViewCell: ArticleCollectionViewCell {
     }
     
     override func updateStyles() {
-        styles = HtmlUtils.Styles(font: WMFFont.for(.boldCallout, compatibleWith: traitCollection), boldFont: WMFFont.for(.boldCallout, compatibleWith: traitCollection), italicsFont: WMFFont.for(.italicCallout, compatibleWith: traitCollection), boldItalicsFont: WMFFont.for(.boldItalicCallout, compatibleWith: traitCollection), color: theme.colors.primaryText, linkColor: theme.colors.link, lineSpacing: 1, lineBreakMode: .byTruncatingTail)
+        styles = HtmlUtils.Styles(font: WMFFont.for(.boldCallout, compatibleWith: traitCollection), boldFont: WMFFont.for(.boldCallout, compatibleWith: traitCollection), italicsFont: WMFFont.for(.boldItalicCallout, compatibleWith: traitCollection), boldItalicsFont: WMFFont.for(.boldItalicCallout, compatibleWith: traitCollection), color: theme.colors.primaryText, linkColor: theme.colors.link, lineSpacing: 1, lineBreakMode: .byTruncatingTail)
     }
     
     private var collectionViewAvailableWidth: CGFloat = 0


### PR DESCRIPTION
**Phabricator:** 
[T390046](https://phabricator.wikimedia.org/)

### Notes

This PR introduces the following fixes for `SavedArticlesCollectionViewCell`:

- **Truncation of Long Titles**: 
Titles in `SavedArticlesCollectionViewCell` now use `lineBreakMode` set to `byTruncatingTail`. A new `lineBreakMode` property in `HtmlUtils.Styles` defaults to `byWordWrapping` and is overridden in `SavedArticlesCollectionViewCell` to `byTruncatingTail`.

- **Visual Consistency for Italic Titles**: 
In `updateStyles`, italic title styles have been updated to match the visual weight (bold) of regular titles using `boldItalicCallout`.

### Test Steps [T390046]
- Open the Wikipedia iOS app (version 7.7.2.5001) on iOS 18.3.2.
- Navigate to the Saved tab.
- Save an article with a long title (e.g., Creation of the Gods II: Demon Force) and view it in the list.
- Save an article with an italicized title (e.g., a film title) and compare its appearance with a regular title.

### Screenshots/Videos
|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/0eea69d9-88f2-463d-bef3-d44a20a5d246)|![image New](https://github.com/user-attachments/assets/1761fd96-86a0-4d4b-a3e6-dbe36356d37a)
