### PR TITLE
Fix share crash if gallery image doesn't load

### DIFF
--- a/Wikipedia/Code/WMFImageGalleryViewController.m
+++ b/Wikipedia/Code/WMFImageGalleryViewController.m
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable, nonatomic, strong) NSData *imageData;
 
-//used for metadaata
+// used for metadaata
 @property (nonatomic, strong, nullable) MWKImageInfo *imageInfo;
 
 @end
@@ -209,11 +209,12 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Actions
 
 - (void)didTapCloseButton {
-    [self dismissViewControllerAnimated:YES completion:^{
-        if ([self.dismissDelegate respondsToSelector:@selector(galleryDidDismiss:)]) {
-            [self.dismissDelegate galleryDidDismiss:self];
-        }
-    }];
+    [self dismissViewControllerAnimated:YES
+                             completion:^{
+                                 if ([self.dismissDelegate respondsToSelector:@selector(galleryDidDismiss:)]) {
+                                     [self.dismissDelegate galleryDidDismiss:self];
+                                 }
+                             }];
 }
 
 - (void)didTapShareButton {
@@ -225,7 +226,9 @@ NS_ASSUME_NONNULL_BEGIN
     @weakify(self);
     [[[MWKDataStore shared] cacheController] fetchImageWithURL:url
         failure:^(NSError *_Nonnull error) {
-            [[WMFToastManager sharedInstance] showErrorAlert:error sticky:NO dismissPreviousToasts:NO tapCallBack:NULL];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[WMFToastManager sharedInstance] showErrorAlert:error sticky:NO dismissPreviousToasts:NO tapCallBack:NULL];
+            });
         }
         success:^(WMFImageDownload *_Nonnull download) {
             @strongify(self);
@@ -241,7 +244,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark NYTPhotosViewControllerDelegate
 
 - (UIView *_Nullable)photosViewController:(NYTPhotosViewController *)photosViewController referenceViewForPhoto:(id<NYTPhoto>)photo {
-    return nil; //TODO: remove this and re-enable animations when tickets for fixing anmimations are addressed
+    return nil; // TODO: remove this and re-enable animations when tickets for fixing anmimations are addressed
     return [self.referenceViewDelegate referenceViewForImageController:self];
 }
 
@@ -286,16 +289,17 @@ NS_ASSUME_NONNULL_BEGIN
     caption.infoTapCallback = ^{
         @strongify(self);
         if (imageInfo.filePageURL) {
-            
+
             // First dismiss self
-            [self dismissViewControllerAnimated:YES completion:^{
-                if ([self.dismissDelegate respondsToSelector:@selector(galleryDidTapInfoButton:)]) {
-                    [self.dismissDelegate galleryDidTapInfoButton:self];
-                }
-                
-                // then navigate to in-app web view
-                [self wmf_navigateToURL:imageInfo.filePageURL.wmf_urlByPrependingSchemeIfSchemeless];
-            }];
+            [self dismissViewControllerAnimated:YES
+                                     completion:^{
+                                         if ([self.dismissDelegate respondsToSelector:@selector(galleryDidTapInfoButton:)]) {
+                                             [self.dismissDelegate galleryDidTapInfoButton:self];
+                                         }
+
+                                         // then navigate to in-app web view
+                                         [self wmf_navigateToURL:imageInfo.filePageURL.wmf_urlByPrependingSchemeIfSchemeless];
+                                     }];
         }
     };
     // Use the screen bounds height as a reliable fallback since self.view may not
@@ -307,7 +311,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)updateImageForPhotoAfterUserInteractionIsFinished:(id<NYTPhoto> _Nullable)photo {
-    //Exclude UITrackingRunLoopMode so the update doesn't happen while the user is pinching or scrolling
+    // Exclude UITrackingRunLoopMode so the update doesn't happen while the user is pinching or scrolling
     dispatch_async(dispatch_get_main_queue(), ^{
         [self performSelector:@selector(updateImageForPhoto:) withObject:photo afterDelay:0 inModes:@[NSDefaultRunLoopMode]];
     });
@@ -339,10 +343,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface WMFPOTDPhoto : WMFBasePhoto <WMFPhoto>
 
-//used to fetch imageInfo
+// used to fetch imageInfo
 @property (nonatomic, strong, nullable) NSDate *potdDate;
 
-//set to display a thumbnail during download
+// set to display a thumbnail during download
 @property (nonatomic, strong, nullable) MWKImageInfo *thumbnailImageInfo;
 
 @end
@@ -504,7 +508,7 @@ NS_ASSUME_NONNULL_BEGIN
         [[[MWKDataStore shared] cacheController] fetchImageWithURL:[galleryImage bestImageURL]
             failure:^(NSError *_Nonnull error) {
                 if (error) {
-                    //show error
+                    // show error
                     return;
                 }
             }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T425580

### Notes
Fixes share button crash if image fails to load. Note most of this diff is automatic linting changes. The crash was fixed by switching to the [main thread](https://github.com/wikimedia/wikipedia-ios/compare/T425580?expand=1#diff-ea28e7963a6ec619e58915de9d2531cb0ff0eafa2e26763ae890ac3372f0fffbR230) before presenting the toast.

### Test Steps
1. (Temporarily) modify the return URL in WMFChangeImageSourceURLSizePrefix to something invalid, to mimic our previous image parsing issues:

```
NSString *WMFChangeImageSourceURLSizePrefix(NSString *sourceURL, NSInteger newSizePrefix) __attribute__((overloadable)) {
    return @"https://www.invalidurlasldkfjalsdkjf.com";
    if (!sourceURL) {
        return nil;
    }
    ....
```

2. Run app, POTD on Explore will be blank, tap into it.
3. Gallery won't load, tap Share button.
4. Ensure Toast appears instead of crashing.

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
