### PR TITLE
Improve performance of article summary fetch

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsHostingController.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsHostingController.swift
@@ -15,8 +15,10 @@ public class WMFArticleTabsHostingController<HostedView: View>: WMFComponentHost
         self.doneButtonText = doneButtonText
         super.init(rootView: rootView)
         
+        // Defining format outside the block fixes a retain cycle on WMFArticleTabsViewModel
+        let format = viewModel.localizedStrings.navBarTitleFormat
         viewModel.updateNavigationBarTitleAction = { [weak self] numTabs in
-            let newNavigationBarTitle = String.localizedStringWithFormat(viewModel.localizedStrings.navBarTitleFormat, numTabs)
+            let newNavigationBarTitle = String.localizedStringWithFormat(format, numTabs)
             self?.configureNavigationBar(newNavigationBarTitle)
         }
     }
@@ -34,8 +36,7 @@ public class WMFArticleTabsHostingController<HostedView: View>: WMFComponentHost
     }
     
     private func configureNavigationBar(_ title: String? = nil) {
-        guard let title else { return }
-        let titleConfig = WMFNavigationBarTitleConfig(title: title, customView: nil, alignment: .centerCompact)
+        let titleConfig = WMFNavigationBarTitleConfig(title: title ?? "", customView: nil, alignment: .centerCompact)
         
         let closeConfig = WMFNavigationBarCloseButtonConfig(text: doneButtonText, target: self, action: #selector(tappedDone), alignment: .leading)
 

--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
@@ -93,7 +93,7 @@ fileprivate struct WMFArticleTabsViewContent: View {
         .onAppear {
             Task {
                 if tab.info == nil {
-                    let populatedTab = await viewModel.populateSummary(tab.data)
+                    let populatedTab = await viewModel.populateArticleSummary(tab.data)
                     let info = ArticleTab.Info(subtitle: populatedTab.articles.last?.description, image: populatedTab.articles.last?.imageURL, description: populatedTab.articles.last?.extract)
                     tab.info = info
                 }

--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
@@ -92,9 +92,11 @@ fileprivate struct WMFArticleTabsViewContent: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onAppear {
             Task {
-                let populatedTab = await viewModel.populateSummary(tab.data)
-                let info = ArticleTab.Info(subtitle: populatedTab.articles.last?.description, image: populatedTab.articles.last?.imageURL, description: populatedTab.articles.last?.extract)
-                tab.info = info
+                if tab.info == nil {
+                    let populatedTab = await viewModel.populateSummary(tab.data)
+                    let info = ArticleTab.Info(subtitle: populatedTab.articles.last?.description, image: populatedTab.articles.last?.imageURL, description: populatedTab.articles.last?.extract)
+                    tab.info = info
+                }
             }
         }
     }
@@ -161,7 +163,7 @@ fileprivate struct WMFArticleTabsViewContent: View {
     }
     
     private func loadingTabContent() -> some View {
-        Text("Loading")
+        Text("")
     }
     
     private func standardTabContent() -> some View {

--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
@@ -42,7 +42,7 @@ public struct WMFArticleTabsView: View {
             .padding(.horizontal, 8)
         }
         .background(Color(theme.midBackground))
-        .toolbarBackground(Color(uiColor: (theme.paperBackground)), for: .automatic)
+        .toolbarBackground(Color(theme.midBackground), for: .automatic)
     }
 }
 
@@ -81,7 +81,7 @@ fileprivate struct WMFArticleTabsViewContent: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .background(Color(theme.paperBackground))
+        .background(Color(theme.chromeBackground))
         .cornerRadius(12)
         .shadow(color: Color.black.opacity(0.05), radius: 16, x: 0, y: 0)
         .contentShape(Rectangle())
@@ -141,6 +141,7 @@ fileprivate struct WMFArticleTabsViewContent: View {
             tabTitle(title: tab.title)
                 .padding(.horizontal, 10)
                 .padding(.top, 10)
+                .padding(.bottom, 2)
 
             VStack(alignment: .leading) {
                 Text(viewModel.localizedStrings.mainPageSubtitle)
@@ -155,8 +156,7 @@ fileprivate struct WMFArticleTabsViewContent: View {
                 Text(viewModel.localizedStrings.mainPageDescription)
                     .font(Font(WMFFont.for(.caption1)))
                     .foregroundStyle(Color(theme.text))
-                    .lineSpacing(5)
-                    .padding(.bottom, 5)
+                    .lineSpacing(1.4)
             }
             .padding([.horizontal], 10)
         }
@@ -185,10 +185,13 @@ fileprivate struct WMFArticleTabsViewContent: View {
                         }
                         .frame(height: CGFloat(viewModel.calculateImageHeight()))
                     } else {
-                        tabTitle(title: tab.title)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.trailing, 40)
-                            .padding([.leading, .top], 10)
+                        VStack(alignment: .leading, spacing: 2) {
+                            tabTitle(title: tab.title)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.trailing, 40)
+                                .padding([.leading, .top], 10)
+                            tabText(tab: tab)
+                        }
                     }
                 }
 
