### PR TITLE
Navigation bar bug fixes

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Extensions/Navigation Bar/WMFNavigationBarConfiguring.swift
+++ b/WMFComponents/Sources/WMFComponents/Extensions/Navigation Bar/WMFNavigationBarConfiguring.swift
@@ -57,16 +57,16 @@ public struct WMFNavigationBarProfileButtonConfig {
     public let needsBadge: Bool
     public let target: Any
     public let action: Selector
-    public let trailingBarButtonItem: UIBarButtonItem?
+    public let leadingBarButtonItem: UIBarButtonItem?
     
-    public init(accessibilityLabelNoNotifications: String, accessibilityLabelHasNotifications: String, accessibilityHint: String, needsBadge: Bool, target: Any, action: Selector, trailingBarButtonItem: UIBarButtonItem?) {
+    public init(accessibilityLabelNoNotifications: String, accessibilityLabelHasNotifications: String, accessibilityHint: String, needsBadge: Bool, target: Any, action: Selector, leadingBarButtonItem: UIBarButtonItem?) {
         self.accessibilityLabelNoNotifications = accessibilityLabelNoNotifications
         self.accessibilityLabelHasNotifications = accessibilityLabelHasNotifications
         self.accessibilityHint = accessibilityHint
         self.needsBadge = needsBadge
         self.target = target
         self.action = action
-        self.trailingBarButtonItem = trailingBarButtonItem
+        self.leadingBarButtonItem = leadingBarButtonItem
     }
 }
 
@@ -181,10 +181,18 @@ public extension WMFNavigationBarConfiguring where Self: UIViewController {
             navigationItem.titleView = nil
         }
         
-        
-        var rightBarButtonItems: [UIBarButtonItem] = []
-        
         if let profileButtonConfig {
+            
+            var rightBarButtonItems: [UIBarButtonItem] = []
+            
+            var profileLeadingButton: UIBarButtonItem? = profileButtonConfig.leadingBarButtonItem
+            
+            if let dataController = try? WMFArticleTabsDataController(),
+               let tabsButtonConfig,
+               !dataController.shouldShowArticleTabs {
+                profileLeadingButton = tabsButtonConfig.leadingBarButtonItem
+            }
+            
             let image = profileButtonImage(theme: WMFAppEnvironment.current.theme, needsBadge: profileButtonConfig.needsBadge)
             let profileButton = UIBarButtonItem(image: image, style: .plain, target: profileButtonConfig.target, action: profileButtonConfig.action)
             
@@ -193,26 +201,28 @@ public extension WMFNavigationBarConfiguring where Self: UIViewController {
             
             rightBarButtonItems.append(profileButton)
 
-            if let trailing = profileButtonConfig.trailingBarButtonItem {
-                rightBarButtonItems.append(trailing)
+            if let profileLeadingButton {
+                rightBarButtonItems.append(profileLeadingButton)
             }
-        }
-
-        if let dataController = try? WMFArticleTabsDataController(),
-           let tabsButtonConfig, dataController.shouldShowArticleTabs {
-
-            let image = WMFSFSymbolIcon.for(symbol: .tabsIcon)
-            let tabsButton = UIBarButtonItem(image: image, style: .plain, target: tabsButtonConfig.target, action: tabsButtonConfig.action)
             
-            rightBarButtonItems.append(tabsButton)
+            if let dataController = try? WMFArticleTabsDataController(),
+               let tabsButtonConfig,
+               dataController.shouldShowArticleTabs {
+                
+                let image = WMFSFSymbolIcon.for(symbol: .tabsIcon)
+                let tabsButton = UIBarButtonItem(image: image, style: .plain, target: tabsButtonConfig.target, action: tabsButtonConfig.action)
+                
+                rightBarButtonItems.append(tabsButton)
 
-            if let leadingBarButtonItem = tabsButtonConfig.leadingBarButtonItem {
-                rightBarButtonItems.append(leadingBarButtonItem)
+                if let leadingBarButtonItem = tabsButtonConfig.leadingBarButtonItem {
+                    rightBarButtonItems.append(leadingBarButtonItem)
+                }
+                
             }
+            
+            navigationItem.rightBarButtonItems = rightBarButtonItems
+            
         }
-        
-        navigationItem.rightBarButtonItems = rightBarButtonItems
-
         
         // Setup close button if needed
         if let closeButtonConfig {

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -688,7 +688,7 @@ class ArticleViewController: ThemeableViewController, HintPresenting, UIScrollVi
             }
         }
         
-        let profileButtonConfig = profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, trailingBarButtonItem: nil)
+        let profileButtonConfig = profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, leadingBarButtonItem: nil)
         let tabsButtonConfig = tabsButtonConfig(target: self, action: #selector(userDidTapTabs), dataStore: dataStore)
         
         let searchViewController = SearchViewController(source: .article, customArticleCoordinatorNavigationController: navigationController)
@@ -710,7 +710,7 @@ class ArticleViewController: ThemeableViewController, HintPresenting, UIScrollVi
     
     private func updateProfileButton() {
 
-        let config = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, trailingBarButtonItem: nil)
+        let config = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, leadingBarButtonItem: nil)
 
         updateNavigationBarProfileButton(needsBadge: config.needsBadge, needsBadgeLabel: CommonStrings.profileButtonBadgeTitle, noBadgeLabel: CommonStrings.profileButtonTitle)
     }

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -194,7 +194,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
             }
         }
         
