### PR TITLE
Fix stack overflow crash on Which Came First results screen

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Results/Articles View/WMFWhichCameFirstArticlesView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Results/Articles View/WMFWhichCameFirstArticlesView.swift
@@ -125,22 +125,20 @@ private struct ArticleCardMenuWrapper: View {
             .accessibilityAddTraits(.isButton)
             .accessibilityLabel(cardAccessibilityLabel)
             .accessibilityHint(viewModel.localizedStrings.openArticleRelatedEventHint)
-            .accessibilityActions {
-                accessibilityAction(named: viewModel.localizedStrings.openArticleTitle) {
-                    if let url = item.articleURL { viewModel.didTapArticle?(url) }
-                }
-                accessibilityAction(named: viewModel.localizedStrings.openInNewTabTitle) {
-                    if let url = item.articleURL { viewModel.didTapOpenInNewTab?(url) }
-                }
-                accessibilityAction(named: viewModel.localizedStrings.openInBackgroundTabTitle) {
-                    if let url = item.articleURL { viewModel.didTapOpenInBackgroundTab?(url) }
-                }
-                accessibilityAction(named: item.isSaved ? viewModel.localizedStrings.unsaveTitle : viewModel.localizedStrings.saveForLaterTitle) {
-                    viewModel.toggleSave(for: item)
-                }
-                accessibilityAction(named: viewModel.localizedStrings.shareArticleTitle) {
-                    if let url = item.articleURL { viewModel.didShareArticle?(url) }
-                }
+            .accessibilityAction(named: Text(viewModel.localizedStrings.openArticleTitle)) {
+                if let url = item.articleURL { viewModel.didTapArticle?(url) }
+            }
+            .accessibilityAction(named: Text(viewModel.localizedStrings.openInNewTabTitle)) {
+                if let url = item.articleURL { viewModel.didTapOpenInNewTab?(url) }
+            }
+            .accessibilityAction(named: Text(viewModel.localizedStrings.openInBackgroundTabTitle)) {
+                if let url = item.articleURL { viewModel.didTapOpenInBackgroundTab?(url) }
+            }
+            .accessibilityAction(named: Text(item.isSaved ? viewModel.localizedStrings.unsaveTitle : viewModel.localizedStrings.saveForLaterTitle)) {
+                viewModel.toggleSave(for: item)
+            }
+            .accessibilityAction(named: Text(viewModel.localizedStrings.shareArticleTitle)) {
+                if let url = item.articleURL { viewModel.didShareArticle?(url) }
             }
             .onTapGesture {
                 if let url = item.articleURL { viewModel.didTapArticleToEvent?(url) }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T428100

### Notes
* Replace the per-card `.accessibilityActions { }` builder with flat `.accessibilityAction(named:)` modifiers; on iOS 18 the actions-builder recursed in SwiftUI's view-build pass and overflowed the stack.

### Test Steps
1. Run branch in an iOS device or simulator
2. Go to results screen
3. Everything should work as expected

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
