### PR TITLE
Remove providence tracker

### DIFF
--- a/Wikipedia/Code/URL+LinkParsing.swift
+++ b/Wikipedia/Code/URL+LinkParsing.swift
@@ -123,9 +123,7 @@ extension URL {
     }
     
     fileprivate func wmf_URLForSharing(with wprov: String) -> URL {
-        let queryItems = [URLQueryItem(name: "wprov", value: wprov)]
         var components = URLComponents(url: self, resolvingAgainstBaseURL: false)
-        components?.queryItems = queryItems
         return components?.wmf_URLWithLanguageVariantCode(wmf_languageVariantCode) ?? self
     }
     


### PR DESCRIPTION
PLEASE remove this junk. I know it only takes like five seconds
to remove it when I bookmark or share links but it's the five most
annoying seconds of every day—many times per day even since I link a
lot to Wikipedia. With this line removed, a lot of the other functions
in this file become nops so feel free to squash in some commits that
remove all of them as you merge this. Wikipedia is something we all
created for the public benefit, not to be annoying and painful like
commercial malware is.
