### PR TITLE
Maybe fix reading lists crash

### DIFF
--- a/WMF Framework/ReadingListsAPIController.swift
+++ b/WMF Framework/ReadingListsAPIController.swift
@@ -259,11 +259,15 @@ public class ReadingListsAPIController: Fetcher {
                 DispatchQueue.global().async {
                     let taskGroup = WMFTaskGroup()
                     var listsByName: [String: (Int64?, Error?)] = [:]
+                    let serialQueue = DispatchQueue(label: "org.wikimedia.readingLists.listsByName")
+                    
                     for list in lists {
                         taskGroup.enter()
                         self.createList(name: list.name, description: list.description, completion: { (listID, error) in
+                            serialQueue.sync {
+                                listsByName[list.name] = (listID, error)
+                            }
                             taskGroup.leave()
-                            listsByName[list.name] = (listID, error)
                         })
                     }
                     taskGroup.wait()


### PR DESCRIPTION
**Phabricator:** 

### Notes
This crash was seen in the LG external beta. This doesn't look like a new crash, but this is a good time to try and fix before we roll out.

Crash:
```
Thread 12 Crashed:
0   WMF                           	0x0000000103498d40 specialized Dictionary.subscript.getter + 0 (/<compiler-generated>:0)
1   WMF                           	0x0000000103498d40 closure #1 in closure #2 in ReadingListsAPIController.createLists(_:completion:) + 776 (ReadingListsAPIController.swift:272)
2   WMF                           	0x00000001032d37d0 <deduplicated_symbol> + 28
```

There could be some concurrency issues when writing to the `listsByName` dictionary in this method, since this write is occurring on different threads in a network completion handler. 

I wrapped this write up in a serial dispatch queue. Ensuring taskGroup.leave() isn't called until after the write could also help.

### Test Steps
1. Create a few reading lists while you are logged in and have syncing on. Ensure no crash.
