### PR TITLE
Replace empty testExample stubs in WMFLocalizations and WMFTestKitchen

### DIFF
--- a/WMFLocalizations/Tests/WMFLocalizationsTests/WMFLocalizationsTests.swift
+++ b/WMFLocalizations/Tests/WMFLocalizationsTests/WMFLocalizationsTests.swift
@@ -3,7 +3,16 @@ import XCTest
 @testable import WMFTranslateWikiLocalizations
 
 final class WMFLocalizationsTests: XCTestCase {
-    func testExample() throws {
-        
+
+    func testWMFLocalizedStringResolvesKnownEnglishKey() {
+        // "search-title" is defined in the en.lproj Localizable.strings with the value "Search".
+        let result = WMFLocalizedString("search-title", value: "Search", comment: "")
+        XCTAssertEqual(result, "Search")
+    }
+
+    func testWMFLocalizedStringFallsBackToValueForUnknownKey() {
+        // For a key that exists in no bundle, the function should fall back to the supplied `value:`.
+        let result = WMFLocalizedString("wmf-localizations-tests-nonexistent-key", value: "fallback", comment: "")
+        XCTAssertEqual(result, "fallback")
     }
 }

--- a/WMFTestKitchen/Tests/WMFTestKitchenTests/WMFTestKitchenTests.swift
+++ b/WMFTestKitchen/Tests/WMFTestKitchenTests/WMFTestKitchenTests.swift
@@ -2,11 +2,46 @@ import XCTest
 @testable import WMFTestKitchen
 
 final class WMFTestKitchenTests: XCTestCase {
-    func testExample() throws {
-        // XCTest Documentation
-        // https://developer.apple.com/documentation/xctest
 
-        // Defining Test Cases and Test Methods
-        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    func testStreamConfigDecodesNestedProducerConfig() throws {
+        let json = """
+        {
+          "stream": "test.stream",
+          "canary_events_enabled": true,
+          "schema_title": "analytics/test/1.0.0",
+          "producers": {
+            "metrics_platform_client": {
+              "provide_values": ["agent_app_install_id", "performer_session_id"]
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let config = try JSONDecoder().decode(StreamConfig.self, from: json)
+
+        XCTAssertEqual(config.streamName, "test.stream")
+        XCTAssertTrue(config.canaryEventsEnabled)
+        XCTAssertEqual(config.schemaTitle, "analytics/test/1.0.0")
+        XCTAssertEqual(
+            config.producerConfig?.metricsPlatformClientConfig?.requestedValues,
+            ["agent_app_install_id", "performer_session_id"]
+        )
+        XCTAssertTrue(config.hasRequestedContextValuesConfig())
+    }
+
+    func testStreamConfigReportsNoRequestedValuesWhenProducerMissing() throws {
+        let json = """
+        {
+          "stream": "test.stream",
+          "canary_events_enabled": false
+        }
+        """.data(using: .utf8)!
+
+        let config = try JSONDecoder().decode(StreamConfig.self, from: json)
+
+        XCTAssertEqual(config.streamName, "test.stream")
+        XCTAssertFalse(config.canaryEventsEnabled)
+        XCTAssertNil(config.producerConfig)
+        XCTAssertFalse(config.hasRequestedContextValuesConfig())
     }
 }


### PR DESCRIPTION
## Summary
Two Swift packages — `WMFLocalizations` and `WMFTestKitchen` — each shipped a single `XCTestCase` containing only an empty `func testExample()` body. Despite the "TestKitchen" name, both packages contain real production code (`WMFLocalizedString`, `CommonStrings`, and the WMFTestKitchen instrumentation pipeline), so dropping the test targets is not desirable. This PR replaces the empty stubs with minimal real assertions:

- **`WMFLocalizationsTests`**
  - `testWMFLocalizedStringResolvesKnownEnglishKey` — verifies that `WMFLocalizedString("search-title", value: "Search", …)` returns `"Search"` from the `en.lproj` bundle.
  - `testWMFLocalizedStringFallsBackToValueForUnknownKey` — verifies the in-code `value:` fallback path runs when no bundle resolves the key.
- **`WMFTestKitchenTests`**
  - `testStreamConfigDecodesNestedProducerConfig` — round-trips a JSON dict through `JSONDecoder` to confirm the snake_case `CodingKeys` mapping holds at every nesting level, and that `hasRequestedContextValuesConfig()` returns `true` when `provide_values` is present.
  - `testStreamConfigReportsNoRequestedValuesWhenProducerMissing` — same flow with the `producers` key omitted, asserting `hasRequestedContextValuesConfig()` returns `false`.

No production code is touched.

## Test plan
- [x] `xcodebuild test -scheme WMFLocalizations-Package -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5'` — 2/2 passing.
- [x] `xcodebuild test -scheme WMFTestKitchen -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5'` — 2/2 passing.
- [x] No new compiler/linter warnings introduced.