### PR TITLE
Tabs - Current tab closing bug

### DIFF
--- a/Wikipedia/Code/ArticleCoordinator.swift
+++ b/Wikipedia/Code/ArticleCoordinator.swift
@@ -159,7 +159,16 @@ final class ArticleCoordinator: NSObject, Coordinator, ArticleTabCoordinating {
             return false
         }
         articleVC.isRestoringState = isRestoringState
-        
+        articleVC.showTabsOverview = { [weak navigationController, weak self] in
+            guard let navController = navigationController, let self = self else { return }
+
+            TabsCoordinatorManager.shared.presentTabsOverview(
+                from: navController,
+                theme: self.theme,
+                dataStore: self.dataStore
+            )
+        }
+
         trackArticleTab(articleViewController: articleVC)
         
         switch tabConfig {

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -188,6 +188,7 @@ class ArticleViewController: ThemeableViewController, HintPresenting, UIScrollVi
         super.init(nibName: nil, bundle: nil)
         self.theme = theme
         hidesBottomBarWhenPushed = true
+        
     }
     
     deinit {
@@ -467,9 +468,11 @@ class ArticleViewController: ThemeableViewController, HintPresenting, UIScrollVi
         DonateFunnel.shared.logArticleProfile(project: project, metricsID: metricsID)
         profileCoordinator?.start()
     }
-    
+
+    var showTabsOverview: (() -> Void)?
+
     @objc func userDidTapTabs() {
-        _ = tabsCoordinator?.start()
+        showTabsOverview?()
         if let wikimediaProject = WikimediaProject(siteURL: articleURL) {
             ArticleTabsFunnel.shared.logIconClick(interface: .article, project: wikimediaProject)
         }

--- a/Wikipedia/Code/TabsOverviewCoordinator.swift
+++ b/Wikipedia/Code/TabsOverviewCoordinator.swift
@@ -189,8 +189,6 @@ final class TabsCoordinatorManager {
 
     private var tabsOverviewCoordinator: TabsOverviewCoordinator?
 
-    private init() {}
-
     func presentTabsOverview(from navigationController: UINavigationController, theme: Theme, dataStore: MWKDataStore) {
         let coordinator = TabsOverviewCoordinator(navigationController: navigationController, theme: theme, dataStore: dataStore)
         self.tabsOverviewCoordinator = coordinator

--- a/Wikipedia/Code/TabsOverviewCoordinator.swift
+++ b/Wikipedia/Code/TabsOverviewCoordinator.swift
@@ -182,7 +182,7 @@ extension TabsOverviewCoordinator: WMFArticleTabsLoggingDelegate {
 }
 
 /// Manages the lifecycle of TabsOverviewCoordinator independently of article tabs.
-/// Ensures the tabs UI rworks even if the current article tab is closed.
+/// Ensures the tabs UI works even if the current article tab is closed.
 final class TabsCoordinatorManager {
 
     static let shared = TabsCoordinatorManager()

--- a/Wikipedia/Code/TabsOverviewCoordinator.swift
+++ b/Wikipedia/Code/TabsOverviewCoordinator.swift
@@ -180,3 +180,21 @@ extension TabsOverviewCoordinator: WMFArticleTabsLoggingDelegate {
     }
 
 }
+
+/// Manages the lifecycle of TabsOverviewCoordinator independently of article tabs.
+/// Ensures the tabs UI rworks even if the current article tab is closed.
+final class TabsCoordinatorManager {
+
+    static let shared = TabsCoordinatorManager()
+
+    private var tabsOverviewCoordinator: TabsOverviewCoordinator?
+
+    private init() {}
+
+    func presentTabsOverview(from navigationController: UINavigationController, theme: Theme, dataStore: MWKDataStore) {
+        let coordinator = TabsOverviewCoordinator(navigationController: navigationController, theme: theme, dataStore: dataStore)
+        self.tabsOverviewCoordinator = coordinator
+
+        coordinator.start()
+    }
+}


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T396160

### Notes
* Fixes a bug where tabs would be unresponsive after closing the current tab if you came from the article
* Creates a TabsCoordinatorManager singleton to be used from ArticleCoordinator, removing the lifecycle management from ArticleVC and keep the coordinator alive when closing the current article
* NOTE: That could be used everywhere tabs are called, however, due to the release schedule and the need to test extensively, that will be done in a follow-up

### Test Steps
1. Open an article
2. Go to tabs overview
3. Close the current article tab
4. Ensure all the other tabs remain responsive
