### PR TITLE
Fix encoding of non-english characters on HTMLUtils

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Utility/HTMLUtils.swift
+++ b/WMFComponents/Sources/WMFComponents/Utility/HTMLUtils.swift
@@ -80,7 +80,8 @@ public struct HtmlUtils {
     // MARK: - NSAttributedString - Public
     
     public static func nsAttributedStringFromHtml(_ html: String, styles: Styles) throws -> NSAttributedString {
-        let attributedString = NSMutableAttributedString(string: html)
+        let cleanHTML = sanitizedHTML(html)
+        let attributedString = NSMutableAttributedString(string: cleanHTML)
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = styles.lineSpacing
         paragraphStyle.lineBreakMode = styles.lineBreakMode
@@ -90,8 +91,8 @@ public struct HtmlUtils {
             .paragraphStyle: paragraphStyle
         ]
         attributedString.setAttributes(attributes, range: html.fullNSRange)
-        
-        let listInsertData = try listInsertData(html: html, styles: styles)
+
+        let listInsertData = try listInsertData(html: cleanHTML, styles: styles)
         insertListData(into: attributedString, listInsertData: listInsertData, styles: styles)
         
         let allStyleData = try allStyleData(html: attributedString.string)
@@ -217,16 +218,48 @@ public struct HtmlUtils {
             nsAttributedString.replaceCharacters(in: data.range, with: data.replaceText)
         }
     }
-    
+
+    public static func sanitizedHTML(_ html: String) -> String {
+        let pattern = #"href=\"([^\"]+)\""#
+            guard let regex = try? NSRegularExpression(pattern: pattern) else {
+                return html
+            }
+
+            var cleanHTML = html
+            let matches = regex.matches(in: html, range: html.fullNSRange)
+
+            for match in matches.reversed() {
+                guard let range = Range(match.range(at: 1), in: html) else { continue }
+                let rawHref = String(html[range])
+
+                if let url = URL(string: rawHref),
+                   var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+                    // Custom character set - don't escape parentheses, colons, or slashes
+                    let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;=")
+                    if let comp = components.path.addingPercentEncoding(withAllowedCharacters: allowed) {
+                        components.percentEncodedPath = comp
+                    }
+                    let encodedHref = components.url?.absoluteString ?? rawHref
+
+                    let fullRange = match.range(at: 0)
+                    if let swiftRange = Range(fullRange, in: html) {
+                        cleanHTML.replaceSubrange(swiftRange, with: #"href="\#(encodedHref)""#)
+                    }
+                }
+            }
+
+            return cleanHTML
+       }
+
     // MARK: - AttributedString - Public
     
     public static func attributedStringFromHtml(_ html: String, styles: Styles) throws -> AttributedString {
-        
-        var attributedString = AttributedString(html)
+        let cleanHTML = sanitizedHTML(html)
+        var attributedString = AttributedString(cleanHTML)
         attributedString.font = styles.font
         attributedString.foregroundColor = styles.color
         
-        let listInsertData = try listInsertData(html: html, styles: styles)
+        let listInsertData = try listInsertData(html: cleanHTML, styles: styles)
         insertListData(into: &attributedString, listInsertData: listInsertData, styles: styles)
         
         let allStyleData = try allStyleData(html: String(attributedString.characters))

--- a/WMFComponents/Tests/WMFComponentsTests/HtmlUtilsTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/HtmlUtilsTests.swift
@@ -20,12 +20,48 @@ final class HtmlUtilsTests: XCTestCase {
     }
 
     func testMalformedListHtml() throws {
-        
+
         let html = "<div class=\"mw-fr-edit-messages\"><div class=\"cdx-message mw-fr-message-box cdx-message--inline cdx-message--notice\"><span class=\"cdx-message__icon\"></span><div class=\"cdx-message__content\"><p><b>Note:</b> Edits to this page from new or unregistered users are subject to review prior to publication (<a href=\"/wiki/Wikipedia:Pending_changes\" title=\"Wikipedia:Pending changes\">help</a>).\n</p><div id=\"mw-fr-logexcerpt\"><ul class=\'mw-logevent-loglines\'>\n<li data-mw-logid=\"166878532\" data-mw-logaction=\"stable/config\" class=\"mw-logline-stable\"> <a href=\"/w/index.php?title=Special:Log&amp;logid=166878532\" title=\"Special:Log\">21:42, 2 January 2025</a> <a href=\"/wiki/User:Ymblanter\" class=\"mw-userlink\" title=\"User:Ymblanter\"><bdi>Ymblanter</bdi></a> configured pending changes settings for <a href=\"/wiki/Josh_Allen\" title=\"Josh Allen\">Josh Allen</a> [Auto-accept: require &quot;autoconfirmed&quot; permission] (expires 21:42, 2 January 2026 (UTC)) <span class=\"comment\">(Persistent <a href=\"/wiki/Wikipedia:Vandalism\" title=\"Wikipedia:Vandalism\">vandalism</a>; requested at <a href=\"/wiki/Wikipedia:RfPP\" class=\"mw-redirect\" title=\"Wikipedia:RfPP\">WP:RfPP</a> (<a href=\"/wiki/Wikipedia:TW\" class=\"mw-redirect\" title=\"Wikipedia:TW\">TW</a>))</span> <span class=\"mw-logevent-actionlink\">(<a href=\"/w/index.php?title=Josh_Allen&amp;action=history&amp;offset=20250102214253\" title=\"Josh Allen\">hist</a>)</span> </li>\n</ul></ul>\n</div></div></div></div>"
-        
+
         let largeTraitCollection = UITraitCollection(preferredContentSizeCategory: .large)
         let styles: HtmlUtils.Styles = HtmlUtils.Styles(font: WMFFont.for(.callout, compatibleWith: largeTraitCollection), boldFont: WMFFont.for(.boldCallout, compatibleWith: largeTraitCollection), italicsFont: WMFFont.for(.italicCallout, compatibleWith: largeTraitCollection), boldItalicsFont: WMFFont.for(.boldItalicCallout, compatibleWith: largeTraitCollection), color: WMFTheme.light.text, linkColor: WMFTheme.light.link, lineSpacing: 3)
         let attributedString = try HtmlUtils.attributedStringFromHtml(html, styles: styles)
         XCTAssertNotNil(attributedString, "Test extra unordered list did not cause crash")
+    }
+
+    func testHTMLLinkParsingWithNonEnglishCharacters() throws {
+        let largeTraitCollection = UITraitCollection(preferredContentSizeCategory: .large)
+        let styles = HtmlUtils.Styles(
+            font:  WMFFont.for(.callout, compatibleWith: largeTraitCollection),
+            boldFont: WMFFont.for(.boldCallout, compatibleWith: largeTraitCollection),
+            italicsFont: WMFFont.for(.italicCallout, compatibleWith: largeTraitCollection),
+            boldItalicsFont: WMFFont.for(.boldItalicCallout, compatibleWith: largeTraitCollection),
+            color: WMFTheme.light.text,
+            linkColor: WMFTheme.light.link,
+            lineSpacing: 1
+        )
+
+        let htmlSamples = [
+            // Portuguese
+            "<a href=\"https://pt.wikipedia.org/wiki/Usuário:Rpo.castro_(discussão)\">discussão</a>",
+            // Chinese
+            "<a href=\"https://zh.wikipedia.org/wiki/用戶:示例\">示例</a>",
+            // Japanese
+            "<a href=\"https://ja.wikipedia.org/wiki/利用者:テスト\">テスト</a>",
+            // Arabic
+            "<a href=\"https://ar.wikipedia.org/wiki/مستخدم:اختبار\">اختبار</a>",
+            // Hebrew
+            "<a href=\"https://he.wikipedia.org/wiki/משתמש:בדיקה\">בדיקה</a>"
+        ]
+
+        for html in htmlSamples {
+            let attributed = try HtmlUtils.nsAttributedStringFromHtml(html, styles: styles)
+            let linkCount = attributed
+                .attributes(at: 0, effectiveRange: nil)
+                .filter { $0.key == .link }
+                .count
+
+            XCTAssertEqual(linkCount, 1, "Failed to detect link in: \(html)")
+        }
     }
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T395708

### Notes
* This fixes a bug that caused the app to crash when tapping a link with non-en charcaters on talk pages
* Additional sanitization was added to HTMLUtils to allow for the correct parsing of these characters
* Even though the bug was found on talk pages, this change affects all the links in the app that go through HTMLUtils

### Test Steps
1. Run the app in a non-English language (Chinese, Arabic, Spanish, Hebrew, and Russian are some examples) 
2. Click on user page and user talk page links on talk pages topics and responses with non-en chars
3. Do the same on diffs, edit notices, panels with links
4. Make sure links work correctly when tapped, and are properly highlighted

