### PR TITLE
Activity tab - Push on editing contributions

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Activity/WMFActivityViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Activity/WMFActivityViewModel.swift
@@ -18,6 +18,7 @@ import WMFData
     let openSavedArticles: () -> Void
     let openSuggestedEdits: (() -> Void)?
     let openStartEditing: (() -> Void)?
+    let openEditingHistory: (() -> Void)?
     public var savedSlideDataDelegate: SavedArticleSlideDataDelegate?
     public var legacyPageViewsDataDelegate: LegacyPageViewsDataDelegate?
     
@@ -48,6 +49,7 @@ import WMFData
             openSavedArticles: @escaping () -> Void,
             openSuggestedEdits: (() -> Void)?,
             openStartEditing: (() -> Void)?,
+            openEditingHistory: (() -> Void)?,
             loginAction: (() -> Void)?,
             isLoggedIn: Bool) {
         self.openHistory = openHistory
@@ -58,6 +60,7 @@ import WMFData
         self.isLoggedIn = isLoggedIn
         self.openSuggestedEdits = openSuggestedEdits
         self.openStartEditing = openStartEditing
+        self.openEditingHistory = openEditingHistory
     }
     
     func title(for type: ActivityTabDisplayType) -> String {
@@ -80,7 +83,7 @@ import WMFData
     func action(for type: ActivityTabDisplayType) -> (() -> Void)? {
         switch type {
         case .edit:
-            return nil
+            return openEditingHistory
         case .read:
             return openHistory
         case .save:

--- a/Wikipedia/Code/EditInteractionFunnel.swift
+++ b/Wikipedia/Code/EditInteractionFunnel.swift
@@ -52,6 +52,7 @@ final class EditInteractionFunnel {
         case viewClick = "view_click"
         case viewHistoryClick = "view_history_click"
         case viewSavedClick = "view_saved_click"
+        case viewEditedClick = "view_edited_click"
         case feedbackImpression = "feedback_impression"
         case feedbackCloseClick = "feedback_close_click"
         case feedbackSubmitClick = "feedback_submit_click"
@@ -288,8 +289,12 @@ final class EditInteractionFunnel {
         logEvent(activeInterface: .activityTab, action: .viewHistoryClick, actionData: nil, project: project)
     }
     
-    func logActivityTabDidTapEditCapsule(project: WikimediaProject) {
+    func logActivityTabDidTapEditEmptyCapsule(project: WikimediaProject) {
         logEvent(activeInterface: .activityTab, action: .editEntryClick, actionData: nil, project: project)
+    }
+    
+    func logActivityTabDidTapEditPopulatedCapsule(project: WikimediaProject) {
+        logEvent(activeInterface: .activityTab, action: .viewEditedClick, actionData: nil, project: project)
     }
     
     func logActivityTabDidTapSavedCapsule(project: WikimediaProject) {

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -817,7 +817,7 @@ extension WMFAppViewController {
             }
             
             if let wikimediaProject {
-                EditInteractionFunnel.shared.logActivityTabDidTapEditCapsule(project: wikimediaProject)
+                EditInteractionFunnel.shared.logActivityTabDidTapEditEmptyCapsule(project: wikimediaProject)
             }
             
             guard let vc = WMFImageRecommendationsViewController.imageRecommendationsViewController(
@@ -836,7 +836,7 @@ extension WMFAppViewController {
             }
             
             if let wikimediaProject {
-                EditInteractionFunnel.shared.logActivityTabDidTapEditCapsule(project: wikimediaProject)
+                EditInteractionFunnel.shared.logActivityTabDidTapEditEmptyCapsule(project: wikimediaProject)
             }
 
             if let url = URL(string: "https://www.mediawiki.org/wiki/Special:MyLanguage/Wikimedia_Apps/iOS_FAQ#Editing") {
@@ -846,6 +846,27 @@ extension WMFAppViewController {
                 WMFComponentNavigationController(rootViewController: webVC, modalPresentationStyle: .formSheet)
                 navigationController.present(newNavigationVC, animated: true)
             }
+
+        }
+        
+        let openEditingHistory = { [weak self] in
+            
+            guard let self else { return }
+            
+            guard let username = self.dataStore.authenticationManager.authStatePermanentUsername else {
+                return
+            }
+            
+            if let wikimediaProject {
+                EditInteractionFunnel.shared.logActivityTabDidTapEditPopulatedCapsule(project: wikimediaProject)
+            }
+
+            guard let url = self.dataStore.languageLinkController.appLanguage?.siteURL.wmf_URL(withPath: "/wiki/Special:Contributions/\(username)", isMobile: true) else {
+                showGenericError()
+                return
+            }
+
+            navigate(to: url)
 
         }
         
@@ -885,7 +906,7 @@ extension WMFAppViewController {
             getGreeting: greeting,
             viewHistory: CommonStrings.activityTabReadingHistory,
             viewSaved: CommonStrings.activityTabViewSavedArticlesTitle,
-            viewEdited: "",
+            viewEdited: CommonStrings.activityTabViewEditingTitle,
             logIn: CommonStrings.editSignIn,
             loggedOutTitle: CommonStrings.activityTabLoggedOutTitle,
             loggedOutSubtitle: CommonStrings.actitvityTabLoggedOutSubtitle
@@ -898,6 +919,7 @@ extension WMFAppViewController {
             openSavedArticles: openSavedArticlesClosure,
             openSuggestedEdits: openSuggestedEditsClosure,
             openStartEditing: openStartEditing,
+            openEditingHistory: openEditingHistory,
             loginAction: nil,
             isLoggedIn: isLoggedIn)
         


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T392164

### Notes
Adds "View editing history" button to editing capsule. Pushes on contributions web view when tapped.

Note: this PR is dependent on https://github.com/wikimedia/wikipedia-ios/pull/5266.

### Test Steps
1. Add target wiki (or Test) as primary app language.
2. If necessary, force group B or C in developer settings activity tab experiment.
3. Log into an account that has edits within the past week.
4. Confirm "View editing history" button shows and pushes onto contributions web view.

### Screenshots/Videos
https://github.com/user-attachments/assets/a26bc9af-27bb-4c0f-8320-094b87acf30f
