### PR TITLE
T404102: Close Target Size

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
@@ -165,8 +165,8 @@ fileprivate struct WMFArticleTabsViewContent: View {
                     .accessibilityHidden(true)
                     .padding(.horizontal, 8)
                     .padding(.top, -8)
+                    .frame(minWidth: 48, minHeight: 48)
                     .contentShape(Rectangle())
-                    .frame(minWidth: 44, minHeight: 44)
                 }
             }
             if let newTabTitle = viewModel.localizedStrings.mainPageTitle {


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T404102

### Notes
* 

### Test Steps
1. Ensure you can close tabs easily (from a larger tap target, try tapping variety of areas around button to ensure larger target)

### Screenshots/Videos

