### PR TITLE
[TABS] Loading fix

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
@@ -185,7 +185,7 @@ public struct WMFArticleTabsView: View {
                 }
                 .frame(width: geometry.size.width, height: geometry.size.height, alignment: .center)
             }
-            .background(Color(theme.paperBackground))
+            .background(Color(theme.midBackground))
             .scrollBounceBehavior(.always)
         }
     }

--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
@@ -20,7 +20,7 @@ public struct WMFArticleTabsView: View {
     /// Flag to allow us to know if we can scroll to the current tab position
     @State private var isReady: Bool = false
     @State private var cellFrames: [String: CGRect] = [:]
-//    @State private var revealFallbackTriggered: Bool = false
+    @State private var hideLoadingWithDelay = false
 
     public init(viewModel: WMFArticleTabsViewModel) {
         self.viewModel = viewModel
@@ -51,7 +51,7 @@ public struct WMFArticleTabsView: View {
                     }
                 }
 
-                if !shouldHideLoading {
+                if !hideLoadingWithDelay {
                     loadingOverlay
                 }
             }
@@ -70,7 +70,15 @@ public struct WMFArticleTabsView: View {
                 viewModel.maybeStartSecondaryLoads()
             }
         }
-
+        .onChange(of: shouldHideLoading) { ready in
+            guard ready else { return }
+            Task {
+                try? await Task.sleep(nanoseconds: 250_000_000)
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    hideLoadingWithDelay = true
+                }
+            }
+        }
         .background(Color(theme.midBackground))
         .onAppear {
             if viewModel.shouldShowTabsV2 {

--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsView.swift
@@ -21,9 +21,6 @@ public struct WMFArticleTabsView: View {
     @State private var isReady: Bool = false
     @State private var cellFrames: [String: CGRect] = [:]
 
-    @State private var didInitialScroll: Bool = false
-    @State private var didCompensationScroll: Bool = false
-
     public init(viewModel: WMFArticleTabsViewModel) {
         self.viewModel = viewModel
     }
@@ -107,13 +104,7 @@ public struct WMFArticleTabsView: View {
             .animation(.default, value: shouldShowRecs || shouldShowDYK)
         }
     }
-
-    private func areRecommendationsVisible() -> Bool {
-        let recReady = (viewModel.recommendedArticlesViewModel != nil)
-        let recVisible = viewModel.shouldShowSuggestions && viewModel.shouldShowTabsV2 && viewModel.hasMultipleTabs && recReady
-        return recVisible
-    }
-
+    
     // MARK: - Loading / Empty
 
     private var loadingView: some View {
@@ -176,7 +167,7 @@ public struct WMFArticleTabsView: View {
                 .onAppear {
                     Task {
                         if let id = viewModel.currentTabID {
-                            proxy.scrollTo(id, anchor: .bottom)
+                            proxy.scrollTo(id, anchor: .center)
                         }
                     }
                 }
@@ -248,24 +239,18 @@ public struct WMFArticleTabsView: View {
                 }
                 .padding(.horizontal, 8)
                 .onAppear {
-                    guard !didInitialScroll else { return }
-                    didInitialScroll = true
-
                     Task { @MainActor in
-                        try? await Task.sleep(nanoseconds: 150_000_000)
                         if let id = viewModel.currentTabID {
-                            proxy.scrollTo(id, anchor: .bottom)
+                            proxy.scrollTo(id, anchor: .center)
                         }
                     }
                 }
             }
-            .onChange(of: areRecommendationsVisible()) { visible in
-                guard visible, !didCompensationScroll else { return }
-                didCompensationScroll = true
+            .onChange(of: viewModel.recLoaded) { recLoaded in
+                guard recLoaded else { return }
                 Task { @MainActor in
-                    try? await Task.sleep(nanoseconds: 100_000_000)
                     if let id = viewModel.currentTabID {
-                        proxy.scrollTo(id, anchor: .bottom)
+                        proxy.scrollTo(id, anchor: .center)
                     }
                 }
             }

--- a/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Article Tabs/WMFArticleTabsViewModel.swift
@@ -28,7 +28,12 @@ public class WMFArticleTabsViewModel: NSObject, ObservableObject {
     @Published public var hasMultipleTabs: Bool = false
 
     @Published var didYouKnowViewModel: WMFTabsOverviewDidYouKnowViewModel?
-    @Published var recommendedArticlesViewModel: WMFTabsOverviewRecommendationsViewModel?
+    @Published var recommendedArticlesViewModel: WMFTabsOverviewRecommendationsViewModel? {
+        didSet {
+            recLoaded = recommendedArticlesViewModel != nil
+        }
+    }
+    @Published var recLoaded: Bool = false
 
     @Published public var loadDidYouKnowViewModel: (@MainActor () async -> WMFTabsOverviewDidYouKnowViewModel?)?
     @Published public var loadRecommendationsViewModel: (@MainActor () async -> WMFTabsOverviewRecommendationsViewModel?)?


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T407912

### Notes
* Now the loading view, in V2,  adds a loding overlay so we wait until all the data is ready
* Should not change behavior for V1

### Test Steps
1. Run the app in tabs group B or C
2. Add several tabs (10+), make a tab from the bottom row current.
3. Open and close tabs overview - the loading state should disappear when the view is ready - tabs are loaded and current tab is in position, the bottom view is loaded. You should not see the flash of scroll.
4. Make other tabs current, check behavior
5. Enable and disable the bottom view, make sure it works properly
6. Close all tabs, make sure the empty state shows correctly


