### PR TITLE
Fix email auth login button theme

### DIFF
--- a/Wikipedia/Code/WMFTwoFactorPasswordViewController.swift
+++ b/Wikipedia/Code/WMFTwoFactorPasswordViewController.swift
@@ -413,5 +413,7 @@ class WMFTwoFactorPasswordViewController: WMFScrollViewController, UITextFieldDe
         
         displayModeToggle.textColor = theme.colors.link
         subTitleLabel.textColor = theme.colors.secondaryText
+        
+        loginButton.apply(theme: theme)
     }
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T417006

### Notes
Followup on https://github.com/wikimedia/wikipedia-ios/pull/5775. I noticed the email auth code button looked wrong for darker themes, this fixes it.

### Test Steps (optional)
1. Enable "email auth" developer settings toggle. Set theme to dark or black.
2. Login to account with email associated
3. Ensure disabled button is visible.

### Screenshots/Videos

Before:
<img width="564" height="1062" alt="Screenshot 2026-04-03 at 11 41 00 AM" src="https://github.com/user-attachments/assets/b221a036-e9f2-4f4e-a99e-1eed678f5e14" />

After:
<img width="564" height="1062" alt="Screenshot 2026-04-03 at 11 39 02 AM" src="https://github.com/user-attachments/assets/82c6f290-4990-4303-9766-e87e1480ba44" />
