### PR TITLE
T269478: Apply missing label theme colors for onboarding carousel

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -2116,6 +2116,7 @@
 		D8619BA71FBB10240045C8BC /* ReadingListEntry+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8619BA11FBB10240045C8BC /* ReadingListEntry+CoreDataProperties.swift */; };
 		D8635AE8216E2BFC001A7C00 /* HTTPCookieStorage+Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8635AE7216E2BFC001A7C00 /* HTTPCookieStorage+Migration.swift */; };
 		D864D68C1DA3EA3800B86934 /* NumberFormatterExtrasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864D68B1DA3EA3800B86934 /* NumberFormatterExtrasTests.swift */; };
+		D8A3C8F22FBB000100E6073C /* UserDefaultsThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3C8F12FBB000100E6073C /* UserDefaultsThemeTests.swift */; };
 		D8650B7B20350FEE0044DFFA /* NSString+SHA256.h in Headers */ = {isa = PBXBuildFile; fileRef = D8650B7920350FEE0044DFFA /* NSString+SHA256.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D8650B7C20350FEE0044DFFA /* NSString+SHA256.m in Sources */ = {isa = PBXBuildFile; fileRef = D8650B7A20350FEE0044DFFA /* NSString+SHA256.m */; };
 		D87234011E1FF0A500751E83 /* PlacesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87233FF1E1FF0A500751E83 /* PlacesViewController.swift */; };
@@ -4235,6 +4236,7 @@
 		D8619BA11FBB10240045C8BC /* ReadingListEntry+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReadingListEntry+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		D8635AE7216E2BFC001A7C00 /* HTTPCookieStorage+Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPCookieStorage+Migration.swift"; sourceTree = "<group>"; };
 		D864D68B1DA3EA3800B86934 /* NumberFormatterExtrasTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberFormatterExtrasTests.swift; sourceTree = "<group>"; };
+		D8A3C8F12FBB000100E6073C /* UserDefaultsThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsThemeTests.swift; sourceTree = "<group>"; };
 		D864D68D1DA3EDF900B86934 /* NSNumberFormatter+WMFExtras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSNumberFormatter+WMFExtras.swift"; path = "Wikipedia/Code/NSNumberFormatter+WMFExtras.swift"; sourceTree = SOURCE_ROOT; };
 		D8650B7920350FEE0044DFFA /* NSString+SHA256.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSString+SHA256.h"; sourceTree = "<group>"; };
 		D8650B7A20350FEE0044DFFA /* NSString+SHA256.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSString+SHA256.m"; sourceTree = "<group>"; };
@@ -7459,6 +7461,7 @@
 				A452F9FA24081A7200D8ED09 /* LocationManagerTests.swift */,
 				00D280FB247F019C006BEE23 /* Date+ExtensionTests.swift */,
 				FFBA8C1827D824D8009E9B65 /* URL+ExtensionTests.swift */,
+				D8A3C8F12FBB000100E6073C /* UserDefaultsThemeTests.swift */,
 				00A8F58526BDD5E700175B8E /* WidgetSampleContentTests.swift */,
 			);
 			name = Tests;
@@ -9481,6 +9484,7 @@
 				679F0AAD24574AD400EF4A6A /* ArticleViewControllerTests.swift in Sources */,
 				67E3992A24786E2100441831 /* ReadingListManualPerformanceTests.swift in Sources */,
 				D864D68C1DA3EA3800B86934 /* NumberFormatterExtrasTests.swift in Sources */,
+				D8A3C8F22FBB000100E6073C /* UserDefaultsThemeTests.swift in Sources */,
 				A452F9F824081A5500D8ED09 /* MockCLLocationManager.swift in Sources */,
 				67DAEDEC27E8FB63005CF9B6 /* NotificationsCenterDetailViewModelUserTalkMessageTests.swift in Sources */,
 				B0C06B9F218240CA00E481CC /* Collection+AsyncMapTests.swift in Sources */,

--- a/Wikipedia/Code/WMFWelcomeIntroductionViewController.swift
+++ b/Wikipedia/Code/WMFWelcomeIntroductionViewController.swift
@@ -7,6 +7,7 @@ class WMFWelcomeIntroductionViewController: ThemeableViewController {
         guard viewIfLoaded != nil else {
             return
         }
+        descriptionLabel.textColor = theme.colors.secondaryText
         learnMoreButton.setTitleColor(theme.colors.link, for: .normal)
     }
 

--- a/Wikipedia/Code/WMFWelcomePanelViewController.swift
+++ b/Wikipedia/Code/WMFWelcomePanelViewController.swift
@@ -8,6 +8,7 @@ class WMFWelcomePanelViewController: ThemeableViewController {
             return
         }
         scrollView.apply(theme: theme)
+        titleLabel.textColor = theme.colors.primaryText
 
         // Apply theme colors to button configuration
         if var config = nextButton.configuration {

--- a/WikipediaUnitTests/Code/UserDefaultsThemeTests.swift
+++ b/WikipediaUnitTests/Code/UserDefaultsThemeTests.swift
@@ -1,0 +1,38 @@
+@testable import Wikipedia
+import UIKit
+import XCTest
+
+final class UserDefaultsThemeTests: XCTestCase {
+    private let defaultsSuiteName = "UserDefaultsThemeTests"
+
+    func testDefaultThemeReturnsLightForSystemLight() {
+        let defaults = makeDefaults()
+        defaults.themeName = Theme.defaultThemeName
+        defaults.wmf_isImageDimmingEnabled = true
+
+        let theme = defaults.theme(compatibleWith: UITraitCollection(userInterfaceStyle: .light))
+
+        XCTAssertEqual(theme.name, Theme.light.name)
+        XCTAssertEqual(theme.imageOpacity, Theme.light.imageOpacity)
+        XCTAssertFalse(theme.isDark)
+    }
+
+    func testDefaultThemeReturnsBlackForSystemDark() {
+        let defaults = makeDefaults()
+        defaults.themeName = Theme.defaultThemeName
+        defaults.wmf_isImageDimmingEnabled = false
+
+        let theme = defaults.theme(compatibleWith: UITraitCollection(userInterfaceStyle: .dark))
+
+        XCTAssertEqual(theme.name, Theme.black.name)
+        XCTAssertEqual(theme.imageOpacity, Theme.black.imageOpacity)
+        XCTAssertTrue(theme.isDark)
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let defaults = UserDefaults(suiteName: defaultsSuiteName)!
+        // reset defaults
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        return defaults
+    }
+}


### PR DESCRIPTION
**Phabricator: T269478** 

### Notes
- While these cases cannot be reached in real use, this is a simple change to avoid future confusion about the state of these screenshots.
- Add unit tests that verify default theme choice based on system setting

### Test Steps
N/A

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
<img width="200" height="400" alt="app-onboarding-initial-dark" src="https://github.com/user-attachments/assets/0eb84880-4d73-41da-9574-450f574bf1fd" />
<img width="200" height="400" alt="app-onboarding-initial" src="https://github.com/user-attachments/assets/0ba0c4f7-f153-416c-93fc-86c508f83ddc" />
<img width="200" height="400" alt="app-onboarding-initial-lgiht" src="https://github.com/user-attachments/assets/fe0e8720-2bac-498d-a383-90df7011d751" />
<img width="200" height="400" alt="app-onboarding-initial-sepia" src="https://github.com/user-attachments/assets/c108f8d7-437d-478f-9492-adc357ea4147" />
