### PR TITLE
Fix reading list toast display bug

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFReadingListToastPresenter.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFReadingListToastPresenter.swift
@@ -36,7 +36,8 @@ final public class WMFReadingListToastPresenter {
     // MARK: - Public API
 
     public var isToastHidden: Bool {
-        currentToastContainer?.superview == nil
+        currentToastContainer?.superview == nil ||
+        currentToastContainer?.window == nil // indicates it is on screen somewhere but not currently visible
     }
 
     /// Show a toast anchored to a specific view controller


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T421419

### Notes
It seemed like the reading list toast system thought the toast was still on screen, and so was trying to update the toast content in place. Checking for this window var allows it to present again on the new article.

### Test Steps
1. Go to article, save article
2. While toast is displaying, tap link
3. Save new article, toast should display.

### Screenshots/Videos

