### PR TITLE
[YiR V3] Unfreeze + fix contribution slide

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/View Models/WMFYearInReviewContributorSlideViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/View Models/WMFYearInReviewContributorSlideViewModel.swift
@@ -25,6 +25,8 @@ public class WMFYearInReviewContributorSlideViewModel: ObservableObject, WMFYear
     public let infoURL: URL?
     @Published var isIconOn: Bool
     
+    @Published var donateButtonRect: CGRect = .zero
+    
     public init(gifName: String, altText: String, title: String, subtitle: String, loggingID: String, contributionStatus: ContributionStatus, forceHideDonateButton: Bool = false, onTappedDonateButton: @escaping (CGRect) -> Void, onToggleIcon: ((Bool) -> Void)? = nil, onInfoButtonTap: @escaping () -> Void, donateButtonTitle: String, toggleButtonTitle: String, toggleButtonSubtitle: String, isIconOn: Bool = false, infoURL: URL? = nil) {
         self.gifName = gifName
         self.altText = altText

--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/View Models/WMFYearInReviewContributorSlideViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/View Models/WMFYearInReviewContributorSlideViewModel.swift
@@ -16,7 +16,7 @@ public class WMFYearInReviewContributorSlideViewModel: ObservableObject, WMFYear
     public let contributionStatus: ContributionStatus
     public let forceHideDonateButton: Bool
     
-    public let onTappedDonateButton: (CGRect) -> Void
+    public let onTappedDonateButton: () -> Void
     public let onToggleIcon: ((Bool) -> Void)?
     public let onInfoButtonTap: () -> Void
     public let donateButtonTitle: String
@@ -25,9 +25,7 @@ public class WMFYearInReviewContributorSlideViewModel: ObservableObject, WMFYear
     public let infoURL: URL?
     @Published var isIconOn: Bool
     
-    @Published var donateButtonRect: CGRect = .zero
-    
-    public init(gifName: String, altText: String, title: String, subtitle: String, loggingID: String, contributionStatus: ContributionStatus, forceHideDonateButton: Bool = false, onTappedDonateButton: @escaping (CGRect) -> Void, onToggleIcon: ((Bool) -> Void)? = nil, onInfoButtonTap: @escaping () -> Void, donateButtonTitle: String, toggleButtonTitle: String, toggleButtonSubtitle: String, isIconOn: Bool = false, infoURL: URL? = nil) {
+    public init(gifName: String, altText: String, title: String, subtitle: String, loggingID: String, contributionStatus: ContributionStatus, forceHideDonateButton: Bool = false, onTappedDonateButton: @escaping () -> Void, onToggleIcon: ((Bool) -> Void)? = nil, onInfoButtonTap: @escaping () -> Void, donateButtonTitle: String, toggleButtonTitle: String, toggleButtonSubtitle: String, isIconOn: Bool = false, infoURL: URL? = nil) {
         self.gifName = gifName
         self.altText = altText
         self.title = title

--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/View Models/WMFYearInReviewViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/View Models/WMFYearInReviewViewModel.swift
@@ -272,7 +272,7 @@ public class WMFYearInReviewViewModel: ObservableObject {
     private(set) var introV2ViewModel: WMFYearInReviewIntroV2ViewModel?
     private(set) var introV3ViewModel: WMFYearInReviewIntroV3ViewModel?
     
-    private(set) var slides: [WMFYearInReviewSlide] // doesn't include intro
+    @Published var slides: [WMFYearInReviewSlide] // doesn't include intro
     public let shareLink: String
     public let hashtag: String
     public let plaintextURL: String
@@ -1011,6 +1011,23 @@ public class WMFYearInReviewViewModel: ObservableObject {
         }
     }
     
+    private func populateReportAndUpdateSlides() {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.populateYearInReviewReport()
+                Task { @MainActor [weak self] in
+                    
+                    guard let self else { return }
+                    
+                    self.updateSlides(isUserPermanent: isUserPermanent)
+                }
+            } catch {
+                // do nothing
+            }
+        }
+    }
+    
     private func populateReportAndShowFirstSlide() {
         isPopulatingReport = true
         Task { [weak self] in
@@ -1067,6 +1084,10 @@ public class WMFYearInReviewViewModel: ObservableObject {
     public func completedLoginFromIntroV3LoginPrompt() {
         isUserPermanent = true
         populateReportAndShowFirstSlide()
+    }
+    
+    public func donateDidSucceed() {
+        populateReportAndUpdateSlides()
     }
     
     private func incrementSlideIndex() {

--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/View Models/WMFYearInReviewViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/View Models/WMFYearInReviewViewModel.swift
@@ -265,6 +265,7 @@ public class WMFYearInReviewViewModel: ObservableObject {
         }
     }
     @Published var isShowingIntro: Bool = true
+    @Published var donateButtonRect: CGRect = .zero
     
     public let localizedStrings: LocalizedStrings
     
@@ -429,8 +430,8 @@ public class WMFYearInReviewViewModel: ObservableObject {
                                     subtitle: localizedStrings.contributorSubtitle(editCount > 0, donateCount > 0),
                                     loggingID: "", // todo
                                     contributionStatus: .contributor,
-                                    onTappedDonateButton: { [weak self] sourceRect in
-                                        self?.handleDonate(sourceRect: sourceRect)
+                                    onTappedDonateButton: { [weak self] in
+                                        self?.handleDonate()
                                     },
                                     onToggleIcon: { isOn in
                                         self.toggleAppIcon(isOn)
@@ -983,8 +984,8 @@ public class WMFYearInReviewViewModel: ObservableObject {
             loggingID: "",
             contributionStatus: .noncontributor,
             forceHideDonateButton: forceHideDonateButton,
-            onTappedDonateButton: { [weak self] sourceRect in
-                self?.handleDonate(sourceRect: sourceRect)
+            onTappedDonateButton: { [weak self] in
+                self?.handleDonate()
             },
             onInfoButtonTap: tappedInfo,
             donateButtonTitle: localizedStrings.donateButtonTitle,
@@ -1162,17 +1163,9 @@ public class WMFYearInReviewViewModel: ObservableObject {
         }
     }
     
-    func handleDonate(sourceRect: CGRect) {
-        let getSourceRect: () -> CGRect = {
-            for slide in self.slides {
-                switch slide {
-                case .contribution(let viewModel):
-                    return viewModel.donateButtonRect
-                default:
-                    continue
-                }
-            }
-            return .zero
+    func handleDonate() {
+        let getSourceRect: () -> CGRect = { [weak self] in
+            return self?.donateButtonRect ?? .zero
         }
         coordinatorDelegate?.handleYearInReviewAction(.donate(getSourceRect: getSourceRect))
         logYearInReviewDidTapDonate()

--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/View Models/WMFYearInReviewViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/View Models/WMFYearInReviewViewModel.swift
@@ -1163,7 +1163,18 @@ public class WMFYearInReviewViewModel: ObservableObject {
     }
     
     func handleDonate(sourceRect: CGRect) {
-        coordinatorDelegate?.handleYearInReviewAction(.donate(sourceRect: sourceRect))
+        let getSourceRect: () -> CGRect = {
+            for slide in self.slides {
+                switch slide {
+                case .contribution(let viewModel):
+                    return viewModel.donateButtonRect
+                default:
+                    continue
+                }
+            }
+            return .zero
+        }
+        coordinatorDelegate?.handleYearInReviewAction(.donate(getSourceRect: getSourceRect))
         logYearInReviewDidTapDonate()
     }
     

--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/Views/Slide Views/WMFYearInReviewContributionSlideView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/Views/Slide Views/WMFYearInReviewContributionSlideView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct WMFYearInReviewContributionSlideView: View {
     @ObservedObject var viewModel: WMFYearInReviewContributorSlideViewModel
+    @ObservedObject var parentViewModel: WMFYearInReviewViewModel
     @ObservedObject var appEnvironment = WMFAppEnvironment.current
     @Binding var isLoading: Bool
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -117,7 +118,7 @@ struct WMFYearInReviewContributionSlideView: View {
             
             if viewModel.contributionStatus == .noncontributor && !viewModel.forceHideDonateButton {
                 Group {
-                    Button(action: { viewModel.onTappedDonateButton(viewModel.donateButtonRect) }) {
+                    Button(action: { viewModel.onTappedDonateButton() }) {
                         Group {
                             if isLoading {
                                 ProgressView()
@@ -128,7 +129,7 @@ struct WMFYearInReviewContributionSlideView: View {
                                             Color.clear
                                                 .onAppear {
                                                     let frame = geometry.frame(in: .global)
-                                                    viewModel.donateButtonRect = frame
+                                                    parentViewModel.donateButtonRect = frame
                                                 }
                                         }
                                     )

--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/Views/Slide Views/WMFYearInReviewContributionSlideView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/Views/Slide Views/WMFYearInReviewContributionSlideView.swift
@@ -5,7 +5,6 @@ struct WMFYearInReviewContributionSlideView: View {
     @ObservedObject var appEnvironment = WMFAppEnvironment.current
     @Binding var isLoading: Bool
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @State private var buttonRect: CGRect = .zero
     
     var theme: WMFTheme {
         return appEnvironment.theme
@@ -118,12 +117,21 @@ struct WMFYearInReviewContributionSlideView: View {
             
             if viewModel.contributionStatus == .noncontributor && !viewModel.forceHideDonateButton {
                 Group {
-                    Button(action: { viewModel.onTappedDonateButton(buttonRect) }) {
+                    Button(action: { viewModel.onTappedDonateButton(viewModel.donateButtonRect) }) {
                         Group {
                             if isLoading {
                                 ProgressView()
                                     .progressViewStyle(CircularProgressViewStyle(tint: Color(uiColor: theme.destructive)))
                                     .scaleEffect(1.2)
+                                    .background(
+                                        GeometryReader { geometry in
+                                            Color.clear
+                                                .onAppear {
+                                                    let frame = geometry.frame(in: .global)
+                                                    viewModel.donateButtonRect = frame
+                                                }
+                                        }
+                                    )
                             } else {
                                 HStack(alignment: .center, spacing: 6) {
                                     if let uiImage = WMFSFSymbolIcon.for(symbol: .heartFilled, font: .semiboldHeadline) {
@@ -152,15 +160,6 @@ struct WMFYearInReviewContributionSlideView: View {
                     .padding(.horizontal, horizontalSizeClass == .regular ? 64 : 32)
                     .padding(.bottom, 16)
                     .buttonStyle(PlainButtonStyle())
-                    .background(
-                        GeometryReader { geometry in
-                            Color.clear
-                                .onAppear {
-                                    let frame = geometry.frame(in: .global)
-                                    buttonRect = frame
-                                }
-                        }
-                    )
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.top, 12)

--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/Views/Slide Views/WMFYearInReviewContributionSlideView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/Views/Slide Views/WMFYearInReviewContributionSlideView.swift
@@ -4,7 +4,6 @@ struct WMFYearInReviewContributionSlideView: View {
     @ObservedObject var viewModel: WMFYearInReviewContributorSlideViewModel
     @ObservedObject var parentViewModel: WMFYearInReviewViewModel
     @ObservedObject var appEnvironment = WMFAppEnvironment.current
-    @Binding var isLoading: Bool
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     
     var theme: WMFTheme {
@@ -120,7 +119,7 @@ struct WMFYearInReviewContributionSlideView: View {
                 Group {
                     Button(action: { viewModel.onTappedDonateButton() }) {
                         Group {
-                            if isLoading {
+                            if parentViewModel.isLoadingDonate {
                                 ProgressView()
                                     .progressViewStyle(CircularProgressViewStyle(tint: Color(uiColor: theme.destructive)))
                                     .scaleEffect(1.2)

--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/Views/WMFYearInReviewBodyView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/Views/WMFYearInReviewBodyView.swift
@@ -42,7 +42,7 @@ struct WMFYearInReviewBodyView: View {
                             WMFYearInReviewSlideHighlightsView(viewModel: highlightsViewModel)
                         }
                         if case .contribution(let contributionsViewModel) = slide {
-                            WMFYearInReviewContributionSlideView(viewModel: contributionsViewModel, isLoading: $viewModel.isLoadingDonate)
+                            WMFYearInReviewContributionSlideView(viewModel: contributionsViewModel, parentViewModel: viewModel, isLoading: $viewModel.isLoadingDonate)
                         }
                     }
                 }

--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/Views/WMFYearInReviewBodyView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/Views/WMFYearInReviewBodyView.swift
@@ -42,7 +42,7 @@ struct WMFYearInReviewBodyView: View {
                             WMFYearInReviewSlideHighlightsView(viewModel: highlightsViewModel)
                         }
                         if case .contribution(let contributionsViewModel) = slide {
-                            WMFYearInReviewContributionSlideView(viewModel: contributionsViewModel, parentViewModel: viewModel, isLoading: $viewModel.isLoadingDonate)
+                            WMFYearInReviewContributionSlideView(viewModel: contributionsViewModel, parentViewModel: viewModel)
                         }
                     }
                 }

--- a/WMFComponents/Sources/WMFComponents/Components/Year in Review/Views/WMFYearInReviewDonateButton.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Year in Review/Views/WMFYearInReviewDonateButton.swift
@@ -12,7 +12,7 @@ struct WMFYearInReviewDonateButton: View {
 
     var body: some View {
         Button(action: {
-            viewModel.handleDonate(sourceRect: buttonRect)
+            viewModel.handleDonate()
         }) {
 
             ZStack {
@@ -32,19 +32,19 @@ struct WMFYearInReviewDonateButton: View {
                     ProgressView()
                         .progressViewStyle(CircularProgressViewStyle(tint: Color(uiColor: theme.destructive)))
                         .scaleEffect(1.2)
+                        .background(
+                            GeometryReader { geometry in
+                                Color.clear
+                                    .onAppear {
+                                        let frame = geometry.frame(in: .global)
+                                        viewModel.donateButtonRect = frame
+                                    }
+                            }
+                        )
                 }
             }
         }
         .disabled(viewModel.isLoadingDonate)
-        .background(
-            GeometryReader { geometry in
-                Color.clear
-                    .onAppear {
-                        let frame = geometry.frame(in: .global)
-                        buttonRect = frame
-                    }
-            }
-        )
         .animation(.easeInOut, value: viewModel.isLoadingDonate)
     }
 

--- a/WMFComponents/Sources/WMFComponents/Coordinator/YearInReviewCoordinatorDelegate.swift
+++ b/WMFComponents/Sources/WMFComponents/Coordinator/YearInReviewCoordinatorDelegate.swift
@@ -7,7 +7,7 @@ public protocol YearInReviewCoordinatorDelegate: AnyObject {
 public enum YearInReviewCoordinatorAction {
     case tappedIntroV3GetStartedWhileLoggedOut
     case tappedIntroV3DoneWhileLoggedOut
-    case donate(sourceRect: CGRect)
+    case donate(getSourceRect: () -> CGRect)
     case share(image: UIImage)
     case dismiss(hasSeenTwoSlides: Bool)
     case introLearnMore

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewDonateCountSlideDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewDonateCountSlideDataController.swift
@@ -6,6 +6,7 @@ final class YearInReviewDonateCountSlideDataController: YearInReviewSlideDataCon
     let year: Int
     var isEvaluated: Bool = false
     static var containsPersonalizedNetworkData = false
+    static var shouldFreeze = false
     
     private let username: String?
     private let project: WMFProject?

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewMostReadCategoriesSlideDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewMostReadCategoriesSlideDataController.swift
@@ -5,6 +5,7 @@ final class YearInReviewMostReadCategoriesSlideDataController: YearInReviewSlide
     let year: Int
     var isEvaluated: Bool = false
     static var containsPersonalizedNetworkData = false
+    static var shouldFreeze = true
 
     private var mostReadCategories: [String]
 

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewMostReadDateSlideDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewMostReadDateSlideDataController.swift
@@ -5,6 +5,7 @@ final class YearInReviewMostReadDateSlideDataController: YearInReviewSlideDataCo
     let year: Int
     var isEvaluated: Bool = false
     static var containsPersonalizedNetworkData = false
+    static var shouldFreeze = true
     
     var mostReadDate: WMFPageViewDates?
 

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewSaveCountSlideDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewSaveCountSlideDataController.swift
@@ -6,6 +6,7 @@ final class YearInReviewSaveCountSlideDataController: YearInReviewSlideDataContr
     let year: Int
     var isEvaluated: Bool = false
     static var containsPersonalizedNetworkData = true
+    static var shouldFreeze = true
     
     private var savedData: SavedArticleSlideData?
     

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewSlideDataControllerFactory.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewSlideDataControllerFactory.swift
@@ -70,7 +70,7 @@ final class YearInReviewSlideDataControllerFactory {
     
     private func shouldAddSlideDataController(existingSlideIDs: Set<String>, id: WMFYearInReviewPersonalizedSlideID) -> Bool {
         
-        // If slide should not freeze it's data, always return true, which will trigger calculation each time.
+        // If slide should not freeze its data, always return true, which will trigger calculation each time.
         if !id.dataController().shouldFreeze {
             return true
         }

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewSlideDataControllerFactory.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewSlideDataControllerFactory.swift
@@ -69,6 +69,12 @@ final class YearInReviewSlideDataControllerFactory {
     }
     
     private func shouldAddSlideDataController(existingSlideIDs: Set<String>, id: WMFYearInReviewPersonalizedSlideID) -> Bool {
-        !existingSlideIDs.contains(id.rawValue)
+        
+        // If slide should not freeze it's data, always return true, which will trigger calculation each time.
+        if !id.dataController().shouldFreeze {
+            return true
+        }
+        
+        return !existingSlideIDs.contains(id.rawValue)
     }
 }

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewSlideDataControllerProtocol.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewSlideDataControllerProtocol.swift
@@ -13,6 +13,9 @@ protocol YearInReviewSlideDataControllerProtocol {
     
     /// Whether this data controller contains personalized network data (e.g. edit count, synced saved article count). If so, this data is cleared out upon logout in WMFYearInReviewDataController and will be fetched again the next time they log in.
     static var containsPersonalizedNetworkData: Bool { get }
+    
+    /// If true, populateYearInReviewReportData will always fetch and update this slide's data each time it is called. If false, populateYearInReviewReportData will skip this slide's data if it already exists in the report, essentially freezing it until the report is deleted.
+    static var shouldFreeze: Bool { get }
 
     /// Populate the slide’s data in the background context, using dependencies like saved data, page views, or edit stats.
     func populateSlideData(in context: NSManagedObjectContext) async throws

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewViewCountSlideDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/WMFYearInReviewViewCountSlideDataController.swift
@@ -5,6 +5,7 @@ final class YearInReviewViewCountSlideDataController: YearInReviewSlideDataContr
     let year: Int
     var isEvaluated: Bool = false
     static var containsPersonalizedNetworkData = true
+    static var shouldFreeze = false
     
     private var viewCount: Int?
     

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/YearInReviewEditCountSlideDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/YearInReviewEditCountSlideDataController.swift
@@ -6,6 +6,7 @@ final class YearInReviewEditCountSlideDataController: YearInReviewSlideDataContr
     let year: Int
     var isEvaluated: Bool = false
     static var containsPersonalizedNetworkData = true
+    static var shouldFreeze = false
     
     private var editCount: Int?
 

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/YearInReviewLocationSlideDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/YearInReviewLocationSlideDataController.swift
@@ -6,6 +6,7 @@ final class YearInReviewLocationSlideDataController: YearInReviewSlideDataContro
     let year: Int
     var isEvaluated: Bool = false
     static var containsPersonalizedNetworkData = false
+    static var shouldFreeze = true
     
     private var legacyPageViews: [WMFLegacyPageView]
 

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/YearInReviewReadCountSlideDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/YearInReviewReadCountSlideDataController.swift
@@ -6,6 +6,7 @@ final class YearInReviewReadCountSlideDataController: YearInReviewSlideDataContr
     let year: Int
     var isEvaluated: Bool = false
     static var containsPersonalizedNetworkData = false
+    static var shouldFreeze = true
     
     private var readData: WMFYearInReviewReadData?
 

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/YearInReviewTopArticlesSlideDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/Slide Data Controllers/YearInReviewTopArticlesSlideDataController.swift
@@ -6,6 +6,7 @@ final class YearInReviewTopReadArticleSlideDataController: YearInReviewSlideData
     let year: Int
     var isEvaluated: Bool = false
     static var containsPersonalizedNetworkData = false
+    static var shouldFreeze = true
     
     private var articles: [String]?
 

--- a/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Year In Review/WMFYearInReviewDataController.swift
@@ -412,8 +412,21 @@ import CoreData
             )!
 
             cdReport.year = Int32(year)
-
-            var finalCDSlides = cdReport.slides as? Set<CDYearInReviewSlide> ?? []
+            
+            var finalCDSlides: Set<CDYearInReviewSlide> = []
+            
+            // Only preserve existing slides that should freeze
+            for slide in cdReport.slides as? Set<CDYearInReviewSlide> ?? [] {
+                if let cdSlideID = slide.id,
+                   let slideID = WMFYearInReviewPersonalizedSlideID(rawValue: cdSlideID) {
+                    let dataController = slideID.dataController()
+                    if dataController.shouldFreeze {
+                        finalCDSlides.insert(slide)
+                    } else {
+                        backgroundContext.delete(slide)
+                    }
+                }
+            }
 
             for slideDataController in slideDataControllers where slideDataController.isEvaluated {
                 if let cdSlide = try? slideDataController.makeCDSlide(in: backgroundContext) {

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -65,13 +65,15 @@ extension ArticleViewController {
             
             let globalRect = CGRect(x: globalPoint.x, y: globalPoint.y, width: button.frame.width, height: button.frame.height)
             
-            let donateCoordinator = DonateCoordinator(navigationController: navigationController, donateButtonGlobalRect: globalRect, source: .articleCampaignModal(articleURL, asset.metricsID, donateURL), dataStore: dataStore, theme: theme, navigationStyle: .dismissThenPush, setLoadingBlock: { isLoading in
+            let getDonateButtonGlobalRect: () -> CGRect = { globalRect }
+            
+            let donateCoordinator = DonateCoordinator(navigationController: navigationController, source: .articleCampaignModal(articleURL, asset.metricsID, donateURL), dataStore: dataStore, theme: theme, navigationStyle: .dismissThenPush, setLoadingBlock: { isLoading in
                 guard let fundraisingPanelVC = viewController as? FundraisingAnnouncementPanelViewController else {
                     return
                 }
                 
                 fundraisingPanelVC.isLoading = isLoading
-            }, getDonateButtonGlobalRect: nil)
+            }, getDonateButtonGlobalRect: getDonateButtonGlobalRect)
             
             self.donateCoordinator = donateCoordinator
             donateCoordinator.start()

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -71,7 +71,7 @@ extension ArticleViewController {
                 }
                 
                 fundraisingPanelVC.isLoading = isLoading
-            })
+            }, getDonateButtonGlobalRect: nil)
             
             self.donateCoordinator = donateCoordinator
             donateCoordinator.start()

--- a/Wikipedia/Code/DonateCoordinator.swift
+++ b/Wikipedia/Code/DonateCoordinator.swift
@@ -40,14 +40,13 @@ class DonateCoordinator: Coordinator {
     // MARK: Properties
     
     var navigationController: UINavigationController
-    private let donateButtonGlobalRect: CGRect
     private let source: Source
     private let navigationStyle: NavigationStyle
     
     // Code to run when we are fetching donate configs. Typically this changes some donate button into a spinner.
     private let setLoadingBlock: (Bool) -> Void
     
-    private let getDonateButtonGlobalRect: (() -> CGRect)?
+    private let getDonateButtonGlobalRect: (() -> CGRect)
     
     private let dataStore: MWKDataStore
     private let theme: Theme
@@ -103,9 +102,8 @@ class DonateCoordinator: Coordinator {
     
     // MARK: Lifecycle
     
-    init(navigationController: UINavigationController, donateButtonGlobalRect: CGRect, source: Source, dataStore: MWKDataStore, theme: Theme, navigationStyle: NavigationStyle, setLoadingBlock: @escaping (Bool) -> Void, getDonateButtonGlobalRect: (() -> CGRect)?) {
+    init(navigationController: UINavigationController, source: Source, dataStore: MWKDataStore, theme: Theme, navigationStyle: NavigationStyle, setLoadingBlock: @escaping (Bool) -> Void, getDonateButtonGlobalRect: @escaping () -> CGRect) {
         self.navigationController = navigationController
-        self.donateButtonGlobalRect = donateButtonGlobalRect
         self.source = source
         self.dataStore = dataStore
         self.theme = theme
@@ -295,7 +293,7 @@ class DonateCoordinator: Coordinator {
         alert.overrideUserInterfaceStyle = theme.isDark ? .dark : .light
 
         alert.popoverPresentationController?.sourceView = navigationController.view
-        let sourceRect = getDonateButtonGlobalRect?() ?? donateButtonGlobalRect
+        let sourceRect = getDonateButtonGlobalRect()
         alert.popoverPresentationController?.sourceRect = sourceRect
         
         viewControllerToPresentActionSheet?.present(alert, animated: true)

--- a/Wikipedia/Code/DonateCoordinator.swift
+++ b/Wikipedia/Code/DonateCoordinator.swift
@@ -47,6 +47,8 @@ class DonateCoordinator: Coordinator {
     // Code to run when we are fetching donate configs. Typically this changes some donate button into a spinner.
     private let setLoadingBlock: (Bool) -> Void
     
+    private let getDonateButtonGlobalRect: (() -> CGRect)?
+    
     private let dataStore: MWKDataStore
     private let theme: Theme
     
@@ -101,7 +103,7 @@ class DonateCoordinator: Coordinator {
     
     // MARK: Lifecycle
     
-    init(navigationController: UINavigationController, donateButtonGlobalRect: CGRect, source: Source, dataStore: MWKDataStore, theme: Theme, navigationStyle: NavigationStyle, setLoadingBlock: @escaping (Bool) -> Void) {
+    init(navigationController: UINavigationController, donateButtonGlobalRect: CGRect, source: Source, dataStore: MWKDataStore, theme: Theme, navigationStyle: NavigationStyle, setLoadingBlock: @escaping (Bool) -> Void, getDonateButtonGlobalRect: (() -> CGRect)?) {
         self.navigationController = navigationController
         self.donateButtonGlobalRect = donateButtonGlobalRect
         self.source = source
@@ -109,6 +111,7 @@ class DonateCoordinator: Coordinator {
         self.theme = theme
         self.navigationStyle = navigationStyle
         self.setLoadingBlock = setLoadingBlock
+        self.getDonateButtonGlobalRect = getDonateButtonGlobalRect
     }
     
     static func metricsID(for donateSource: Source, languageCode: String?) -> String? {
@@ -292,7 +295,8 @@ class DonateCoordinator: Coordinator {
         alert.overrideUserInterfaceStyle = theme.isDark ? .dark : .light
 
         alert.popoverPresentationController?.sourceView = navigationController.view
-        alert.popoverPresentationController?.sourceRect = donateButtonGlobalRect
+        let sourceRect = getDonateButtonGlobalRect?() ?? donateButtonGlobalRect
+        alert.popoverPresentationController?.sourceRect = sourceRect
         
         viewControllerToPresentActionSheet?.present(alert, animated: true)
     }

--- a/Wikipedia/Code/DonateCoordinator.swift
+++ b/Wikipedia/Code/DonateCoordinator.swift
@@ -47,6 +47,7 @@ class DonateCoordinator: Coordinator {
     private let setLoadingBlock: (Bool) -> Void
     
     private let getDonateButtonGlobalRect: (() -> CGRect)
+    private let donateSuccessAction: (() -> Void)?
     
     private let dataStore: MWKDataStore
     private let theme: Theme
@@ -102,7 +103,7 @@ class DonateCoordinator: Coordinator {
     
     // MARK: Lifecycle
     
-    init(navigationController: UINavigationController, source: Source, dataStore: MWKDataStore, theme: Theme, navigationStyle: NavigationStyle, setLoadingBlock: @escaping (Bool) -> Void, getDonateButtonGlobalRect: @escaping () -> CGRect) {
+    init(navigationController: UINavigationController, source: Source, dataStore: MWKDataStore, theme: Theme, navigationStyle: NavigationStyle, setLoadingBlock: @escaping (Bool) -> Void, getDonateButtonGlobalRect: @escaping () -> CGRect, donateSuccessAction: (() -> Void)? = nil) {
         self.navigationController = navigationController
         self.source = source
         self.dataStore = dataStore
@@ -110,6 +111,7 @@ class DonateCoordinator: Coordinator {
         self.navigationStyle = navigationStyle
         self.setLoadingBlock = setLoadingBlock
         self.getDonateButtonGlobalRect = getDonateButtonGlobalRect
+        self.donateSuccessAction = donateSuccessAction
     }
     
     static func metricsID(for donateSource: Source, languageCode: String?) -> String? {
@@ -467,10 +469,12 @@ extension DonateCoordinator: DonateCoordinatorDelegate {
             showTaxDeductibilityInformation()
         case .nativeFormDidTriggerPaymentSuccess:
             popAndShowSuccessToastFromNativeForm()
+            donateSuccessAction?()
         case .webViewFormThankYouDidTapReturn:
             popFromWebFormThankYouPage()
         case .webViewFormThankYouDidDisappear:
             displayThankYouToastAfterDelay()
+            donateSuccessAction?()
         }
     }
     

--- a/Wikipedia/Code/ProfileCoordinator.swift
+++ b/Wikipedia/Code/ProfileCoordinator.swift
@@ -246,9 +246,14 @@ final class ProfileCoordinator: NSObject, Coordinator, ProfileCoordinatorDelegat
             return
         }
         
-        let donateCoordinator = DonateCoordinator(navigationController: navigationController, donateButtonGlobalRect: targetRects.donateButtonFrame, source: donateSouce, dataStore: dataStore, theme: theme, navigationStyle: .dismissThenPush, setLoadingBlock: { isLoading in
+        let getDonateButtonGlobalRect: () -> CGRect = { [weak self] in
+            
+            self?.targetRects.donateButtonFrame ?? .zero
+        }
+        
+        let donateCoordinator = DonateCoordinator(navigationController: navigationController, source: donateSouce, dataStore: dataStore, theme: theme, navigationStyle: .dismissThenPush, setLoadingBlock: { isLoading in
             viewModel.isLoadingDonateConfigs = isLoading
-        }, getDonateButtonGlobalRect: nil)
+        }, getDonateButtonGlobalRect: getDonateButtonGlobalRect)
         
         donateCoordinator.start()
         

--- a/Wikipedia/Code/ProfileCoordinator.swift
+++ b/Wikipedia/Code/ProfileCoordinator.swift
@@ -248,7 +248,7 @@ final class ProfileCoordinator: NSObject, Coordinator, ProfileCoordinatorDelegat
         
         let donateCoordinator = DonateCoordinator(navigationController: navigationController, donateButtonGlobalRect: targetRects.donateButtonFrame, source: donateSouce, dataStore: dataStore, theme: theme, navigationStyle: .dismissThenPush, setLoadingBlock: { isLoading in
             viewModel.isLoadingDonateConfigs = isLoading
-        })
+        }, getDonateButtonGlobalRect: nil)
         
         donateCoordinator.start()
         

--- a/Wikipedia/Code/SinglePageWebViewController.swift
+++ b/Wikipedia/Code/SinglePageWebViewController.swift
@@ -344,7 +344,7 @@ class SinglePageWebViewController: ThemeableViewController, WMFNavigationBarConf
                 navigationStyle: .push,
                 setLoadingBlock: { [weak self] isLoading in
                     self?.setOverlayButtonLoading(isLoading)
-            })
+                }, getDonateButtonGlobalRect: nil)
             coordinator.start()
             config.donateCoordinator = coordinator
         case .standard:

--- a/Wikipedia/Code/SinglePageWebViewController.swift
+++ b/Wikipedia/Code/SinglePageWebViewController.swift
@@ -335,16 +335,19 @@ class SinglePageWebViewController: ThemeableViewController, WMFNavigationBarConf
                 DonateFunnel.shared.logYearInReviewDonateSlideLearnMoreWebViewDidTapDonateButton(metricsID: metricsID)
             }
             
+            let getDonateButtonGlobalRect: () -> CGRect = { [weak self] in
+                return self?.overlayButtonContainer.frame ?? .zero
+            }
+            
             let coordinator = DonateCoordinator(
                 navigationController: navigationController,
-                donateButtonGlobalRect: overlayButtonContainer.frame,
                 source: .yearInReview,
                 dataStore: dataStore,
                 theme: theme,
                 navigationStyle: .push,
                 setLoadingBlock: { [weak self] isLoading in
                     self?.setOverlayButtonLoading(isLoading)
-                }, getDonateButtonGlobalRect: nil)
+                }, getDonateButtonGlobalRect: getDonateButtonGlobalRect)
             coordinator.start()
             config.donateCoordinator = coordinator
         case .standard:

--- a/Wikipedia/Code/YearInReviewCoordinator.swift
+++ b/Wikipedia/Code/YearInReviewCoordinator.swift
@@ -844,6 +844,11 @@ extension YearInReviewCoordinator: YearInReviewCoordinatorDelegate {
         case .tappedIntroV3DoneWhileLoggedOut:
             showExitConfirmationPromptFromIntroV3Done()
         case .donate(let getSourceRect):
+            
+            let donateSuccessAction: () -> Void = { [weak self] in
+                self?.viewModel?.donateDidSucceed()
+            }
+            
             let donateCoordinator = DonateCoordinator(navigationController: navigationController, source: .yearInReview, dataStore: dataStore, theme: theme, navigationStyle: .present, setLoadingBlock: {  [weak self] loading in
                 guard let self,
                       let viewModel = self.viewModel else {
@@ -851,7 +856,7 @@ extension YearInReviewCoordinator: YearInReviewCoordinatorDelegate {
                 }
 
                 viewModel.isLoadingDonate = loading
-            }, getDonateButtonGlobalRect: getSourceRect)
+            }, getDonateButtonGlobalRect: getSourceRect, donateSuccessAction: donateSuccessAction)
 
             self.donateCoordinator = donateCoordinator
             donateCoordinator.start()

--- a/Wikipedia/Code/YearInReviewCoordinator.swift
+++ b/Wikipedia/Code/YearInReviewCoordinator.swift
@@ -843,15 +843,15 @@ extension YearInReviewCoordinator: YearInReviewCoordinatorDelegate {
             showLoginPromptFromIntroV3GetStarted()
         case .tappedIntroV3DoneWhileLoggedOut:
             showExitConfirmationPromptFromIntroV3Done()
-        case .donate(let rect):
-            let donateCoordinator = DonateCoordinator(navigationController: navigationController, donateButtonGlobalRect: rect, source: .yearInReview, dataStore: dataStore, theme: theme, navigationStyle: .present, setLoadingBlock: {  [weak self] loading in
+        case .donate(let getSourceRect):
+            let donateCoordinator = DonateCoordinator(navigationController: navigationController, donateButtonGlobalRect: .zero, source: .yearInReview, dataStore: dataStore, theme: theme, navigationStyle: .present, setLoadingBlock: {  [weak self] loading in
                 guard let self,
                       let viewModel = self.viewModel else {
                     return
                 }
 
                 viewModel.isLoadingDonate = loading
-            })
+            }, getDonateButtonGlobalRect: getSourceRect)
 
             self.donateCoordinator = donateCoordinator
             donateCoordinator.start()

--- a/Wikipedia/Code/YearInReviewCoordinator.swift
+++ b/Wikipedia/Code/YearInReviewCoordinator.swift
@@ -844,7 +844,7 @@ extension YearInReviewCoordinator: YearInReviewCoordinatorDelegate {
         case .tappedIntroV3DoneWhileLoggedOut:
             showExitConfirmationPromptFromIntroV3Done()
         case .donate(let getSourceRect):
-            let donateCoordinator = DonateCoordinator(navigationController: navigationController, donateButtonGlobalRect: .zero, source: .yearInReview, dataStore: dataStore, theme: theme, navigationStyle: .present, setLoadingBlock: {  [weak self] loading in
+            let donateCoordinator = DonateCoordinator(navigationController: navigationController, source: .yearInReview, dataStore: dataStore, theme: theme, navigationStyle: .present, setLoadingBlock: {  [weak self] loading in
                 guard let self,
                       let viewModel = self.viewModel else {
                     return


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
This PR improves the location of the donate button popover that displays on iPad. It was often off on the contribution slide due to the moment it calculated the donate button frame.

This PR also unfreezes the donate and editing slides, so that they now recalculate each time a user enters the feature. This allows users to donate in the feature and see their app icon become unlocked immediately.

### Test Steps
1. On iPad simulator, fresh install, enable YiR v3 via developer settings. Also enable "Bypass donation".
2. Go to contribution slide, see that it is in a non-contributor state.
3. Tap donate button, ensure popover points to donate button.
4. Go through donation flow, successfully submit a donation.
5. Ensure slide refreshes to show contributor state.

### Screenshots/Videos

https://github.com/user-attachments/assets/66bf1163-6b01-4b0a-9d38-4b0719e00937


