### PR TITLE
Reading Challenge - Add deep link for app store event

### DIFF
--- a/Wikipedia/Code/ActivityTabViewController.swift
+++ b/Wikipedia/Code/ActivityTabViewController.swift
@@ -21,7 +21,7 @@ final class WMFActivityTabHostingController: WMFComponentHostingController<WMFAc
 
     private var readingChallengeCoordinator: ReadingChallengeAnnouncementCoordinator?
 
-    private var disableModalsOnAppearance: Bool = false
+    @objc var disableModalsOnAppearance: Bool = false
     private let widgetInstrument = WidgetFunnel().widgetInstrument
 
     public init(dataStore: MWKDataStore?, theme: Theme, viewModel: WMFActivityTabViewModel, dataController: WMFActivityTabDataController) {
@@ -374,12 +374,13 @@ final class WMFActivityTabHostingController: WMFComponentHostingController<WMFAc
             presentActivityOnboardingOrSurveyIfNeeded()
             return
         }
-
+        
         let readingChallengeCoordinator = ReadingChallengeAnnouncementCoordinator(
             navigationController: navigationController,
             dataStore: dataStore,
             theme: theme,
             fromWidgetJoinChallengeButton: false,
+            fromAppStoreEvent: false,
             isLoggedIn: dataStore.authenticationManager.authStateIsPermanent,
             instrument: widgetInstrument
         )
@@ -415,23 +416,50 @@ final class WMFActivityTabHostingController: WMFComponentHostingController<WMFAc
             }
         }
     }
+    
+    @objc func presentReadingChallengeAnnouncementFromAppStoreEvent() {
+        
+        guard let navigationController, let dataStore else {
+            return
+        }
+        
+        let readingChallengeCoordinator = ReadingChallengeAnnouncementCoordinator(
+            navigationController: navigationController,
+            dataStore: dataStore,
+            theme: theme,
+            fromWidgetJoinChallengeButton: false,
+            fromAppStoreEvent: true,
+            isLoggedIn: dataStore.authenticationManager.authStateIsPermanent,
+            instrument: widgetInstrument
+        )
+
+        readingChallengeCoordinator.onComplete = { [weak self] didPresentSomething in
+
+            self?.readingChallengeCoordinator = nil
+            self?.disableModalsOnAppearance = false
+        }
+
+        self.readingChallengeCoordinator = readingChallengeCoordinator
+
+        readingChallengeCoordinator.start()
+    }
 
     // Explicit method to fire the announcement, meant to be called ONLY when tapping Join on the widget. It differs from presentModalsIfNeeded in these ways:
     // 1. We do not try to present any activity onboarding/survey whatsoever
     // 2. We purposfully set a temp "disableModals" flag, just in case viewDidAppear (which calls presentModalsIfNeeded) fires at the same time. "disableModals" disables all modal attempts in presentModalsIfNeeded.
     // 3. We tell the announcement coordinator that it is from the widget, which bypasses hasSeen flag logic
     @objc func presentReadingChallengeAnnouncementFromWidget() {
+        
         guard let navigationController, let dataStore else {
             return
         }
-
-        disableModalsOnAppearance = true
 
         let readingChallengeCoordinator = ReadingChallengeAnnouncementCoordinator(
             navigationController: navigationController,
             dataStore: dataStore,
             theme: theme,
             fromWidgetJoinChallengeButton: true,
+            fromAppStoreEvent: false,
             isLoggedIn: dataStore.authenticationManager.authStateIsPermanent,
             instrument: widgetInstrument
         )

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -510,7 +510,7 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
             return
         }
         
