### PR TITLE
Drop dangling LegacyCoreDataMigratorTests references

### DIFF
--- a/Test Plans/Wikipedia.xctestplan
+++ b/Test Plans/Wikipedia.xctestplan
@@ -35,7 +35,6 @@
         "ArticleCacheReadingManualTests",
         "ArticleManualPerformanceTests",
         "ArticleViewControllerTests",
-        "LegacyCoreDataMigratorTests",
         "MWKHistoryListPerformanceTests\/testReadPerformance",
         "NSArray_PredicateTests\/testPerformance",
         "NSString_FormattedAttributedStringTests\/testPerformanceExample",

--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/Local Page Content Service & Announcements.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/Local Page Content Service & Announcements.xcscheme
@@ -53,9 +53,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "LegacyCoreDataMigratorTests">
-               </Test>
-               <Test
                   Identifier = "MWKHistoryListPerformanceTests/testReadPerformance">
                </Test>
                <Test

--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/RTL.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/RTL.xcscheme
@@ -51,9 +51,6 @@
                   Identifier = "CircularBitwiseRotationTests">
                </Test>
                <Test
-                  Identifier = "LegacyCoreDataMigratorTests">
-               </Test>
-               <Test
                   Identifier = "MWKArticleEqualityCheckTests">
                </Test>
                <Test

--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme
@@ -68,9 +68,6 @@
                   Identifier = "ArticleViewControllerTests">
                </Test>
                <Test
-                  Identifier = "LegacyCoreDataMigratorTests">
-               </Test>
-               <Test
                   Identifier = "MWKHistoryListPerformanceTests/testReadPerformance">
                </Test>
                <Test


### PR DESCRIPTION
## Summary
`LegacyCoreDataMigratorTests.m` was removed in commit 2551d7985b ("remove legacy core data and image migration", Jul 2016) together with the legacy Core Data migrator it tested. The class name was left behind in the `SkippedTests` list of four project files, where it has been a dangling reference for ~10 years:

- `Test Plans/Wikipedia.xctestplan`
- `Wikipedia.xcodeproj/xcshareddata/xcschemes/RTL.xcscheme`
- `Wikipedia.xcodeproj/xcshareddata/xcschemes/Local Page Content Service & Announcements.xcscheme`
- `Wikipedia.xcodeproj/xcshareddata/xcschemes/Wikipedia.xcscheme`

Remove those four references. No behavior change — skipping a test that does not exist has no effect on the suite.

## Test plan
- [x] `grep -r LegacyCoreDataMigratorTests` returns nothing after the change.
- [x] `xctestplan` is still valid JSON; all three `.xcscheme` files are still well-formed XML.
- [x] `xcodebuild -project Wikipedia.xcodeproj -list` still resolves every scheme.