### PR TITLE
Fix iPad sharing crash

### DIFF
--- a/Wikipedia/Code/ArticleViewController+ArticlePreviewing.swift
+++ b/Wikipedia/Code/ArticleViewController+ArticlePreviewing.swift
@@ -17,9 +17,13 @@ extension ArticleViewController: ArticlePreviewingDelegate {
     }
     
     @objc func shareArticlePreviewActionSelected(with peekController: ArticlePeekPreviewViewController, shareActivityController: UIActivityViewController) {
+        if let popover = shareActivityController.popoverPresentationController {
+            popover.sourceView = peekController.view
+            popover.sourceRect = peekController.view.bounds
+        }
         present(shareActivityController, animated: true, completion: nil)
     }
-    
+
     @objc func viewOnMapArticlePreviewActionSelected(with peekController: ArticlePeekPreviewViewController) {
         let placesURL = NSUserActivity.wmf_URLForActivity(of: .places, withArticleURL: peekController.articleURL)
         UIApplication.shared.open(placesURL, options: [:], completionHandler: nil)

--- a/Wikipedia/Code/ColumnarCollectionViewController.swift
+++ b/Wikipedia/Code/ColumnarCollectionViewController.swift
@@ -539,6 +539,10 @@ extension ColumnarCollectionViewController: ArticlePreviewingDelegate {
     }
     
     @objc func shareArticlePreviewActionSelected(with peekController: ArticlePeekPreviewViewController, shareActivityController: UIActivityViewController) {
+        if let popover = shareActivityController.popoverPresentationController {
+            popover.sourceView = peekController.view
+            popover.sourceRect = peekController.view.bounds
+        }
         present(shareActivityController, animated: true, completion: nil)
     }
     

--- a/Wikipedia/Code/ExploreCardViewController.swift
+++ b/Wikipedia/Code/ExploreCardViewController.swift
@@ -656,6 +656,10 @@ extension ExploreCardViewController: ArticlePreviewingDelegate {
     }
     
     func shareArticlePreviewActionSelected(with peekController: ArticlePeekPreviewViewController, shareActivityController: UIActivityViewController) {
+        if let popover = shareActivityController.popoverPresentationController {
+            popover.sourceView = peekController.view
+            popover.sourceRect = peekController.view.bounds
+        }
         present(shareActivityController, animated: true, completion: nil)
     }
     


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T400922

### Notes
* Fixes the crash on the share popover 
* important: doesn't handle the popover source correctly. That would be more time-consuming, so I focused on fixing the crash only

### Test Steps
1. Long-press items on explore feed, saved articles and article links
2. Hit share
3. It should not crash, a popover should appear (in a weird position, but still fully usable)