-        let readingChallengeCoordinator = ReadingChallengeAnnouncementCoordinator(navigationController: navigationController, dataStore: dataStore, theme: theme, fromWidgetJoinChallengeButton: false, isLoggedIn: dataStore.authenticationManager.authStateIsPermanent, instrument: widgetInstrument)
+        let readingChallengeCoordinator = ReadingChallengeAnnouncementCoordinator(navigationController: navigationController, dataStore: dataStore, theme: theme, fromWidgetJoinChallengeButton: false, fromAppStoreEvent: false, isLoggedIn: dataStore.authenticationManager.authStateIsPermanent, instrument: widgetInstrument)
 
         readingChallengeCoordinator.onComplete = { [weak self] didPresentSomething in
             

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -995,7 +995,7 @@ extension ExploreViewController {
             return
         }
         
-        let readingChallengeCoordinator = ReadingChallengeAnnouncementCoordinator(navigationController: navigationController, dataStore: dataStore, theme: theme, fromWidgetJoinChallengeButton: false, isLoggedIn: dataStore.authenticationManager.authStateIsPermanent, instrument: widgetInstrument)
+        let readingChallengeCoordinator = ReadingChallengeAnnouncementCoordinator(navigationController: navigationController, dataStore: dataStore, theme: theme, fromWidgetJoinChallengeButton: false, fromAppStoreEvent: false, isLoggedIn: dataStore.authenticationManager.authStateIsPermanent, instrument: widgetInstrument)
         
         readingChallengeCoordinator.onComplete = { [weak self] didPresentSomething in
             

--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.m
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.m
@@ -133,6 +133,7 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
         NSUserActivity *activity = [self wmf_activityTabActivity];
         NSString *collectPrize = [url wmf_valueForQueryKey:@"collectPrize"];
         NSString *join = [url wmf_valueForQueryKey:@"join"];
+        NSString *appStoreEvent = [url wmf_valueForQueryKey:@"appStoreEvent"];
         if ([collectPrize isEqualToString:@"true"]) {
             NSMutableDictionary *userInfo = [activity.userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
             userInfo[@"collectPrize"] = @YES;
@@ -140,6 +141,10 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
         } else if ([join isEqualToString:@"true"]) {
             NSMutableDictionary *userInfo = [activity.userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
             userInfo[@"join"] = @YES;
+            activity.userInfo = userInfo;
+        } else if ([appStoreEvent isEqualToString:@"true"]) {
+            NSMutableDictionary *userInfo = [activity.userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
+            userInfo[@"appStoreEvent"] = @YES;
             activity.userInfo = userInfo;
         }
         return activity;

--- a/Wikipedia/Code/ReadingChallengeAnnouncementCoordinator.swift
+++ b/Wikipedia/Code/ReadingChallengeAnnouncementCoordinator.swift
@@ -14,15 +14,17 @@ final class ReadingChallengeAnnouncementCoordinator: NSObject, Coordinator {
     private let theme: Theme
     
     private let fromWidgetJoinChallengeButton: Bool
+    private let fromAppStoreEvent: Bool
     private let isLoggedIn: Bool
 
     private let widgetInstrument: InstrumentImpl
 
-    init(navigationController: UINavigationController, dataStore: MWKDataStore, theme: Theme, fromWidgetJoinChallengeButton: Bool, isLoggedIn: Bool, instrument: InstrumentImpl) {
+    init(navigationController: UINavigationController, dataStore: MWKDataStore, theme: Theme, fromWidgetJoinChallengeButton: Bool, fromAppStoreEvent: Bool, isLoggedIn: Bool, instrument: InstrumentImpl) {
         self.navigationController = navigationController
         self.dataStore = dataStore
         self.theme = theme
         self.fromWidgetJoinChallengeButton = fromWidgetJoinChallengeButton
+        self.fromAppStoreEvent = fromAppStoreEvent
         self.isLoggedIn = isLoggedIn
         self.widgetInstrument = instrument
     }
@@ -34,7 +36,7 @@ final class ReadingChallengeAnnouncementCoordinator: NSObject, Coordinator {
         
         Task { [weak self] in
             guard let self else { return }
-            if fromWidgetJoinChallengeButton {
+            if fromWidgetJoinChallengeButton || fromAppStoreEvent {
                 presentFullPageAnnouncement()
             } else {
                 guard await WMFActivityTabDataController.shared.shouldShowReadingChallengeAnnouncement() else {

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -1282,21 +1282,28 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
             [self showRandomArticleFromShortcutWithSiteURL:[self siteURL] animated:animated];
             break;
         case WMFUserActivityTypeActivity: {
+            
+            WMFActivityTabViewController *activityVC = self.activityTabViewController;
+            activityVC.disableModalsOnAppearance = YES;
+            
             [self dismissPresentedViewControllers];
             [self setSelectedIndex:WMFAppTabTypeRecent];
             [self.currentTabNavigationController popToRootViewControllerAnimated:animated];
             BOOL shouldCollectPrize = [activity.userInfo[@"collectPrize"] boolValue];
             BOOL tappedJoin = [activity.userInfo[@"join"] boolValue];
+            BOOL fromAppStoreEvent = [activity.userInfo[@"appStoreEvent"] boolValue];
 
             if (shouldCollectPrize) {
-                WMFActivityTabViewController *activityVC = self.activityTabViewController;
                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
                     [activityVC presentCollectPrize];
                 });
             } else if (tappedJoin) {
-                WMFActivityTabViewController *activityVC = self.activityTabViewController;
                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
                     [activityVC presentReadingChallengeAnnouncementFromWidget];
+                });
+            } else if (fromAppStoreEvent) {
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    [activityVC presentReadingChallengeAnnouncementFromAppStoreEvent];
                 });
             }
             break;


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
This PR does a couple of things:

1. When tapping the "Join challenge" widget button when the app was in a terminated state, the app would launch, announcement would present, BUT the announcement buttons were not responsive (see bug here https://wikimedia.slack.com/archives/C4DDMJ9CH/p1777648083031519). Moving this `disableModalsOnAppearance` setting earlier in the lifecycle (from [WMFAppViewController.m](https://github.com/wikimedia/wikipedia-ios/compare/8.1.0-followup...fix-join-deep-link?expand=1#diff-53892ba35877905bfabb1572472302074e7251ac44ee8ac623d2b0be877d4953R1287)) fixes this.

2. I am adding the support of another deep link, which we will be using in the App Store event. Tapping this link opens the app and shows the challenge announcement.

### Test Steps

----Fix 1-----
1. Install app on device.
2. Open app, go through app onboarding.
3. Terminate app. Install widget. Change device date to May 11. Tap Join Challenge.
4. App should open on Activity tab and show announcement. Buttons should be responsive (Join, X).

----Store Deep Link-----
1. Install app on device.
2. Terminate app.
3. Paste wikipedia://activity?appStoreEvent=true&source=widget_reading_challenge in Safari.
4. App should open and land you on Activity tab with challenge announcement. Tapping Join should show followup Widget announcement.

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