-        let profileButtonConfig = profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController,  trailingBarButtonItem: nil)
+        let profileButtonConfig = profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController,  leadingBarButtonItem: nil)
         
         let tabsButtonConfig = tabsButtonConfig(target: self, action: #selector(userDidTapTabs), dataStore: dataStore)
         
@@ -226,7 +226,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
     }
     
     @objc func updateProfileButton() {
-        let config = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, trailingBarButtonItem: nil)
+        let config = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, leadingBarButtonItem: nil)
         updateNavigationBarProfileButton(needsBadge: config.needsBadge, needsBadgeLabel: CommonStrings.profileButtonBadgeTitle, noBadgeLabel: CommonStrings.profileButtonTitle)
     }
     

--- a/Wikipedia/Code/HistoryViewController.swift
+++ b/Wikipedia/Code/HistoryViewController.swift
@@ -195,7 +195,7 @@ class HistoryViewController: ArticleFetchedResultsViewController, WMFNavigationB
         let profileButtonConfig: WMFNavigationBarProfileButtonConfig?
         let tabsButtonConfig: WMFNavigationBarTabsButtonConfig?
         if let dataStore {
-            profileButtonConfig = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, trailingBarButtonItem: nil)
+            profileButtonConfig = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, leadingBarButtonItem: nil)
             tabsButtonConfig = self.tabsButtonConfig(target: self, action: #selector(userDidTapTabs), dataStore: dataStore, leadingBarButtonItem: deleteButton)
         } else {
             profileButtonConfig = nil
@@ -211,7 +211,7 @@ class HistoryViewController: ArticleFetchedResultsViewController, WMFNavigationB
             return
         }
 
-        let config = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, trailingBarButtonItem: nil)
+        let config = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, leadingBarButtonItem: nil)
         updateNavigationBarProfileButton(needsBadge: config.needsBadge, needsBadgeLabel: CommonStrings.profileButtonBadgeTitle, noBadgeLabel: CommonStrings.profileButtonTitle)
     }
 

