### PR TITLE
Open article when user taps related article from results view

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstView.swift
@@ -48,7 +48,8 @@ public struct WMFWhichCameFirstView: View {
                 onArticleSaveForLater: gameViewModel.onArticleSaveForLater,
                 onArticleUnsave: gameViewModel.onArticleUnsave,
                 onCheckSavedState: gameViewModel.onCheckSavedState,
-                onArticleShare: gameViewModel.onArticleShare
+                onArticleShare: gameViewModel.onArticleShare,
+                onArticleTapToEvent: gameViewModel.onArticleTapToEvent
             ))
         }
 

--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstViewModel.swift
@@ -125,6 +125,7 @@ public final class WMFWhichCameFirstViewModel: ObservableObject, Identifiable {
     public var onArticleUnsave: WMFWhichCameFirstArticlesViewModel.ArticleTapAction?
     public var onCheckSavedState: ((URL) -> Bool)?
     public var onArticleShare: WMFWhichCameFirstArticlesViewModel.ArticleShareAction?
+    public var onArticleTapToEvent: WMFWhichCameFirstArticlesViewModel.ArticleEventTapAction?
     public var didTapLearnMore: (@MainActor @Sendable () -> Void)?
     public var didTapReportProblem: (@MainActor @Sendable () -> Void)?
 

--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Results/Articles View/WMFWhichCameFirstArticlesViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Results/Articles View/WMFWhichCameFirstArticlesViewModel.swift
@@ -142,7 +142,8 @@ public final class WMFWhichCameFirstArticlesViewModel: ObservableObject {
         didTapOpenInBackgroundTab: ArticleTapAction? = nil,
         didSaveForLater: ArticleTapAction? = nil,
         didUnsaveArticle: ArticleTapAction? = nil,
-        didShareArticle: ArticleShareAction? = nil
+        didShareArticle: ArticleShareAction? = nil,
+        didTapArticleToEvent: ArticleEventTapAction? = nil
     ) {
         self.articleItems = articleItems
         self.localizedStrings = localizedStrings
@@ -152,6 +153,7 @@ public final class WMFWhichCameFirstArticlesViewModel: ObservableObject {
         self.didSaveForLater = didSaveForLater
         self.didUnsaveArticle = didUnsaveArticle
         self.didShareArticle = didShareArticle
+        self.didTapArticleToEvent = didTapArticleToEvent
 
         if let onCheckSavedState {
             for item in articleItems {

--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Results/WMFWhichCameFirstResultsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Results/WMFWhichCameFirstResultsViewModel.swift
@@ -87,6 +87,7 @@ public final class WMFWhichCameFirstResultsViewModel: ObservableObject {
         onArticleUnsave: WMFWhichCameFirstArticlesViewModel.ArticleTapAction? = nil,
         onCheckSavedState: ((URL) -> Bool)? = nil,
         onArticleShare: WMFWhichCameFirstArticlesViewModel.ArticleShareAction? = nil,
+        onArticleTapToEvent: WMFWhichCameFirstArticlesViewModel.ArticleEventTapAction? = nil,
         localizedStrings: LocalizedStrings = LocalizedStrings()
     ) {
         self.score = score
@@ -132,7 +133,8 @@ public final class WMFWhichCameFirstResultsViewModel: ObservableObject {
             didTapOpenInBackgroundTab: onArticleOpenInBackgroundTab,
             didSaveForLater: onArticleSaveForLater,
             didUnsaveArticle: onArticleUnsave,
-            didShareArticle: onArticleShare
+            didShareArticle: onArticleShare,
+            didTapArticleToEvent: onArticleTapToEvent
         )
 
         startCountdownTimer()

--- a/Wikipedia/Code/WhichCameFirstCoordinator.swift
+++ b/Wikipedia/Code/WhichCameFirstCoordinator.swift
@@ -134,6 +134,9 @@ final class WhichCameFirstCoordinator: NSObject, Coordinator {
         viewModel.onArticleShare = { [weak self] url in
             self?.shareArticle(url: url)
         }
+        viewModel.onArticleTapToEvent = { [weak self] url in
+            self?.openArticle(url: url, inNewTab: false)
+        }
         viewModel.didTapLearnMore = { [weak self] in
             self?.showAbout()
         }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T427960

### Notes
* Temp adjustment before we build other parts of the feature, so I'm keeping `onArticleTapToEvent` which will be the permanent action

### Test Steps
1. Go to results screen
2. Tap article card
3. Make sure the game is dismissed and article opens

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
