### PR TITLE
Allow cycling UI if forcing dev challenge state

### DIFF
--- a/Widgets/Widgets/ReadingChallengeWidget.swift
+++ b/Widgets/Widgets/ReadingChallengeWidget.swift
@@ -80,7 +80,12 @@ private extension WMFReadingChallengeWidgetViewModel.DisplaySet {
        
         let lastDate = userDefaults.object(forKey: dateKey.rawValue) as? Date ?? .distantPast
 
-        guard today > lastDate else { return index } // same day, return old index without incrementing
+        guard today > lastDate ||
+               WMFDeveloperSettingsDataController.shared.devReadingChallengeState != nil else {
+            // on same day, return old index without incrementing
+            // but allow increment on same day if forcing a particular state
+            return index
+        }
         
         let nextIndex = (index + 1) % optionsCount
         userDefaults.set(nextIndex, forKey: indexKey.rawValue)


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
Follow-on from dev settings menu tweaks in https://github.com/wikimedia/wikipedia-ios/pull/5809. If you are forcing a widget state, allow it to bypass the "same day" gate so that widget reloads with a random UI.

### Test Steps
1. Add widget, pick a particular state that randomizes (like "enrolled not started")
2. Pick a different state, ensure widget updates.
3. Pick original state again in step 1, ensure widget updates to a random UI/copy. (Note, it may take a couple of tries for it to start randomizing, this is an existing bug).
### Test Steps
1. 

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
