### PR TITLE
Fixes for nearby hang

### DIFF
--- a/WMF Framework/LocationManager.swift
+++ b/WMF Framework/LocationManager.swift
@@ -52,6 +52,10 @@ final public class LocationManager: NSObject {
     /// Returns the current locationManager permission state.
     public var authorizationStatus: CLAuthorizationStatus { locationManager.authorizationStatus }
 
+    /// Timeout tracking vars
+    private var locationTimeoutItem: DispatchWorkItem?
+    private static let locationTimeoutInterval: TimeInterval = 15
+
     /// Starts monitoring location and heading updates.
     public func startMonitoringLocation() {
         
@@ -75,10 +79,13 @@ final public class LocationManager: NSObject {
         startUpdatingHeading()
         isUpdating = true
         DDLogDebug("LocationManager - did start updating location & heading.")
+
+        scheduleLocationTimeout()
     }
 
     /// Stops monitoring location and heading updates.
     public func stopMonitoringLocation() {
+        cancelLocationTimeout()
         locationManager.stopUpdatingLocation()
         stopUpdatingHeading()
         isUpdating = false
@@ -167,15 +174,41 @@ final public class LocationManager: NSObject {
     private func updateHeadingOrientation() {
         locationManager.headingOrientation = device.orientation.clOrientation
     }
+
+    // MARK: - Timeout
+
+    private func scheduleLocationTimeout() {
+        cancelLocationTimeout()
+        let item = DispatchWorkItem { [weak self] in
+            guard let self, self.isUpdating else { return }
+            let error = NSError(
+                domain: kCLErrorDomain,
+                code: CLError.locationUnknown.rawValue,
+                userInfo: [NSLocalizedDescriptionKey: "Location fix timed out"]
+            )
+            DDLogWarn("LocationManager - location fix timed out after \(Self.locationTimeoutInterval)s.")
+            self.delegate?.locationManager?(self, didReceive: error)
+        }
+        locationTimeoutItem = item
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.locationTimeoutInterval,
+            execute: item
+        )
+    }
+
+    private func cancelLocationTimeout() {
+        locationTimeoutItem?.cancel()
+        locationTimeoutItem = nil
+    }
 }
 
-// MARK: - LocationManagerDelegate
+// MARK: - CLLocationManagerDelegate
 
 extension LocationManager: CLLocationManagerDelegate {
 
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard isUpdating, let location = locations.last else { return }
-
+        cancelLocationTimeout()
         self.location = location
         delegate?.locationManager?(self, didUpdate: location)
         DDLogDebug("LocationManager - did update location: \(location).")
@@ -202,18 +235,34 @@ extension LocationManager: CLLocationManagerDelegate {
         }
         #endif
 
+        cancelLocationTimeout()
         delegate?.locationManager?(self, didReceive: error)
         DDLogError("LocationManager - encountered error: \(error).")
     }
-    
+
+    public func locationManagerDidPauseLocationUpdates(_ manager: CLLocationManager) {
+        guard isUpdating else { return }
+        cancelLocationTimeout()
+        let error = NSError(
+            domain: kCLErrorDomain,
+            code: CLError.locationUnknown.rawValue,
+            userInfo: [NSLocalizedDescriptionKey: "Location updates paused by system"]
+        )
+        DDLogWarn("LocationManager - location updates paused by system, reporting as timeout.")
+        delegate?.locationManager?(self, didReceive: error)
+    }
+
     public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         let status = manager.authorizationStatus
         DDLogDebug("LocationManager - did change authorization status \(status.rawValue).")
         delegate?.locationManager?(self, didUpdateAuthorized: status.isAuthorized)
 
         if status.isAuthorized {
+            cancelLocationTimeout()
             authorizedCompletion?()
             authorizedCompletion = nil
+        } else {
+            cancelLocationTimeout()
         }
     }
 }

