### PR TITLE
Fix deeplinking when game is open

### DIFF
--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -1219,6 +1219,7 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
             showSettings(with: appearanceSettingsVC, animated: animated)
 
         default:
+            dismissPresentedViewControllers()
             if processLinkUserActivity(activity) {
                 done()
                 return true


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T427855

### Notes
* Dismisses presented VC's before pushing a deep link 

### Test Steps
1. Open the game (or the splash screen, or results screen) 
2. Background the app, click on an article link outside the app
3. Make sure the game is dismissed and the article open
4. Progress is already saved per questions answered

### Checklist
- [ ] Checked against Swift 6 strict concurrency

