### PR TITLE
Fix location manager crash

### DIFF
--- a/WMF Framework/LocationManagerFactory.swift
+++ b/WMF Framework/LocationManagerFactory.swift
@@ -2,6 +2,12 @@ import Foundation
 
 @objc public final class LocationManagerFactory: NSObject {
     @objc static func coarseLocationManager() -> LocationManagerProtocol {
-        return LocationManager(configuration: .coarse)
+        if Thread.isMainThread {
+            return LocationManager(configuration: .coarse)
+        } else {
+            return DispatchQueue.main.sync {
+                LocationManager(configuration: .coarse)
+            }
+        }
     }
 }


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
* This one seems to happen only in debug mode, Anthony tested and didn't get a crash, but it's preventing from debugging

### Test Steps
1. Run the app on a device
2. Make sure it doesn't crash here 
https://github.com/wikimedia/wikipedia-ios/blob/d9944c795de01de3d9e8669d4751716467cedef7/WMF%20Framework/LocationManager.swift#L103

### Screenshots/Videos

