### PR TITLE
Widget ui cleanup

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Reading Challenge Widget/WMFReadingChallengeWidgetView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Reading Challenge Widget/WMFReadingChallengeWidgetView.swift
@@ -125,7 +125,8 @@ public struct WMFReadingChallengeWidgetView: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding()
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
             wIconOverlay
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -155,7 +156,8 @@ public struct WMFReadingChallengeWidgetView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .padding(.horizontal, 20).padding(.vertical, 16)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
             wIconOverlay
         }
     }
@@ -170,14 +172,16 @@ public struct WMFReadingChallengeWidgetView: View {
                         .frame(maxHeight: 100)
                 }
             }
-            .padding()
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
             wIconOverlay
         }
     }
 
     private var noButtonsSmallView: some View {
         ZStack {
-            VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .center, spacing: 0) {
+                Spacer()
                 if let uiImage = UIImage(named: viewModel.displaySet.image, in: .module, with: nil) {
                     Image(uiImage: uiImage)
                         .resizable()
@@ -199,6 +203,19 @@ public struct WMFReadingChallengeWidgetView: View {
                             .font(Font(WMFFont.for(.boldTitle1)))
                             .foregroundColor(viewModel.displaySet.color2)
                     }
+                case .streakOngoingRead:
+                    HStack(alignment: .center) {
+                        if let icon = viewModel.displaySet.icon {
+                            Image(uiImage: icon)
+                                .font(Font(WMFFont.for(.boldTitle3)))
+                                .foregroundStyle(viewModel.displaySet.color2)
+                        }
+                        Text(viewModel.displaySet.title)
+                            .font(Font(WMFFont.for(.boldTitle3)))
+                            .foregroundColor(viewModel.displaySet.color2)
+                            .multilineTextAlignment(.center)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
 
                 case .challengeConcludedIncomplete:
                     if let subtitle = viewModel.displaySet.subtitle {
@@ -233,10 +250,12 @@ public struct WMFReadingChallengeWidgetView: View {
                     Text(viewModel.displaySet.title)
                         .font(Font(WMFFont.for(.boldFootnote)))
                         .foregroundColor(viewModel.displaySet.color2)
+                    Spacer()
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .padding(.horizontal, 20).padding(.vertical, 16)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
             wIconOverlay
         }
     }
@@ -280,7 +299,8 @@ public struct WMFReadingChallengeWidgetView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .padding(.horizontal, 20).padding(.vertical, 16)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
             wIconOverlay
         }
     }

--- a/Wikipedia/Code/ReadingChallengeWidgetAnnouncementCoordinator.swift
+++ b/Wikipedia/Code/ReadingChallengeWidgetAnnouncementCoordinator.swift
@@ -34,7 +34,7 @@ final class ReadingChallengeWidgetAnnouncementCoordinator {
         if let sheet = controller.sheetPresentationController {
             if UIDevice.current.userInterfaceIdiom == .pad {
                 sheet.detents = [.large()]
-                controller.preferredContentSize = CGSize(width: 640, height: 720)
+                // controller.preferredContentSize = CGSize(width: 640, height: 720)
             } else {
                 sheet.detents = [.medium(), .large()]
             }
@@ -44,7 +44,16 @@ final class ReadingChallengeWidgetAnnouncementCoordinator {
         }
 
         controller.modalPresentationStyle = .pageSheet
-        presenting.present(controller, animated: true)
+        presenting.present(controller, animated: true) {
+            let closeButton = UIBarButtonItem(image: WMFSFSymbolIcon.for(symbol: .xMark), style: .plain, target: nil, action: nil)
+            closeButton.primaryAction = UIAction { [weak controller] _ in
+                controller?.dismiss(animated: true) {
+                    self.onDismiss?()
+                }
+            }
+            controller.navigationItem.leftBarButtonItem = closeButton
+            controller.navigationItem.rightBarButtonItem = nil
+        }
     }
 
     private func makeViewModel() -> WMFFeatureAnnouncementViewModel {


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T418955
https://phabricator.wikimedia.org/T418952

### Notes
* ipad large variant contents are being cut off across stages - fixed with smaller fonts + padding
* make sure referencing correct type tokens, and scaling down when device sizes are smaller (see @william's implementation) - fixed with smaller fonts
* Updated close icon

### Test Steps
1. 

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