--- a/Wikipedia/Code/PlacesViewController.swift
+++ b/Wikipedia/Code/PlacesViewController.swift
@@ -253,7 +253,7 @@ class PlacesViewController: ArticleLocationCollectionViewController, UISearchBar
     }
 
     private var profileButtonConfig: WMFNavigationBarProfileButtonConfig {
-        return self.profileButtonConfig(target: self, action: #selector(didTapProfileButton), dataStore: dataStore, yirDataController: yirDataController, trailingBarButtonItem: nil)
+        return self.profileButtonConfig(target: self, action: #selector(didTapProfileButton), dataStore: dataStore, yirDataController: yirDataController, leadingBarButtonItem: nil)
     }
     
     private var tabsButtonConfig: WMFNavigationBarTabsButtonConfig {
@@ -454,7 +454,7 @@ class PlacesViewController: ArticleLocationCollectionViewController, UISearchBar
     }
 
     private func updateProfileButton() {
-        let profileButtonConfig = self.profileButtonConfig(target: self, action: #selector(didTapProfileButton), dataStore: dataStore, yirDataController: yirDataController,  trailingBarButtonItem: nil)
+        let profileButtonConfig = self.profileButtonConfig(target: self, action: #selector(didTapProfileButton), dataStore: dataStore, yirDataController: yirDataController,  leadingBarButtonItem: nil)
         updateNavigationBarProfileButton(needsBadge: profileButtonConfig.needsBadge, needsBadgeLabel: CommonStrings.profileButtonBadgeTitle, noBadgeLabel: CommonStrings.profileButtonTitle)
     }
 

--- a/Wikipedia/Code/SavedViewController.swift
+++ b/Wikipedia/Code/SavedViewController.swift
@@ -261,7 +261,7 @@ class SavedViewController: ThemeableViewController, WMFNavigationBarConfiguring,
         let profileButtonConfig: WMFNavigationBarProfileButtonConfig?
         let tabsButtonConfig: WMFNavigationBarTabsButtonConfig?
         if let dataStore {
-            profileButtonConfig = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, trailingBarButtonItem: nil)
+            profileButtonConfig = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, leadingBarButtonItem: nil)
             tabsButtonConfig = self.tabsButtonConfig(target: self, action: #selector(userDidTapTabs), dataStore: dataStore, leadingBarButtonItem: moreBarButtonItem)
         } else {
             profileButtonConfig = nil
@@ -330,7 +330,7 @@ class SavedViewController: ThemeableViewController, WMFNavigationBarConfiguring,
             return
         }
         
-        let config = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, trailingBarButtonItem: moreBarButtonItem)
+        let config = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, leadingBarButtonItem: nil)
         updateNavigationBarProfileButton(needsBadge: config.needsBadge, needsBadgeLabel: CommonStrings.profileButtonBadgeTitle, noBadgeLabel: CommonStrings.profileButtonTitle)
     }
     

--- a/Wikipedia/Code/SavedViewController.swift
+++ b/Wikipedia/Code/SavedViewController.swift
@@ -225,6 +225,8 @@ class SavedViewController: ThemeableViewController, WMFNavigationBarConfiguring,
             // reassign so activeEditableCollection gets reset
             currentView = .savedArticles
         }
+        
+        configureNavigationBar()
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Wikipedia/Code/SearchViewController.swift
+++ b/Wikipedia/Code/SearchViewController.swift
@@ -196,7 +196,7 @@ class SearchViewController: ArticleCollectionViewController, WMFNavigationBarCon
         let profileButtonConfig: WMFNavigationBarProfileButtonConfig?
         let tabsButtonConfig: WMFNavigationBarTabsButtonConfig?
         if let dataStore {
-            profileButtonConfig = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, trailingBarButtonItem: nil)
+            profileButtonConfig = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, leadingBarButtonItem: nil)
             tabsButtonConfig = self.tabsButtonConfig(target: self, action: #selector(userDidTapTabs), dataStore: dataStore)
         } else {
             profileButtonConfig = nil
@@ -214,7 +214,7 @@ class SearchViewController: ArticleCollectionViewController, WMFNavigationBarCon
             return
         }
 
-        let config = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, trailingBarButtonItem: nil)
+        let config = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, leadingBarButtonItem: nil)
         updateNavigationBarProfileButton(needsBadge: config.needsBadge, needsBadgeLabel: CommonStrings.profileButtonBadgeTitle, noBadgeLabel: CommonStrings.profileButtonTitle)
     }
     

--- a/Wikipedia/Code/UIViewController+ProfileButton.swift
+++ b/Wikipedia/Code/UIViewController+ProfileButton.swift
@@ -7,7 +7,7 @@ extension UIViewController {
         return WMFNavigationBarTabsButtonConfig(accessibilityLabel: "", accessibilityHint: "", target: target, action: action, leadingBarButtonItem: leadingBarButtonItem, trailingBarButtonItem: trailingBarButtonItem)
     }
     
