### PR TITLE
Do not show article tooltips if nav bar is hidden

### DIFF
--- a/Wikipedia/Code/ArticleViewController+Tooltips.swift
+++ b/Wikipedia/Code/ArticleViewController+Tooltips.swift
@@ -43,7 +43,8 @@ extension ArticleViewController {
     }
 
     @objc private func showTooltipsIfNecessary() {
-        guard let navigationBar = navigationController?.navigationBar
+        guard let navigationBar = navigationController?.navigationBar,
+              !navigationBar.isHidden
         else {
             return
         }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T403998

### Notes
* 

### Test Steps
1. Fresh install
2. Go to article, immediately scroll down, ensure tooltips do not show.
3. Go to another article, do not immediately scroll down, ensure tooltips show as before.

### Screenshots/Videos

