### PR TITLE
Allow pinch to zoom when reading articles

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -128,6 +128,7 @@ import WMFData
         let enableYiRVLoginExperimentControl = WMFFormItemSelectViewModel(title: "Force Year in Review Login Experiment Control", isSelected: WMFDeveloperSettingsDataController.shared.enableYiRLoginExperimentControl)
         let enableYiRVLoginExperimentB = WMFFormItemSelectViewModel(title: "Force Year in Review Login Experiment B", isSelected: WMFDeveloperSettingsDataController.shared.enableYiRLoginExperimentB)
         let forceHcaptchaChallenge = WMFFormItemSelectViewModel(title: "Force hCaptcha Challenge", isSelected: WMFDeveloperSettingsDataController.shared.forceHCaptchaChallenge)
+        let allowGestureZoomArticleWebview = WMFFormItemSelectViewModel(title: "Allow pinch to zoom when reading articles", isSelected: WMFDeveloperSettingsDataController.shared.allowGestureZoomArticleWebview)
 
         formViewModel = WMFFormViewModel(sections: [
             WMFFormSectionSelectViewModel(items: [
@@ -140,7 +141,8 @@ import WMFData
                 showYiRV3,
                 enableYiRVLoginExperimentControl,
                 enableYiRVLoginExperimentB,
-                forceHcaptchaChallenge
+                forceHcaptchaChallenge,
+                allowGestureZoomArticleWebview
             ], selectType: .multi)
         ])
 
@@ -186,6 +188,10 @@ import WMFData
             control: enableYiRVLoginExperimentControl,
             b: enableYiRVLoginExperimentB
         )
+
+        allowGestureZoomArticleWebview.$isSelected
+            .sink { isSelected in WMFDeveloperSettingsDataController.shared.allowGestureZoomArticleWebview = isSelected }
+            .store(in: &subscribers)
     }
 
     public func clearAllReadingChallengePersistence() {

--- a/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
@@ -94,6 +94,11 @@ public protocol WMFDeveloperSettingsDataControlling: AnyObject {
         set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.forceHCaptchaChallenge.rawValue, value: newValue) }
     }
 
+    public var allowGestureZoomArticleWebview: Bool {
+        get { (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.allowGestureZoomArticleWebview.rawValue)) ?? false }
+        set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.allowGestureZoomArticleWebview.rawValue, value: newValue) }
+    }
+
     public var showGamesV1: Bool {
         get { (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.developerSettingsShowGamesV1.rawValue)) ?? false }
         set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.developerSettingsShowGamesV1.rawValue, value: newValue) }

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -42,6 +42,7 @@ public enum WMFUserDefaultsKey: String {
     case isSubscribedToEchoNotifications = "is-subscribed-to-echo-notifications"
     case forceHCaptchaChallenge = "force-hcaptcha-challenge"
     case activityTabReadingChallenge = "activity-tab-reading-challenge"
+    case allowGestureZoomArticleWebview = "allow-gesture-zoom-article-webview"
     
     // Reading challenge widget keys
     case hasEnrolledInReadingChallenge2026 = "has-enrolled-in-reading-challenge-2026"

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -226,6 +226,7 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
     lazy var webViewConfiguration: WKWebViewConfiguration = {
         let configuration = WKWebViewConfiguration()
         configuration.setURLSchemeHandler(schemeHandler, forURLScheme: schemeHandler.scheme)
+        configuration.ignoresViewportScaleLimits = true
         return configuration
     }()
 

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -224,6 +224,7 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
     lazy var webViewConfiguration: WKWebViewConfiguration = {
         let configuration = WKWebViewConfiguration()
         configuration.setURLSchemeHandler(schemeHandler, forURLScheme: schemeHandler.scheme)
+        configuration.ignoresViewportScaleLimits = true
         return configuration
     }()
 

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -226,7 +226,11 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
     lazy var webViewConfiguration: WKWebViewConfiguration = {
         let configuration = WKWebViewConfiguration()
         configuration.setURLSchemeHandler(schemeHandler, forURLScheme: schemeHandler.scheme)
-        configuration.ignoresViewportScaleLimits = true
+
+        if WMFDeveloperSettingsDataController.shared.allowGestureZoomArticleWebview {
+            configuration.ignoresViewportScaleLimits = true
+        }
+
         return configuration
     }()
 


### PR DESCRIPTION
Overrides user-scalable=no in the article webview

**Phabricator:** 
https://phabricator.wikimedia.org/T424079

### Notes

Allow pinch to zoom in the article webview

I frequently use pinch to zoom on the web (both desktop and mobile) to zoom into article text or images without relayout of the entire article webpage but the mobile app does not allow usage of this gesture. This PR allows using pinch-to-zoom in the mobile app exclusively in the article webview.

Since iOS 10+ Safari allows pinch to zoom even with `user-scalable=no` in the HTML. WKWebView however respects `user-scalable=no` and does not allow zooming by default. This change sets webview's configuration to `ignoresViewportScaleLimits` to match behavior of Safari and allow pinch to zoom. Note W3C recommendation https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/viewport#user-scalable.

A broader, perhaps more correct fix, is to set `user-scalable=yes` in the content being served. It looks like `user-scalable` in the HTML content being served is being set by https://github.com/wikimedia/mediawiki-services-mobileapps/blob/master/lib/transformations/pcs/head.js#L71 introduced in change [b3bed0a05861401f83d84e93d436d08bb77da1c4](https://github.com/wikimedia/mediawiki-services-mobileapps/commit/b3bed0a05861401f83d84e93d436d08bb77da1c4)

If there is interest in enabling pinch to zoom, I could potentially make a change in that repo if there is consensus that it is the right spot, instead of this repo `wikipedia-ios`. Please see Note 2 below regarding Android.

* Note 1 : I did not find the current zoom level used in wikipedia-ios. There is an old commit https://github.com/wikimedia/wikipedia-ios/commit/a376a1030bcae896768e1565006eb23d7ca9c524 that uses the zoom level in `getElementRect()`. From a quick search it looks like `getElementRect()` itself is not used in wikipedia-ios. So, this change should not have any impact other than allowing the user to zoom in with gestures.
* Note 2 : Associated Android PR. On Android the webview cannot be configured to ignore viewport scale limits so the corresponding change on Android will require modifying HTML content before loading in webview. The Android PR will depend on the decision whether to make the change in PCS to serve pages with `user-scalable=yes`. If the served pages cannot be changed, then for the Android app, the loaded content will have to override user-scalable before parsing the HTML in webview.

### Test Steps

Test iOS wikipedia app with this change. Pinch to zoom in article webviews matches behavior in Safari.
