### PR TITLE
Fix WMFArticleDataControllerTests to wait for async completion

### DIFF
--- a/WMFData/Tests/WMFDataTests/WMFArticleDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFArticleDataControllerTests.swift
@@ -35,6 +35,8 @@ final class WMFArticleDataControllerTests: XCTestCase {
              expectation.fulfill()
          }
 
+         wait(for: [expectation], timeout: 10.0)
+
          guard let statusToTest else {
              XCTFail("Missing statusToTest")
              return
@@ -63,6 +65,8 @@ final class WMFArticleDataControllerTests: XCTestCase {
              }
              expectation.fulfill()
          }
+
+         wait(for: [expectation], timeout: 10.0)
 
          guard let statusToTest else {
              XCTFail("Missing statusToTest")


### PR DESCRIPTION
## Summary
- `testFetchWatchStatus` and `testFetchWatchStatusWithRollbackRights` create an `XCTestExpectation` but never call `wait(for:)`. The `guard let statusToTest` and the `XCTAssert*` calls run before `fetchArticleInfo`'s completion handler returns. They currently pass only because `WMFMockWatchlistMediaWikiService` happens to invoke its completion synchronously — the tests would silently break the moment the mock became async.
- Adds `wait(for: [expectation], timeout: 10.0)` before the assertions in both tests, matching the established pattern used in `WMFWatchlistDataControllerTests`.
- The mock returns `watchlist-get-watch-status-watched.json` for the no-rollback path and `watchlist-get-watch-status-and-rollback-rights-unwatched.json` for the with-rollback path; the existing expected values already matched those fixtures, so no assertion values needed to change.

## Test plan
- [x] `xcodebuild test -scheme WMFData -only-testing:WMFDataTests/WMFArticleDataControllerTests` — both tests pass (verified locally on iPhone 16, iOS 18.5).
- [x] Full `WMFDataTests` target: 111/111 passing on this branch.