### PR TITLE
Convert NSAttributedString link to URL before adding attribute

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Utility/HTMLUtils.swift
+++ b/WMFComponents/Sources/WMFComponents/Utility/HTMLUtils.swift
@@ -159,8 +159,15 @@ public struct HtmlUtils {
         // Style Link
         if let linkColor = styles.linkColor {
             for (linkRange, linkHref) in zip(allStyleData.link.completeNSRanges, allStyleData.link.targetAttributeValues) {
+                
+                // Here the href might contain special characters, making the URL invalid. We must encode it first.
+                // For example:
+                // https://en.wikipedia.org/wiki/Stephen_of_La_Ferté
+                
+                guard let url = URL(string: linkHref) else { continue }
+                
                 nsAttributedString.addAttribute(.foregroundColor, value: linkColor, range: linkRange)
-                nsAttributedString.addAttribute(.link, value: linkHref, range: linkRange)
+                nsAttributedString.addAttribute(.link, value: url, range: linkRange)
             }
         }
         

--- a/WMFComponents/Sources/WMFComponents/Utility/HTMLUtils.swift
+++ b/WMFComponents/Sources/WMFComponents/Utility/HTMLUtils.swift
@@ -160,10 +160,9 @@ public struct HtmlUtils {
         if let linkColor = styles.linkColor {
             for (linkRange, linkHref) in zip(allStyleData.link.completeNSRanges, allStyleData.link.targetAttributeValues) {
                 
-                // Here the href might contain special characters, making the URL invalid. We must encode it first.
+                // Here the linkHref might contain special characters, making linkHref invalid and crash when tapped. Turning it into a URL first automatically handles encoding.
                 // For example:
                 // https://en.wikipedia.org/wiki/Stephen_of_La_Ferté
-                
                 guard let url = URL(string: linkHref) else { continue }
                 
                 nsAttributedString.addAttribute(.foregroundColor, value: linkColor, range: linkRange)

--- a/WMFComponents/Tests/WMFComponentsTests/HtmlUtilsTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/HtmlUtilsTests.swift
@@ -35,6 +35,19 @@ final class HtmlUtilsTests: XCTestCase {
         let linkAttribute = attributed.attribute(.link, at: 0, effectiveRange: nil)
         XCTAssertNotNil(linkAttribute, "The link attribute should be present.")
     }
+    
+    func testHtmlLinkWithSpecialCharacter() throws {
+        let html = "<a rel=\"mw:WikiLink\" href=\"https://en.wikipedia.org/wiki/Stephen_of_La_Ferté\" title=\"Stephen of La Ferté\" id=\"mwFQ\">Patriarch Stephen</a>"
+        let attributed = try HtmlUtils.nsAttributedStringFromHtml(html, styles: .testStyle)
+        
+        // Preferrable that this is a URL type: https://developer.apple.com/documentation/Foundation/NSAttributedString/Key/link
+        if let linkAttributeURL = attributed.attribute(.link, at: 0, effectiveRange: nil) as? URL {
+            XCTAssertEqual(linkAttributeURL.absoluteString, "https://en.wikipedia.org/wiki/Stephen_of_La_Fert%C3%A9", "Special characters can cause crashes in UITextView - é should be encoded.")
+        } else if let linkAttributeString = attributed.attribute(.link, at: 0, effectiveRange: nil) as? String {
+            XCTAssertEqual(linkAttributeString, "https://en.wikipedia.org/wiki/Stephen_of_La_Fert%C3%A9", "Special characters can cause crashes in UITextView - é should be encoded.")
+        }
+        
+    }
 }
 
 fileprivate extension HtmlUtils.Styles {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T395708

### Notes
The attribute value assigned to .link in this NSAttributedString is a String type and looks like "https://en.wikipedia.org/wiki/Stephen_of_La_Ferté", which apparently UITextView crashes on even before the UITextView delegate `tappedLink(...)` is even called.

My original plan was to convert this string into a URL, then convert to URLComponents, extract the path, encode that path, then reconstruct the completed `hrefString` with the encoded path. But it turns out the system [prefers](https://developer.apple.com/documentation/Foundation/NSAttributedString/Key/link) a URL type for this anyways, which must automatically handle the encoding. And if you look at the SwiftUI-equivalent [area](https://github.com/wikimedia/wikipedia-ios/pull/5314/files#diff-be29e3fe09cceba8dcf2f3bda24e0728c8314a4b180e54318dadfd1e77af313eR348) in this class (AttributedString), it's already converting it to a URL.

### Test Steps
1. Confirm Arabic links do not crash in Did You Know
2. Confirm Japanese talk pages do not crash

### Screenshots/Videos

