### PR TITLE
Random reading challenge fixes

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Activity Tab/WMFActivityTabDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Activity Tab/WMFActivityTabDataController.swift
@@ -256,6 +256,8 @@ public actor WMFActivityTabDataController {
         hasEnrolledInReadingChallenge2026 = true
         hasSeenFullPageReadingChallengeAnnouncement2026 = true
         // Do NOT mark widget announcement seen here — show it after enrollment
+        
+        UserDefaults(suiteName: Self.sharedGroupID)?.synchronize()
     }
 
     public func setHasSeenFullPageAnnouncement() {

--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFPageViewsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFPageViewsDataController.swift
@@ -440,6 +440,10 @@ extension WMFPageViewsDataController {
             if streakStartedAfterEnrollmentCutoff {
                 return .challengeConcludedNoStreak
             }
+            
+            if cappedStreak == 0 {
+                return .challengeConcludedNoStreak
+            }
         }
         
         if todayStart > maxDateToCompleteStreak {

--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFPageViewsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFPageViewsDataController.swift
@@ -422,6 +422,9 @@ extension WMFPageViewsDataController {
         }
 
         guard isEnrolled else {
+            if todayStart > endDateStart {
+                return .challengeConcludedNoStreak
+            }
             return .notEnrolled
         }
 

--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFPageViewsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFPageViewsDataController.swift
@@ -455,7 +455,15 @@ extension WMFPageViewsDataController {
             }
             
             if cappedStreak == 0 {
-                return .challengeConcludedNoStreak
+                
+                // Show user's highest streak achieved up until that point
+                let highestStreak = try await computeLongestStreak(calendar: calendar, now: now, startDate: config.startDate)
+                
+                if highestStreak > 1 {
+                    return .challengeConcludedIncomplete(streak: highestStreak)
+                } else {
+                    return .challengeConcludedNoStreak
+                }
             }
         }
         
@@ -534,6 +542,53 @@ extension WMFPageViewsDataController {
             let streakStartedAfterEnrollmentCutoff = streak > 0 && streakStartDate > endDateStart
 
             return (streak, hasReadToday, streakStartedAfterEnrollmentCutoff)
+        }
+    }
+    
+    private func computeLongestStreak(
+        calendar: Calendar,
+        now: Date,
+        startDate: Date
+    ) async throws -> Int {
+
+        let startOfChallengeStart = calendar.startOfDay(for: startDate)
+        let todayStart = calendar.startOfDay(for: now)
+
+        // Early exit if now is before startDate
+        guard todayStart >= startOfChallengeStart else { return 0 }
+
+        let backgroundContext = try coreDataStore.newBackgroundContext
+
+        return try await backgroundContext.perform {
+            let fetchRequest: NSFetchRequest<CDPageView> = CDPageView.fetchRequest()
+            fetchRequest.propertiesToFetch = ["timestamp"]
+            let allViews = try backgroundContext.fetch(fetchRequest)
+
+            var daysWithRead = Set<DateComponents>()
+            for view in allViews {
+                guard let ts = view.timestamp else { continue }
+                guard calendar.startOfDay(for: ts) >= startOfChallengeStart else { continue }
+                let comps = calendar.dateComponents([.year, .month, .day], from: ts)
+                daysWithRead.insert(comps)
+            }
+
+            var longestStreak = 0
+            var currentStreak = 0
+            var cursor = startOfChallengeStart
+
+            while cursor <= todayStart {
+                let comps = calendar.dateComponents([.year, .month, .day], from: cursor)
+                if daysWithRead.contains(comps) {
+                    currentStreak += 1
+                    longestStreak = max(longestStreak, currentStreak)
+                } else {
+                    currentStreak = 0
+                }
+                guard let next = calendar.date(byAdding: .day, value: 1, to: cursor) else { break }
+                cursor = next
+            }
+
+            return longestStreak
         }
     }
 }

