### PR TITLE
T422760 core UI and T422761 results screen

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/Cards/WMFWhichCameFirstCardView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/Cards/WMFWhichCameFirstCardView.swift
@@ -64,7 +64,7 @@ public struct WMFWhichCameFirstCardView: View {
                 .padding(16)
             }
 
-            if viewModel.isRevealed {
+            if viewModel.isRevealed && (viewModel.isSelected || !viewModel.isSelectedCardCorrect && viewModel.isSelected) {
                 resultIcon
                     .padding([.bottom, .trailing], 12)
             }

--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Results/WMFWhichCameFirstResultsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Results/WMFWhichCameFirstResultsView.swift
@@ -109,7 +109,7 @@ public struct WMFWhichCameFirstResultsView: View {
                         .accessibilityHidden(true)
                 }
                 Text(viewModel.localizedStrings.countdownLabel(from: viewModel.nextGameCountdownString))
-                    .font(Font(WMFFont.for(.callout)))
+                    .font(Font(WMFFont.for(.callout)).monospacedDigit())
                 // Specifically left as hardcoded color
                     .foregroundStyle(Color.black)
                     .minimumScaleFactor(0.8)
@@ -181,19 +181,19 @@ public struct WMFWhichCameFirstResultsView: View {
                     )
                     Divider()
                     statCell(
-                        symbol: .flameFill,
+                        symbol: .starSquare,
                         value: viewModel.currentStreak.map { "\($0)" } ?? "–",
                         label: viewModel.localizedStrings.currentStreakLabel
                     )
                     Divider()
                     statCell(
-                        symbol: .trophy,
+                        symbol: .medal,
                         value: viewModel.bestStreak.map { "\($0)" } ?? "–",
                         label: viewModel.localizedStrings.bestStreakLabel
                     )
                     Divider()
                     statCell(
-                        symbol: .medal,
+                        symbol: .flagPatternCheckered,
                         value: viewModel.averageScore.map { formattedAverageScore($0) } ?? "–",
                         label: viewModel.localizedStrings.averageScoreLabel
                     )
@@ -207,19 +207,19 @@ public struct WMFWhichCameFirstResultsView: View {
                             label: viewModel.localizedStrings.gamesPlayedLabel
                         )
                         statCell(
-                            symbol: .flameFill,
+                            symbol: .starSquare,
                             value: viewModel.currentStreak.map { "\($0)" } ?? "–",
                             label: viewModel.localizedStrings.currentStreakLabel
                         )
                     }
                     HStack(spacing: 0) {
                         statCell(
-                            symbol: .trophy,
+                            symbol: .medal,
                             value: viewModel.bestStreak.map { "\($0)" } ?? "–",
                             label: viewModel.localizedStrings.bestStreakLabel
                         )
                         statCell(
-                            symbol: .medal,
+                            symbol: .flagPatternCheckered,
                             value: viewModel.averageScore.map { "\($0)" } ?? "–",
                             label: viewModel.localizedStrings.averageScoreLabel
                         )

--- a/WMFComponents/Sources/WMFComponents/Style/WMFIcon.swift
+++ b/WMFComponents/Sources/WMFComponents/Style/WMFIcon.swift
@@ -58,6 +58,7 @@ public enum WMFSFSymbolIcon {
     case checkmarkSquareFill
     case square
     case star
+    case starSquare
     case starFill
     case starCircleFill
     case person
@@ -422,6 +423,8 @@ public enum WMFSFSymbolIcon {
             image = UIImage(systemName: "medal", withConfiguration: configuration)
         case .flagPatternCheckered:
             image = UIImage(systemName: "flag.pattern.checkered", withConfiguration: configuration)
+        case .starSquare:
+            image = UIImage(systemName: "star.square.on.square", withConfiguration: configuration)
         }
         
         image = image?.withRenderingMode(.alwaysTemplate)

--- a/Wikipedia/Code/WhichCameFirstCoordinator.swift
+++ b/Wikipedia/Code/WhichCameFirstCoordinator.swift
@@ -310,6 +310,7 @@ final class WhichCameFirstCoordinator: NSObject, Coordinator {
         mailVC.mailComposeDelegate = self
 
         mailVC.setSubject(WMFLocalizedString("games-email-report-subject", value: "Issue Report - Wikipedia games", comment: "Email subject line for reporting a problem with the Wikipedia games feature."))
+        mailVC.setToRecipients(["ios-support@wikimedia.org"])
 
         let body = [
             WMFLocalizedString("games-email-report-body-encountered", value: "I have encountered a problem with the Wikipedia games feature:", comment: "Opening line of the problem report email body for the Wikipedia games feature."),


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T422761
https://phabricator.wikimedia.org/T422760

### Notes
* 

### Test Steps
1. 

### Checklist
- [ ] Checked against Swift 6 strict concurrency
- [x] 23 when a user answers correctly, the x icon on the non-correct event shouldn't show -- the x icon should only show if the user answers the question incorrectly
- [x] 5 "next game" line in scorecard keeps swaying to stay centered [x]
- [x] 6 wrong icon used for current streak, best streak, and average score in scoresheet [x]
- [x] 12ssue report not including wiki email in To: line [x]
- [ ] 17 nothing happens when tapping on article card [Out of scope of this ticket, taken care of elsewhere]

### Screenshots/Videos
