### PR TITLE
Fix hidden game card upon app update

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -39,7 +39,6 @@ import WMFData
     @Published public var showGamesV2: Bool = WMFDeveloperSettingsDataController.shared.showGamesV2 {
         didSet {
             WMFDeveloperSettingsDataController.shared.showGamesV2 = showGamesV2
-            NotificationCenter.default.post(name: WMFNSNotification.gamesV1SettingDidChange, object: nil)
         }
     }
     

--- a/WMFData/Sources/WMFData/Notifications/WMFNSNotification.swift
+++ b/WMFData/Sources/WMFData/Notifications/WMFNSNotification.swift
@@ -8,7 +8,7 @@ public enum WMFNSNotification {
     public static let coreDataStoreSetup = Notification.Name(WMFNotificationName.coreDataStoreSetup.rawValue)
     public static let sharedCacheStoreSetup = Notification.Name(WMFNotificationName.sharedCacheStoreSetup.rawValue)
     public static let readingChallengeWidgetReload = Notification.Name(WMFNotificationName.readingChallengeWidgetReload.rawValue)
-    public static let gamesV1SettingDidChange = Notification.Name(WMFNotificationName.gamesV1SettingDidChange.rawValue)
+    public static let refreshExploreForGamesCard = Notification.Name(WMFNotificationName.refreshExploreForGamesCard.rawValue)
     public static let whichCameFirstSessionDidUpdate = Notification.Name(WMFNotificationName.whichCameFirstSessionDidUpdate.rawValue)
     public static let gamesAllSessionsCleared = Notification.Name(WMFNotificationName.gamesAllSessionsCleared.rawValue)
     
@@ -26,7 +26,7 @@ private enum WMFNotificationName: String {
     case coreDataStoreSetup = "WMFDataCoreDataStoreSetup"
     case sharedCacheStoreSetup = "WMFDataSharedCacheStoreSetup"
     case readingChallengeWidgetReload = "WMFDataReadingChallengeWidgetReload"
-    case gamesV1SettingDidChange = "WMFDataGamesV1SettingDidChange"
+    case refreshExploreForGamesCard = "WMFDataRefreshExploreForGamesCard"
     case whichCameFirstSessionDidUpdate = "WMFDataWhichCameFirstSessionDidUpdate"
     case gamesAllSessionsCleared = "WMFDataGamesAllSessionsCleared"
 }

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -63,6 +63,7 @@ public enum WMFUserDefaultsKey: String {
 
     // Games announcement
     case hasSeenGamesAnnouncement = "has-seen-games-announcement"
+    case needsDailyGameFeedRefresh = "needs-daily-game-feed-refresh"
 
     // Games dev settings
     case developerSettingsShowGamesV2 = "dev-settings-show-games-v2"

--- a/Wikipedia/Code/ExploreViewController.swift
+++ b/Wikipedia/Code/ExploreViewController.swift
@@ -105,7 +105,7 @@ class ExploreViewController: ColumnarCollectionViewController, ExploreCardViewCo
         NotificationCenter.default.addObserver(self, selector: #selector(databaseHousekeeperDidComplete), name: .databaseHousekeeperDidComplete, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(applicationDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(coreDataStoreSetup), name: WMFNSNotification.coreDataStoreSetup, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(gamesV1SettingDidChange), name: WMFNSNotification.gamesV1SettingDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshExploreForGamesCard), name: WMFNSNotification.refreshExploreForGamesCard, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(whichCameFirstSessionDidUpdate(_:)), name: WMFNSNotification.whichCameFirstSessionDidUpdate, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(gamesAllSessionsCleared), name: WMFNSNotification.gamesAllSessionsCleared, object: nil)
 
@@ -1544,7 +1544,7 @@ extension ExploreViewController {
         configureNavigationBar()
     }
 
-    @objc func gamesV1SettingDidChange() {
+    @objc func refreshExploreForGamesCard() {
         updateFeedSources(userInitiated: false)
     }
 }

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -15,7 +15,7 @@ NSString *const WMFViewContextDidSave = @"WMFViewContextDidSave";
 NSString *const WMFViewContextDidResetNotification = @"WMFViewContextDidResetNotification";
 
 NSString *const WMFLibraryVersionKey = @"WMFLibraryVersion";
-static const NSInteger WMFCurrentLibraryVersion = 19;
+static const NSInteger WMFCurrentLibraryVersion = 20;
 
 NSString *const WMFCoreDataSynchronizerInfoFileName = @"Wikipedia.info";
 
@@ -279,7 +279,7 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
                     if (article.savedDate == nil && article.isSavedMigrated) {
                         if (articleURL != nil) {
                             DDLogInfo(@"[SavedMigration] Revert hook firing for key=%@ (unsave)", article.key);
-                            NSArray<NSURL *> *urls = @[ articleURL ];
+                            NSArray<NSURL *> *urls = @[articleURL];
                             [WMFArticleSavedStateMigrationManager.shared removeFromSavedWithURLs:urls];
                         }
                     }
@@ -532,6 +532,15 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
         [self importViewedArticlesIntoWMFDataWithDataStoreMOC:moc];
         [moc wmf_setValue:@(19) forKey:WMFLibraryVersionKey];
         if ([moc hasChanges] && ![moc save:nil]) {
+            DDLogError(@"Error saving during migration: %@", migrationError);
+            return;
+        }
+    }
+
+    if (currentLibraryVersion < 20) {
+        [self.feedContentController toggleContentGroupOfKind:WMFContentGroupKindDailyGame isOn:YES updateFeed:NO];
+        [moc wmf_setValue:@(20) forKey:WMFLibraryVersionKey];
+        if ([moc hasChanges] && ![moc save:&migrationError]) {
             DDLogError(@"Error saving during migration: %@", migrationError);
             return;
         }
@@ -872,7 +881,7 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
 
 #pragma mark - Remote Configuration
 
-- (void)updateLocalConfigurationFromRemoteConfigurationWithCompletion:(nullable void (^)(NSError * _Nullable))completion {
+- (void)updateLocalConfigurationFromRemoteConfigurationWithCompletion:(nullable void (^)(NSError *_Nullable))completion {
     void (^combinedCompletion)(NSError *) = ^(NSError *error) {
         if (completion) {
             completion(error);

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -538,7 +538,7 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
     }
 
     if (currentLibraryVersion < 20) {
-        [self.feedContentController toggleContentGroupOfKind:WMFContentGroupKindDailyGame isOn:YES updateFeed:NO];
+        [self.feedContentController toggleContentGroupOfKind:WMFContentGroupKindDailyGame isOn:YES updateFeed:YES];
         [moc wmf_setValue:@(20) forKey:WMFLibraryVersionKey];
         if ([moc hasChanges] && ![moc save:&migrationError]) {
             DDLogError(@"Error saving during migration: %@", migrationError);

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -538,7 +538,7 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
     }
 
     if (currentLibraryVersion < 20) {
-        [self.feedContentController toggleContentGroupOfKind:WMFContentGroupKindDailyGame isOn:YES updateFeed:YES];
+        [self.feedContentController toggleContentGroupOfKind:WMFContentGroupKindDailyGame isOn:YES updateFeed:NO];
         [moc wmf_setValue:@(20) forKey:WMFLibraryVersionKey];
         if ([moc hasChanges] && ![moc save:&migrationError]) {
             DDLogError(@"Error saving during migration: %@", migrationError);

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -539,6 +539,7 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
 
     if (currentLibraryVersion < 20) {
         [self.feedContentController toggleContentGroupOfKind:WMFContentGroupKindDailyGame isOn:YES updateFeed:NO];
+        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"needs-daily-game-feed-refresh"];
         [moc wmf_setValue:@(20) forKey:WMFLibraryVersionKey];
         if ([moc hasChanges] && ![moc save:&migrationError]) {
             DDLogError(@"Error saving during migration: %@", migrationError);

--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -988,7 +988,7 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
             let key = WMFUserDefaultsKey.needsDailyGameFeedRefresh.rawValue
             if UserDefaults.standard.bool(forKey: key) {
                 UserDefaults.standard.removeObject(forKey: key)
-                NotificationCenter.default.post(name: WMFNSNotification.gamesV1SettingDidChange, object: nil)
+                NotificationCenter.default.post(name: WMFNSNotification.refreshExploreForGamesCard, object: nil)
             }
         }
 

--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -985,6 +985,11 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
             resumeAndAnnouncementsCompleteGroup.leave()
             self.performTasksThatShouldOccurAfterBecomeActiveAndResume()
             self.showLoggedOutPanelIfNeeded()
+            let key = WMFUserDefaultsKey.needsDailyGameFeedRefresh.rawValue
+            if UserDefaults.standard.bool(forKey: key) {
+                UserDefaults.standard.removeObject(forKey: key)
+                NotificationCenter.default.post(name: WMFNSNotification.gamesV1SettingDidChange, object: nil)
+            }
         }
 
         dataStore.feedContentController.startContentSources()


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
Only upon app version upgrade, the Explore feed card preference in Settings was defaulting to Off. I am fixing this by:

1. Adding a one-time migration step to add the daily game card as a preference.
2. After this step occurs, triggering the Explore feed to refresh so that the card pops up

Note I am repurposing gamesV1SettingDidChange notification to trigger an Explore reload...it wasn't used anymore.

### Test Steps
1. Install version in app store
2. Then run from this branch. You should see the Explore card. Check settings > Explore feed, Games toggle should be on. 

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
