### PR TITLE
Fix article toolbar theming bug

### DIFF
--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -1420,6 +1420,7 @@ private extension ArticleViewController {
 
     func setupToolbar() {
         toolbarController = ArticleToolbarController(delegate: self)
+        toolbarController?.apply(theme: theme)
         navigationController?.setToolbarHidden(false, animated: false)
     }
 


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T421327

### Notes
Fix article toolbar theming bug. In viewDidLoad's applyTheme call, the toolbar was not yet created. Adding the call upon toolbar creation fixes it.

### Test Steps
1. Set dark or black theme.
2. Visit article
3. Confirm toolbar is properly themed.