@@ -205,12 +208,13 @@ fileprivate struct WMFArticleTabsViewContent: View {
             }
 
             if tab.info?.image != nil {
-                tabTitle(title: tab.title)
-                    .padding(.horizontal, 10)
-                    .padding(.top, 10)
+                VStack(alignment: .leading, spacing: 2) {
+                    tabTitle(title: tab.title)
+                        .padding(.horizontal, 10)
+                        .padding(.top, 10)
+                    tabText(tab: tab)
+                }
             }
-
-            tabText(tab: tab)
 
             if tab.info?.image == nil {
                 Spacer()
@@ -224,27 +228,32 @@ fileprivate struct WMFArticleTabsViewContent: View {
             .font(Font(WMFFont.for(.georgiaCallout)))
             .foregroundStyle(Color(theme.text))
             .lineLimit(1)
+            .padding(.bottom, 2)
     }
     
     private func tabText(tab: ArticleTab) -> some View {
-        VStack(alignment: .leading) {
-            if let subtitle = tab.info?.subtitle {
-                Text(subtitle)
-                    .font(Font(WMFFont.for(.caption1)))
-                    .foregroundStyle(Color(theme.secondaryText))
-                    .lineLimit(1)
+        VStack(alignment: .leading, spacing: 0) {
+            Group {
+                if let subtitle = tab.info?.subtitle {
+                    Text(subtitle)
+                } else {
+                    Text(" ")
+                        .hidden()
+                }
             }
+            .font(Font(WMFFont.for(.caption1)))
+            .foregroundStyle(Color(theme.secondaryText))
+            .lineLimit(1)
+            
             Divider()
                 .frame(width: 24)
-                .padding(.top, 4)
-                .padding(.bottom, 6)
+                .padding(.vertical, 8)
                 .foregroundStyle(Color(uiColor: theme.border))
             if let description = tab.info?.description {
                 Text(description)
                     .font(Font(WMFFont.for(.caption1)))
                     .foregroundStyle(Color(theme.text))
-                    .lineSpacing(5)
-                    .padding(.bottom, 5)
+                    .lineSpacing(1.4)
             } else {
                 Spacer()
             }

--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
@@ -24,13 +24,18 @@ public struct WMFArticleTabsView: View {
             ScrollView {
                 LazyVGrid(columns: Array(repeating: gridItem, count: columns)) {
                     ForEach(viewModel.articleTabs.sorted(by: { $0.dateCreated < $1.dateCreated })) { tab in
-                        if tab.isMain {
-                            tabCardView(content: mainPageTabContent(tab: tab), tabData: tab.data, tab: tab)
+                        if tab.isLoading {
+                            tabCardView(content: loadingTabContent(tab: tab), tabData: tab.data, tab: tab)
                                 .padding(4)
-                            
                         } else {
-                            tabCardView(content: standardTabContent(tab: tab), tabData: tab.data, tab: tab)
-                                .padding(4)
+                            if tab.isMain {
+                                tabCardView(content: mainPageTabContent(tab: tab), tabData: tab.data, tab: tab)
+                                    .padding(4)
+                                
+                            } else {
+                                tabCardView(content: standardTabContent(tab: tab), tabData: tab.data, tab: tab)
+                                    .padding(4)
+                            }
                         }
                     }
                 }
@@ -100,6 +105,10 @@ public struct WMFArticleTabsView: View {
             }
             .padding([.horizontal], 10)
         }
+    }
+    
+    private func loadingTabContent(tab: ArticleTab) -> some View {
+        Text("Loading")
     }
 
     
@@ -180,6 +189,16 @@ public struct WMFArticleTabsView: View {
                         viewModel.closeTab(tab: tab)
                     }
                 }
+            }
+            .onAppear {
+                Task {
+                    let populatedTab = await viewModel.populateSummary(tabData)
+                    tab.image = populatedTab.articles.last?.imageURL
+                    tab.subtitle = populatedTab.articles.last?.description
+                    tab.description = populatedTab.articles.last?.summary
+                    tab.isLoading = false
+                }
+                
             }
     }
 

--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
@@ -25,8 +25,6 @@ public struct WMFArticleTabsView: View {
                 LazyVGrid(columns: Array(repeating: gridItem, count: columns)) {
                     ForEach(viewModel.articleTabs.sorted(by: { $0.dateCreated < $1.dateCreated })) { tab in
                         WMFArticleTabsViewContent(viewModel: viewModel, tab: tab)
-                            .accessibilityElement(children: .combine)
-                            .accessibilityLabel(viewModel.getAccessibilityLabel(for: tab))
                             .accessibilityActions {
                                 accessibilityAction(named: viewModel.localizedStrings.openTabAccessibility) {
                                     viewModel.didTapTab(tab.data)
@@ -68,11 +66,17 @@ fileprivate struct WMFArticleTabsViewContent: View {
         Group {
             if tab.isMain {
                 mainPageTabContent()
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(viewModel.getAccessibilityLabel(for: tab))
             } else {
                 if tab.info == nil {
                     loadingTabContent()
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel(viewModel.getAccessibilityLabel(for: tab))
                 } else {
                     standardTabContent()
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel(viewModel.getAccessibilityLabel(for: tab))
                 }
             }
         }

--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsViewModel.swift
@@ -57,16 +57,12 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
     private func loadTabs() async {
         do {
             let tabs = try await dataController.fetchAllArticleTabs()
-            // let populatedTabs = await populateSummaries(tabs)
             self.articleTabs = tabs.map { tab in
                 ArticleTab(
-                    image: tab.articles.last?.imageURL,
                     title: tab.articles.last?.title.underscoresToSpaces ?? "",
-                    subtitle: tab.articles.last?.description,
-                    description: tab.articles.last?.summary,
                     dateCreated: tab.timestamp,
-                    data: tab,
-                    isLoading: true
+                    info: nil,
+                    data: tab
                 )
             }
             self.shouldShowCloseButton = articleTabs.count > 1
@@ -112,7 +108,7 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
             label += " " + localizedStrings.mainPageSubtitle
         } else {
             label += tab.title
-            if let subtitle = tab.subtitle {
+            if let subtitle = tab.info?.subtitle {
                 label += " " + subtitle
             }
         }
@@ -137,22 +133,24 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
 }
 
 public class ArticleTab: Identifiable, ObservableObject {
-    @Published var image: URL?
-    @Published var title: String
-    @Published var subtitle: String?
-    @Published var description: String?
+    
+    struct Info {
+        let subtitle: String?
+        let image: URL?
+        let description: String?
+    }
+    
+    let title: String
+    @Published var info: Info?
+    
     let dateCreated: Date
     let data: WMFArticleTabsDataController.WMFArticleTab
-    @Published var isLoading: Bool
 
-    public init(image: URL?, title: String, subtitle: String?, description: String?, dateCreated: Date, data: WMFArticleTabsDataController.WMFArticleTab, isLoading: Bool) {
-        self.image = image
+    init(title: String, dateCreated: Date, info: Info?, data: WMFArticleTabsDataController.WMFArticleTab) {
         self.title = title
-        self.subtitle = subtitle
-        self.description = description
+        self.info = info
         self.dateCreated = dateCreated
         self.data = data
-        self.isLoading = isLoading
     }
     
     public var id: String {
@@ -161,12 +159,5 @@ public class ArticleTab: Identifiable, ObservableObject {
     
     var isMain: Bool {
         return data.articles.last?.isMain ?? false
-    }
-    
-    func update(image: URL?, title: String, subtitle: String?, description: String?) {
-        self.image = image
-        self.title = title
-        self.subtitle = subtitle
-        self.description = description
     }
 }

--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsViewModel.swift
@@ -9,7 +9,6 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
     @Published var count: Int
     
     private let dataController: WMFArticleTabsDataController
-    public var onTabCountChanged: ((Int) -> Void)?
     public var updateNavigationBarTitleAction: ((Int) -> Void)?
 
     public let didTapTab: (WMFArticleTabsDataController.WMFArticleTab) -> Void
@@ -67,7 +66,6 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
             }
             self.shouldShowCloseButton = articleTabs.count > 1
             self.count = articleTabs.count
-            onTabCountChanged?(count)
             updateNavigationBarTitleAction?(count)
         } catch {
             // Handle error appropriately

--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsViewModel.swift
@@ -54,7 +54,7 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
     private func loadTabs() async {
         do {
             let tabs = try await dataController.fetchAllArticleTabs()
-            self.articleTabs = tabs.map { tab in
+            articleTabs = tabs.map { tab in
                 ArticleTab(
                     title: tab.articles.last?.title.underscoresToSpaces ?? "",
                     dateCreated: tab.timestamp,
@@ -62,7 +62,7 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
                     data: tab
                 )
             }
-            self.shouldShowCloseButton = articleTabs.count > 1
+            shouldShowCloseButton = articleTabs.count > 1
             updateNavigationBarTitleAction?(articleTabs.count)
         } catch {
             // Handle error appropriately
@@ -116,9 +116,10 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
             do {
                 try await dataController.deleteArticleTab(identifier: tab.data.identifier)
                 
-                Task { @MainActor in
+                Task { @MainActor [weak self]  in
+                    guard let self else { return }
                     articleTabs.removeAll { $0 == tab }
-                    self.shouldShowCloseButton = articleTabs.count > 1
+                    shouldShowCloseButton = articleTabs.count > 1
                     updateNavigationBarTitleAction?(articleTabs.count)
                 }
                 
@@ -126,10 +127,6 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
                 debugPrint("Error closing tab: \(error)")
             }
         }
-    }
-    
-    func tabsCount() async throws -> Int {
-        return try await dataController.tabsCount()
     }
 }
 

--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsViewModel.swift
@@ -14,7 +14,7 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
 
     public let didTapTab: (WMFArticleTabsDataController.WMFArticleTab) -> Void
     public let didTapAddTab: () -> Void
-    public let populateSummaries: @Sendable ([WMFArticleTabsDataController.WMFArticleTab]) async -> [WMFArticleTabsDataController.WMFArticleTab]
+    public let populateSummary: @Sendable (WMFArticleTabsDataController.WMFArticleTab) async -> WMFArticleTabsDataController.WMFArticleTab
     
     public let localizedStrings: LocalizedStrings
     
@@ -22,7 +22,7 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
                 localizedStrings: LocalizedStrings,
                 didTapTab: @escaping (WMFArticleTabsDataController.WMFArticleTab) -> Void,
                 didTapAddTab: @escaping () -> Void,
-                populateSummaries: @escaping @Sendable ([WMFArticleTabsDataController.WMFArticleTab]) async -> [WMFArticleTabsDataController.WMFArticleTab]) {
+                populateSummary: @escaping @Sendable (WMFArticleTabsDataController.WMFArticleTab) async -> WMFArticleTabsDataController.WMFArticleTab) {
         self.dataController = dataController
         self.localizedStrings = localizedStrings
         self.articleTabs = []
@@ -30,7 +30,7 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
         self.count = 0
         self.didTapTab = didTapTab
         self.didTapAddTab = didTapAddTab
-        self.populateSummaries = populateSummaries
+        self.populateSummary = populateSummary
         super.init()
         Task {
             await loadTabs()
@@ -57,15 +57,16 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
     private func loadTabs() async {
         do {
             let tabs = try await dataController.fetchAllArticleTabs()
-            let populatedTabs = await populateSummaries(tabs)
-            self.articleTabs = populatedTabs.map { tab in
+            // let populatedTabs = await populateSummaries(tabs)
+            self.articleTabs = tabs.map { tab in
                 ArticleTab(
                     image: tab.articles.last?.imageURL,
                     title: tab.articles.last?.title.underscoresToSpaces ?? "",
                     subtitle: tab.articles.last?.description,
                     description: tab.articles.last?.summary,
                     dateCreated: tab.timestamp,
-                    data: tab
+                    data: tab,
+                    isLoading: true
                 )
             }
             self.shouldShowCloseButton = articleTabs.count > 1
@@ -135,21 +136,23 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
     }
 }
 
-public struct ArticleTab: Identifiable {
-    let image: URL?
-    let title: String
-    let subtitle: String?
-    let description: String?
+public class ArticleTab: Identifiable, ObservableObject {
+    @Published var image: URL?
+    @Published var title: String
+    @Published var subtitle: String?
+    @Published var description: String?
     let dateCreated: Date
     let data: WMFArticleTabsDataController.WMFArticleTab
+    @Published var isLoading: Bool
 
-    public init(image: URL?, title: String, subtitle: String?, description: String?, dateCreated: Date, data: WMFArticleTabsDataController.WMFArticleTab) {
+    public init(image: URL?, title: String, subtitle: String?, description: String?, dateCreated: Date, data: WMFArticleTabsDataController.WMFArticleTab, isLoading: Bool) {
         self.image = image
         self.title = title
         self.subtitle = subtitle
         self.description = description
         self.dateCreated = dateCreated
         self.data = data
+        self.isLoading = isLoading
     }
     
     public var id: String {
@@ -158,5 +161,12 @@ public struct ArticleTab: Identifiable {
     
     var isMain: Bool {
         return data.articles.last?.isMain ?? false
+    }
+    
+    func update(image: URL?, title: String, subtitle: String?, description: String?) {
+        self.image = image
+        self.title = title
+        self.subtitle = subtitle
+        self.description = description
     }
 }

--- a/WMFData/Sources/WMFData/Data Controllers/Article Tabs/WMFArticleTabsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Article Tabs/WMFArticleTabsDataController.swift
@@ -98,7 +98,6 @@ public class WMFArticleTabsDataController: WMFArticleTabsDataControlling {
     
     public let coreDataStore: WMFCoreDataStore
     private let developerSettingsDataController: WMFDeveloperSettingsDataControlling
-    private let articleSummaryDataController: WMFArticleSummaryDataControlling
     
     lazy var backgroundContext: NSManagedObjectContext? = {
         let backgroundContext = try? coreDataStore.newBackgroundContext
@@ -109,14 +108,12 @@ public class WMFArticleTabsDataController: WMFArticleTabsDataControlling {
     // MARK: - Lifecycle
     
     init(coreDataStore: WMFCoreDataStore? = WMFDataEnvironment.current.coreDataStore,
-         developerSettingsDataController: WMFDeveloperSettingsDataControlling = WMFDeveloperSettingsDataController.shared,
-         articleSummaryDataController: WMFArticleSummaryDataControlling = WMFArticleSummaryDataController()) throws {
+         developerSettingsDataController: WMFDeveloperSettingsDataControlling = WMFDeveloperSettingsDataController.shared) throws {
         guard let coreDataStore else {
             throw WMFDataControllerError.coreDataStoreUnavailable
         }
         self.coreDataStore = coreDataStore
         self.developerSettingsDataController = developerSettingsDataController
-        self.articleSummaryDataController = articleSummaryDataController
     }
     
     // MARK: Entry point

--- a/WMFData/Sources/WMFData/Data Controllers/Article Tabs/WMFArticleTabsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Article Tabs/WMFArticleTabsDataController.swift
@@ -582,7 +582,9 @@ public class WMFArticleTabsDataController: WMFArticleTabsDataControlling {
             return articleTabs
         }
         
-        return try await databaseTabsWithArticleSummaries(databaseTabs: databaseTabs)
+        return databaseTabs
+        
+        // return try await databaseTabsWithArticleSummaries(databaseTabs: databaseTabs)
     }
     
     private func databaseTabsWithArticleSummaries(databaseTabs: [WMFArticleTab]) async throws -> [WMFArticleTab] {

--- a/WMFData/Sources/WMFData/Data Controllers/Article Tabs/WMFArticleTabsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Article Tabs/WMFArticleTabsDataController.swift
@@ -582,9 +582,7 @@ public class WMFArticleTabsDataController: WMFArticleTabsDataControlling {
             return articleTabs
         }
         
-        return databaseTabs
-        
-        // return try await databaseTabsWithArticleSummaries(databaseTabs: databaseTabs)
+        return try await databaseTabsWithArticleSummaries(databaseTabs: databaseTabs)
     }
     
     private func databaseTabsWithArticleSummaries(databaseTabs: [WMFArticleTab]) async throws -> [WMFArticleTab] {

--- a/WMFData/Sources/WMFDataMocks/WMFMockArticleTabsDataController.swift
+++ b/WMFData/Sources/WMFDataMocks/WMFMockArticleTabsDataController.swift
@@ -163,7 +163,7 @@ public final class WMFMockArticleTabsDataController: WMFArticleTabsDataControlli
                 let article = WMFArticleTabsDataController.WMFArticle(
                     identifier: UUID(), title: title,
                     description: "Description for \(title)",
-                    summary: "Summary for \(title)",
+                    extract: "Summary for \(title)",
                     imageURL: URL(string: imageURL),
                     project: enProject
                 )

--- a/WMFData/Tests/WMFDataTests/WMFArticleTabsDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFArticleTabsDataControllerTests.swift
@@ -306,29 +306,14 @@ final class WMFArticleTabsDataControllerTests: XCTestCase {
         }
     }
     
-    // Mock implementation
-    class MockArticleSummaryDataController: WMFArticleSummaryDataControlling {
-        func fetchArticleSummary(project: WMFProject, title: String) async throws -> WMFArticleSummary {
-            return WMFArticleSummary(
-                displayTitle: title,
-                description: "Description for \(title)",
-                extractHtml: "<p>Extract for \(title)</p>",
-                thumbnailURL: URL(string: "https://example.com/\(title).jpg"),
-                extract: "Extract for \(title)"
-            )
-        }
-    }
-    
     func testFetchAllArticleTabs() async throws {
         guard let store else {
             throw TestsError.missingStore
         }
         
         // Create and inject the mock controller
-        let mockController = MockArticleSummaryDataController()
         let dataController = try WMFArticleTabsDataController(
-            coreDataStore: store,
-            articleSummaryDataController: mockController
+            coreDataStore: store
         )
         
         // Create two tabs with articles
@@ -359,11 +344,10 @@ final class WMFArticleTabsDataControllerTests: XCTestCase {
             XCTFail("First tab not found")
             return
         }
+        
+        
         XCTAssertEqual(firstTab.articles.count, 1, "First tab should have one article")
         XCTAssertEqual(firstTab.articles[0].title, "Cat")
-        XCTAssertEqual(firstTab.articles[0].description, "Description for Cat")
-        XCTAssertEqual(firstTab.articles[0].summary, "Extract for Cat")
-        XCTAssertEqual(firstTab.articles[0].imageURL?.absoluteString, "https://example.com/Cat.jpg")
         
         // Verify second tab
         guard let secondTab = tabs.first(where: { $0.identifier == identifier2.tabIdentifier }) else {
@@ -372,8 +356,5 @@ final class WMFArticleTabsDataControllerTests: XCTestCase {
         }
         XCTAssertEqual(secondTab.articles.count, 1, "Second tab should have one article")
         XCTAssertEqual(secondTab.articles[0].title, "Dog")
-        XCTAssertEqual(secondTab.articles[0].description, "Description for Dog")
-        XCTAssertEqual(secondTab.articles[0].summary, "Extract for Dog")
-        XCTAssertEqual(secondTab.articles[0].imageURL?.absoluteString, "https://example.com/Dog.jpg")
     }
 }

--- a/Wikipedia/Code/TabsOverviewCoordinator.swift
+++ b/Wikipedia/Code/TabsOverviewCoordinator.swift
@@ -102,7 +102,7 @@ final class TabsOverviewCoordinator: Coordinator {
             }
             
             var newArticles = Array(tab.articles.prefix(tab.articles.count - 1))
-            let newArticle = WMFArticleTabsDataController.WMFArticle(identifier: topArticle.identifier, title: topArticle.title, description: article.wikidataDescription, summary: article.snippet, imageURL: nil, project: topArticle.project)
+            let newArticle = WMFArticleTabsDataController.WMFArticle(identifier: topArticle.identifier, title: topArticle.title, description: article.wikidataDescription, summary: article.snippet, imageURL: article.thumbnailURL, project: topArticle.project)
             newArticles.append(newArticle)
             let newTab = WMFArticleTabsDataController.WMFArticleTab(identifier: tab.identifier, timestamp: tab.timestamp, isCurrent: tab.isCurrent, articles: newArticles)
             completion(newTab)

--- a/Wikipedia/Code/TabsOverviewCoordinator.swift
+++ b/Wikipedia/Code/TabsOverviewCoordinator.swift
@@ -102,7 +102,7 @@ final class TabsOverviewCoordinator: Coordinator {
             }
             
             var newArticles = Array(tab.articles.prefix(tab.articles.count - 1))
-            let newArticle = WMFArticleTabsDataController.WMFArticle(identifier: topArticle.identifier, title: topArticle.title, description: article.wikidataDescription, summary: article.snippet, imageURL: article.thumbnailURL, project: topArticle.project)
+            let newArticle = WMFArticleTabsDataController.WMFArticle(identifier: topArticle.identifier, title: topArticle.title, description: article.wikidataDescription, extract: article.snippet, imageURL: article.thumbnailURL, project: topArticle.project)
             newArticles.append(newArticle)
             let newTab = WMFArticleTabsDataController.WMFArticleTab(identifier: tab.identifier, timestamp: tab.timestamp, isCurrent: tab.isCurrent, articles: newArticles)
             completion(newTab)


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T392918

### Notes
Previously, I had set up the data controller's [fetchAllTabs](https://github.com/wikimedia/wikipedia-ios/compare/T392918?expand=1#diff-468f032d0680cb3596bfe25134d4cffc429c943d231469c2f8456a2789c57af6L585)() to fetch the article summary for all of the user's tabs, which could be up to 500 API calls at once when the tabs overview screen appears. Now I am fetching onAppearance of the particular tab grid item, so that we are only fetching what is necessary for the user at that moment.

I assist with the transition between a loading state and a populated state, I refactored the existing content view of a grid item into a separate SwiftUI view called `WMFArticleTabsViewContent`.

As far as caching goes, I'm letting the system do its default network caching. As I proxy the calls, I can see that followup calls to the same summary endpoint returns 304 Not Modified, which means it is leaning on internal cache already. This will provide a good balance between caching and refreshing in the case of vandalism. The server will control if the article has been updated and will no longer return a Not Modified response, which will cause the app to download again and refresh.

### Test Steps
1. Open a lot of tabs. Watch networking traffic via a proxy.
2. Open tabs overview. Ensure only the tabs seen on screen are fetching the summary endpoint (`https://{lang}.wikipedia.org/api/rest_v1/page/summary/{title}`)
3. As you scroll down, confirm more summary endpoints are fetched as-needed and the grid item shows the data as it did before.