--- a/Wikipedia/Code/WMFNearbyContentSource.m
+++ b/Wikipedia/Code/WMFNearbyContentSource.m
@@ -66,65 +66,63 @@ static const CLLocationDistance WMFNearbyUpdateDistanceThresholdInMeters = 25000
 }
 
 - (void)loadNewContentInManagedObjectContext:(NSManagedObjectContext *)moc force:(BOOL)force completion:(dispatch_block_t)completion {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (![self.locationManager isAuthorized]) {
-            [moc performBlock:^{
-                [moc removeAllContentGroupsOfKind:WMFContentGroupKindLocation];
-                if (![[NSUserDefaults standardUserDefaults] wmf_exploreDidPromptForLocationAuthorization]) {
-                    [self showAuthorizationPlaceholderInManagedObjectContext:moc
-                                                                  completion:^{
-                                                                      if (completion) {
-                                                                          completion();
-                                                                      }
-                                                                  }];
-                } else if (completion) {
+    if (![self.locationManager isAuthorized]) {
+        [moc performBlock:^{
+            [moc removeAllContentGroupsOfKind:WMFContentGroupKindLocation];
+            if (![[NSUserDefaults standardUserDefaults] wmf_exploreDidPromptForLocationAuthorization]) {
+                [self showAuthorizationPlaceholderInManagedObjectContext:moc
+                                                              completion:^{
+                                                                  if (completion) {
+                                                                      completion();
+                                                                  }
+                                                              }];
+            } else if (completion) {
+                completion();
+            }
+        }];
+    } else {
+        [moc performBlock:^{
+            [moc removeAllContentGroupsOfKind:WMFContentGroupKindLocationPlaceholder];
+        }];
+
+        if (self.locationManager.location == nil) {
+            self.isFetchingInitialLocation = YES;
+            self.moc = moc;
+            self.completion = completion;
+            [self.locationManager startMonitoringLocation];
+        } else {
+            dispatch_block_t done = ^{
+                if (completion) {
                     completion();
                 }
-            }];
-        } else {
-            [moc performBlock:^{
-                [moc removeAllContentGroupsOfKind:WMFContentGroupKindLocationPlaceholder];
-            }];
-
-            if (self.locationManager.location == nil) {
-                self.isFetchingInitialLocation = YES;
-                self.moc = moc;
-                self.completion = completion;
-                [self.locationManager startMonitoringLocation];
-            } else {
-                dispatch_block_t done = ^{
-                    if (completion) {
-                        completion();
-                    }
-                };
-                [self getGroupForLocation:self.locationManager.location
-                    inManagedObjectContext:moc
-                    force:force
-                    completion:^(WMFContentGroup *group, CLLocation *location, CLPlacemark *placemark) {
-                        id content = group.fullContent.object;
-                        if (group && [content isKindOfClass:[NSArray class]] && [content count] > 0) {
-                            NSDate *now = [NSDate date];
-                            NSDate *todayMidnightUTC = [now wmf_midnightUTCDateFromLocalDate];
-                            if (force) {
-                                group.date = now;
-                                group.midnightUTCDate = todayMidnightUTC;
-                            }
-                            done();
-                            return;
+            };
+            [self getGroupForLocation:self.locationManager.location
+                inManagedObjectContext:moc
+                force:force
+                completion:^(WMFContentGroup *group, CLLocation *location, CLPlacemark *placemark) {
+                    id content = group.fullContent.object;
+                    if (group && [content isKindOfClass:[NSArray class]] && [content count] > 0) {
+                        NSDate *now = [NSDate date];
+                        NSDate *todayMidnightUTC = [now wmf_midnightUTCDateFromLocalDate];
+                        if (force) {
+                            group.date = now;
+                            group.midnightUTCDate = todayMidnightUTC;
                         }
-                        [self fetchResultsForLocation:location
-                                            placemark:placemark
-                               inManagedObjectContext:moc
-                                           completion:^{
-                                               done();
-                                           }];
-                    }
-                    failure:^(NSError *error) {
                         done();
-                    }];
-            }
+                        return;
+                    }
+                    [self fetchResultsForLocation:location
+                                        placemark:placemark
+                           inManagedObjectContext:moc
+                                       completion:^{
+                                           done();
+                                       }];
+                }
+                failure:^(NSError *error) {
+                    done();
+                }];
         }
-    });
+    }
 }
 
 - (void)removeAllContentInManagedObjectContext:(NSManagedObjectContext *)moc {


### PR DESCRIPTION
**Phabricator:** 

### Notes
This is the last actionable crash I could find from the LG Testflight external beta build. I don't think this one is widespread, so I don't think we have to merge this one now if we're unsure about it. I think users that hit this freeze do not have a location that is resolved for the Explore feed card (hang starts in WMFNearbyContentSource.m). There are two fixes here:

1. Removed a `dispatch_async(dispatch_get_main_queue(), ^{` wrapper in WMFNearbyContentSource's `loadNewContentInManagedObjectContext` method. None of the other content sources have this line, and the existing moc.perform calls should already happen on the correct thread.
2. Added timeout logic in LocationManager in case a location never returns.

### Test Steps
1. Light regression test of Explore feed location card (ensure you see it and can enable it). Note: for me this card disappears after I tap the enable button. This happens on the existing App Store build for me too, so I think it's an existing issue or perhaps I just live in a dead zone regarding nearby location suggestions.
2. Light regression on Places tab.