### PR TITLE
Fix tab bar disappearance bug

### DIFF
--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -547,6 +547,14 @@ class ArticleViewController: ThemeableViewController, HintPresenting, UIScrollVi
         if let tooltips = presentedViewController as? WMFTooltipViewController {
             tooltips.dismiss(animated: true)
         }
+        
+        
+        guard #available(iOS 18.0, *),
+              UIDevice.current.userInterfaceIdiom == .pad else {
+            return
+        }
+        
+        self.tabBarController?.setTabBarHidden(false, animated: true)
     }
 
     // MARK: Article load
@@ -1207,15 +1215,18 @@ class ArticleViewController: ThemeableViewController, HintPresenting, UIScrollVi
         updateTableOfContentsHighlightIfNecessary()
 
         calculateNavigationBarHiddenState(scrollView: webView.scrollView)
+        
+        guard #available(iOS 18.0, *),
+              UIDevice.current.userInterfaceIdiom == .pad else {
+            return
+        }
 
-        if #available(iOS 18.0, *) {
-            let velocity = scrollView.panGestureRecognizer.velocity(in: scrollView).y
+        let velocity = scrollView.panGestureRecognizer.velocity(in: scrollView).y
 
-            if velocity < 0 { // Scrolling down
-                tabBarController?.setTabBarHidden(true, animated: true)
-            } else if velocity > 0 { // Scrolling up
-                tabBarController?.setTabBarHidden(false, animated: true)
-            }
+        if velocity < 0 { // Scrolling down
+            tabBarController?.setTabBarHidden(true, animated: true)
+        } else if velocity > 0 { // Scrolling up
+            tabBarController?.setTabBarHidden(false, animated: true)
         }
     }
     

--- a/Wikipedia/Code/ColumnarCollectionViewController.swift
+++ b/Wikipedia/Code/ColumnarCollectionViewController.swift
@@ -89,6 +89,16 @@ class ColumnarCollectionViewController: ThemeableViewController, ColumnarCollect
         }
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        guard #available(iOS 18.0, *),
+              UIDevice.current.userInterfaceIdiom == .pad else {
+            return
+        }
+        
+        self.tabBarController?.setTabBarHidden(false, animated: true)
+    }
+    
     open func viewWillHaveFirstAppearance(_ animated: Bool) {
         // subclassers can override
     }
@@ -392,7 +402,11 @@ class ColumnarCollectionViewController: ThemeableViewController, ColumnarCollect
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         _maxViewed = max(_maxViewed, percentViewed)
 
-        guard UIDevice.current.userInterfaceIdiom == .pad, #available(iOS 18.0, *) else { return }
+        guard #available(iOS 18.0, *),
+              UIDevice.current.userInterfaceIdiom == .pad,
+            UITraitCollection.current.horizontalSizeClass == .regular else {
+            return
+        }
 
         let velocity = scrollView.panGestureRecognizer.velocity(in: scrollView).y
         if velocity < -30 {
@@ -413,8 +427,8 @@ class ColumnarCollectionViewController: ThemeableViewController, ColumnarCollect
     }
 
     private func handleShortContentBounce(_ scrollView: UIScrollView, immediately: Bool) {
-        guard UIDevice.current.userInterfaceIdiom == .pad,
-              #available(iOS 18.0, *) else { return }
+        guard #available(iOS 18.0, *),
+              UIDevice.current.userInterfaceIdiom == .pad else { return }
 
         let visibleHeight = scrollView.bounds.height
                            - scrollView.adjustedContentInset.top


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T399741

### Notes
I think this may have been introduced in https://github.com/wikimedia/wikipedia-ios/pull/5200. To fix this, I am adding more checks for iPad and I am also asking it to unhide when navigating away from ArticleViewController and ColumnarCollectionViewController.

### Test Steps
1. Navigate to featured article on iPhone.
2.  Scroll down until the navigation bar disappears.
3. Swipe back.
4. Confirm tab bar is still visible and tappable.