### PR TITLE
Do not push an article deep link into a presented navigation controller

### DIFF
--- a/Wikipedia/Code/ReadingChallengeAnnouncementCoordinator.swift
+++ b/Wikipedia/Code/ReadingChallengeAnnouncementCoordinator.swift
@@ -270,8 +270,13 @@ final class ReadingChallengeAnnouncementCoordinator: NSObject, Coordinator {
             if let sheet = controller.sheetPresentationController {
                 sheet.prefersGrabberVisible = true
                 sheet.prefersScrollingExpandsWhenScrolledToEdge = false
-                sheet.detents = [.medium(), .large()]
-                sheet.selectedDetentIdentifier = .medium
+                sheet.detents = [
+                        .custom(identifier: .init("fraction65")) { context in
+                            context.maximumDetentValue * 0.65
+                        },
+                        .large()
+                    ]
+                    sheet.selectedDetentIdentifier = .init("fraction65")
             }
         }
 

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -43,7 +43,7 @@ extension WMFAppViewController {
             return false
         }
 
-        guard let navigationController = self.currentNavigationController else {
+        guard let navigationController = self.currentTabNavigationController else {
             return false
         }
 


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
More modal presentation fixes! This time when deep linking to an article. (see screenshots)

### Test Steps
1. General regression test of deep linking to an article.
2. Confirm deep linking to an article doesn't cause the announcement buttons to become unresponsive.
3. Confirm deep linking to an article doesn't push article on inside of announcement modal.

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos

Deep linking when announcement is displayed and app is backgrounded:

https://github.com/user-attachments/assets/7d2c412a-6897-4261-8b93-c316277f6cc3

Deep linking when app is terminated (note: need to clear the widget persistence to reset the first announcement):

https://github.com/user-attachments/assets/84227af6-77d7-49f6-b14a-953cf6c38c2f