### PR TITLE
Fix notifications crash

### DIFF
--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.h
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.h
@@ -31,7 +31,6 @@ extern NSString *const WMFNavigateToActivityNotification;
 + (instancetype)wmf_settingsViewActivity;
 + (instancetype)wmf_appearanceSettingsActivity;
 + (instancetype)wmf_languageSettingsActivity;
-+ (instancetype)wmf_notificationSettingsActivity;
 
 + (nullable instancetype)wmf_activityForWikipediaScheme:(NSURL *)url;
 

--- a/Wikipedia/Code/NotificationsCenterViewController.swift
+++ b/Wikipedia/Code/NotificationsCenterViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import WMF
 import SwiftUI
 import WMFComponents
+import WMFData
 
 @objc
 final class NotificationsCenterViewController: ThemeableViewController, WMFNavigationBarConfiguring {
@@ -888,9 +889,14 @@ extension NotificationsCenterViewController: NotificationsCenterCellDelegate {
                     self.closeSwipeActionsPanelIfNecessary()
                 })
             case .notificationSubscriptionSettings(let data):
-                alertAction = UIAlertAction(title: data.text, style: .default, handler: { alertAction in
-                    let userActivity = NSUserActivity.wmf_notificationSettings()
-                    NSUserActivity.wmf_navigate(to: userActivity)
+                alertAction = UIAlertAction(title: data.text, style: .default, handler: { [weak self] alertAction in
+                    guard let self,
+                          let navVC = self.navigationController else {
+                        return
+                    }
+                    let coordinator = SettingsCoordinator(navigationController: navVC, theme: theme, dataStore: MWKDataStore.shared(), dataController: WMFSettingsDataController.shared)
+                    coordinator.handleSettingsAction(.notifications)
+                    
                     if !cellViewModel.isRead {
                         self.viewModel.markAsReadOrUnread(viewModels: [cellViewModel], shouldMarkRead: true)
                         self.logMarkReadOrUnreadAction(model: cellViewModel, selectionToken: nil, shouldMarkRead: true)


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
There's a crash in the LG TestFlight external beta from the Notifications Center > More menu. This fixes it, though note that this notifications screen still has the https://phabricator.wikimedia.org/T421303 bug.

### Test Steps
1. Log in, go to notifications center.
2. Swipe notification, tap More.
3. Tap Notification Settings. Ensure app does not crash.