### PR TITLE
Tabs - Fix delete tab bug

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Article Tabs/WMFArticleTabsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Article Tabs/WMFArticleTabsDataController.swift
@@ -104,6 +104,7 @@ public class WMFArticleTabsDataController: WMFArticleTabsDataControlling {
         get {
             if _backgroundContext == nil {
                 _backgroundContext = try? coreDataStore?.newBackgroundContext
+                _backgroundContext?.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
             }
             return _backgroundContext
         } set {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T392919

### Notes
I think I may have caused a bug [here](https://github.com/wikimedia/wikipedia-ios/pull/5300/files#diff-468f032d0680cb3596bfe25134d4cffc429c943d231469c2f8456a2789c57af6L104) in #5300 by removing the merge policy. Currently in `main`, deleting a tab often fails from the tabs overview (typically when visiting overview the 2nd time). 

### Test Steps
1. Open several tabs
2. Visit tabs overview, confirm you can delete a tab.
3. Dismiss, open more tabs.
4. Visit tabs overview, confirm you can still delete tabs.
