### PR TITLE
T269478: Don't re-run UI and E2E tests on merge to main

### DIFF
--- a/.github/workflows/run_e2e_ui_tests.yml
+++ b/.github/workflows/run_e2e_ui_tests.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - 'main'
-  push:
-    branches:
-      - 'main'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/run_ui_tests.yml
+++ b/.github/workflows/run_ui_tests.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - 'main'
-  push:
-    branches:
-      - 'main'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
**Phabricator: T269478** 

### Notes
* Don't re-run UI and E2E tests on merge to main. This is duplicative work that's causing runner availability pressure.

### Test Steps
N/A

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