--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFPageViewsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFPageViewsDataController.swift
@@ -407,6 +407,8 @@ extension WMFPageViewsDataController {
         let removeDateStart = calendar.startOfDay(for: config.removeDate)
         let startDateStart = calendar.startOfDay(for: config.startDate)
         let endDateStart = calendar.startOfDay(for: config.endDate)
+        let oneDayInSeconds = 60 * 60  * 24
+        let maxDateToCompleteStreak = calendar.startOfDay(for:endDateStart.addingTimeInterval(TimeInterval((config.streakGoal * oneDayInSeconds))))
 
         if todayStart > removeDateStart {
             return .challengeRemoved
@@ -438,7 +440,9 @@ extension WMFPageViewsDataController {
             if streakStartedAfterEnrollmentCutoff {
                 return .challengeConcludedNoStreak
             }
-
+        }
+        
+        if todayStart > maxDateToCompleteStreak {
             return cappedStreak > 1
                 ? .challengeConcludedIncomplete(streak: cappedStreak)
                 : .challengeConcludedNoStreak

--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFPageViewsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFPageViewsDataController.swift
@@ -387,6 +387,9 @@ extension WMFPageViewsDataController {
         func devBool(_ key: WMFUserDefaultsKey) -> Bool {
             devDefaults?.bool(forKey: key.rawValue) ?? false
         }
+        func setDevBool(_ key: WMFUserDefaultsKey, value: Bool) {
+            devDefaults?.set(true, forKey: key.rawValue)
+        }
         if devBool(.devForceReadingChallengeEnabled) {
             let storedStreak = devDefaults?.integer(forKey: WMFUserDefaultsKey.devForceReadingChallengeStreakCount.rawValue) ?? 0
             let devStreak = storedStreak == 0 ? 7 : storedStreak
@@ -431,8 +434,15 @@ extension WMFPageViewsDataController {
 
         // Cap at goal — completion is terminal, no need to count beyond it
         let cappedStreak = min(streak, config.streakGoal)
+        
+        // Note: once a user successfully completes a reading streak, computeStreak starts to evaluate to 0 a few days later.
+        // This user defaults boolean gets around that bug
+        if devBool(.userCompletedReadingChallenge) {
+            return .challengeCompleted
+        }
 
         if cappedStreak >= config.streakGoal {
+            setDevBool(.userCompletedReadingChallenge, value: true)
             return .challengeCompleted
         }
 

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -54,4 +54,5 @@ public enum WMFUserDefaultsKey: String {
     case devForceReadingChallengeStreakOngoingNotYetRead = "dev-force-reading-challenge-streak-ongoing-not-yet-read"
     case devForceReadingChallengeEnabled = "dev-force-reading-challenge-enabled"
     case devForceReadingChallengeStreakCount = "dev-force-reading-challenge-streak-count"
+    case userCompletedReadingChallenge = "user-completed-reading-challenge"
 }

--- a/Widgets/Widgets/ReadingChallengeWidget.swift
+++ b/Widgets/Widgets/ReadingChallengeWidget.swift
@@ -45,6 +45,9 @@ struct ReadingChallengeProvider: TimelineProvider {
 
             let coreDataStore = try await WMFCoreDataStore(appContainerURL: appContainerURL)
             let controller = try WMFPageViewsDataController(coreDataStore: coreDataStore)
+            
+            UserDefaults(suiteName: "group.org.wikimedia.wikipedia")?.synchronize()
+            
             let isEnrolled = UserDefaults(suiteName: "group.org.wikimedia.wikipedia")?.bool(forKey: WMFUserDefaultsKey.hasEnrolledInReadingChallenge2026.rawValue) ?? false
             return try await controller.fetchReadingChallengeState(isEnrolled: isEnrolled)
         } catch {

--- a/Wikipedia/Code/ActivityTabViewController.swift
+++ b/Wikipedia/Code/ActivityTabViewController.swift
@@ -17,6 +17,7 @@ final class WMFActivityTabHostingController: WMFComponentHostingController<WMFAc
     private let hostingController: WMFActivityTabHostingController
     public let viewModel: WMFActivityTabViewModel
     private let dataController: WMFActivityTabDataController
+    @objc public var temporarilySuppressAppearanceModals: Bool = false
 
     public init(dataStore: MWKDataStore?, theme: Theme, viewModel: WMFActivityTabViewModel, dataController: WMFActivityTabDataController) {
         self.dataStore = dataStore
@@ -171,6 +172,7 @@ final class WMFActivityTabHostingController: WMFComponentHostingController<WMFAc
         }
 
         presentModalsIfNeeded()
+        temporarilySuppressAppearanceModals = false
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -314,6 +316,11 @@ final class WMFActivityTabHostingController: WMFComponentHostingController<WMFAc
 
     @MainActor
     private func presentModalsIfNeeded() {
+        
+        guard !temporarilySuppressAppearanceModals else {
+            return
+        }
+        
         Task {
             
             let needsReadingChallengeAnnouncement = await shouldShowReadingChallengeAnnouncement()

--- a/Wikipedia/Code/ActivityTabViewController.swift
+++ b/Wikipedia/Code/ActivityTabViewController.swift
@@ -315,19 +315,21 @@ final class WMFActivityTabHostingController: WMFComponentHostingController<WMFAc
     @MainActor
     private func presentModalsIfNeeded() {
         Task {
-            let hasSeenActivityTab = await dataController.getHasSeenActivityTab()
-            if !hasSeenActivityTab {
-                presentOnboarding()
-                ActivityTabFunnel.shared.logOnboardingDidAppear()
-                await dataController.setHasSeenActivityTab(true)
-            } else if await dataController.shouldShowSurvey() {
-                presentSurveyIfNeeded()
+            
+            let needsReadingChallengeAnnouncement = await shouldShowReadingChallengeAnnouncement()
+            if needsReadingChallengeAnnouncement {
+                presentReadingChallengeWidgetAnnouncementIfNeeded()
             } else {
-                let didPresentChallenge = await presentReadingChallengeAnnouncementIfNeeded()
-                if !didPresentChallenge {
-                    presentReadingChallengeWidgetAnnouncementIfNeeded()
+                let hasSeenActivityTab = await dataController.getHasSeenActivityTab()
+                if !hasSeenActivityTab {
+                    presentOnboarding()
+                    ActivityTabFunnel.shared.logOnboardingDidAppear()
+                    await dataController.setHasSeenActivityTab(true)
+                } else if await dataController.shouldShowSurvey() {
+                    presentSurveyIfNeeded()
                 }
             }
+            
         }
 
         viewModel.didTapPrimaryLoggedOutCTA = { [weak self] in
@@ -338,16 +340,24 @@ final class WMFActivityTabHostingController: WMFComponentHostingController<WMFAc
             self?.navigateToSearch()
         }
     }
-
+    
     @discardableResult
-    private func presentReadingChallengeAnnouncementIfNeeded() async -> Bool {
+    private func shouldShowReadingChallengeAnnouncement() async -> Bool {
         guard presentedViewController == nil else { return false }
         guard isViewLoaded && view.window != nil else { return false }
         guard let dataStore else { return false }
         let isLoggedIn = dataStore.authenticationManager.authStateIsPermanent
         guard await WMFActivityTabDataController.shared.shouldShowReadingChallengeAnnouncement(isLoggedIn: isLoggedIn) else { return false }
-        presentReadingChallengeAnnouncement(dataStore: dataStore)
         return true
+    }
+
+    private func presentReadingChallengeAnnouncementIfNeeded() async {
+        guard await shouldShowReadingChallengeAnnouncement(),
+            let dataStore else {
+            return
+        }
+        
+        presentReadingChallengeAnnouncement(dataStore: dataStore)
     }
     
     private func presentReadingChallengeAnnouncement(dataStore: MWKDataStore) {

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -464,7 +464,6 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
             navigationController?.setToolbarHidden(false, animated: false)
         }
         
-        listenForTooltips()
         presentModalsIfNeeded()
         trackBeganViewingDate()
         coordinator?.syncTabsOnArticleAppearance()
@@ -506,15 +505,19 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
         Task { @MainActor in
             if await needsReadingChallengeAnnouncement() {
                 presentReadingChallengeAnnouncement(dataStore: dataStore)
-
-            } else if needsYearInReviewAnnouncement() {
-                willDisplayYearInReviewModal = true
-                updateProfileButton()
-                presentYearInReviewAnnouncement()
-
+                
             } else {
-                willDisplayYearInReviewModal = false
-                showFundraisingCampaignAnnouncementIfNeeded()
+                listenForTooltips()
+                
+                if needsYearInReviewAnnouncement() {
+                    willDisplayYearInReviewModal = true
+                    updateProfileButton()
+                    presentYearInReviewAnnouncement()
+
+                } else {
+                    willDisplayYearInReviewModal = false
+                    showFundraisingCampaignAnnouncementIfNeeded()
+                }
             }
         }
     }

--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.m
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.m
@@ -132,9 +132,14 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
     } else if ([url.host isEqualToString:@"activity"]) {
         NSUserActivity *activity = [self wmf_activityTabActivity];
         NSString *collectPrize = [url wmf_valueForQueryKey:@"collectPrize"];
+        NSString *join = [url wmf_valueForQueryKey:@"join"];
         if ([collectPrize isEqualToString:@"true"]) {
             NSMutableDictionary *userInfo = [activity.userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
             userInfo[@"collectPrize"] = @YES;
+            activity.userInfo = userInfo;
+        } else if ([join isEqualToString:@"true"]) {
+            NSMutableDictionary *userInfo = [activity.userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
+            userInfo[@"join"] = @YES;
             activity.userInfo = userInfo;
         }
         return activity;

--- a/Wikipedia/Code/ReadingChallengeAnnouncementCoordinator.swift
+++ b/Wikipedia/Code/ReadingChallengeAnnouncementCoordinator.swift
@@ -122,6 +122,9 @@ final class ReadingChallengeAnnouncementCoordinator: NSObject, Coordinator {
     private func enroll() {
         Task {
             await WMFActivityTabDataController.shared.enrollInReadingChallenge()
+            
+            // Sometimes widget continues to show the "Join challenge" state. Delaying slightly here in case it takes a bit for UserDefaults to propagate.
+            try? await Task.sleep(for: .seconds(0.5))
             WidgetController.shared.reloadReadingChallengeWidget()
         }
     }

--- a/Wikipedia/Code/ReadingChallengeAnnouncementCoordinator.swift
+++ b/Wikipedia/Code/ReadingChallengeAnnouncementCoordinator.swift
@@ -122,9 +122,6 @@ final class ReadingChallengeAnnouncementCoordinator: NSObject, Coordinator {
     private func enroll() {
         Task {
             await WMFActivityTabDataController.shared.enrollInReadingChallenge()
-            
-            // Sometimes widget continues to show the "Join challenge" state. Delaying slightly here in case it takes a bit for UserDefaults to propagate.
-            try? await Task.sleep(for: .seconds(0.5))
             WidgetController.shared.reloadReadingChallengeWidget()
         }
     }

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1244,10 +1244,13 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
             break;
         case WMFUserActivityTypeActivity:
             [self dismissPresentedViewControllers];
+            self.activityTabViewController.temporarilySuppressAppearanceModals = YES; // We are trying to deep link, don't let other modals get in the way.
             [self setSelectedIndex:WMFAppTabTypeRecent];
             [self.currentTabNavigationController popToRootViewControllerAnimated:animated];
             if ([activity.userInfo[@"collectPrize"] isEqual:@YES]) {
                 [self.activityTabViewController presentCollectPrize];
+            } else if ([activity.userInfo[@"join"] isEqual:@YES]) {
+                [self.activityTabViewController presentReadingChallengeAnnouncementFromWidget];
             }
             break;
         case WMFUserActivityTypeContent: {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T418956

### Notes
This is built off of https://github.com/wikimedia/wikipedia-ios/pull/5791

These are fixes I decided to try when testing the states on that one.

Bug 1: Start a reading streak towards the end of May. Without breaking the reading streak, change the device date through June 1st. The state switches too early to the "Challenge concluded: incomplete" state on June 1st. We should allow the user to continue the streak up until June 25th.

Bug 2: Get the widget into the "Join challenge" state. Change the device date past May 31st. The widget remains in the "Join challenge" state. We shouldn't allow them to enroll past May 31st.

Bug 3: If user successfully completes a streak, they correctly see the "Challenge completed successfully" state. But if you change the device date a couple of more dates into the future (without visiting articles, thus breaking the streak) the widget state switches to a "Challenge concluded: no streak state" state. The user should remain on the "Challenge completed successfully" state so they can claim their prize into the future.

Bug 4: Sometimes tapping "Join widget" doesn't bring up the announcement modal. I haven't fully been able to figure out why, but I did a few tweaks to the modal ordering + listening in for the existing "join=true" url parameter so that the announcement is prioritized more. Not certain if this fixes it but I think it won't hurt anything.

### Test Steps
1. Test bugs above, confirm they are fixed

