### PR TITLE
Add WMFEmptyViewModelTests covering filterString branches

### DIFF
--- a/WMFComponents/Tests/WMFComponentsTests/WMFEmptyViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFEmptyViewModelTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import WMFComponents
+
+final class WMFEmptyViewModelTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeLocalizedStrings(
+        attributedFilterString: ((Int) -> AttributedString)? = nil
+    ) -> WMFEmptyViewModel.LocalizedStrings {
+        return WMFEmptyViewModel.LocalizedStrings(
+            title: "No results",
+            subtitle: "Try adjusting your filters.",
+            titleFilter: nil,
+            buttonTitle: nil,
+            attributedFilterString: attributedFilterString
+        )
+    }
+
+    private func makeViewModel(numberOfFilters: Int?) -> WMFEmptyViewModel {
+        return WMFEmptyViewModel(
+            localizedStrings: makeLocalizedStrings(),
+            image: nil,
+            imageColor: nil,
+            numberOfFilters: numberOfFilters
+        )
+    }
+
+    // MARK: - Tests
+
+    func testFilterStringReturnsNilWhenNumberOfFiltersIsNil() {
+        let viewModel = makeViewModel(numberOfFilters: nil)
+        let strings = makeLocalizedStrings(attributedFilterString: { _ in
+            XCTFail("attributedFilterString closure should not be invoked when numberOfFilters is nil")
+            return AttributedString("unreachable")
+        })
+        XCTAssertNil(viewModel.filterString(localizedStrings: strings))
+    }
+
+    func testFilterStringReturnsNilWhenClosureIsNil() {
+        let viewModel = makeViewModel(numberOfFilters: 3)
+        let strings = makeLocalizedStrings(attributedFilterString: nil)
+        XCTAssertNil(viewModel.filterString(localizedStrings: strings))
+    }
+
+    func testFilterStringPassesNumberOfFiltersToClosure() {
+        let viewModel = makeViewModel(numberOfFilters: 5)
+        var capturedCount: Int?
+        let strings = makeLocalizedStrings(attributedFilterString: { count in
+            capturedCount = count
+            return AttributedString("filters: \(count)")
+        })
+
+        let result = viewModel.filterString(localizedStrings: strings)
+
+        XCTAssertEqual(capturedCount, 5)
+        XCTAssertEqual(result, AttributedString("filters: 5"))
+    }
+
+    func testFilterStringReflectsUpdatedNumberOfFilters() {
+        // numberOfFilters is @Published; assigning a new value should be picked up
+        // by subsequent calls to filterString(localizedStrings:).
+        let viewModel = makeViewModel(numberOfFilters: 1)
+        let strings = makeLocalizedStrings(attributedFilterString: { count in
+            return AttributedString("count=\(count)")
+        })
+
+        XCTAssertEqual(viewModel.filterString(localizedStrings: strings), AttributedString("count=1"))
+
+        viewModel.numberOfFilters = 7
+        XCTAssertEqual(viewModel.filterString(localizedStrings: strings), AttributedString("count=7"))
+
+        viewModel.numberOfFilters = nil
+        XCTAssertNil(viewModel.filterString(localizedStrings: strings))
+    }
+}


### PR DESCRIPTION
## Summary
`WMFEmptyViewModel` shipped without a corresponding test file. Its `filterString(localizedStrings:)` method has three behavioral branches and an `@Published numberOfFilters` whose mutations need to flow through to subsequent calls. This PR adds a new `WMFEmptyViewModelTests` `XCTestCase` covering those branches. No production code is touched.

The four tests:

- `testFilterStringReturnsNilWhenNumberOfFiltersIsNil` — guards the `guard let numberOfFilters` branch and asserts the optional closure is never invoked when there is no filter count.
- `testFilterStringReturnsNilWhenClosureIsNil` — asserts that with a real `numberOfFilters` but `localizedStrings.attributedFilterString == nil`, the result is `nil` (the optional-chain in the implementation collapses).
- `testFilterStringPassesNumberOfFiltersToClosure` — happy path: confirms the model passes its current `numberOfFilters` into the closure and returns the closure's `AttributedString`.
- `testFilterStringReflectsUpdatedNumberOfFilters` — mutates `numberOfFilters` after construction and confirms subsequent calls reflect the new value (and going back to `nil` returns nil again).

## Test plan
- [x] `xcodebuild test -scheme WMFComponents -only-testing:WMFComponentsTests/WMFEmptyViewModelTests` — 4/4 passing.
- [x] Full `WMFComponentsTests` target: 177/177 passing (previous 173 + 4 new).
- [x] No new compiler/linter warnings introduced.