### PR TITLE
Fix alert presentation crash

### DIFF
--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -573,6 +573,9 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
     private func presentGamesAnnouncementAlert(gamesDataController: WMFGamesDataController) {
         guard let navigationController else { return }
 
+        // Never present over an existing modal — doing so crashes with "already presenting". Defer to next launch.
+        guard navigationController.presentedViewController == nil else { return }
+
         // Mark as seen as soon as it is displayed so it is never shown again if user taps background to dismiss
         gamesDataController.markGamesAnnouncementSeen()
 

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -1090,12 +1090,15 @@ extension ExploreViewController {
     private func presentGamesAnnouncementAlert(gamesDataController: WMFGamesDataController) {
         guard let navigationController else { return }
 
+        // Never present over an existing modal — doing so crashes with "already presenting". Defer to next launch.
+        guard navigationController.presentedViewController == nil else { return }
+
         let alert = UIAlertController(
             title: CommonStrings.gamesAnnouncementTitle,
             message: CommonStrings.gamesAnnouncementMessage,
             preferredStyle: .actionSheet
         )
-        
+
         // Mark as seen as soon as it is displayed so it is never shown twice, regardless of how it
         // is dismissed (button tap, outside tap, or app backgrounding).
         gamesDataController.markGamesAnnouncementSeen()
@@ -1104,7 +1107,6 @@ extension ExploreViewController {
             action: "impression",
             actionSource: "game_announce"
         )
-        navigationController.present(alert, animated: true)
 
         alert.addAction(UIAlertAction(title: CommonStrings.gamesAnnouncementPlayButton, style: .default) { [weak self] _ in
             guard let self else { return }

--- a/Wikipedia/Code/WhichCameFirstCoordinator.swift
+++ b/Wikipedia/Code/WhichCameFirstCoordinator.swift
@@ -52,6 +52,10 @@ final class WhichCameFirstCoordinator: NSObject, Coordinator {
 
     @discardableResult
     func start() -> Bool {
+
+        // do not show alert if user already tapped card
+        gamesDataController.markGamesAnnouncementSeen()
+
         let splashViewController = makeSplashViewController()
         let nav = WMFComponentNavigationController(
             rootViewController: splashViewController,


### PR DESCRIPTION
**Phabricator:** 

### Notes
* Fixes alert over modal crash

### Test Steps
1. Reset the game
2. Try to enter game before seeing modal, make sure it doesn't display again when backgrounding/foregrounding
3. Reset games
4. Try to open a modal over article or explore, background and foregrounding app with modal opened

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
