### PR TITLE
Activity tab - analytics adjustments

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Activity/WMFActivityViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Activity/WMFActivityViewModel.swift
@@ -142,13 +142,14 @@ import WMFData
     }
 
     func getGroupAssigment() -> WMFActivityTabExperimentsDataController.ActivityTabExperimentAssignment {
-        guard let dataController = WMFActivityTabExperimentsDataController.shared else {
+        guard let dataController = WMFActivityTabExperimentsDataController.shared,
+            let project else {
             return .control
         }
         var assignment: WMFActivityTabExperimentsDataController.ActivityTabExperimentAssignment = .control
 
         do {
-            let currentAssigment = try dataController.getActivityTabExperimentAssignment()
+            let currentAssigment = try dataController.getActivityTabExperimentAssignment(project: project)
             assignment = currentAssigment
         } catch {
             debugPrint("Error fetching activity tab experiment: \(error)")

--- a/WMFData/Sources/WMFData/Data Controllers/Activity/WMFActivityTabExperimentsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Activity/WMFActivityTabExperimentsDataController.swift
@@ -93,7 +93,8 @@ public final class WMFActivityTabExperimentsDataController {
         return experimentEndDate >= Date()
     }
 
-    public func getActivityTabExperimentAssignment() throws -> ActivityTabExperimentAssignment {
+    public func getActivityTabExperimentAssignment(project: WMFProject) throws -> ActivityTabExperimentAssignment {
+
         let devSettingsController = WMFDeveloperSettingsDataController.shared
 
         if devSettingsController.setActivityTabGroupA {
@@ -102,6 +103,10 @@ public final class WMFActivityTabExperimentsDataController {
             return .genericCTA
         } else if devSettingsController.setActivityTabGroupC {
             return .suggestedEdit
+        }
+
+        guard project.qualifiesActivityTabExperiment() else {
+            throw CustomError.invalidProject
         }
 
         guard isBeforeEndDate else {

--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
@@ -97,6 +97,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       disablePerformanceAntipatternChecker = "YES"
+      language = "fr"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Wikipedia/Code/EditInteractionFunnel.swift
+++ b/Wikipedia/Code/EditInteractionFunnel.swift
@@ -253,17 +253,14 @@ final class EditInteractionFunnel {
     
     // MARK: - Activity Tab Events
     
-    func logActivityTabGroupAssignment(project: WikimediaProject) {
-        
-        guard let groupAssignment = try? WMFActivityTabExperimentsDataController.shared?.getActivityTabExperimentAssignment() else {
-            return
-        }
-        
+    func logActivityTabGroupAssignment(groupAssignment: Int, project: WikimediaProject) {
+
         let groupAssignmentString: String
         switch groupAssignment {
-        case .control: groupAssignmentString = "activity_a"
-        case .genericCTA: groupAssignmentString = "activity_b"
-        case .suggestedEdit: groupAssignmentString = "activity_c"
+        case 0: groupAssignmentString = "activity_a"
+        case 1: groupAssignmentString = "activity_b"
+        case 2: groupAssignmentString = "activity_c"
+        default: groupAssignmentString = "activity_a"
         }
         
         logEvent(activeInterface: nil, action: .launch, actionData:["group": groupAssignmentString], project: project)

--- a/Wikipedia/Code/HistoryViewController.swift
+++ b/Wikipedia/Code/HistoryViewController.swift
@@ -178,8 +178,10 @@ class HistoryViewController: ArticleFetchedResultsViewController, WMFNavigationB
     }
 
     private func configureNavigationBar() {
-        
-        let experimentAssignment = (try? WMFActivityTabExperimentsDataController.shared?.getActivityTabExperimentAssignment()) ?? .control
+        guard let language  = dataStore.languageLinkController.appLanguage?.languageCode else { return }
+        let wmfLanguage = WMFLanguage(languageCode: language, languageVariantCode: nil)
+        let project = WMFProject.wikipedia(wmfLanguage)
+        let experimentAssignment = (try? WMFActivityTabExperimentsDataController.shared?.getActivityTabExperimentAssignment(project: project)) ?? .control
         let alignment: WMFNavigationBarTitleConfig.Alignment = experimentAssignment == .control ? .leadingCompact : .centerCompact
         
         var titleConfig: WMFNavigationBarTitleConfig = WMFNavigationBarTitleConfig(title: CommonStrings.historyTabTitle, customView: nil, alignment: alignment)

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -132,21 +132,24 @@ extension WMFAppViewController {
         }
         
         do {
-            _ = try dataController.assignActivityTabExperiment(project: wmfProject)
-            EditInteractionFunnel.shared.logActivityTabGroupAssignment(project: project)
+            let assignment = try dataController.assignActivityTabExperiment(project: wmfProject)
+            EditInteractionFunnel.shared.logActivityTabGroupAssignment(groupAssignment: assignment.rawValue, project: project)
         } catch {
             DDLogError("Error fetching activity tab experiment: \(error)")
         }
     }
 
     @objc func getAssignmentForActivityTabExperiment() -> Int {
-        guard let dataController = WMFActivityTabExperimentsDataController.shared else {
+        guard let dataController = WMFActivityTabExperimentsDataController.shared,
+              let primaryLanguage = dataStore.languageLinkController.appLanguage,
+              let project = WikimediaProject(siteURL: primaryLanguage.siteURL),
+              let wmfProject = project.wmfProject else {
             return 0
         }
         var assignment = 0 // start as control
-        
+
         do {
-            let currentAssigment = try dataController.getActivityTabExperimentAssignment()
+            let currentAssigment = try dataController.getActivityTabExperimentAssignment(project: wmfProject)
             assignment = currentAssigment.rawValue
         } catch {
             DDLogError("Error reading activity tab assignment: \(error)")


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T394332

### Notes
* Some users were having duplicate assignments. I couldn't reproduce this case, but I'm adding an early return for the get assignment method, and passing down the assignment to the analytics call instead of making another call to the data controller when logging, just to clean it up a bit

### Test Steps
1. Run the app in a valid language, check assigment. 
2. Change language to an invalid one (note the UI doesn't update unless you re-run from xcode or close the app on the device, that's another bug)
3. Run the app again, or close and reopen. Make sure the user is not assigned to a different group
4. Change the language to a valid one and verify step 3 again


