### PR TITLE
Add disabled colors to login button

### DIFF
--- a/Wikipedia/Code/WMFAuthButton.swift
+++ b/Wikipedia/Code/WMFAuthButton.swift
@@ -52,6 +52,20 @@ class WMFAuthButton: AutoLayoutSafeMultiLineButton, Themeable {
         config.titleAlignment = .center
 
         configuration = config
+        
+        configurationUpdateHandler = { [weak self] button in
+            guard let self, var config = button.configuration else { return }
+
+            if button.state == .disabled {
+                config.background.backgroundColor = self.theme.colors.baseBackground
+                config.baseForegroundColor = self.theme.colors.inputAccessoryButtonTint
+            } else {
+                config.background.backgroundColor = self.theme.colors.link
+                config.baseForegroundColor = self.theme.colors.paperBackground
+            }
+
+            button.configuration = config
+        }
 
         invalidateIntrinsicContentSize()
         setNeedsLayout()


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T417006#11779655

### Notes
Fixes disabled state colors for WMFAuth button.

### Test Steps
1. Easiest to test from login view controller, but also can be tested from other areas like create a new reading list (from toast), create account, article description editor, etc.
