### PR TITLE
Bug - Fix nav bar leading button assigment

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Extensions/Navigation Bar/WMFNavigationBarConfiguring.swift
+++ b/WMFComponents/Sources/WMFComponents/Extensions/Navigation Bar/WMFNavigationBarConfiguring.swift
@@ -204,12 +204,6 @@ public extension WMFNavigationBarConfiguring where Self: UIViewController {
             
             var rightBarButtonItems: [UIBarButtonItem] = []
             
-            var profileLeadingButton: UIBarButtonItem? = profileButtonConfig.leadingBarButtonItem
-            
-            if let tabsButtonConfig {
-                profileLeadingButton = tabsButtonConfig.leadingBarButtonItem
-            }
-            
             let image = profileButtonImage(theme: WMFAppEnvironment.current.theme, needsBadge: profileButtonConfig.needsBadge)
             let profileButton = UIBarButtonItem(image: image, style: .plain, target: profileButtonConfig.target, action: profileButtonConfig.action)
             
@@ -217,10 +211,6 @@ public extension WMFNavigationBarConfiguring where Self: UIViewController {
             profileButton.accessibilityIdentifier = profileButtonAccessibilityID
             
             rightBarButtonItems.append(profileButton)
-
-            if let profileLeadingButton {
-                rightBarButtonItems.append(profileLeadingButton)
-            }
             
             if let tabsButtonConfig {
                 
@@ -236,7 +226,6 @@ public extension WMFNavigationBarConfiguring where Self: UIViewController {
             }
             
             navigationItem.rightBarButtonItems = rightBarButtonItems
-            
         }
         
         // Setup close button if needed


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T399971

### Notes
*  Fix the assignment of the leading button on the navigation bar to avoid duplication
* With the release of tabs bar to all, the leading bar assignment was being duplicated and causing a crash when trying to insert the items in the rightBarButtonItems array

### Test Steps
1. Run the app, click on all tabs quickly - make sure no buttons are duplicated, especially on the places, saved and history tabs, which contain a leading button item
2. Make sure nothing crashes and all buttons work normally

