### PR TITLE
Fix iPadOS 26 Search > History tooltip

### DIFF
--- a/Wikipedia/Code/AppViewControllerTipWrapper.swift
+++ b/Wikipedia/Code/AppViewControllerTipWrapper.swift
@@ -38,6 +38,22 @@ import WMFComponents
         (appViewController.currentTabNavigationController?.viewControllers.count ?? 0) == 1 else {
             return
         }
+        
+        // It seems like tabBarItem does not have a recognizable frame on iPad for TipUIPopoverViewController to point to. We are going to add a fake view that is about the area of the center of the tab bar, and remove the popover arrows.
+
+        var targetViewIPad: UIView? = nil
+        if #available(iOS 26, *) {
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                appViewController.view.addSubview(tabSearchTargetViewIPad)
+                NSLayoutConstraint.activate([
+                    appViewController.view.centerXAnchor.constraint(equalTo: tabSearchTargetViewIPad.centerXAnchor, constant: 0),
+                    appViewController.view.topAnchor.constraint(equalTo: tabSearchTargetViewIPad.topAnchor, constant: -150),
+                    tabSearchTargetViewIPad.widthAnchor.constraint(equalToConstant: 1),
+                    tabSearchTargetViewIPad.heightAnchor.constraint(equalToConstant: 1)
+                ])
+                targetViewIPad = tabSearchTargetViewIPad
+            }
+        }
 
         tipObservationTask =  Task { @MainActor [weak self, weak appViewController] in
             guard let self, let appViewController else { return }
@@ -45,8 +61,16 @@ import WMFComponents
             for await status in tip.statusUpdates {
                 if status == .available {
                     
-                    let popoverController = TipUIPopoverViewController(tip, sourceItem: searchTabBarItem)
+                    let popoverController = TipUIPopoverViewController(tip, sourceItem: targetViewIPad ?? searchTabBarItem)
                     popoverController.overrideUserInterfaceStyle = appViewController.theme.isDark ? .dark : .light
+                    
+                    if #available(iOS 26, *) {
+                        if UIDevice.current.userInterfaceIdiom == .pad {
+                            popoverController.view.tintColor = appViewController.theme.colors.secondaryText
+                            popoverController.popoverPresentationController?.permittedArrowDirections = []
+                        }
+                    }
+                    
                     self.tooltipVC = popoverController
                     appViewController.present(popoverController, animated: true) {
                         popoverController.presentationController?.delegate = self
@@ -93,6 +117,14 @@ fileprivate struct HistoryInSearchTip: Tip {
     }
     
     var image: SwiftUI.Image? {
+        if #available(iOS 26, *) {
+            if UIDevice.current.userInterfaceIdiom == .pad,
+            let iconName = WMFSFSymbolIcon.magnifyingGlass.name {
+                return Image(systemName: iconName)
+            } else {
+                return nil
+            }
+        }
         return nil
     }
 }


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
When bringing `main` changes into `liquid-glass`, I missed an iPad26 workaround for displaying the Search > History tooltip in a centered manner. This should fix it.

### Test Steps
1. Fresh install on iPadOS 26.
2. You should see tooltip on Explore centered below floating tab bar.

Background: https://wikimedia.slack.com/archives/C4DDMJ9CH/p1772827252332369

### Screenshots
<img width="403" height="559" alt="Screenshot 2026-03-31 at 10 25 28 AM" src="https://github.com/user-attachments/assets/0d6edf51-5d94-4a26-bc6c-f1373ef92197" />

