### PR TITLE
Incomplete game bug

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstViewModel.swift
@@ -163,6 +163,9 @@ public final class WMFWhichCameFirstViewModel: ObservableObject, Identifiable {
     private var sessionIdentifier: UUID?
     private var loadTask: Task<Void, Never>?
     private var animationTask: Task<Void, Never>?
+
+    /// Guards `load()` so it only runs once per game presentation, and  `viewWillAppear` doesn't reload the game everytime
+    private var hasLoaded = false
     
     @Published public var isLoggedIn: Bool = false
     public var onLogIn: (@MainActor @Sendable () -> Void)?
@@ -183,6 +186,8 @@ public final class WMFWhichCameFirstViewModel: ObservableObject, Identifiable {
     }
 
     func load() {
+        guard !hasLoaded else { return }
+        hasLoaded = true
         loadTask?.cancel()
         animationTask?.cancel()
         phase = .loading
@@ -213,6 +218,7 @@ public final class WMFWhichCameFirstViewModel: ObservableObject, Identifiable {
                 rebuildCardViewModels()
                 presentQuestion()
             } catch {
+                hasLoaded = false
                 phase = .error(error.localizedDescription)
             }
         }

--- a/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
@@ -13,6 +13,7 @@ public class WMFGamesDataController {
         case missingContentData
         case sessionNotFound
         case invalidPickedOption
+        case insufficientQuestions
     }
 
     // MARK: - Properties
@@ -292,6 +293,11 @@ extension WMFGamesDataController {
 
         let response = try await onThisDayDataController.fetchOnThisDay(project: project, month: month, day: day)
         let questions = Self.makeWhichCameFirstQuestions(from: response.events, month: month, day: day, count: Self.whichCameFirstQuestionCount)
+
+        guard questions.count == Self.whichCameFirstQuestionCount else {
+            throw CustomError.insufficientQuestions
+        }
+
         let gameState = WMFWhichCameFirstGameState(questions: questions)
 
         let contentData = try encodeWhichCameFirstGameState(gameState)


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T427854

### Notes
* I couldn't replicate the bug and couldn't find an inconsistency on the data controller, but the missing second dot made me wonder if the question set was shorter than 5 questions, so I added a guard against less than 5 questions
* Also added a guard againt reloading the game every time, to always retrieve the current state

### Test Steps
1. Complete the game
2. Make sure you see the explore feed card, splash screen and game results screen in the correct state

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
