### PR TITLE
Revert simulator resolution workflow change

### DIFF
--- a/.github/workflows/run_ui_tests.yml
+++ b/.github/workflows/run_ui_tests.yml
@@ -54,14 +54,63 @@ jobs:
         run: |
           sudo xcode-select -switch "/Applications/Xcode_${XCODE_VERSION}.app"
 
-      - name: Run WikipediaUITests
+      - name: Resolve simulator
+        id: simulator
         run: |
-          echo "Running WikipediaUITests on ${SIMULATOR_NAME} iOS ${IOS_VERSION} with Xcode ${XCODE_VERSION}"
+          xcrun simctl list devices available --json > simulators.json
+          SIMULATOR_ID=$(python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          ios_version = os.environ["IOS_VERSION"]
+          simulator_name = os.environ["SIMULATOR_NAME"]
+          runtime_id = f"com.apple.CoreSimulator.SimRuntime.iOS-{ios_version.replace('.', '-')}"
+
+          with open("simulators.json") as file:
+              simulators = json.load(file)
+
+          matches = [
+              device
+              for device in simulators.get("devices", {}).get(runtime_id, [])
+              if device.get("name") == simulator_name and device.get("isAvailable")
+          ]
+
+          if len(matches) != 1:
+              print(
+                  f"Expected exactly one available {simulator_name} simulator for iOS {ios_version}; found {len(matches)}.",
+                  file=sys.stderr
+              )
+              print("Available iOS simulator devices:", file=sys.stderr)
+              for runtime, devices in sorted(simulators.get("devices", {}).items()):
+                  if not runtime.startswith("com.apple.CoreSimulator.SimRuntime.iOS-"):
+                      continue
+                  version = runtime.removeprefix("com.apple.CoreSimulator.SimRuntime.iOS-").replace("-", ".")
+                  names = sorted({
+                      device.get("name", "<unknown>")
+                      for device in devices
+                      if device.get("isAvailable")
+                  })
+                  if names:
+                      print(f"  iOS {version}: {', '.join(names)}", file=sys.stderr)
+              sys.exit(1)
+
+          print(matches[0]["udid"])
+          PY
+          )
+          echo "simulator_id=${SIMULATOR_ID}" >> "$GITHUB_OUTPUT"
+          echo "Resolved ${SIMULATOR_NAME} iOS ${IOS_VERSION} to ${SIMULATOR_ID}"
+
+      - name: Run WikipediaUITests
+        env:
+          SIMULATOR_ID: ${{ steps.simulator.outputs.simulator_id }}
+        run: |
+          echo "Running WikipediaUITests on ${SIMULATOR_NAME} iOS ${IOS_VERSION} (${SIMULATOR_ID}) with Xcode ${XCODE_VERSION}"
           xcodebuild test \
             -scheme WikipediaUITests \
             -project Wikipedia.xcodeproj \
             -testPlan UITests \
-            -destination "platform=iOS Simulator,name=${SIMULATOR_NAME},OS=${IOS_VERSION}" \
+            -destination "platform=iOS Simulator,id=${SIMULATOR_ID}" \
             -resultBundlePath "WikipediaUITests_TestResults" \
             | xcpretty
           EXIT_CODE=${PIPESTATUS[0]}

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -13,7 +13,6 @@ env:
   XCODE_VERSION: "26.2"
   IOS_VERSION: "26.2"
   SCHEMES: "Wikipedia WMFComponents WMFData"
-  SIMULATOR_NAME: "iPhone 16"
 
 concurrency:
   group: "unit-tests-${{ github.ref }}"  # One group per branch
@@ -39,17 +38,21 @@ jobs:
 
       - name: Test ${{ matrix.scheme }} scheme
         run: |
-          echo "Running scheme: ${{ matrix.scheme }} on ${SIMULATOR_NAME} iOS ${IOS_VERSION} with Xcode ${XCODE_VERSION}"
-          xcodebuild test \
-            -scheme "${{ matrix.scheme }}" \
-            -project Wikipedia.xcodeproj \
-            -destination "platform=iOS Simulator,name=${SIMULATOR_NAME},OS=${IOS_VERSION}" \
-            -resultBundlePath "${{ matrix.scheme }}_TestResults" \
-            | xcpretty
-          EXIT_CODE=${PIPESTATUS[0]}
-          if [ "$EXIT_CODE" -ne 0 ]; then
-            exit "$EXIT_CODE"
-          fi
+          xcrun simctl list
+          SIMULATORS=("iPhone 16")
+          for SIMULATOR in "${SIMULATORS[@]}"; do
+            echo "Running scheme: ${{ matrix.scheme }} on ${SIMULATOR} iOS ${IOS_VERSION} with Xcode ${XCODE_VERSION}"
+            xcodebuild test \
+              -scheme "${{ matrix.scheme }}" \
+              -project Wikipedia.xcodeproj \
+              -destination "platform=iOS Simulator,name=$SIMULATOR,OS=$IOS_VERSION" \
+              -resultBundlePath "${{ matrix.scheme }}_TestResults" \
+              | xcpretty
+            EXIT_CODE=${PIPESTATUS[0]}
+            if [ "$EXIT_CODE" -ne 0 ]; then
+              exit "$EXIT_CODE"
+            fi
+          done
 
       - name: Coverage summary
         if: success()


### PR DESCRIPTION
## Summary

Reverts #5849 by backing out merge commit `811d2ad139a3cf9bc46807f2b1a2756fb630143a`.

This restores the previous unit/UI test workflow behavior and removes the direct named-destination simplification introduced by that PR.
