### PR TITLE
Remove history > search module in Activity

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Activity Tab/WMFActivityTabView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Activity Tab/WMFActivityTabView.swift
@@ -100,9 +100,6 @@ public struct WMFActivityTabView: View {
                 Section {
                     VStack(spacing: 16) {
                         if viewModel.customizeViewModel.isTimeSpentReadingOn {
-                            if viewModel.needsHistoryCallout {
-                                historyCalloutView(loggedIn: true)
-                            }
                             headerView
                                 .accessibilityElement()
                                 .accessibilityLabel(viewModel.articlesReadViewModel.usernamesReading)
@@ -241,11 +238,6 @@ public struct WMFActivityTabView: View {
     private func loggedOutList(proxy: ScrollViewProxy) -> some View {
         if viewModel.sections.count == 0 {
             VStack {
-                if viewModel.needsHistoryCallout {
-                    historyCalloutView(loggedIn: false)
-                        .padding(.top, 16)
-                        .padding([.leading, .trailing], 16)
-                }
                 Section {
                     loggedOutView
                         .accessibilityElement(children: .contain)
@@ -268,14 +260,6 @@ public struct WMFActivityTabView: View {
             .background(Color(uiColor: theme.paperBackground).edgesIgnoringSafeArea(.all))
         } else {
             List {
-                if viewModel.needsHistoryCallout {
-                    Section {
-                        historyCalloutView(loggedIn: false)
-                            .padding(16)
-                            .listRowInsets(EdgeInsets())
-                    }
-                    .listRowSeparator(.hidden)
-                }
                 Section {
                     loggedOutView
                         .accessibilityElement(children: .contain)
@@ -473,57 +457,6 @@ public struct WMFActivityTabView: View {
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(accessibilityLabel)
             .accessibilityAddTraits(.isButton)
-    }
-
-    private func historyCalloutView(loggedIn: Bool) -> some View {
-       let bodyString = loggedIn
-            ? viewModel.localizedStrings.historyCalloutBodyLoggedIn
-            : viewModel.localizedStrings.historyCalloutBodyLoggedOut
-        let bodyAttributed = (try? AttributedString(markdown: bodyString)) ?? AttributedString(bodyString)
-
-        return VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .top, spacing: 8) {
-                Text("🔍")
-                    .accessibilityHidden(true)
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(viewModel.localizedStrings.historyCalloutTitle)
-                        .font(Font(WMFFont.for(.boldSubheadline)))
-                        .foregroundStyle(Color(uiColor: theme.link))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .accessibilityAddTraits(.isHeader)
-                    Text(bodyAttributed)
-                        .font(Font(WMFFont.for(.subheadline)))
-                        .foregroundStyle(Color(uiColor: theme.link))
-                        .onTapGesture {
-                            viewModel.didTapSearchTab?()
-                        }
-                }
-                Button {
-                    viewModel.setClosedHIstoryCallout()
-                } label: {
-                    if let closeIconName = WMFSFSymbolIcon.closeCircleFill.name {
-                        Image(systemName: closeIconName)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 22, height: 22)
-                            .symbolRenderingMode(.palette)
-                            .foregroundStyle(
-                                Color(uiColor: theme.secondaryText),
-                                Color(uiColor: theme.secondaryText.withAlphaComponent(0.2))
-                            )
-                    }
-                }
-                .buttonStyle(BorderlessButtonStyle())
-                .accessibilityLabel(viewModel.localizedStrings.calloutCloseButtonAccesibilityHint)
-            }
-        }
-        .padding(16)
-        .background(Color(uiColor: theme.link.withAlphaComponent(0.15)))
-        .cornerRadius(10)
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(Color(uiColor: theme.link.withAlphaComponent(0.3)), lineWidth: 0.5)
-        )
     }
 
     private func showPlus(displayCount: Int, totalSavedCount: Int) -> Bool {

--- a/WMFComponents/Sources/WMFComponents/Components/Activity Tab/WMFActivityTabViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Activity Tab/WMFActivityTabViewModel.swift
@@ -192,7 +192,6 @@ public final class WMFActivityTabViewModel: ObservableObject {
     @Published var globalEditCount: Int?
     @Published public var isLoading: Bool = false
     public var isEmpty: Bool = false
-    @Published public var needsHistoryCallout: Bool = true
     @Published public var showBabyGlobe: Bool = true
     public var onTapGlobalEdits: (() -> Void)?
     public var fetchDataCompleteAction: ((Bool) -> Void)?
@@ -301,7 +300,6 @@ public final class WMFActivityTabViewModel: ObservableObject {
             isLoading = false
             isFirstTimeLoading = false
             fetchDataCompleteAction?(fromAppearance)
-            needsHistoryCallout = await getNeedsHistoryCallout()
         }
     }
 
@@ -316,17 +314,6 @@ public final class WMFActivityTabViewModel: ObservableObject {
         } catch {
             debugPrint("Error getting global edit count: \(error)")
             globalEditCount = nil
-        }
-    }
-
-    public func getNeedsHistoryCallout() async -> Bool {
-        return await dataController.getNeedsHistoryCallout()
-    }
-
-    public func setClosedHIstoryCallout() {
-        needsHistoryCallout = false
-        Task {
-            await dataController.setNeedsHistoryCallout(false)
         }
     }
 

--- a/WMFData/Sources/WMFData/Data Controllers/Activity Tab/WMFActivityTabDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Activity Tab/WMFActivityTabDataController.swift
@@ -167,33 +167,6 @@ public actor WMFActivityTabDataController {
         }
     }
 
-    private var seenHistoryCallout: Bool {
-        get {
-            return (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.activityTabSeenHistoryCallout.rawValue)) ?? false
-        } set {
-            try? userDefaultsStore?.save(key: WMFUserDefaultsKey.activityTabSeenHistoryCallout.rawValue, value: newValue)
-        }
-    }
-
-    public func getNeedsHistoryCallout() -> Bool {
-        guard let endDate = historyCalloutEndDate, endDate >= Date() else {
-            return false
-        }
-        return !seenHistoryCallout
-    }
-
-    public func setNeedsHistoryCallout(_ value: Bool) {
-        seenHistoryCallout = !value
-    }
-
-    private var historyCalloutEndDate: Date? {
-        var dateComponents = DateComponents()
-        dateComponents.year = 2026
-        dateComponents.month = 4
-        dateComponents.day = 24
-        return Calendar.current.date(from: dateComponents)
-    }
-
     public func setHasSeenActivityTab(_ value: Bool) {
         self.hasSeenActivityTab = value
     }

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -40,7 +40,6 @@ public enum WMFUserDefaultsKey: String {
     case showSearchLanguageBar = "show-search-language-bar"
     case openAppOnSearchTab = "open-app-on-search-tab"
     case isSubscribedToEchoNotifications = "is-subscribed-to-echo-notifications"
-    case activityTabSeenHistoryCallout = "activity-tab-seen-history-callout"
     case forceHCaptchaChallenge = "force-hcaptcha-challenge"
     case activityTabReadingChallenge = "activity-tab-reading-challenge"
     


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
Removing the history > search module in activity tab. Ok'ed by Product since the end date was April 24th. Fixes this little jump:

https://github.com/user-attachments/assets/ca413718-e4f1-4058-bf74-c43a44443eba

### Test Steps
1. Launch app while logged out, visit activity. Confirm no jump.

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
