### PR TITLE
T269478: Convert NumberFormatterExtrasTests to use Swift Testing

### DIFF
--- a/WikipediaUnitTests/Code/NumberFormatterExtrasTests.swift
+++ b/WikipediaUnitTests/Code/NumberFormatterExtrasTests.swift
@@ -1,27 +1,29 @@
-import XCTest
+import Foundation
+import Testing
 
-class NumberFormatterExtrasTests: XCTestCase {
-    
-    func testThousands() {
-        var number: UInt64 = 215
-        var format: String = NumberFormatter.localizedThousandsStringFromNumber(NSNumber(value: number as UInt64))
-        XCTAssertTrue(format.contains("215"))
-        
-        number = 1500
-        format = NumberFormatter.localizedThousandsStringFromNumber(NSNumber(value: number as UInt64))
-        XCTAssertTrue(format.contains("1.5"))
-        
-        number = 538000
-        format = NumberFormatter.localizedThousandsStringFromNumber(NSNumber(value: number as UInt64))
-        XCTAssertTrue(format.contains("538"))
-        
-        number = 867530939
-        format = NumberFormatter.localizedThousandsStringFromNumber(NSNumber(value: number as UInt64))
-        XCTAssertTrue(format.contains("867.5"))
-        
-        number = 312490123456
-        format = NumberFormatter.localizedThousandsStringFromNumber(NSNumber(value: number as UInt64))
-        XCTAssertTrue(format.contains("312.5"))
+struct NumberFormatterExtrasTests {
+
+    struct ThousandsCase: Encodable, Sendable, CustomTestStringConvertible {
+        let number: UInt64
+        let expectedSubstring: String
+
+        var testDescription: String {
+            "\(number) contains \(expectedSubstring)"
+        }
+
+        static let all: [Self] = [
+            ThousandsCase(number: 215, expectedSubstring: "215"),
+            ThousandsCase(number: 1500, expectedSubstring: "1.5"),
+            ThousandsCase(number: 538000, expectedSubstring: "538"),
+            ThousandsCase(number: 867530939, expectedSubstring: "867.5"),
+            ThousandsCase(number: 312490123456, expectedSubstring: "312.5")
+        ]
     }
-    
+
+    @Test(arguments: ThousandsCase.all)
+    func thousands(testCase: ThousandsCase) {
+        let format = NumberFormatter.localizedThousandsStringFromNumber(NSNumber(value: testCase.number))
+
+        #expect(format.contains(testCase.expectedSubstring))
+    }
 }


### PR DESCRIPTION
**Phabricator: T269478** 

### Notes
* Convert NumberFormatterExtrasTests to use Swift Testing

### Test Steps
N/A

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
N/A