-    func profileButtonConfig(target: Any, action: Selector, dataStore: MWKDataStore, yirDataController: WMFYearInReviewDataController?, trailingBarButtonItem: UIBarButtonItem?) -> WMFNavigationBarProfileButtonConfig {
+    func profileButtonConfig(target: Any, action: Selector, dataStore: MWKDataStore, yirDataController: WMFYearInReviewDataController?, leadingBarButtonItem: UIBarButtonItem?) -> WMFNavigationBarProfileButtonConfig {
         var hasUnreadNotifications: Bool = false
         
         let isTemporaryAccount = WMFTempAccountDataController.shared.primaryWikiHasTempAccountsEnabled && dataStore.authenticationManager.authStateIsTemporary
@@ -31,6 +31,6 @@ extension UIViewController {
         
         let accessibilityHint = CommonStrings.profileButtonAccessibilityHint
         
-        return WMFNavigationBarProfileButtonConfig(accessibilityLabelNoNotifications: CommonStrings.profileButtonTitle, accessibilityLabelHasNotifications: CommonStrings.profileButtonBadgeTitle, accessibilityHint: accessibilityHint, needsBadge: hasUnreadNotifications, target: target, action: action, trailingBarButtonItem: trailingBarButtonItem)
+        return WMFNavigationBarProfileButtonConfig(accessibilityLabelNoNotifications: CommonStrings.profileButtonTitle, accessibilityLabelHasNotifications: CommonStrings.profileButtonBadgeTitle, accessibilityHint: accessibilityHint, needsBadge: hasUnreadNotifications, target: target, action: action, leadingBarButtonItem: leadingBarButtonItem)
     }
 }

--- a/Wikipedia/Code/WMFActivityTabViewController.swift
+++ b/Wikipedia/Code/WMFActivityTabViewController.swift
@@ -91,7 +91,7 @@ final class WMFActivityTabHostingController: WMFComponentHostingController<WMFAc
         let titleConfig = WMFNavigationBarTitleConfig(title: CommonStrings.activityTitle, customView: nil, alignment: .leadingCompact)
         let profileButtonConfig: WMFNavigationBarProfileButtonConfig?
         if let dataStore {
-            profileButtonConfig = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController,  trailingBarButtonItem: nil)
+            profileButtonConfig = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController,  leadingBarButtonItem: nil)
         } else {
             profileButtonConfig = nil
         }
@@ -156,7 +156,7 @@ final class WMFActivityTabHostingController: WMFComponentHostingController<WMFAc
             return
         }
         
-        let config = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, trailingBarButtonItem: nil)
+        let config = self.profileButtonConfig(target: self, action: #selector(userDidTapProfile), dataStore: dataStore, yirDataController: yirDataController, leadingBarButtonItem: nil)
         updateNavigationBarProfileButton(needsBadge: config.needsBadge, needsBadgeLabel: CommonStrings.profileButtonBadgeTitle, noBadgeLabel: CommonStrings.profileButtonTitle)
     }
 }

--- a/Wikipedia/Code/WMFSettingsViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFSettingsViewController+Extensions.swift
@@ -28,7 +28,7 @@ import WMFData
             closeButtonConfig = WMFNavigationBarCloseButtonConfig(text: CommonStrings.doneTitle, target: self, action: #selector(closeButtonPressed), alignment: .trailing)
         } else {
             closeButtonConfig = nil
-            profileButtonConfig = WMFNavigationBarProfileButtonConfig(accessibilityLabelNoNotifications: CommonStrings.profileButtonTitle, accessibilityLabelHasNotifications: CommonStrings.profileButtonBadgeTitle, accessibilityHint: profileAccessibilityHint, needsBadge: needsProfileBadge, target: self, action: #selector(tappedProfile), trailingBarButtonItem: nil)
+            profileButtonConfig = WMFNavigationBarProfileButtonConfig(accessibilityLabelNoNotifications: CommonStrings.profileButtonTitle, accessibilityLabelHasNotifications: CommonStrings.profileButtonBadgeTitle, accessibilityHint: profileAccessibilityHint, needsBadge: needsProfileBadge, target: self, action: #selector(tappedProfile), leadingBarButtonItem: nil)
         }
         
         configureNavigationBar(titleConfig: titleConfig, closeButtonConfig: closeButtonConfig, profileButtonConfig: profileButtonConfig, tabsButtonConfig: nil, searchBarConfig: nil, hideNavigationBarOnScroll: true)


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T390991

### Notes
This fixes some navigation bar issues I noticed after merging some tabs work. In the default dev settings, where tabs are not enabled, we do want a variable leading bar button item next to the profile button. This is so that Places, Saved, and History have their leading button next to profile when tabs is disabled.

I also noticed that the editor lost most of its navigation bar buttons. This fix ensures we only assign rightBarButtonItems if they have provided a profile config, so that editor is unaffected.

### Test Steps
1. Run app with tabs dev settings toggle off. Ensure Places, Saved, and History have it's variable leading navigation bar button next to profile.
2. Go to article editor, ensure navigation bar buttons display as before.
3. Enable tabs in dev settings toggle. Revisit root views, ensure tabs button displays as expected.
