### PR TITLE
Update article download progress view

### DIFF
--- a/Wikipedia/Code/SavedProgressViewController.swift
+++ b/Wikipedia/Code/SavedProgressViewController.swift
@@ -9,9 +9,53 @@ class SavedProgressViewController: UIViewController, Themeable {
     
     fileprivate var theme: Theme = Theme.standard
 
+    private var glassEffectView: UIVisualEffectView?
+
+    private var innerContainerView: UIView? { view.subviews.first }
+
+    private let horizontalPadding: CGFloat = 16
+    private let bottomPadding: CGFloat = 8
+
     override func viewDidLoad() {
         super.viewDidLoad()
         label.text = WMFLocalizedString("saved-pages-progress-syncing", value: "Article download in progress...", comment: "Text for article download progress bar label")
+        label.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        label.adjustsFontForContentSizeCategory = true
+        setupPillShape()
+    }
+
+    private func setupPillShape() {
+        // Root view is transparent — the inner container is the visible pill
+        view.backgroundColor = .clear
+
+        guard let pill = innerContainerView else { return }
+
+        // Remove the storyboard's edge-to-edge constraints so we can add horizontal insets
+        for constraint in view.constraints where constraint.firstItem === pill || constraint.secondItem === pill {
+            view.removeConstraint(constraint)
+        }
+
+        pill.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            pill.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: horizontalPadding),
+            pill.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -horizontalPadding),
+            pill.topAnchor.constraint(equalTo: view.topAnchor),
+            pill.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -bottomPadding)
+        ])
+
+        pill.clipsToBounds = true
+        pill.layer.cornerRadius = 24
+        pill.layer.cornerCurve = .circular
+
+        if #available(iOS 26.0, *) {
+            let glassEffect = UIGlassEffect(style: .regular)
+            glassEffect.tintColor = theme.colors.paperBackground.withAlphaComponent(0.85)
+            let effectView = UIVisualEffectView(effect: glassEffect)
+            effectView.frame = pill.bounds
+            effectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            pill.insertSubview(effectView, at: 0)
+            glassEffectView = effectView
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -70,8 +114,18 @@ class SavedProgressViewController: UIViewController, Themeable {
     
     func apply(theme: Theme) {
         self.theme = theme
-        view.backgroundColor = theme.colors.hintBackground
-        label.textColor = theme.colors.secondaryText
+        view.backgroundColor = .clear
+        if #available(iOS 26.0, *) {
+            glassEffectView?.effect = {
+                let glassEffect = UIGlassEffect(style: .regular)
+                glassEffect.tintColor = theme.colors.paperBackground.withAlphaComponent(0.85)
+                return glassEffect
+            }()
+            innerContainerView?.backgroundColor = .clear
+        } else {
+            innerContainerView?.backgroundColor = theme.colors.paperBackground
+        }
+        label.textColor = theme.colors.primaryText
         progressView.progressTintColor = theme.colors.accent
     }
 }

--- a/Wikipedia/Code/SavedProgressViewController.swift
+++ b/Wikipedia/Code/SavedProgressViewController.swift
@@ -1,4 +1,4 @@
-import UIKit
+import WMFComponents
 
 class SavedProgressViewController: UIViewController, Themeable {
     @IBOutlet weak var label: UILabel!
@@ -19,7 +19,7 @@ class SavedProgressViewController: UIViewController, Themeable {
     override func viewDidLoad() {
         super.viewDidLoad()
         label.text = WMFLocalizedString("saved-pages-progress-syncing", value: "Article download in progress...", comment: "Text for article download progress bar label")
-        label.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        label.font = WMFFont.for(.subheadline)
         label.adjustsFontForContentSizeCategory = true
         setupPillShape()
     }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T422385

### Notes
* Removes blue background, adds liquid glass material, makes it pill shaped

### Test Steps
1. Log into an account with sync enabled
2. Observe the saved tab, the view takes a moment to show
3. The blue background should be gone
4. It should disappear when download is complete
5. Check iPad

### Screenshots/Videos
- Before 
<img width="400" height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-24 at 16 04 32" src="https://github.com/user-attachments/assets/a5ea16b4-42bd-4fac-9a3c-16e3cfe23e11" />

- After
<img width="400" height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-06 at 11 48 48" src="https://github.com/user-attachments/assets/7b96608d-0a18-412a-b718-cddce01ea78b" />


