### PR TITLE
feat: App Intent for exposing search functionality to Siri and Spotlight

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -4708,6 +4708,10 @@
 		FFE891452445150B0058B642 /* AppTabBarDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTabBarDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A76E10E02E1C581400A0F600 /* App Intent */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "App Intent"; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		00021DDE24D48EFD00476F97 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -7463,6 +7467,7 @@
 		BC45D58D1C32FD58007C72F3 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				A76E10E02E1C581400A0F600 /* App Intent */,
 				6730D8DD2A05BFA40035255B /* Editing */,
 				67033E122A61B23700896852 /* Watchlist */,
 				67DC5BDB23A00DF500B03A84 /* Article */,
@@ -8846,6 +8851,9 @@
 				00021DED24D48EFE00476F97 /* PBXTargetDependency */,
 				676C864A26D40AEB00A704C1 /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				A76E10E02E1C581400A0F600 /* App Intent */,
+			);
 			name = Wikipedia;
 			packageProductDependencies = (
 			);
@@ -8946,6 +8954,9 @@
 				D8CE24DA1E698E2400DAE2E0 /* PBXTargetDependency */,
 				676C867526D4170100A704C1 /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				A76E10E02E1C581400A0F600 /* App Intent */,
+			);
 			name = Experimental;
 			packageProductDependencies = (
 			);
@@ -8970,6 +8981,9 @@
 				D8EC3DCF1E9BDA35006712EB /* PBXTargetDependency */,
 				D8EC3DD11E9BDA35006712EB /* PBXTargetDependency */,
 				676C867226D416FB00A704C1 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A76E10E02E1C581400A0F600 /* App Intent */,
 			);
 			name = Staging;
 			packageProductDependencies = (

--- a/Wikipedia/Code/App Intent/WikipediaSearchAppIntent.swift
+++ b/Wikipedia/Code/App Intent/WikipediaSearchAppIntent.swift
@@ -1,0 +1,56 @@
+import AppIntents
+
+@available(iOS 16.0, *)
+struct WikipediaSearchAppIntent: AppIntent {
+    static var title: LocalizedStringResource = "Search Wikipedia"
+    static var description = IntentDescription("Search for articles on Wikipedia")
+    static var openAppWhenRun: Bool = true
+    
+    @Parameter(title: "Search Term", description: "What would you like to search for on Wikipedia?")
+    var searchTerm: String?
+    
+    static var parameterSummary: some ParameterSummary {
+        Summary("Search Wikipedia for \(\.$searchTerm)")
+    }
+    
+    func perform() async throws -> some IntentResult {
+        guard let searchTerm = searchTerm?.trimmingCharacters(in: .whitespacesAndNewlines), !searchTerm.isEmpty else {
+            
+            let searchURL = URL(string: "wikipedia://search")!
+            await MainActor.run {
+                UIApplication.shared.open(searchURL)
+            }
+            return .result()
+        }
+        
+        var components = URLComponents(string: "wikipedia://search")!
+        components.queryItems = [URLQueryItem(name: "q", value: searchTerm)]
+        
+        let searchURL = components.url ?? URL(string: "wikipedia://search")!
+        
+        await MainActor.run {
+            UIApplication.shared.open(searchURL)
+        }
+        
+        return .result()
+    }
+}
+
+// MARK: - App Shortcuts Provider
+
+@available(iOS 16.0, *)
+struct WikipediaAppShortcutsProvider: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: WikipediaSearchAppIntent(),
+            phrases: [
+                "Search Wikipedia",
+                "Search \(.applicationName)",
+                "Look up on Wikipedia",
+                "Find on Wikipedia"
+            ],
+            shortTitle: "Search Wikipedia",
+            systemImageName: "magnifyingglass"
+        )
+    }
+}

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1309,10 +1309,19 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
             [self setSelectedIndex:WMFAppTabTypeRecent];
             [self.currentTabNavigationController popToRootViewControllerAnimated:animated];
             break;
-        case WMFUserActivityTypeSearch:
-            [self switchToSearchAnimated:animated];
-            [self.searchViewController makeSearchBarBecomeFirstResponder];
-            break;
+        case WMFUserActivityTypeSearch: {
+            NSString *searchTerm = [activity wmf_searchTerm];
+            if (searchTerm && searchTerm.length > 0) {
+                // If we have a search term, perform the search
+                [self dismissPresentedViewControllers];
+                [self switchToSearchAnimated:animated];
+                [self.searchViewController searchAndMakeResultsVisibleForSearchTerm:searchTerm animated:animated];
+            } else {
+                // If no search term, just open the search tab and focus the search bar
+                [self switchToSearchAnimated:animated];
+                [self.searchViewController makeSearchBarBecomeFirstResponder];
+            }
+        } break;
         case WMFUserActivityTypeSearchResults:
             [self dismissPresentedViewControllers];
             [self.searchViewController searchAndMakeResultsVisibleForSearchTerm:[activity wmf_searchTerm] animated:animated];

--- a/WikipediaUnitTests/Code/NSUserActivity+WMFExtensionsTest.m
+++ b/WikipediaUnitTests/Code/NSUserActivity+WMFExtensionsTest.m
@@ -52,5 +52,26 @@
                           @"https://en.wikipedia.org/w/index.php?search=dog&title=Special:Search&fulltext=1");
 }
 
+- (void)testBasicSearchSchemeURL {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://search"];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypeSearch);
+    XCTAssertNil([activity wmf_searchTerm]);
+}
+
+- (void)testSearchSchemeURLWithQuery {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://search?q=Einstein"];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypeSearch);
+    XCTAssertEqualObjects([activity wmf_searchTerm], @"Einstein");
+}
+
+- (void)testSearchSchemeURLWithEncodedQuery {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://search?q=Albert%20Einstein"];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypeSearch);
+    XCTAssertEqualObjects([activity wmf_searchTerm], @"Albert Einstein");
+}
+
 @end
 


### PR DESCRIPTION
**Phabricator:** 

https://phabricator.wikimedia.org/T397238

### Notes

- I implemented App Intents to expose Wikipedia's search functionality to Siri and Spotlight for iOS 16+
- I added comprehensive unit tests covering URL scheme parsing and search term extraction.

### Test Steps
1. Build and run the app on an iOS 16+ device (App Intents don't work reliably in simulator)

2. Test Siri Integration:

      - Say "Hey Siri, search Wikipedia for Einstein"
      - Say "Hey Siri, look up cats on Wikipedia"
      - Verify the app opens and automatically searches for the specified term

3. Test Spotlight Integration:

      - Open Spotlight search (swipe down on home screen)
      - Type "Wikipedia"
      - Verify "Search Wikipedia" action appears with magnifying glass icon under "Top hit"
      - Tap the action and verify the app opens to the Search tab

### Screenshots/Videos

<img src="https://github.com/user-attachments/assets/a5956f96-10eb-44c3-b903-78073d81a6cf" width="300" />

<img src="https://github.com/user-attachments/assets/1e96ee83-9514-4a6a-986b-1cb099088504" width="300" />

