### PR TITLE
T269478: Suppress games announcement for UI testing

### DIFF
--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -27,6 +27,7 @@ private let wmfLastRemoteAppConfigCheckAbsoluteTimeKey = "WMFLastRemoteAppConfig
 private let wmfTempAccountConfigCheckAbsoluteTimeKey = "WMFTempAccountConfigCheckAbsoluteTimeKey"
 private let wmfResetPreferredLanguages = "WMFResetPreferredLanguages"
 private let wmfSuppressActivityTabOnboardingForTesting = "WMFSuppressActivityTabOnboardingForTesting"
+private let wmfSuppressGamesAnnouncementForTesting = "WMFSuppressGamesAnnouncementForTesting"
 private let wmfSuppressReadingChallengeAnnouncementForTesting = "WMFSuppressReadingChallengeAnnouncementForTesting"
 
 // KVO context pointers
@@ -866,6 +867,10 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
                 key: WMFUserDefaultsKey.hasSeenActivityTabNewOnboarding.rawValue,
                 value: true
             )
+        }
+
+        if UserDefaults.standard.bool(forKey: wmfSuppressGamesAnnouncementForTesting) {
+            UserDefaults.standard.set(true, forKey: WMFUserDefaultsKey.hasSeenGamesAnnouncement.rawValue)
         }
     }
 

--- a/WikipediaUITests/Config/UITestConfiguration.swift
+++ b/WikipediaUITests/Config/UITestConfiguration.swift
@@ -14,6 +14,7 @@ struct UITestConfiguration {
     let httpClientProfile: String
     let resetsPreferredLanguages: Bool
     let suppressesActivityTabOnboarding: Bool
+    let suppressesGamesAnnouncement: Bool
     let suppressesReadingChallengeAnnouncement: Bool
     let themeName: String?
     let languageCode: String
@@ -26,6 +27,7 @@ struct UITestConfiguration {
         onboardingState: OnboardingState = .completed,
         resetsPreferredLanguages: Bool = true,
         suppressesActivityTabOnboarding: Bool = true,
+        suppressesGamesAnnouncement: Bool = true,
         suppressesReadingChallengeAnnouncement: Bool = true
     ) {
         self.onboardingState = onboardingState
@@ -33,6 +35,7 @@ struct UITestConfiguration {
         self.themeName = ProcessInfo.processInfo.value(for: .appThemeName)
         self.resetsPreferredLanguages = resetsPreferredLanguages
         self.suppressesActivityTabOnboarding = suppressesActivityTabOnboarding
+        self.suppressesGamesAnnouncement = suppressesGamesAnnouncement
         self.suppressesReadingChallengeAnnouncement = suppressesReadingChallengeAnnouncement
         self.languageCode = ProcessInfo.processInfo.value(for: .uiTestLanguageCode) ?? defaultLanguageCode
     }
@@ -54,6 +57,10 @@ struct UITestConfiguration {
 
         if suppressesActivityTabOnboarding {
             argumentValues.append(UITestLaunchArgumentValue(.suppressActivityTabOnboarding, value: "YES"))
+        }
+
+        if suppressesGamesAnnouncement {
+            argumentValues.append(UITestLaunchArgumentValue(.suppressGamesAnnouncement, value: "YES"))
         }
 
         argumentValues.append(UITestLaunchArgumentValue(.appleLanguages, value: "(\(languageCode))"))

--- a/WikipediaUITests/Config/UITestLaunchArgument.swift
+++ b/WikipediaUITests/Config/UITestLaunchArgument.swift
@@ -7,6 +7,7 @@ enum UITestLaunchArgument: String {
     case httpClientProfile = "-WMFTestHTTPClientProfile"
     case resetPreferredLanguages = "-WMFResetPreferredLanguages"
     case suppressActivityTabOnboarding = "-WMFSuppressActivityTabOnboardingForTesting"
+    case suppressGamesAnnouncement = "-WMFSuppressGamesAnnouncementForTesting"
     case suppressReadingChallengeAnnouncement = "-WMFSuppressReadingChallengeAnnouncementForTesting"
     case uiTestLanguageCode = "-WMFUITestLanguageCode"
 }

--- a/WikipediaUITests/Robots/WikipediaAppRobot.swift
+++ b/WikipediaUITests/Robots/WikipediaAppRobot.swift
@@ -31,6 +31,7 @@ extension XCTestCase {
         onboardingState: UITestConfiguration.OnboardingState,
         resetsPreferredLanguages: Bool = true,
         suppressesActivityTabOnboarding: Bool = true,
+        suppressesGamesAnnouncement: Bool = true,
         suppressesReadingChallengeAnnouncement: Bool = true
     ) -> WikipediaAppRobot {
         let app = XCUIApplication()
@@ -38,6 +39,7 @@ extension XCTestCase {
             onboardingState: onboardingState,
             resetsPreferredLanguages: resetsPreferredLanguages,
             suppressesActivityTabOnboarding: suppressesActivityTabOnboarding,
+            suppressesGamesAnnouncement: suppressesGamesAnnouncement,
             suppressesReadingChallengeAnnouncement: suppressesReadingChallengeAnnouncement
         )
         app.configureForUITestLaunch(configuration: configuration)


### PR DESCRIPTION
**Phabricator: T269478** 

### Notes
* Suppress games announcement for UI testing

### Test Steps
N/A

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
N/A