### PR TITLE
Fix history core data hang

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/History/WMFHistoryViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/History/WMFHistoryViewModel.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import WMFData
 
+@MainActor
 public final class WMFHistoryViewModel: ObservableObject {
 
     // MARK: - Nested Types
@@ -64,7 +65,9 @@ public final class WMFHistoryViewModel: ObservableObject {
         self.historyDataController = historyDataController
         self.topPadding = topPadding
 
-        loadHistory()
+        Task { [weak self] in
+            self?.loadHistory()
+        }
     }
 
     // MARK: - Public functions
@@ -86,9 +89,7 @@ public final class WMFHistoryViewModel: ObservableObject {
             return HistorySection(dateWithoutTime: dataSection.dateWithoutTime, items: items)
         }
 
-        DispatchQueue.main.async {
-            self.sections = viewModelSections
-        }
+        sections = viewModelSections
         isEmpty = dataSections.isEmpty || dataSections.allSatisfy { $0.items.isEmpty }
     }
 
@@ -101,9 +102,7 @@ public final class WMFHistoryViewModel: ObservableObject {
 
         section.items.remove(at: itemIndex)
         if section.items.isEmpty {
-            DispatchQueue.main.async {
-                self.sections.removeAll(where: { $0.dateWithoutTime == section.dateWithoutTime })
-            }
+            sections.removeAll(where: { $0.dateWithoutTime == section.dateWithoutTime })
         }
         historyDataController.deleteHistoryItem(item)
 
@@ -125,14 +124,10 @@ public final class WMFHistoryViewModel: ObservableObject {
         newSections[sectionIndex].items[itemIndex].isSaved = newIsSaved
         sections = newSections
 
-        Task {
-            await MainActor.run {
-                if newIsSaved {
-                    historyDataController.saveHistoryItem(sections[sectionIndex].items[itemIndex])
-                } else {
-                    historyDataController.unsaveHistoryItem(sections[sectionIndex].items[itemIndex])
-                }
-            }
+        if newIsSaved {
+            historyDataController.saveHistoryItem(sections[sectionIndex].items[itemIndex])
+        } else {
+            historyDataController.unsaveHistoryItem(sections[sectionIndex].items[itemIndex])
         }
     }
     

--- a/WMFComponents/Tests/WMFComponentsTests/WMFHistoryViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFHistoryViewModelTests.swift
@@ -35,6 +35,7 @@ class FakeHistoryDataController: WMFHistoryDataControllerProtocol {
 
 // MARK: - WMFHistoryViewModel Tests
 
+@MainActor
 final class WMFHistoryViewModelTests: XCTestCase {
 
     var cancellables = Set<AnyCancellable>()
@@ -63,7 +64,7 @@ final class WMFHistoryViewModelTests: XCTestCase {
 
     // MARK: - Test loadHistory
 
-    func testLoadHistoryPopulatesSections() {
+    func testLoadHistoryPopulatesSections() async {
         let today = Calendar.current.startOfDay(for: Date())
         let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: today)!
 
@@ -103,30 +104,27 @@ final class WMFHistoryViewModelTests: XCTestCase {
 
         let viewModel = createViewModel(with: fakeController)
 
-        let expectation = XCTestExpectation(description: "Wait for loadHistory to update sections")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            XCTAssertEqual(viewModel.sections.count, 2, "There should be 2 sections loaded.")
+        await Task.yield() // allow the deferred loadHistory Task to run
 
-            if let todaySection = viewModel.sections.first(where: { Calendar.current.isDate($0.dateWithoutTime, inSameDayAs: today) }) {
-                XCTAssertEqual(todaySection.items.count, 2, "Today's section should have 2 items.")
-            } else {
-                XCTFail("Today's section not found.")
-            }
+        XCTAssertEqual(viewModel.sections.count, 2, "There should be 2 sections loaded.")
 
-            if let yesterdaySection = viewModel.sections.first(where: { Calendar.current.isDate($0.dateWithoutTime, inSameDayAs: yesterday) }) {
-                XCTAssertEqual(yesterdaySection.items.count, 1, "Yesterday's section should have 1 item.")
-            } else {
-                XCTFail("Yesterday's section not found.")
-            }
-            XCTAssertFalse(viewModel.isEmpty, "ViewModel should not be empty when sections have items.")
-            expectation.fulfill()
+        if let todaySection = viewModel.sections.first(where: { Calendar.current.isDate($0.dateWithoutTime, inSameDayAs: today) }) {
+            XCTAssertEqual(todaySection.items.count, 2, "Today's section should have 2 items.")
+        } else {
+            XCTFail("Today's section not found.")
         }
-        wait(for: [expectation], timeout: 1.0)
+
+        if let yesterdaySection = viewModel.sections.first(where: { Calendar.current.isDate($0.dateWithoutTime, inSameDayAs: yesterday) }) {
+            XCTAssertEqual(yesterdaySection.items.count, 1, "Yesterday's section should have 1 item.")
+        } else {
+            XCTFail("Yesterday's section not found.")
+        }
+        XCTAssertFalse(viewModel.isEmpty, "ViewModel should not be empty when sections have items.")
     }
 
     // MARK: - Test delete functionality
 
-    func testDeleteItemInViewModel() {
+    func testDeleteItemInViewModel() async {
         let today = Calendar.current.startOfDay(for: Date())
         let item = HistoryItem(id: "1",
                                url: URL(string: "https://example.com/1")!,
@@ -144,11 +142,7 @@ final class WMFHistoryViewModelTests: XCTestCase {
 
         let viewModel = createViewModel(with: fakeController)
 
-        let loadExpectation = XCTestExpectation(description: "Wait for history to load")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            loadExpectation.fulfill()
-        }
-        wait(for: [loadExpectation], timeout: 1.0)
+        await Task.yield() // allow the deferred loadHistory Task to run
 
         XCTAssertEqual(viewModel.sections.count, 1, "There should be one section initially.")
         guard let firstSection = viewModel.sections.first else {
@@ -162,26 +156,19 @@ final class WMFHistoryViewModelTests: XCTestCase {
 
         XCTAssertEqual(fakeController.deletedItems.count, 1, "deleteHistoryItem should be called once.")
         XCTAssertEqual(fakeController.deletedItems.first?.id, historyItem.id, "Deleted item's id should match.")
-
         XCTAssertEqual(firstSection.items.count, 0, "Section should have 0 items after deletion.")
-
-        let deletionExpectation = XCTestExpectation(description: "Wait for section removal")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            XCTAssertEqual(viewModel.sections.count, 0, "ViewModel sections should be empty after deleting the last item.")
-            deletionExpectation.fulfill()
-        }
-        wait(for: [deletionExpectation], timeout: 1.0)
+        XCTAssertEqual(viewModel.sections.count, 0, "ViewModel sections should be empty after deleting the last item.")
     }
 
     // MARK: - Test save/unsave functionality
 
-    func testSaveOrUnsave() {
+    func testSaveOrUnsave() async {
 
         let today = Calendar.current.startOfDay(for: Date())
         let savedItem = HistoryItem(
             id: "1",
             url: URL(string: "https://example.com/1")!,
-            titleHtml: "Article 1",
+            titleHtml: "Article 1",
             description: nil,
             shortDescription: nil,
             imageURLString: nil,
@@ -192,7 +179,7 @@ final class WMFHistoryViewModelTests: XCTestCase {
         let unsavedItem = HistoryItem(
             id: "2",
             url: URL(string: "https://example.com/2")!,
-            titleHtml: "Article 2",
+            titleHtml: "Article 2",
             description: nil,
             shortDescription: nil,
             imageURLString: nil,
@@ -207,22 +194,19 @@ final class WMFHistoryViewModelTests: XCTestCase {
 
         let viewModel = createViewModel(with: fakeController)
 
-        viewModel.loadHistory()
-        RunLoop.main.run(until: Date().addingTimeInterval(0.1)) // wait for section to load
+        await Task.yield()
 
         guard let loadedSection = viewModel.sections.first,
               loadedSection.items.count == 2
         else {
-            XCTFail("HistorySection didn’t load correctly")
+            XCTFail("HistorySection didn't load correctly")
             return
         }
-        let firstItem  = section.items[0]  // true
-        let secondItem = section.items[1]  // false
+        let firstItem  = section.items[0]
+        let secondItem = section.items[1]
 
         viewModel.saveOrUnsave(item: firstItem,  in: loadedSection)
         viewModel.saveOrUnsave(item: secondItem, in: loadedSection)
-
-        RunLoop.main.run(until: Date().addingTimeInterval(0.1)) // wait for async save/unsave
 
         XCTAssertEqual(
             fakeController.unsavedItems.map(\.id),
@@ -239,7 +223,7 @@ final class WMFHistoryViewModelTests: XCTestCase {
 
     // MARK: - Test onTap action
 
-    func testOnTapAction() {
+    func testOnTapAction() async {
         let today = Calendar.current.startOfDay(for: Date())
         let item = HistoryItem(id: "1",
                                url: URL(string: "https://example.com/1")!,
@@ -266,11 +250,7 @@ final class WMFHistoryViewModelTests: XCTestCase {
             tappedItem = item
         }
 
-        let loadExpectation = XCTestExpectation(description: "Wait for history to load")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            loadExpectation.fulfill()
-        }
-        wait(for: [loadExpectation], timeout: 1.0)
+        await Task.yield()
 
         guard let loadedSection = viewModel.sections.first,
               let historyItem = loadedSection.items.first else {


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
* Makes the whole View Model MainActor to prevent blocking the main thread in data operations

### Test Steps
1. Ideally, in a device with a long history, navigate to search and make sure it doesn't hang


