### PR TITLE
Hide search widget announcement from prod

### DIFF
--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -1045,7 +1045,10 @@ extension ExploreViewController {
             updateProfileButton()
             presentYearInReviewAnnouncement()
         }
+        
+        #if DEBUG
         presentSearchWidgetAnnouncement()
+        #endif
     }
     
     private func needsYearInReviewAnnouncement() -> Bool {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T352836

### Notes
Matching https://github.com/wikimedia/wikipedia-ios/pull/5338 to temporarily hide the search widget announcement in our next release.

### Test Steps
1. Fresh install app on simulator, run Wikipedia scheme in Xcode. You will see feature announcement after onboarding dismisses.
2. Temporarily change the Wikipedia scheme build configuration to Release: ![Screenshot 2025-07-09 at 4 14 11 PM](https://github.com/user-attachments/assets/4e8ed599-bdfe-481f-86aa-acb0b2c4b515)
3. Repeat step 1. You should not see the feature announcement after onboarding dismisses.

