### PR TITLE
Smooth over article toolbar transition

### DIFF
--- a/Wikipedia/Code/ArticleToolbarController.swift
+++ b/Wikipedia/Code/ArticleToolbarController.swift
@@ -94,6 +94,18 @@ class ArticleToolbarController: Themeable {
 
     private func createMoreButton(needsWatchButton: Bool = false, needsUnwatchHalfButton: Bool = false, needsUnwatchFullButton: Bool = false, previousArticleTab: WMFArticleTabsDataController.WMFArticle? = nil, nextArticleTab: WMFArticleTabsDataController.WMFArticle? = nil) -> IconBarButtonItem {
 
+        
+        let moreImage = WMFSFSymbolIcon.for(symbol: .ellipsisCircle)?.withConfiguration(UIImage.SymbolConfiguration(weight: .light))
+        
+        let menu = createMoreMenu(needsWatchButton: needsWatchButton, needsUnwatchHalfButton: needsUnwatchHalfButton, needsUnwatchFullButton: needsUnwatchFullButton, previousArticleTab: previousArticleTab, nextArticleTab: nextArticleTab)
+
+        let item = IconBarButtonItem(image: moreImage, menu: menu)
+
+        item.accessibilityLabel = CommonStrings.moreButton
+        return item
+    }
+    
+    private func createMoreMenu(needsWatchButton: Bool = false, needsUnwatchHalfButton: Bool = false, needsUnwatchFullButton: Bool = false, previousArticleTab: WMFArticleTabsDataController.WMFArticle? = nil, nextArticleTab: WMFArticleTabsDataController.WMFArticle? = nil) -> UIMenu {
         var actions: [UIAction] = []
 
         let image = WMFIcon.pencil
@@ -138,19 +150,25 @@ class ArticleToolbarController: Themeable {
         }
 
         let menu = UIMenu(title: "", options: .displayInline, children: actions)
-
-        let moreImage = WMFSFSymbolIcon.for(symbol: .ellipsisCircle)?.withConfiguration(UIImage.SymbolConfiguration(weight: .light))
-
-        let item = IconBarButtonItem(image: moreImage, menu: menu)
-
-        item.accessibilityLabel = CommonStrings.moreButton
-        return item
+        return menu
     }
 
     func updateMoreButton(needsWatchButton: Bool = false, needsUnwatchHalfButton: Bool = false, needsUnwatchFullButton: Bool = false, previousArticleTab: WMFArticleTabsDataController.WMFArticle?, nextArticleTab: WMFArticleTabsDataController.WMFArticle?) {
-        self.moreButton = createMoreButton(needsWatchButton: needsWatchButton, needsUnwatchHalfButton: needsUnwatchHalfButton, needsUnwatchFullButton: needsUnwatchFullButton, previousArticleTab: previousArticleTab, nextArticleTab: nextArticleTab)
+        
+        let updatedMenu = createMoreMenu(
+            needsWatchButton: needsWatchButton,
+            needsUnwatchHalfButton: needsUnwatchHalfButton,
+            needsUnwatchFullButton: needsUnwatchFullButton,
+            previousArticleTab: previousArticleTab,
+            nextArticleTab: nextArticleTab
+        )
+        if let button = moreButton.customView as? UIButton {
+            button.menu = updatedMenu
+        } else {
+            moreButton.menu = updatedMenu
+        }
+        
         moreButton.apply(theme: theme)
-        update()
     }
 
     var moreButtonSourceView: UIView? {

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -523,8 +523,12 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
+        if let _ = navigationController?.viewControllers.last as? ArticleViewController {
+            // We are moving to another ArticleViewController. Not hiding the system toolbar for a smoother transition.
+        } else {
+            navigationController?.setToolbarHidden(true, animated: true)
+        }
         
-        navigationController?.setToolbarHidden(true, animated: true)
         wTipObservationTask?.cancel()
         wTipObservationTask = nil
         saveArticleScrollPosition()


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
Something I noticed when debugging article toasts - we are losing the liquid glass bottom toolbar transition because we hide the toolbar upon Article disappearance no matter what. If we don't hide it when moving to another Article, the transition looks more blobby (though that may not be desired).

The more menu button changes are slighter than they look - when we need to update it (like with watch status), we are replacing the context menu rather than re-creating the entire more button again (which also caused transition weirdness).

Just a suggestion, there's no bug / design review task associated with this.

Old:
https://github.com/user-attachments/assets/6846f1a5-d60e-47dd-aea4-8aba12607c64

New:
https://github.com/user-attachments/assets/d4407dbe-3cbe-4b6d-be42-e220b77cb03c