### PR TITLE
Bring back hardcoded size for widget announcement

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Reading Challenge Widget/WMFReadingChallengeWidgetView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Reading Challenge Widget/WMFReadingChallengeWidgetView.swift
@@ -343,13 +343,29 @@ public struct WMFReadingChallengeWidgetView: View {
                                             .foregroundStyle(buttonForeground)
                                             .frame(width: 14, height: 14)
                                         Text(button1Title)
-                                            .font(Font(WMFFont.for(.semiboldSubheadline)))
+                                            .font(Font(WMFFont.for(.footnote)))
                                             .foregroundColor(buttonForeground)
                                     }
                                     .padding(.horizontal, 14).padding(.vertical, 8)
                                     .frame(maxWidth: .infinity)
                                     .background(buttonBackground)
                                     .clipShape(Capsule())
+                                }
+                            } else {
+                                if let button1Title = viewModel.displaySet.button1Title,
+                                   let button1URL = viewModel.displaySet.button1URL {
+                                    Link(destination: button1URL) {
+                                        HStack(spacing: 4) {
+                                            Text(button1Title)
+                                                .font(Font(WMFFont.for(.footnote)))
+                                                .foregroundColor(buttonForeground)
+                                        }
+                                        .padding(.horizontal, 14)
+                                        .padding(.vertical, 8)
+                                        .frame(maxWidth: .infinity)
+                                        .background(buttonBackground)
+                                        .clipShape(Capsule())
+                                    }
                                 }
                             }
                             if let button2Title = viewModel.displaySet.button2Title,
@@ -363,7 +379,7 @@ public struct WMFReadingChallengeWidgetView: View {
                                             .foregroundStyle(buttonForeground)
                                             .frame(width: 14, height: 14)
                                         Text(button2Title)
-                                            .font(Font(WMFFont.for(.semiboldSubheadline)))
+                                            .font(Font(WMFFont.for(.footnote)))
                                             .foregroundColor(buttonForeground)
                                     }
                                     .padding(.horizontal, 14).padding(.vertical, 8)
@@ -374,7 +390,6 @@ public struct WMFReadingChallengeWidgetView: View {
                             }
                         }
                     }
-                    .padding()
                     .frame(maxWidth: .infinity)
                     if let uiImage = UIImage(named: viewModel.displaySet.image, in: .module, with: nil) {
                         Image(uiImage: uiImage)

--- a/Wikipedia/Code/ReadingChallengeWidgetAnnouncementCoordinator.swift
+++ b/Wikipedia/Code/ReadingChallengeWidgetAnnouncementCoordinator.swift
@@ -34,7 +34,7 @@ final class ReadingChallengeWidgetAnnouncementCoordinator {
         if let sheet = controller.sheetPresentationController {
             if UIDevice.current.userInterfaceIdiom == .pad {
                 sheet.detents = [.large()]
-                // controller.preferredContentSize = CGSize(width: 640, height: 720)
+                controller.preferredContentSize = CGSize(width: 640, height: 720)
             } else {
                 sheet.detents = [.medium(), .large()]
             }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T418955

### Notes
* Just brings back hardcoded size for widget announcement
* and brings back button for collect prize

### Test Steps
1. 

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
