### PR TITLE
Reading challenge - Announcement presentation fixes

### DIFF
--- a/Wikipedia/Code/ActivityTabViewController.swift
+++ b/Wikipedia/Code/ActivityTabViewController.swift
@@ -368,6 +368,11 @@ final class WMFActivityTabHostingController: WMFComponentHostingController<WMFAc
 
     @MainActor
     private func presentModalsIfNeeded() {
+        
+        // Do not replace an in-flight reading challenge coordinator.
+        guard readingChallengeCoordinator == nil else {
+            return
+        }
 
         // Prioritize reading challenge, then fall back to Activity onboarding or survey view if that doesn't present
         guard let navigationController, let dataStore else {
@@ -419,6 +424,11 @@ final class WMFActivityTabHostingController: WMFComponentHostingController<WMFAc
     
     @objc func presentReadingChallengeAnnouncementFromAppStoreEvent() {
         
+        // Do not replace an in-flight reading challenge coordinator.
+        guard readingChallengeCoordinator == nil else {
+            return
+        }
+        
         guard let navigationController, let dataStore else {
             return
         }
@@ -449,6 +459,11 @@ final class WMFActivityTabHostingController: WMFComponentHostingController<WMFAc
     // 2. We purposfully set a temp "disableModals" flag, just in case viewDidAppear (which calls presentModalsIfNeeded) fires at the same time. "disableModals" disables all modal attempts in presentModalsIfNeeded.
     // 3. We tell the announcement coordinator that it is from the widget, which bypasses hasSeen flag logic
     @objc func presentReadingChallengeAnnouncementFromWidget() {
+        
+        // Do not replace an in-flight reading challenge coordinator.
+        guard readingChallengeCoordinator == nil else {
+            return
+        }
         
         guard let navigationController, let dataStore else {
             return

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -504,6 +504,11 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
     /// Catch-all method for deciding what is the best modal to present on top of Article at this point. This method needs careful if-else logic so that we do not present two modals at the same time, which may unexpectedly suppress one.
     private func presentModalsIfNeeded() {
         
+        // Do not replace an in-flight reading challenge coordinator.
+        guard readingChallengeCoordinator == nil else {
+            return
+        }
+        
         // Prioritize reading challenge, then fall back to Activity onboarding or survey view if that doesn't present
         guard let navigationController else {
             presentYearInReviewAnnouncementOrFundraisingIfNeeded()

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -989,6 +989,11 @@ extension ExploreViewController {
     /// Catch-all method for deciding what is the best modal to present on top of Explore at this point. This method needs careful if-else logic so that we do not present two modals at the same time, which may unexpectedly suppress one.
     private func presentModalsIfNeeded() {
         
+        // Do not replace an in-flight reading challenge coordinator.
+        guard readingChallengeCoordinator == nil else {
+            return
+        }
+        
         // Prioritize reading challenge, then fall back to Activity onboarding or survey view if that doesn't present
         guard let navigationController, let dataStore else {
             presentYearInReviewAnnouncementOrTooltipsIfNeeded()

--- a/Wikipedia/Code/ReadingChallengeAnnouncementCoordinator.swift
+++ b/Wikipedia/Code/ReadingChallengeAnnouncementCoordinator.swift
@@ -141,12 +141,11 @@ final class ReadingChallengeAnnouncementCoordinator: NSObject, Coordinator {
 
         let navController = WMFComponentNavigationController(rootViewController: onboardingController, modalPresentationStyle: .pageSheet)
 
-        markSeen()
-
-        navigationController.present(navController, animated: true) {
+        navigationController.present(navController, animated: true) { [weak self] in
+            self?.markSeen()
             UIAccessibility.post(notification: .layoutChanged, argument: nil)
             // Instrument: impression on announcement view
-            self.widgetInstrument.submitInteraction(action: "impression", actionSource: "widget_challenge_announce")
+            self?.widgetInstrument.submitInteraction(action: "impression", actionSource: "widget_challenge_announce")
         }
     }
 


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T426094

### Notes
Added some defensive coding around the announcement presentation. If the coordinator property is already populated, then the announcement should already be on screen. We don't want to kick off another presentation, which would cause the existing coordinator to deinitialize (and thus cause the buttons to become unresponsive).

I also moved the `markSeen()` button to after the full page announcement successfully presents. If some other modal causes collisions with it, the completion block would not run. So we are only marking as seen in the completion block, so that if collisions occur, it will re-attempt again later.

### Test Steps
1. Fresh install app and launch so that the Explore announcement shows. While announcement is on screen, background app, then return to app. Ensure buttons are still responsive and challenge can be joined.
2. Light regression testing around the markSeen change. Ensure announcement doesn't show again once you have seen it once.

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
