### PR TITLE
Stabilize unit tests: remove timing waits and silent-pass guards

### DIFF
--- a/WMFComponents/Tests/WMFComponentsTests/WMFDonateViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFDonateViewModelTests.swift
@@ -168,15 +168,10 @@ final class WMFDonateViewModelTests: XCTestCase {
         
         // Select amount button
         firstButtonVM.isSelected = true
-        
-        let expectation = XCTestExpectation(description: "Waiting for textfield amount to update")
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            XCTAssertEqual(viewModel.textfieldViewModel.amount, firstButtonVM.amount)
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 2.0)
+
+        // The button-selection -> textfield update propagates synchronously through Combine,
+        // so the new amount is observable immediately without waiting.
+        XCTAssertEqual(viewModel.textfieldViewModel.amount, firstButtonVM.amount)
     }
     
     func testUpdateTextfieldSelectsAmountButtonUSD() {
@@ -201,17 +196,11 @@ final class WMFDonateViewModelTests: XCTestCase {
         
         // Update textfield
         viewModel.textfieldViewModel.amount = 3
-        
-        let expectation = XCTestExpectation(description: "Waiting for button selections to update")
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            // Confirm first button is now selected
-            let newFirstButton = viewModel.buttonViewModels[0]
-            XCTAssertTrue(newFirstButton.isSelected)
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 2.0)
+
+        // The textfield -> button-selection update propagates synchronously through Combine.
+        // Confirm first button is now selected.
+        let newFirstButton = viewModel.buttonViewModels[0]
+        XCTAssertTrue(newFirstButton.isSelected)
     }
     
     func testSelectTransactionFeeUpdatesTextfieldAndAmountButtonUSD() {
@@ -237,17 +226,10 @@ final class WMFDonateViewModelTests: XCTestCase {
         
         // Select transaction fee
         viewModel.transactionFeeOptInViewModel.isSelected = true
-        
-        let expectation = XCTestExpectation(description: "Waiting for textfield amount to update")
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            
-            // Confirm textfield has updated
-            XCTAssertEqual(viewModel.textfieldViewModel.amount, 3.35)
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 2.0)
+
+        // The transaction-fee -> textfield update propagates synchronously through Combine.
+        // Confirm textfield has updated.
+        XCTAssertEqual(viewModel.textfieldViewModel.amount, 3.35)
     }
     
     func testSmallAmountTriggersMinimumErrorUSD() {

--- a/WMFData/Tests/WMFDataTests/WMFArticleDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFArticleDataControllerTests.swift
@@ -15,16 +15,14 @@ final class WMFArticleDataControllerTests: XCTestCase {
         WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
     }
     
-    func testFetchWatchStatus() {
+    func testFetchWatchStatus() throws {
         let controller = WMFArticleDataController()
 
          let expectation = XCTestExpectation(description: "Fetch Watch Status")
         var statusToTest: WMFArticleDataController.WMFArticleInfoResponse?
-        
-        guard let request = try? WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: false, needsCategories: false) else {
-            return
-        }
-        
+
+        let request = try WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: false, needsCategories: false)
+
         controller.fetchArticleInfo(title: "Cat", project: enProject, request: request) { result in
              switch result {
              case .success(let status):
@@ -46,16 +44,14 @@ final class WMFArticleDataControllerTests: XCTestCase {
          XCTAssertNil(statusToTest.userHasRollbackRights)
      }
 
-     func testFetchWatchStatusWithRollbackRights() {
+     func testFetchWatchStatusWithRollbackRights() throws {
          let controller = WMFArticleDataController()
 
          let expectation = XCTestExpectation(description: "Fetch Watch Status")
          var statusToTest: WMFArticleDataController.WMFArticleInfoResponse?
-         
-         guard let request = try? WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: true, needsCategories: false) else {
-             return
-         }
-         
+
+         let request = try WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: true, needsCategories: false)
+
          controller.fetchArticleInfo(title: "Cat", project: enProject, request: request) { result in
              switch result {
              case .success(let status):


### PR DESCRIPTION
## Summary

Two test-only reliability fixes to the existing unit suites. No production code changes.

### `WMFDonateViewModelTests` — remove wall-clock waits
Three tests selected a value, then waited via `DispatchQueue.main.asyncAfter(deadline: .now() + 1.0)` + `wait(for:timeout: 2.0)` before asserting. The `WMFDonateViewModel` button/textfield/transaction-fee propagation chain is **fully synchronous** (plain Combine `.sink` with `.dropFirst()` — no `debounce`, `throttle`, `Task`, or `DispatchQueue`), so the values are observable immediately after the mutation. The waits added ~3s of dead time per run and coupled the tests to wall-clock timing (a flake risk on loaded CI). They now assert synchronously and each run in ~0.001s (down from ~1s+).

### `WMFArticleDataControllerTests` — surface request-construction failures
Both tests built their `ArticleInfoRequest` with `try?` + `guard … else { return }`, which **silently passes** the test if construction ever throws (no assertion runs). Changed the two tests to `throws` and use `try`, so a construction failure is reported as a real failure. This matches the pattern already used in `WMFYearInReviewDataControllerCreateOrRetrieveTests`.

## Testing
- `xcodebuild test -scheme WMFData` (iPhone 16, iOS 18.5) → 122 tests pass, 0 failures.
- `xcodebuild test -scheme WMFComponents` (iPhone 16, iOS 18.5) → 206 tests pass, 0 failures; the 3 rewritten Donate tests run in 0.001s each.
- SwiftLint `--strict` on both changed files: 0 violations.

## Notes
- No associated Phabricator ticket — this is self-initiated test cleanup/stabilization.
- A follow-up could add a shared `XCTestCase` base that restores `WMFDataEnvironment.current` in `tearDown` (no test currently resets the global singleton); deferred here to keep this PR narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)