### PR TITLE
T402752: Inserting links when editing - no search results

### DIFF
--- a/WMF Framework/HasText.swift
+++ b/WMF Framework/HasText.swift
@@ -3,7 +3,7 @@ extension String {
         return !isEmpty
     }
     public var wmf_hasNonWhitespaceText: Bool {
-        return wmf_hasText && !self.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return wmf_hasText && !self.trimmingCharacters(in: .whitespaces).isEmpty
     }
     public var wmf_hasAlphanumericText: Bool {
         return wmf_hasText && (self.components(separatedBy: .alphanumerics).count > 1)


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T402752

### Notes
I narrowed down the problem which is that the search function doesn't recognize strings of text pulled from the page when editing as non-whitespace text and therefore will not initiate properly unless the user adds something (even just a space), thereby making the function recognise the string as non-whitespace and then working as intended. 

(reposted PR as correctly formatted)