### PR TITLE
Fix email auth freeze

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFReadingListToastPresenter.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFReadingListToastPresenter.swift
@@ -127,6 +127,9 @@ final public class WMFReadingListToastPresenter {
     private func addToast(to outsidePresenter: UIViewController, config: WMFReadingListToastConfig) {
         guard isToastHidden else { return }
         
+        // iOS 26 workaround: UIHostingController conflicts with active first responder
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        
         // Note: using top window as a presenter fixes freezing during pan and matches WMFToastPresenter
         guard let presenter = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFReadingListToastPresenter.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFReadingListToastPresenter.swift
@@ -127,9 +127,6 @@ final public class WMFReadingListToastPresenter {
     private func addToast(to outsidePresenter: UIViewController, config: WMFReadingListToastConfig) {
         guard isToastHidden else { return }
         
-        // iOS 26 workaround: UIHostingController conflicts with active first responder
-        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-        
         // Note: using top window as a presenter fixes freezing during pan and matches WMFToastPresenter
         guard let presenter = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFReadingListToastView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFReadingListToastView.swift
@@ -51,7 +51,8 @@ public struct WMFReadingListToastView: View {
         .contentShape(Rectangle())
         .onTapGesture { config.tapAction?() }
         .modifier(ToastGlassModifier(theme: theme))
-
+        .focusable(false)
+        .focusEffectDisabled(true)
     }
     @ViewBuilder
     private func iconView(_ icon: UIImage) -> some View {

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFToastPresenter.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFToastPresenter.swift
@@ -79,10 +79,7 @@ public final class WMFToastPresenter {
         allowsBackgroundTapToDismiss: Bool = false,
         dismissAction: (@Sendable (DismissEvent) -> Void)? = nil
     ) {
-        
-        // iOS 26 workaround: UIHostingController conflicts with active first responder
-        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-        
+
         guard let containerView = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
             .flatMap({ $0.windows })

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFToastPresenter.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFToastPresenter.swift
@@ -79,6 +79,10 @@ public final class WMFToastPresenter {
         allowsBackgroundTapToDismiss: Bool = false,
         dismissAction: (@Sendable (DismissEvent) -> Void)? = nil
     ) {
+        
+        // iOS 26 workaround: UIHostingController conflicts with active first responder
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        
         guard let containerView = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
             .flatMap({ $0.windows })

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFToastPresenter.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFToastPresenter.swift
@@ -30,8 +30,8 @@ public final class WMFToastPresenter {
     private var backgroundTapGestureRecognizer: UITapGestureRecognizer?
     private var dismissWorkItem: DispatchWorkItem?
     private var dismissAction: (@Sendable (DismissEvent) -> Void)?
-    /// True while the current toast's dismiss animation is running.
-    private var isDismissing: Bool = false
+    
+    private var currentKeyboardHeight = CGFloat(0)
 
     // MARK: - Lifecycle
 
@@ -39,6 +39,7 @@ public final class WMFToastPresenter {
 
     private init() {
         subscribeToAppEnvironmentChanges()
+        subscribeToKeyboardChanges()
     }
 
     // MARK: - AppEnvironment Subscription
@@ -47,6 +48,11 @@ public final class WMFToastPresenter {
         WMFAppEnvironment.publisher
             .sink(receiveValue: { [weak self] _ in self?.appEnvironmentDidChange() })
             .store(in: &cancellables)
+    }
+    
+    private func subscribeToKeyboardChanges() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillChangeFrame(_:)), name: UIWindow.keyboardWillChangeFrameNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIWindow.keyboardWillHideNotification, object: nil)
     }
 
     // MARK: - Subclass Overrides
@@ -62,6 +68,18 @@ public final class WMFToastPresenter {
         if let borderLayer = currentToast?.layer.sublayers?.first(where: { $0.borderWidth > 0 }) {
             borderLayer.borderColor = theme.border.withAlphaComponent(0.15).cgColor
         }
+    }
+    
+    @objc private func keyboardWillChangeFrame(_ notification: Notification) {
+        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+              let window = UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }).flatMap({ $0.windows }).first(where: { $0.isKeyWindow }) else { return }
+        
+        let keyboardHeight = window.bounds.height - keyboardFrame.minY
+        currentKeyboardHeight = max(0, keyboardHeight)
+    }
+
+    @objc private func keyboardWillHide(_ notification: Notification) {
+        currentKeyboardHeight = 0
     }
 
     // MARK: - Public API.
@@ -165,7 +183,7 @@ public final class WMFToastPresenter {
             equalTo: containerView.safeAreaLayoutGuide.trailingAnchor,
             constant: -16
         )
-        let toolbarOffset = containerView.rootViewController?.visibleToolbarHeightAboveSafeArea() ?? 0
+        let toolbarOffset = currentKeyboardHeight > 0 ? currentKeyboardHeight : containerView.rootViewController?.visibleToolbarHeightAboveSafeArea() ?? 0
         // When a tab bar or toolbar is present, offset above it with extra spacing.
         // When neither is present, pin closer to the bottom of the safe area.
         let bottomConstant: CGFloat
@@ -314,6 +332,7 @@ public final class WMFToastPresenter {
 
 extension UIViewController {
     func visibleToolbarHeightAboveSafeArea() -> CGFloat {
+        
         // If there's a modal presented over the full screen, the tab bar is not visible.
         if let presented = presentedViewController,
            presented.modalPresentationStyle == .fullScreen || presented.modalPresentationStyle == .overFullScreen {

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFToastView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Toasts/WMFToastView.swift
@@ -17,30 +17,35 @@ struct WMFToastView: View {
     private var spacing: CGFloat { 16 }
 
     var body: some View {
-        if #available(iOS 26.0, *) {
-            contentView
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, vPad)
-                .padding(.horizontal, hPad)
-                .padding(.vertical, 6)
-                .glassEffect(
-                    .regular
-                        .tint(Color(uiColor: theme.paperBackground).opacity(0.85))
-                        .interactive(),
-                    in: .rect(cornerRadius: 24, style: .circular)
-                )
-                .onTapGesture { config.tapAction?() }
+        Group {
+            if #available(iOS 26.0, *) {
+                contentView
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, vPad)
+                    .padding(.horizontal, hPad)
+                    .padding(.vertical, 6)
+                    .glassEffect(
+                        .regular
+                            .tint(Color(uiColor: theme.paperBackground).opacity(0.85))
+                            .interactive(),
+                        in: .rect(cornerRadius: 24, style: .circular)
+                    )
+                    .onTapGesture { config.tapAction?() }
 
-        } else {
-            contentView
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, vPad)
-                .padding(.horizontal, hPad)
-                .padding(.vertical, 6)
-                .onTapGesture { config.tapAction?() }
-                .background(Color(uiColor: theme.paperBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 24, style: .circular))
+            } else {
+                contentView
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, vPad)
+                    .padding(.horizontal, hPad)
+                    .padding(.vertical, 6)
+                    .onTapGesture { config.tapAction?() }
+                    .background(Color(uiColor: theme.paperBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 24, style: .circular))
+            }
         }
+        .focusable(false)
+        .focusEffectDisabled(true)
+        
     }
 
     @ViewBuilder

--- a/Wikipedia/Code/WMFReadingListToastManager.swift
+++ b/Wikipedia/Code/WMFReadingListToastManager.swift
@@ -88,7 +88,6 @@ import WMFComponents
                 Task { @MainActor in
                     guard let self, let articleURL else { return }
                     guard let article = self.dataStore.fetchArticle(with: articleURL) else { return }
-                    self.toastPresenter?.dismissToast()
                     self.performDefaultAction(article: article)
                 }
             }
@@ -170,8 +169,10 @@ import WMFComponents
         )
     }
 
+    @MainActor
     private func performDefaultAction(article: WMFArticle) {
         guard let presenter else { return }
+        toastPresenter?.dismissToast()
 
         let addVC = AddArticlesToReadingListViewController(
             with: dataStore,
@@ -190,6 +191,7 @@ import WMFComponents
         presenter.present(nav, animated: true)
     }
 
+    @MainActor
     private func performConfirmationAction(readingList: ReadingList) {
         guard let presenter else { return }
 
@@ -207,12 +209,7 @@ import WMFComponents
 
         themeableNavigationController = nav
 
-        presenter.present(nav, animated: true) { [weak self] in
-            guard let self, let toastPresenter = self.toastPresenter else { return }
-            Task { @MainActor in
-                toastPresenter.dismissToast()
-            }
-        }
+        presenter.present(nav, animated: true)
     }
 
     private func loadImageOffMain(from url: URL) async -> UIImage? {

--- a/Wikipedia/Code/WMFReadingListToastManager.swift
+++ b/Wikipedia/Code/WMFReadingListToastManager.swift
@@ -194,6 +194,7 @@ import WMFComponents
     @MainActor
     private func performConfirmationAction(readingList: ReadingList) {
         guard let presenter else { return }
+        toastPresenter?.dismissToast()
 
         let detailVC = ReadingListDetailViewController(
             for: readingList,


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T422086

### Notes
We had another toast freeze when failing to enter the incorrect email auth code. I think this is a similar bug as https://github.com/wikimedia/wikipedia-ios/pull/5746, mainly that our toasts freeze up when displayed or presented at the same time as the keyboard focus state. I am now adding a couple of modifiers to our toasts view.:

```
.focusable(false)
.focusEffectDisabled(true)
```

That does seem to fix this bug, so hopefully it will also fix it in other contexts we may not have found yet.


### Test Steps
1. Enable email auth code toggle in dev settings
2. Log into account with email associated
3. In email auth popup, enter an _incorrect_ code.
4. App should not freeze, you should see error message toast on top of keyboard.
5. Ensure I didn't accidentally bring back create reading list bugs (https://phabricator.wikimedia.org/T421012).

### Screenshots/Videos

