### PR TITLE
T269478: Updating more tests away from expectation to async + Swift Testing

### DIFF
--- a/WMFComponents/Tests/WMFComponentsTests/WMFDonateViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFDonateViewModelTests.swift
@@ -1,236 +1,162 @@
-import XCTest
+import Foundation
+import Testing
 @testable import WMFComponents
 @testable import WMFData
 @testable import WMFDataMocks
 
-final class WMFDonateViewModelTests: XCTestCase {
-    
-    private var paymentMethods: WMFPaymentMethods?
-    private var donateConfig: WMFDonateConfig?
-    
+@MainActor
+struct WMFDonateViewModelTests {
+
     private let merchantID = "merchant.id"
-    
-    override func setUp(completion: @escaping (Error?) -> Void) {
-        WMFDataEnvironment.current.basicService = WMFMockBasicService()
-        WMFDataEnvironment.current.serviceEnvironment = .staging
-        
-        let controller = WMFDonateDataController.shared
-        
-        controller.fetchConfigs(for: "US") { result in
-            switch result {
-            case .success:
-                let data = controller.loadConfigs()
-                self.paymentMethods = data.paymentMethods
-                self.donateConfig = data.donateConfig
-                completion(nil)
-            case .failure(let error):
-                completion(error)
-            }
-        }
-    }
-    
-    func testViewModelInstantiatesWithCorrectDefaultsUSD() {
-        
-        guard let donateConfig,
-              let paymentMethods else {
-            XCTFail("Failure mocking donate config and payment methods")
-            return
-        }
-        
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD",  languageCode: "EN", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", appInstallID: nil, coordinatorDelegate: nil, loggingDelegate: nil) else {
-            XCTFail("View model failed to instantiate")
-            return
-        }
-        XCTAssertEqual(viewModel.buttonViewModels.count, 7)
+
+    @Test
+    func viewModelInstantiatesWithCorrectDefaultsUSD() async throws {
+        let viewModel = try await makeViewModel(countryCode: "US", currencyCode: "USD", languageCode: "EN", appInstallID: nil)
+
+        #expect(viewModel.buttonViewModels.count == 7)
         
         let firstButtonVM = viewModel.buttonViewModels[0]
-        XCTAssertEqual(firstButtonVM.currencyCode, "USD")
-        XCTAssertFalse(firstButtonVM.isSelected)
-        XCTAssertEqual(firstButtonVM.amount, 3)
+        #expect(firstButtonVM.currencyCode == "USD")
+        #expect(firstButtonVM.isSelected == false)
+        #expect(firstButtonVM.amount == 3)
         
         let secondButtonVM = viewModel.buttonViewModels[1]
-        XCTAssertEqual(secondButtonVM.currencyCode, "USD")
-        XCTAssertFalse(secondButtonVM.isSelected)
-        XCTAssertEqual(secondButtonVM.amount, 10)
+        #expect(secondButtonVM.currencyCode == "USD")
+        #expect(secondButtonVM.isSelected == false)
+        #expect(secondButtonVM.amount == 10)
         
         let thirdButtonVM = viewModel.buttonViewModels[2]
-        XCTAssertEqual(thirdButtonVM.currencyCode, "USD")
-        XCTAssertFalse(thirdButtonVM.isSelected)
-        XCTAssertEqual(thirdButtonVM.amount, 15)
+        #expect(thirdButtonVM.currencyCode == "USD")
+        #expect(thirdButtonVM.isSelected == false)
+        #expect(thirdButtonVM.amount == 15)
         
         let fourthButtonVM = viewModel.buttonViewModels[3]
-        XCTAssertEqual(fourthButtonVM.currencyCode, "USD")
-        XCTAssertFalse(fourthButtonVM.isSelected)
-        XCTAssertEqual(fourthButtonVM.amount, 25)
+        #expect(fourthButtonVM.currencyCode == "USD")
+        #expect(fourthButtonVM.isSelected == false)
+        #expect(fourthButtonVM.amount == 25)
         
         let fifthButtonVM = viewModel.buttonViewModels[4]
-        XCTAssertEqual(fifthButtonVM.currencyCode, "USD")
-        XCTAssertFalse(fifthButtonVM.isSelected)
-        XCTAssertEqual(fifthButtonVM.amount, 50)
+        #expect(fifthButtonVM.currencyCode == "USD")
+        #expect(fifthButtonVM.isSelected == false)
+        #expect(fifthButtonVM.amount == 50)
         
         let sixthButtonVM = viewModel.buttonViewModels[5]
-        XCTAssertEqual(sixthButtonVM.currencyCode, "USD")
-        XCTAssertFalse(sixthButtonVM.isSelected)
-        XCTAssertEqual(sixthButtonVM.amount, 75)
+        #expect(sixthButtonVM.currencyCode == "USD")
+        #expect(sixthButtonVM.isSelected == false)
+        #expect(sixthButtonVM.amount == 75)
         
         let seventhButtonVM = viewModel.buttonViewModels[6]
-        XCTAssertEqual(seventhButtonVM.currencyCode, "USD")
-        XCTAssertFalse(seventhButtonVM.isSelected)
-        XCTAssertEqual(seventhButtonVM.amount, 100)
+        #expect(seventhButtonVM.currencyCode == "USD")
+        #expect(seventhButtonVM.isSelected == false)
+        #expect(seventhButtonVM.amount == 100)
         
-        XCTAssertEqual(viewModel.textfieldViewModel.currencyCode, "USD")
-        XCTAssertEqual(viewModel.textfieldViewModel.amount, 0)
+        #expect(viewModel.textfieldViewModel.currencyCode == "USD")
+        #expect(viewModel.textfieldViewModel.amount == 0)
         
-        XCTAssertFalse(viewModel.transactionFeeOptInViewModel.isSelected)
+        #expect(viewModel.transactionFeeOptInViewModel.isSelected == false)
         
-        XCTAssertNil(viewModel.emailOptInViewModel)
-        XCTAssertNil(viewModel.errorViewModel)
+        #expect(viewModel.emailOptInViewModel == nil)
+        #expect(viewModel.errorViewModel == nil)
     }
     
-    func testViewModelInstantiatesWithCorrectDefaultsUYU() {
-        
-        guard let donateConfig,
-              let paymentMethods else {
-            XCTFail("Failure mocking donate config and payment methods")
-            return
-        }
-        
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("UYU"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "UY", currencyCode: "UYU", languageCode: "ES", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", appInstallID: UUID().uuidString, coordinatorDelegate: nil, loggingDelegate: nil) else {
-            XCTFail("View model failed to instantiate")
-            return
-        }
-        XCTAssertEqual(viewModel.buttonViewModels.count, 7)
+    @Test
+    func viewModelInstantiatesWithCorrectDefaultsUYU() async throws {
+        let viewModel = try await makeViewModel(countryCode: "UY", currencyCode: "UYU", languageCode: "ES")
+
+        #expect(viewModel.buttonViewModels.count == 7)
         
         let firstButtonVM = viewModel.buttonViewModels[0]
-        XCTAssertEqual(firstButtonVM.currencyCode, "UYU")
-        XCTAssertFalse(firstButtonVM.isSelected)
-        XCTAssertEqual(firstButtonVM.amount, 100)
+        #expect(firstButtonVM.currencyCode == "UYU")
+        #expect(firstButtonVM.isSelected == false)
+        #expect(firstButtonVM.amount == 100)
         
         let secondButtonVM = viewModel.buttonViewModels[1]
-        XCTAssertEqual(secondButtonVM.currencyCode, "UYU")
-        XCTAssertFalse(secondButtonVM.isSelected)
-        XCTAssertEqual(secondButtonVM.amount, 200)
+        #expect(secondButtonVM.currencyCode == "UYU")
+        #expect(secondButtonVM.isSelected == false)
+        #expect(secondButtonVM.amount == 200)
         
         let thirdButtonVM = viewModel.buttonViewModels[2]
-        XCTAssertEqual(thirdButtonVM.currencyCode, "UYU")
-        XCTAssertFalse(thirdButtonVM.isSelected)
-        XCTAssertEqual(thirdButtonVM.amount, 300)
+        #expect(thirdButtonVM.currencyCode == "UYU")
+        #expect(thirdButtonVM.isSelected == false)
+        #expect(thirdButtonVM.amount == 300)
         
         let fourthButtonVM = viewModel.buttonViewModels[3]
-        XCTAssertEqual(fourthButtonVM.currencyCode, "UYU")
-        XCTAssertFalse(fourthButtonVM.isSelected)
-        XCTAssertEqual(fourthButtonVM.amount, 500)
+        #expect(fourthButtonVM.currencyCode == "UYU")
+        #expect(fourthButtonVM.isSelected == false)
+        #expect(fourthButtonVM.amount == 500)
         
         let fifthButtonVM = viewModel.buttonViewModels[4]
-        XCTAssertEqual(fifthButtonVM.currencyCode, "UYU")
-        XCTAssertFalse(fifthButtonVM.isSelected)
-        XCTAssertEqual(fifthButtonVM.amount, 1000)
+        #expect(fifthButtonVM.currencyCode == "UYU")
+        #expect(fifthButtonVM.isSelected == false)
+        #expect(fifthButtonVM.amount == 1000)
         
         let sixthButtonVM = viewModel.buttonViewModels[5]
-        XCTAssertEqual(sixthButtonVM.currencyCode, "UYU")
-        XCTAssertFalse(sixthButtonVM.isSelected)
-        XCTAssertEqual(sixthButtonVM.amount, 1500)
+        #expect(sixthButtonVM.currencyCode == "UYU")
+        #expect(sixthButtonVM.isSelected == false)
+        #expect(sixthButtonVM.amount == 1500)
         
         let seventhButtonVM = viewModel.buttonViewModels[6]
-        XCTAssertEqual(seventhButtonVM.currencyCode, "UYU")
-        XCTAssertFalse(seventhButtonVM.isSelected)
-        XCTAssertEqual(seventhButtonVM.amount, 2000)
+        #expect(seventhButtonVM.currencyCode == "UYU")
+        #expect(seventhButtonVM.isSelected == false)
+        #expect(seventhButtonVM.amount == 2000)
         
-        XCTAssertEqual(viewModel.textfieldViewModel.currencyCode, "UYU")
-        XCTAssertEqual(viewModel.textfieldViewModel.amount, 0)
+        #expect(viewModel.textfieldViewModel.currencyCode == "UYU")
+        #expect(viewModel.textfieldViewModel.amount == 0)
         
-        XCTAssertFalse(viewModel.transactionFeeOptInViewModel.isSelected)
+        #expect(viewModel.transactionFeeOptInViewModel.isSelected == false)
         
-        XCTAssertNotNil(viewModel.emailOptInViewModel)
-        XCTAssertEqual(viewModel.emailOptInViewModel?.isSelected, false)
-        XCTAssertNil(viewModel.errorViewModel)
+        #expect(viewModel.emailOptInViewModel != nil)
+        #expect(viewModel.emailOptInViewModel?.isSelected == false)
+        #expect(viewModel.errorViewModel == nil)
     }
     
-    func testSelectAmountButtonUpdatesTextfieldUSD() {
-        guard let donateConfig,
-              let paymentMethods else {
-            XCTFail("Failure mocking donate config and payment methods")
-            return
-        }
-        
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", appInstallID: UUID().uuidString, coordinatorDelegate: nil, loggingDelegate: nil) else {
-            XCTFail("View model failed to instantiate")
-            return
-        }
+    @Test
+    func selectAmountButtonUpdatesTextfieldUSD() async throws {
+        let viewModel = try await makeViewModel(countryCode: "US", currencyCode: "USD", languageCode: "EN")
         
         // Confirm initial values are correct
         viewModel.textfieldViewModel.hasFocus = false
         let firstButtonVM = viewModel.buttonViewModels[0]
-        XCTAssertFalse(firstButtonVM.isSelected)
-        XCTAssertEqual(viewModel.textfieldViewModel.amount, 0)
+        #expect(firstButtonVM.isSelected == false)
+        #expect(viewModel.textfieldViewModel.amount == 0)
         
         viewModel.textfieldViewModel.hasFocus = false
         
         // Select amount button
         firstButtonVM.isSelected = true
         
-        let expectation = XCTestExpectation(description: "Waiting for textfield amount to update")
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            XCTAssertEqual(viewModel.textfieldViewModel.amount, firstButtonVM.amount)
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 2.0)
+        #expect(viewModel.textfieldViewModel.amount == firstButtonVM.amount)
     }
     
-    func testUpdateTextfieldSelectsAmountButtonUSD() {
-        guard let donateConfig,
-              let paymentMethods else {
-            XCTFail("Failure mocking donate config and payment methods")
-            return
-        }
-        
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", appInstallID: UUID().uuidString, coordinatorDelegate: nil, loggingDelegate: nil) else {
-            XCTFail("View model failed to instantiate")
-            return
-        }
+    @Test
+    func updateTextfieldSelectsAmountButtonUSD() async throws {
+        let viewModel = try await makeViewModel(countryCode: "US", currencyCode: "USD", languageCode: "EN")
         
         viewModel.textfieldViewModel.hasFocus = false
         
         
         // Confirm initial values are correct
         let firstButtonVM = viewModel.buttonViewModels[0]
-        XCTAssertFalse(firstButtonVM.isSelected)
-        XCTAssertEqual(viewModel.textfieldViewModel.amount, 0)
+        #expect(firstButtonVM.isSelected == false)
+        #expect(viewModel.textfieldViewModel.amount == 0)
         
         // Update textfield
         viewModel.textfieldViewModel.amount = 3
         
-        let expectation = XCTestExpectation(description: "Waiting for button selections to update")
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            // Confirm first button is now selected
-            let newFirstButton = viewModel.buttonViewModels[0]
-            XCTAssertTrue(newFirstButton.isSelected)
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 2.0)
+        // Confirm first button is now selected
+        let newFirstButton = viewModel.buttonViewModels[0]
+        #expect(newFirstButton.isSelected)
     }
     
-    func testSelectTransactionFeeUpdatesTextfieldAndAmountButtonUSD() {
-        guard let donateConfig,
-              let paymentMethods else {
-            XCTFail("Failure mocking donate config and payment methods")
-            return
-        }
-        
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", appInstallID: UUID().uuidString, coordinatorDelegate: nil, loggingDelegate: nil) else {
-            XCTFail("View model failed to instantiate")
-            return
-        }
+    @Test
+    func selectTransactionFeeUpdatesTextfieldAndAmountButtonUSD() async throws {
+        let viewModel = try await makeViewModel(countryCode: "US", currencyCode: "USD", languageCode: "EN")
         
         viewModel.textfieldViewModel.hasFocus = false
         
         // Confirm initial values are correct
-        XCTAssertEqual(viewModel.textfieldViewModel.amount, 0)
-        XCTAssertFalse(viewModel.transactionFeeOptInViewModel.isSelected)
+        #expect(viewModel.textfieldViewModel.amount == 0)
+        #expect(viewModel.transactionFeeOptInViewModel.isSelected == false)
         
         // Set amount to 3 initially
         viewModel.textfieldViewModel.amount = 3
@@ -238,33 +164,17 @@ final class WMFDonateViewModelTests: XCTestCase {
         // Select transaction fee
         viewModel.transactionFeeOptInViewModel.isSelected = true
         
-        let expectation = XCTestExpectation(description: "Waiting for textfield amount to update")
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            
-            // Confirm textfield has updated
-            XCTAssertEqual(viewModel.textfieldViewModel.amount, 3.35)
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 2.0)
+        // Confirm textfield has updated
+        #expect(viewModel.textfieldViewModel.amount == 3.35)
     }
     
-    func testSmallAmountTriggersMinimumErrorUSD() {
-        guard let donateConfig,
-              let paymentMethods else {
-            XCTFail("Failure mocking donate config and payment methods")
-            return
-        }
-        
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", appInstallID: UUID().uuidString, coordinatorDelegate: nil, loggingDelegate: nil) else {
-            XCTFail("View model failed to instantiate")
-            return
-        }
+    @Test
+    func smallAmountTriggersMinimumErrorUSD() async throws {
+        let viewModel = try await makeViewModel(countryCode: "US", currencyCode: "USD", languageCode: "EN")
         
         // Confirm initial values are correct
-        XCTAssertEqual(viewModel.textfieldViewModel.amount, 0)
-        XCTAssertNil(viewModel.errorViewModel)
+        #expect(viewModel.textfieldViewModel.amount == 0)
+        #expect(viewModel.errorViewModel == nil)
         
         // Set amount to something small
         viewModel.textfieldViewModel.amount = 0.25
@@ -272,24 +182,16 @@ final class WMFDonateViewModelTests: XCTestCase {
         // Trigger validation
         viewModel.validateAmount()
         
-        XCTAssertNotNil(viewModel.errorViewModel)
+        #expect(viewModel.errorViewModel != nil)
     }
     
-    func testLargeAmountTriggersMaximumErrorUSD() {
-        guard let donateConfig,
-              let paymentMethods else {
-            XCTFail("Failure mocking donate config and payment methods")
-            return
-        }
-        
-        guard let viewModel = WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode("USD"), donateConfig: donateConfig, paymentMethods: paymentMethods, countryCode: "US", currencyCode: "USD", languageCode: "EN", merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", appInstallID: UUID().uuidString, coordinatorDelegate: nil, loggingDelegate: nil) else {
-            XCTFail("View model failed to instantiate")
-            return
-        }
+    @Test
+    func largeAmountTriggersMaximumErrorUSD() async throws {
+        let viewModel = try await makeViewModel(countryCode: "US", currencyCode: "USD", languageCode: "EN")
         
         // Confirm initial values are correct
-        XCTAssertEqual(viewModel.textfieldViewModel.amount, 0)
-        XCTAssertNil(viewModel.errorViewModel)
+        #expect(viewModel.textfieldViewModel.amount == 0)
+        #expect(viewModel.errorViewModel == nil)
         
         // Set amount to something large
         viewModel.textfieldViewModel.amount = 30000
@@ -297,7 +199,34 @@ final class WMFDonateViewModelTests: XCTestCase {
         // Trigger validation
         viewModel.validateAmount()
         
-        XCTAssertNotNil(viewModel.errorViewModel)
+        #expect(viewModel.errorViewModel != nil)
+    }
+
+    private func makeViewModel(countryCode: String, currencyCode: String, languageCode: String, appInstallID: String? = UUID().uuidString) async throws -> WMFDonateViewModel {
+        let donateData = try await loadDonateData()
+        return try #require(WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode(currencyCode), donateConfig: donateData.donateConfig, paymentMethods: donateData.paymentMethods, countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", appInstallID: appInstallID, coordinatorDelegate: nil, loggingDelegate: nil))
+    }
+
+    private func loadDonateData() async throws -> (donateConfig: WMFDonateConfig, paymentMethods: WMFPaymentMethods) {
+        WMFDataEnvironment.current.serviceEnvironment = .staging
+        let controller = WMFDonateDataController(service: WMFMockBasicService(), sharedCacheStore: WMFMockKeyValueStore())
+        try await controller.fetchConfigs(for: "US")
+
+        let data = controller.loadConfigs()
+        return (
+            donateConfig: try #require(data.donateConfig),
+            paymentMethods: try #require(data.paymentMethods)
+        )
+    }
+}
+
+private extension WMFDonateDataController {
+    func fetchConfigs(for countryCode: String) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            fetchConfigs(for: countryCode) { result in
+                continuation.resume(with: result)
+            }
+        }
     }
 }
 

--- a/WMFComponents/Tests/WMFComponentsTests/WMFImageRecommendationsViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFImageRecommendationsViewModelTests.swift
@@ -1,9 +1,11 @@
-import XCTest
+import Testing
 @testable import WMFComponents
 @testable import WMFData
 @testable import WMFDataMocks
 
-final class WMFImageRecommendationsViewModelTests: XCTestCase {
+@MainActor
+@Suite(.serialized)
+struct WMFImageRecommendationsViewModelTests {
     
     private let csProject = WMFProject.wikipedia(WMFLanguage(languageCode: "cs", languageVariantCode: nil))
     
@@ -16,49 +18,49 @@ final class WMFImageRecommendationsViewModelTests: XCTestCase {
             WMFSurveyViewModel.OptionViewModel(text: "I don’t know this subject", apiIdentifer: "unfamiliar")
     ]
 
-    override func setUpWithError() throws {
+    init() {
         WMFDataEnvironment.current.mediaWikiService = WMFMockGrowthTasksService()
         WMFDataEnvironment.current.basicService = WMFMockBasicService()
     }
 
-    func testFetchInitialImageRecommendations() throws {
+    @Test
+    func fetchInitialImageRecommendations() async {
         let viewModel = WMFImageRecommendationsViewModel(project: csProject, semanticContentAttribute: .forceLeftToRight, isPermanent: true, localizedStrings: localizedStrings, surveyOptions: surveyOptions, needsSuppressPosting: false)
 
-        let expectation = XCTestExpectation(description: "Fetch Image Recommendations")
-        
-        viewModel.fetchImageRecommendationsIfNeeded {
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 3.0)
-        
-        XCTAssertEqual(viewModel.imageRecommendations.count, 9, "Unexpected image recommendations count.")
-        XCTAssertNotNil(viewModel.currentRecommendation, "currentRecommendation should not be nil after fetching recommendations")
-        XCTAssertNotNil(viewModel.currentRecommendation?.articleSummary, "currentRecommendation.articleSummary should not be nil after fetching recommendations")
+        await viewModel.fetchImageRecommendationsIfNeeded()
+
+        #expect(viewModel.imageRecommendations.count == 9)
+        #expect(viewModel.currentRecommendation != nil)
+        #expect(viewModel.currentRecommendation?.articleSummary != nil)
     }
     
-    func testFetchNextImageRecommendation() throws {
+    @Test
+    func fetchNextImageRecommendation() async {
         let viewModel = WMFImageRecommendationsViewModel(project: csProject, semanticContentAttribute: .forceLeftToRight, isPermanent: true, localizedStrings: localizedStrings, surveyOptions: surveyOptions, needsSuppressPosting: false)
-        
-        let expectation1 = XCTestExpectation(description: "Fetch Image Recommendations")
-        
-        viewModel.fetchImageRecommendationsIfNeeded {
-            expectation1.fulfill()
-        }
-        
-        wait(for: [expectation1], timeout: 3.0)
-        
-        let expectation2 = XCTestExpectation(description: "Fetch Next Image Recommendation")
-        viewModel.next {
-            expectation2.fulfill()
-        }
-        
-        wait(for: [expectation2], timeout: 3.0)
-        
-        XCTAssertEqual(viewModel.imageRecommendations.count, 8, "Unexpected image recommendations count.")
 
-        XCTAssertNotNil(viewModel.currentRecommendation, "currentRecommendation should not be nil after next()")
-        XCTAssertNotNil(viewModel.currentRecommendation?.articleSummary, "currentRecommendation.articleSummary should not be nil after next()")
+        await viewModel.fetchImageRecommendationsIfNeeded()
+        await viewModel.next()
+
+        #expect(viewModel.imageRecommendations.count == 8)
+        #expect(viewModel.currentRecommendation != nil)
+        #expect(viewModel.currentRecommendation?.articleSummary != nil)
+    }
+}
+
+private extension WMFImageRecommendationsViewModel {
+    func fetchImageRecommendationsIfNeeded() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            fetchImageRecommendationsIfNeeded {
+                continuation.resume()
+            }
+        }
     }
 
+    func next() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            next {
+                continuation.resume()
+            }
+        }
+    }
 }

--- a/WMFData/Tests/WMFDataTests/WMFArticleDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFArticleDataControllerTests.swift
@@ -1,79 +1,51 @@
-import XCTest
+import Foundation
+import Testing
 @testable import WMFData
 @testable import WMFDataMocks
 
-final class WMFArticleDataControllerTests: XCTestCase {
-    
+@Suite(.serialized)
+struct WMFArticleDataControllerTests {
+
     private let enProject = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
-    
-    override func setUp() async throws {
-        WMFDataEnvironment.current.appData = WMFAppData(appLanguages:[
+
+    init() {
+        WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [
             WMFLanguage(languageCode: "en", languageVariantCode: nil)
         ])
         WMFDataEnvironment.current.mediaWikiService = WMFMockWatchlistMediaWikiService()
         WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
         WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
     }
-    
-    func testFetchWatchStatus() {
+
+    @Test
+    func fetchWatchStatus() async throws {
         let controller = WMFArticleDataController()
+        let request = try WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: false, needsCategories: false)
 
-         let expectation = XCTestExpectation(description: "Fetch Watch Status")
-        var statusToTest: WMFArticleDataController.WMFArticleInfoResponse?
-        
-        guard let request = try? WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: false, needsCategories: false) else {
-            return
+        let status = try await controller.fetchArticleInfo(title: "Cat", project: enProject, request: request)
+
+        #expect(status.watched)
+        #expect(status.userHasRollbackRights == nil)
+    }
+
+    @Test
+    func fetchWatchStatusWithRollbackRights() async throws {
+        let controller = WMFArticleDataController()
+        let request = try WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: true, needsCategories: false)
+
+        let status = try await controller.fetchArticleInfo(title: "Cat", project: enProject, request: request)
+
+        #expect(status.watched == false)
+        #expect(status.userHasRollbackRights == true)
+    }
+}
+
+private extension WMFArticleDataController {
+    func fetchArticleInfo(title: String, project: WMFProject, request: ArticleInfoRequest) async throws -> WMFArticleInfoResponse {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchArticleInfo(title: title, project: project, request: request) { result in
+                continuation.resume(with: result)
+            }
         }
-        
-        controller.fetchArticleInfo(title: "Cat", project: enProject, request: request) { result in
-             switch result {
-             case .success(let status):
-                 statusToTest = status
-             case .failure(let error):
-                 XCTFail("Failure fetching watch status: \(error)")
-             }
-             expectation.fulfill()
-         }
-
-         wait(for: [expectation], timeout: 10.0)
-
-         guard let statusToTest else {
-             XCTFail("Missing statusToTest")
-             return
-         }
-
-         XCTAssertTrue(statusToTest.watched)
-         XCTAssertNil(statusToTest.userHasRollbackRights)
-     }
-
-     func testFetchWatchStatusWithRollbackRights() {
-         let controller = WMFArticleDataController()
-
-         let expectation = XCTestExpectation(description: "Fetch Watch Status")
-         var statusToTest: WMFArticleDataController.WMFArticleInfoResponse?
-         
-         guard let request = try? WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: true, needsCategories: false) else {
-             return
-         }
-         
-         controller.fetchArticleInfo(title: "Cat", project: enProject, request: request) { result in
-             switch result {
-             case .success(let status):
-                 statusToTest = status
-             case .failure(let error):
-                 XCTFail("Failure fetching watch status: \(error)")
-             }
-             expectation.fulfill()
-         }
-
-         wait(for: [expectation], timeout: 10.0)
-
-         guard let statusToTest else {
-             XCTFail("Missing statusToTest")
-             return
-         }
-
-         XCTAssertFalse(statusToTest.watched)
-         XCTAssertTrue((statusToTest.userHasRollbackRights ?? false))
-     }
+    }
 }

--- a/WMFData/Tests/WMFDataTests/WMFDeveloperSettingsDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFDeveloperSettingsDataControllerTests.swift
@@ -1,64 +1,107 @@
-import XCTest
+import Foundation
+import Testing
 @testable import WMFData
 @testable import WMFDataMocks
 
-final class WMFDeveloperSettingsDataControllerTests: XCTestCase {
-    
-    private var controller: WMFDeveloperSettingsDataController?
-    
-    override func setUp() async throws {
-        WMFDataEnvironment.current.basicService = WMFMockBasicService()
+@Suite(.serialized)
+struct WMFDeveloperSettingsDataControllerTests {
+
+    private let controller: WMFDeveloperSettingsDataController
+
+    init() {
+        WMFDataEnvironment.current.basicService = WMFFeatureConfigRequestMockService()
         WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
         WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [WMFLanguage(languageCode: "en", languageVariantCode: nil)])
-        self.controller = WMFDeveloperSettingsDataController()
+        controller = WMFDeveloperSettingsDataController()
     }
-    
-    func testFetchFeatureConfigAndLoad() {
-        
-        guard let controller else {
-            XCTFail("Missing WMFDeveloperSettingsDataController")
+
+    @Test
+    func fetchFeatureConfigAndLoad() async throws {
+        try await controller.fetchFeatureConfig()
+
+        let config = try #require(controller.loadFeatureConfig())
+        let yirConfig = try #require(config.common.yir(year: 2025))
+
+        #expect(yirConfig.year == 2025)
+        #expect(yirConfig.activeStartDateString == "2025-12-01T00:00:00Z")
+        #expect(yirConfig.activeEndDateString == "2026-02-01T00:00:00Z")
+        #expect(yirConfig.dataStartDateString == "2025-01-01T00:00:00Z")
+        #expect(yirConfig.dataEndDateString == "2025-12-01T00:00:00Z")
+        #expect(yirConfig.languages == 300)
+        #expect(yirConfig.articles == 10000000)
+        #expect(yirConfig.savedArticlesApps == 37574993)
+        #expect(yirConfig.viewsApps == 1000000000)
+        #expect(yirConfig.editsApps == 124356)
+        #expect(yirConfig.editsPerMinute == 342)
+        #expect(yirConfig.averageArticlesReadPerYear == 335)
+        #expect(yirConfig.edits == 81987181)
+        #expect(yirConfig.editsEN == 31000000)
+        #expect(yirConfig.bytesAddedEN == 1000000000)
+        #expect(yirConfig.hoursReadEN == 2423171000)
+        #expect(yirConfig.yearsReadEN == 275000)
+        #expect(yirConfig.topReadEN.count == 5)
+        #expect(yirConfig.topReadPercentages.count == 8)
+        #expect(yirConfig.hideCountryCodes.count == 22)
+        #expect(yirConfig.hideDonateCountryCodes.count == 30)
+    }
+}
+
+private final class WMFFeatureConfigRequestMockService: WMFService {
+    func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<Data, Error>) -> Void) {
+        completion(.failure(WMFServiceError.unexpectedResponse))
+    }
+
+    func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<[String: Any]?, Error>) -> Void) {
+        completion(.failure(WMFServiceError.unexpectedResponse))
+    }
+
+    func performDecodableGET<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void) {
+        guard isFeatureConfigRequest(request) else {
+            completion(.failure(WMFServiceError.unexpectedResponse))
             return
         }
-        
-        let expectation = XCTestExpectation(description: "Fetch Config")
-        
-        controller.fetchFeatureConfig { error in
-            guard error == nil else {
-                XCTFail("Failure fetching feature config")
-                return
-            }
-            
-            guard let config = controller.loadFeatureConfig(),
-                  let yirConfig = config.common.yir(year: 2025) else {
-                XCTFail("Failure loading feature config")
-                return
-            }
-            
-            XCTAssertEqual(yirConfig.year, 2025, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.activeStartDateString, "2025-12-01T00:00:00Z", "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.activeEndDateString, "2026-02-01T00:00:00Z", "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.dataStartDateString, "2025-01-01T00:00:00Z", "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.dataEndDateString, "2025-12-01T00:00:00Z", "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.languages, 300, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.articles, 10000000, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.savedArticlesApps, 37574993, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.viewsApps, 1000000000, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.editsApps, 124356, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.editsPerMinute, 342, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.averageArticlesReadPerYear, 335, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.edits, 81987181, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.editsEN, 31000000, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.bytesAddedEN, 1000000000, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.hoursReadEN, 2423171000, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.yearsReadEN, 275000, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.topReadEN.count, 5, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.topReadPercentages.count, 8, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.hideCountryCodes.count, 22, "Unexpected feature config yir")
-            XCTAssertEqual(yirConfig.hideDonateCountryCodes.count, 30, "Unexpected feature config yir")
-            
-            expectation.fulfill()
+
+        WMFMockBasicService(jsonResourceName: "feature-get-config").performDecodableGET(request: request, completion: completion)
+    }
+
+    func performDecodablePOST<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void) {
+        completion(.failure(WMFServiceError.unexpectedResponse))
+    }
+
+    func clearCachedData() {}
+
+    private func isFeatureConfigRequest(_ request: WMFServiceRequest) -> Bool {
+        request.method == .GET &&
+            (isProductionFeatureConfigRequest(request) || isStagingFeatureConfigRequest(request))
+    }
+
+    private func isProductionFeatureConfigRequest(_ request: WMFServiceRequest) -> Bool {
+        request.url?.host == "en.wikipedia.org" &&
+            request.url?.path == "/api/rest_v1/feed/configuration"
+    }
+
+    private func isStagingFeatureConfigRequest(_ request: WMFServiceRequest) -> Bool {
+        guard let url = request.url,
+              url.host == "test.wikipedia.org",
+              url.path == "/wiki/MediaWiki:AppsFeatureConfig.json",
+              let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems else {
+            return false
         }
-        
-        wait(for: [expectation], timeout: 2.0)
+
+        return queryItems.contains(URLQueryItem(name: "action", value: "raw"))
+    }
+}
+
+private extension WMFDeveloperSettingsDataController {
+    func fetchFeatureConfig() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            fetchFeatureConfig { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
     }
 }

--- a/WMFData/Tests/WMFDataTests/WMFDonateDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFDonateDataControllerTests.swift
@@ -1,191 +1,181 @@
-import XCTest
 import Contacts
+import Foundation
+import Testing
 @testable import WMFData
 @testable import WMFDataMocks
 
-final class WMFDonateDataControllerTests: XCTestCase {
-    
-    private let controller: WMFDonateDataController = WMFDonateDataController.shared
+@Suite(.serialized)
+struct WMFDonateDataControllerTests {
 
-    override func setUp() async throws {
-        WMFDataEnvironment.current.basicService = WMFMockBasicService()
-        WMFDataEnvironment.current.serviceEnvironment = .staging
-        WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
-        self.controller.reset()
-        self.controller.service = WMFDataEnvironment.current.basicService
-        self.controller.sharedCacheStore = WMFDataEnvironment.current.sharedCacheStore
+    private let controller: WMFDonateDataController
+
+    init() {
+        controller = WMFDonateDataController(service: WMFDonateRequestMockService(), sharedCacheStore: WMFMockKeyValueStore())
+        controller.reset()
     }
-    
-    func testFetchDonateConfig() {
-        
-        let expectation = XCTestExpectation(description: "Fetch Donate Configs")
-        
-        controller.fetchConfigs(for: "US") { result in
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
-                XCTFail("Failure fetching configs: \(error)")
-            }
-            
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 10.0)
-        
+
+    @Test
+    func fetchDonateConfig() async throws {
+        try await controller.fetchConfigs(for: "US")
+
         let donateData = controller.loadConfigs()
-        
-        let paymentMethods = donateData.paymentMethods
-        let donateConfig = donateData.donateConfig
-        
-        XCTAssertNotNil(paymentMethods, "Expected Payment Methods")
-        XCTAssertNotNil(donateConfig, "Expected Donate Config")
-        
-        guard let paymentMethods,
-              let donateConfig else {
-            return
-        }
-        
-        XCTAssertEqual(donateConfig.version, 1, "Unexpected version")
-        XCTAssertEqual(donateConfig.currencyMinimumDonation["USD"], 1, "Unexpected USD minimum")
-        XCTAssertEqual(donateConfig.currencyMaximumDonation["USD"], 25000, "Unexpected USD maximum")
-        XCTAssertEqual(donateConfig.currencyAmountPresets["USD"]?.count, 7, "Unexpected USD default options count")
-        XCTAssertEqual(donateConfig.currencyAmountPresets["USD"]?[0], 3, "Unexpected USD default option first value")
-        XCTAssertEqual(donateConfig.currencyTransactionFees["default"], 0.35, "Unexpected default transaction fee")
-        XCTAssertTrue(donateConfig.countryCodeEmailOptInRequired.contains("AR"), "Missing AR from email opt in required list")
-        XCTAssertEqual(paymentMethods.applePayPaymentNetworks, [.amex, .discover, .maestro, .masterCard, .visa], "Unexpected Apple Pay payment networks")
+        let paymentMethods = try #require(donateData.paymentMethods)
+        let donateConfig = try #require(donateData.donateConfig)
+
+        #expect(donateConfig.version == 1)
+        #expect(donateConfig.currencyMinimumDonation["USD"] == 1)
+        #expect(donateConfig.currencyMaximumDonation["USD"] == 25000)
+        #expect(donateConfig.currencyAmountPresets["USD"]?.count == 7)
+        #expect(donateConfig.currencyAmountPresets["USD"]?[0] == 3)
+        #expect(donateConfig.currencyTransactionFees["default"] == 0.35)
+        #expect(donateConfig.countryCodeEmailOptInRequired.contains("AR"))
+        #expect(paymentMethods.applePayPaymentNetworks == [.amex, .discover, .maestro, .masterCard, .visa])
     }
-    
-    func testDonateSubmitPayment() {
-        
-        let expectation = XCTestExpectation(description: "Submit Payment")
-        
-        let nameComponents = PersonNameComponents()
-        let addressComponents = CNPostalAddress()
-        
-        controller.submitPayment(amount: 3, countryCode: "US", currencyCode: "USD", languageCode: "EN", paymentToken: "fake-token", paymentNetwork: "Discover", donorNameComponents: nameComponents, recurring: true, donorEmail: "wikimediaTester1@gmail.com", donorAddressComponents: addressComponents, emailOptIn: nil, transactionFee: false, metricsID: "enUS_2024_09_iOS", appVersion: "7.4.3", appInstallID: UUID().uuidString) { result in
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
-                XCTFail("Failure submitting payment: \(error)")
-            }
-            
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 10.0)
+
+    @Test
+    func donateSubmitPayment() async throws {
+        try await controller.submitPayment()
     }
-    
-    func testFetchDonateConfigWithNoCacheAndNoInternetConnection() {
-        WMFDataEnvironment.current.basicService = WMFMockServiceNoInternetConnection()
-        controller.service = WMFDataEnvironment.current.basicService
-        
-        let expectation = XCTestExpectation(description: "Fetch Donate Configs")
-        
-        controller.fetchConfigs(for: "US") { result in
-            switch result {
-            case .success:
-                
-                XCTFail("Unexpected success")
-                
-            case .failure:
-                break
-            }
-            
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 10.0)
-        
+
+    @Test
+    func fetchDonateConfigWithNoCacheAndNoInternetConnection() async throws {
+        controller.service = WMFMockServiceNoInternetConnection()
+
+        let error = try #require(await #expect(throws: NSError.self) {
+            try await controller.fetchConfigs(for: "US")
+        })
+        #expect(error.domain == NSURLErrorDomain)
+        #expect(error.code == NSURLErrorNotConnectedToInternet)
+
         let donateData = controller.loadConfigs()
-        
-        let paymentMethods = donateData.paymentMethods
-        let donateConfig = donateData.donateConfig
-        
-        XCTAssertNil(paymentMethods, "Expected Payment Methods")
-        XCTAssertNil(donateConfig, "Expected Donate Config")
+
+        #expect(donateData.paymentMethods == nil)
+        #expect(donateData.donateConfig == nil)
     }
-    
-    func testFetchDonateConfigWithCacheAndNoInternetConnection() {
 
-        let expectation1 = XCTestExpectation(description: "Fetch Donate Configs with Internet Connection")
-        let expectation2 = XCTestExpectation(description: "Fetch Donate Configs without Internet Connection")
+    @Test
+    func fetchDonateConfigWithCacheAndNoInternetConnection() async throws {
+        try await controller.fetchConfigs(for: "US")
 
-        var connectedPaymentMethods: WMFPaymentMethods?
-        var connectedDonateConfig: WMFDonateConfig?
-        var notConnectedPaymentMethods: WMFPaymentMethods?
-        var notConnectedDonateConfig: WMFDonateConfig?
-        
-        // First fetch successfully to populate cache
-        controller.fetchConfigs(for: "US") { result in
-            switch result {
-            case .success:
-                
-                let donateData = self.controller.loadConfigs()
-                
-                connectedPaymentMethods = donateData.paymentMethods
-                connectedDonateConfig = donateData.donateConfig
-                
-                // Drop Internet Connection
-                WMFDataEnvironment.current.basicService = WMFMockServiceNoInternetConnection()
-                self.controller.service = WMFDataEnvironment.current.basicService
+        let connectedDonateData = controller.loadConfigs()
+        let connectedPaymentMethods = try #require(connectedDonateData.paymentMethods)
+        let connectedDonateConfig = try #require(connectedDonateData.donateConfig)
 
-                // Fetch again
-                self.controller.fetchConfigs(for: "US") { result in
-                    switch result {
-                    case .success:
-                        
-                        XCTFail("Unexpected disconnected success")
-                        
-                    case .failure:
-                        
-                        // Despite failure, we still expect to be able to load configs from cache
-                        let donateData = self.controller.loadConfigs()
-                        notConnectedPaymentMethods = donateData.paymentMethods
-                        notConnectedDonateConfig = donateData.donateConfig
-                        
-                    }
-                    
-                    expectation2.fulfill()
-                }
-            case .failure:
-                XCTFail("Unexpected connected failure")
-            }
-            
-            expectation1.fulfill()
+        controller.service = WMFMockServiceNoInternetConnection()
+
+        let error = try #require(await #expect(throws: NSError.self) {
+            try await controller.fetchConfigs(for: "US")
+        })
+        #expect(error.domain == NSURLErrorDomain)
+        #expect(error.code == NSURLErrorNotConnectedToInternet)
+
+        let notConnectedDonateData = controller.loadConfigs()
+        let notConnectedPaymentMethods = try #require(notConnectedDonateData.paymentMethods)
+        let notConnectedDonateConfig = try #require(notConnectedDonateData.donateConfig)
+
+        #expect(connectedPaymentMethods.applePayPaymentNetworks == notConnectedPaymentMethods.applePayPaymentNetworks)
+        #expect(connectedDonateConfig.version == notConnectedDonateConfig.version)
+    }
+
+    @Test
+    func donateSubmitPaymentNoInternetConnection() async throws {
+        controller.service = WMFMockServiceNoInternetConnection()
+
+        let error = try #require(await #expect(throws: NSError.self) {
+            try await controller.submitPayment()
+        })
+        #expect(error.domain == NSURLErrorDomain)
+        #expect(error.code == NSURLErrorNotConnectedToInternet)
+    }
+}
+
+private final class WMFDonateRequestMockService: WMFService {
+    func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<Data, Error>) -> Void) {
+        completion(.failure(WMFServiceError.unexpectedResponse))
+    }
+
+    func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<[String: Any]?, Error>) -> Void) {
+        completion(.failure(WMFServiceError.unexpectedResponse))
+    }
+
+    func performDecodableGET<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void) {
+        if isPaymentMethodsRequest(request) {
+            WMFMockBasicService(jsonResourceName: "donate-get-payment-methods").performDecodableGET(request: request, completion: completion)
+        } else if isDonateConfigRequest(request) {
+            WMFMockBasicService(jsonResourceName: "donate-get-config").performDecodableGET(request: request, completion: completion)
+        } else {
+            completion(.failure(WMFServiceError.unexpectedResponse))
         }
-        
-        wait(for: [expectation1], timeout: 10.0)
-        wait(for: [expectation2], timeout: 10.0)
-        
-        XCTAssertNotNil(connectedPaymentMethods, "Expected Payment Methods")
-        XCTAssertNotNil(connectedDonateConfig, "Expected Donate Config")
-        XCTAssertNotNil(notConnectedPaymentMethods, "Expected Payment Methods")
-        XCTAssertNotNil(notConnectedDonateConfig, "Expected Donate Config")
-    }
-    
-    func testDonateSubmitPaymentNoInternetConnection() {
-        WMFDataEnvironment.current.basicService = WMFMockServiceNoInternetConnection()
-        controller.service = WMFDataEnvironment.current.basicService
-        
-        let expectation = XCTestExpectation(description: "Submit Payment")
-        
-        let nameComponents = PersonNameComponents()
-        let addressComponents = CNPostalAddress()
-        
-        controller.submitPayment(amount: 3, countryCode: "US", currencyCode: "USD", languageCode: "EN", paymentToken: "fake-token", paymentNetwork: "Discover", donorNameComponents: nameComponents, recurring: true, donorEmail: "wikimediaTester1@gmail.com", donorAddressComponents: addressComponents, emailOptIn: nil, transactionFee: false, metricsID: "enUS_2024_09_iOS", appVersion: "7.4.3", appInstallID: UUID().uuidString) { result in
-            switch result {
-            case .success:
-                XCTFail("Expected submitPayment to fail")
-            case .failure:
-                break
-            }
-            
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 10.0)
     }
 
+    func performDecodablePOST<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void) {
+        if isSubmitPaymentRequest(request) {
+            WMFMockBasicService(jsonResourceName: "donate-post-submit-payment-success").performDecodablePOST(request: request, completion: completion)
+        } else {
+            completion(.failure(WMFServiceError.unexpectedResponse))
+        }
+    }
+
+    func clearCachedData() {}
+
+    private func isPaymentMethodsRequest(_ request: WMFServiceRequest) -> Bool {
+        request.method == .GET &&
+            request.url?.host == "payments.wikimedia.org" &&
+            request.parameters?["action"] as? String == "getPaymentMethods" &&
+            request.parameters?["country"] as? String == "US" &&
+            request.parameters?["format"] as? String == "json"
+    }
+
+    private func isDonateConfigRequest(_ request: WMFServiceRequest) -> Bool {
+        request.method == .GET &&
+            request.url?.path == "/wiki/MediaWiki:AppsDonationConfig.json" &&
+            ["donate.wikimedia.org", "test.wikipedia.org"].contains(request.url?.host) &&
+            request.parameters?["action"] as? String == "raw"
+    }
+
+    private func isSubmitPaymentRequest(_ request: WMFServiceRequest) -> Bool {
+        request.method == .POST &&
+            request.url?.host == "payments.wikimedia.org" &&
+            request.parameters?["action"] as? String == "submitPayment" &&
+            request.parameters?["amount"] as? String == "3" &&
+            request.parameters?["country"] as? String == "US" &&
+            request.parameters?["currency"] as? String == "USD"
+    }
+}
+
+private extension WMFDonateDataController {
+    func fetchConfigs(for countryCode: String) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            fetchConfigs(for: countryCode) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+    func submitPayment() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let nameComponents = PersonNameComponents()
+            let addressComponents = CNPostalAddress()
+
+            submitPayment(
+                amount: 3,
+                countryCode: "US",
+                currencyCode: "USD",
+                languageCode: "EN",
+                paymentToken: "fake-token",
+                paymentNetwork: "Discover",
+                donorNameComponents: nameComponents,
+                recurring: true,
+                donorEmail: "wikimediaTester1@gmail.com",
+                donorAddressComponents: addressComponents,
+                emailOptIn: nil,
+                transactionFee: false,
+                metricsID: "enUS_2024_09_iOS",
+                appVersion: "7.4.3",
+                appInstallID: UUID().uuidString
+            ) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
 }

--- a/WMFData/Tests/WMFDataTests/WMFFundraisingCampaignDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFFundraisingCampaignDataControllerTests.swift
@@ -1,406 +1,247 @@
-import XCTest
+import Foundation
+import Testing
 @testable import WMFData
 @testable import WMFDataMocks
 
-final class WMFFundraisingCampaignDataControllerTests: XCTestCase {
-    
+@Suite(.serialized)
+struct WMFFundraisingCampaignDataControllerTests {
+
     private let enProject = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
     private let esProject = WMFProject.wikipedia(WMFLanguage(languageCode: "es", languageVariantCode: nil))
     private let nlProject = WMFProject.wikipedia(WMFLanguage(languageCode: "nl", languageVariantCode: nil))
+    private let controller: WMFFundraisingCampaignDataController
 
-    private var controller: WMFFundraisingCampaignDataController = WMFFundraisingCampaignDataController.shared
-    
-    override func setUp() async throws {
-        WMFDataEnvironment.current.basicService = WMFMockBasicService()
-        WMFDataEnvironment.current.serviceEnvironment = .staging
-        WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
-        self.controller.reset()
-        self.controller.service = WMFDataEnvironment.current.basicService
-        self.controller.sharedCacheStore = WMFDataEnvironment.current.sharedCacheStore
-    }
-    
-    func validFirstDayDate() -> Date {
-        let dateFormatter = DateFormatter.mediaWikiAPIDateFormatter
-        let date = dateFormatter.date(from: "2023-10-01T12:00:00Z")
-        return date!
-    }
-    
-    func validFirstDayPlus6HoursDate() -> Date {
-        let dateFormatter = DateFormatter.mediaWikiAPIDateFormatter
-        let date = dateFormatter.date(from: "2023-10-01T18:00:00Z")
-        return date!
-    }
-    
-    func validFirstDayPlus30HoursDate() -> Date {
-        let dateFormatter = DateFormatter.mediaWikiAPIDateFormatter
-        let date = dateFormatter.date(from: "2023-10-02T18:00:00Z")
-        return date!
-    }
-    
-    func validLastDayDate() -> Date {
-        let dateFormatter = DateFormatter.mediaWikiAPIDateFormatter
-        let date = dateFormatter.date(from: "2023-11-13T12:00:00Z")
-        return date!
-    }
-    
-    func validLastDayPlus30HoursDate() -> Date {
-        let dateFormatter = DateFormatter.mediaWikiAPIDateFormatter
-        let date = dateFormatter.date(from: "2023-11-14T18:00:00Z")
-        return date!
-    }
-    
-    func invalidDate() -> Date {
-        let dateFormatter = DateFormatter.mediaWikiAPIDateFormatter
-        let date = dateFormatter.date(from: "2023-12-15T12:00:00Z")
-        return date!
+    init() {
+        controller = WMFFundraisingCampaignDataController.shared
+        controller.reset()
+        controller.service = WMFFundraisingCampaignRequestMockService()
+        controller.sharedCacheStore = WMFMockKeyValueStore()
     }
 
-    func testFetchConfigAndLoadAssetWithValidCountryValidDateValidWiki() {
-        let expectation = XCTestExpectation(description: "Fetch Config")
-        
+    @Test
+    func fetchConfigAndLoadAssetWithValidCountryValidDateValidWiki() async throws {
         let validCountry = "NL"
-        let validDate = validFirstDayDate()
-        let validENProject = enProject
-        let validNLProject = nlProject
-        
-        controller.fetchConfig(countryCode: validCountry, currentDate: validDate) { result in
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
-                XCTFail("Failure fetching config: \(error)")
-            }
-            
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 10.0)
-        
-        guard let enWikiAsset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validENProject, currentDate: validDate),
-              let nlWikiAsset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validNLProject, currentDate: validDate) else {
-            XCTFail("Missing assets")
+        let validDate = try validFirstDayDate()
+
+        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+
+        let enWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: enProject, currentDate: validDate))
+        let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
+
+        #expect(enWikiAsset.id == "NL_2023_11")
+        #expect(enWikiAsset.textHtml == "<b>Wikipedia is not for sale.</b><br><i>A personal appeal from Jimmy Wales</i><br><br>Today I humbly ask you to reflect on the number of times you have used the Wikipedia app this year, the value you’ve gotten from it, and whether you’re able to give €2 back. The Wikimedia Foundation relies on readers to support the technology that makes Wikipedia and our other projects possible. Being a nonprofit means there is no danger that someone will buy Wikipedia and turn it into their personal playground. If Wikipedia has given you €2 worth of knowledge this year, please give back. Thank you. — <i>Jimmy Wales, founder, Wikimedia Foundation</i>")
+        #expect(enWikiAsset.footerHtml == "By donating, you agree to our <a href='https://foundation.wikimedia.org/wiki/Donor_privacy_policy/en'>donor policy</a>.")
+        #expect(enWikiAsset.actions.count == 3)
+        #expect(enWikiAsset.actions[0].title == "Donate now")
+        #expect(enWikiAsset.actions[0].url == URL(string: "https://donate.wikimedia.org/?uselang=en&appeal=JimmyQuote&utm_medium=WikipediaApp&utm_campaign=iOS&utm_source=app_2023_enNL_iOS_control"))
+        #expect(enWikiAsset.actions[1].title == "Maybe later")
+        #expect(enWikiAsset.actions[2].title == "I already donated")
+        #expect(enWikiAsset.currencyCode == "EUR")
+
+        #expect(nlWikiAsset.id == "NL_2023_11")
+        #expect(nlWikiAsset.textHtml == "<b>Wikipedia is niet te koop.</b><br><i>Een persoonlijke boodschap van Jimmy Wales.</i><br><br>Sta je weleens stil bij de keren dat je de Wikipedia-app hebt gebruikt dit jaar? Als je dat nuttig vond, zou je dan €&nbsp;2 willen geven? De Wikimedia Foundation is afhankelijk van lezers die de technologie willen ondersteunen die Wikipedia en andere projecten mogelijk maakt. Omdat we een non-profitorganisatie zijn, bestaat er geen gevaar dat iemand ineens Wikipedia koopt en ermee aan de haal gaat. Als je vindt dat Wikipedia je dit jaar €&nbsp;2 aan kennis heeft gegeven, overweeg dan een donatie. Alvast bedankt. — <i>Jimmy Wales, oprichter van de Wikimedia Foundation</i>")
+        #expect(nlWikiAsset.footerHtml == "Als je doneert, ga je akkoord met ons <a href='https://foundation.wikimedia.org/wiki/Donor_privacy_policy/nl'>privacybeleid voor donateurs</a>.")
+        #expect(nlWikiAsset.actions.count == 3)
+        #expect(nlWikiAsset.actions[0].title == "Doneer nu")
+        #expect(nlWikiAsset.actions[0].url == URL(string: "https://donate.wikimedia.org/?uselang=nl&appeal=JimmyQuote&utm_medium=WikipediaApp&utm_campaign=iOS&utm_source=app_2023_nlNL_iOS_control"))
+        #expect(nlWikiAsset.actions[1].title == "Misschien later")
+        #expect(nlWikiAsset.actions[2].title == "Ik heb al gedoneerd")
+        #expect(nlWikiAsset.currencyCode == "EUR")
+    }
+
+    @Test
+    func fetchConfigAndLoadAssetWithInvalidCountryValidDateValidWiki() async throws {
+        let invalidCountry = "US"
+        let validDate = try validFirstDayDate()
+
+        try await controller.fetchConfig(countryCode: invalidCountry, currentDate: validDate)
+
+        #expect(controller.loadActiveCampaignAsset(countryCode: invalidCountry, wmfProject: enProject, currentDate: validDate) == nil)
+        #expect(controller.loadActiveCampaignAsset(countryCode: invalidCountry, wmfProject: nlProject, currentDate: validDate) == nil)
+    }
+
+    @Test
+    func fetchConfigAndLoadAssetWithValidCountryInvalidDateValidWiki() async throws {
+        let validCountry = "NL"
+        let invalidDate = try invalidDate()
+
+        try await controller.fetchConfig(countryCode: validCountry, currentDate: invalidDate)
+
+        #expect(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: enProject, currentDate: invalidDate) == nil)
+        #expect(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: invalidDate) == nil)
+    }
+
+    @Test
+    func fetchConfigAndLoadAssetWithValidCountryValidDateInvalidWiki() async throws {
+        let validCountry = "NL"
+        let validDate = try validFirstDayDate()
+
+        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+
+        #expect(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: esProject, currentDate: validDate) == nil)
+    }
+
+    @Test
+    func fetchConfigAndLoadAssetWithNoCacheAndNoInternetConnection() async throws {
+        controller.service = WMFMockServiceNoInternetConnection()
+
+        let validCountry = "NL"
+        let validDate = try validFirstDayDate()
+
+        let error = try #require(await #expect(throws: NSError.self) {
+            try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+        })
+        #expect(error.domain == NSURLErrorDomain)
+        #expect(error.code == NSURLErrorNotConnectedToInternet)
+
+        let asset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate)
+        #expect(asset == nil)
+    }
+
+    @Test
+    func fetchConfigAndLoadAssetWithCacheAndNoInternetConnection() async throws {
+        let validCountry = "NL"
+        let validDate = try validFirstDayDate()
+
+        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+        let connectedAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
+
+        controller.service = WMFMockServiceNoInternetConnection()
+
+        let error = try #require(await #expect(throws: NSError.self) {
+            try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+        })
+        #expect(error.domain == NSURLErrorDomain)
+        #expect(error.code == NSURLErrorNotConnectedToInternet)
+
+        let notConnectedAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
+        #expect(connectedAsset.id == notConnectedAsset.id)
+        #expect(connectedAsset.textHtml == notConnectedAsset.textHtml)
+    }
+
+    @Test
+    func loadHiddenAsset() async throws {
+        let validCountry = "NL"
+        let validDate = try validFirstDayDate()
+
+        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+
+        let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
+        controller.markAssetAsPermanentlyHidden(asset: nlWikiAsset)
+
+        let hiddenNLWikiAsset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate)
+        #expect(hiddenNLWikiAsset == nil)
+    }
+
+    @Test
+    func loadMaybeLaterAssetSixHoursLater() async throws {
+        let validCountry = "NL"
+        let validDate = try validFirstDayDate()
+
+        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+
+        let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
+        controller.markAssetAsMaybeLater(asset: nlWikiAsset, currentDate: validDate)
+
+        let nlWikiAssetSixHoursLater = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: try validFirstDayPlus6HoursDate())
+        #expect(nlWikiAssetSixHoursLater == nil)
+    }
+
+    @Test
+    func loadMaybeLaterAssetThirtyHoursLater() async throws {
+        let validCountry = "NL"
+        let validDate = try validFirstDayDate()
+
+        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+
+        let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
+        controller.markAssetAsMaybeLater(asset: nlWikiAsset, currentDate: validDate)
+
+        let nlWikiAssetThirtyHoursLater = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: try validFirstDayPlus30HoursDate())
+        #expect(nlWikiAssetThirtyHoursLater != nil)
+    }
+
+    @Test
+    func loadMaybeLaterAssetAfterCampaignEnds() async throws {
+        let validCountry = "NL"
+        let validDate = try validLastDayDate()
+
+        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+
+        let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
+        controller.markAssetAsMaybeLater(asset: nlWikiAsset, currentDate: validDate)
+
+        let nlWikiAssetThirtyHoursLater = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: try validLastDayPlus30HoursDate())
+        #expect(nlWikiAssetThirtyHoursLater == nil)
+    }
+
+    private func validFirstDayDate() throws -> Date {
+        try date(from: "2023-10-01T12:00:00Z")
+    }
+
+    private func validFirstDayPlus6HoursDate() throws -> Date {
+        try date(from: "2023-10-01T18:00:00Z")
+    }
+
+    private func validFirstDayPlus30HoursDate() throws -> Date {
+        try date(from: "2023-10-02T18:00:00Z")
+    }
+
+    private func validLastDayDate() throws -> Date {
+        try date(from: "2023-11-13T12:00:00Z")
+    }
+
+    private func validLastDayPlus30HoursDate() throws -> Date {
+        try date(from: "2023-11-14T18:00:00Z")
+    }
+
+    private func invalidDate() throws -> Date {
+        try date(from: "2023-12-15T12:00:00Z")
+    }
+
+    private func date(from string: String) throws -> Date {
+        try #require(DateFormatter.mediaWikiAPIDateFormatter.date(from: string))
+    }
+}
+
+private final class WMFFundraisingCampaignRequestMockService: WMFService {
+    func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<Data, Error>) -> Void) {
+        completion(.failure(WMFServiceError.unexpectedResponse))
+    }
+
+    func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<[String: Any]?, Error>) -> Void) {
+        completion(.failure(WMFServiceError.unexpectedResponse))
+    }
+
+    func performDecodableGET<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void) {
+        guard isCampaignConfigRequest(request) else {
+            completion(.failure(WMFServiceError.unexpectedResponse))
             return
         }
-        
-        XCTAssertEqual(enWikiAsset.id, "NL_2023_11", "Unexpected config id")
-        XCTAssertEqual(enWikiAsset.textHtml, "<b>Wikipedia is not for sale.</b><br><i>A personal appeal from Jimmy Wales</i><br><br>Today I humbly ask you to reflect on the number of times you have used the Wikipedia app this year, the value you’ve gotten from it, and whether you’re able to give €2 back. The Wikimedia Foundation relies on readers to support the technology that makes Wikipedia and our other projects possible. Being a nonprofit means there is no danger that someone will buy Wikipedia and turn it into their personal playground. If Wikipedia has given you €2 worth of knowledge this year, please give back. Thank you. — <i>Jimmy Wales, founder, Wikimedia Foundation</i>", "Unexpected EN asset text")
-        XCTAssertEqual(enWikiAsset.footerHtml, "By donating, you agree to our <a href='https://foundation.wikimedia.org/wiki/Donor_privacy_policy/en'>donor policy</a>.", "Unexpected EN asset footer")
-        XCTAssertEqual(enWikiAsset.actions.count, 3, "Unexpected EN asset actions count")
-        
-        XCTAssertEqual(enWikiAsset.actions[0].title, "Donate now", "Unexpected EN asset positive action title")
-        XCTAssertEqual(enWikiAsset.actions[0].url, URL(string: "https://donate.wikimedia.org/?uselang=en&appeal=JimmyQuote&utm_medium=WikipediaApp&utm_campaign=iOS&utm_source=app_2023_enNL_iOS_control")!, "Unexpected EN asset positive action url")
-        XCTAssertEqual(enWikiAsset.actions[1].title, "Maybe later", "Unexpected EN asset negative action title")
-        XCTAssertEqual(enWikiAsset.actions[2].title, "I already donated", "Unexpected EN asset negative action title")
-        XCTAssertEqual(enWikiAsset.currencyCode, "EUR", "Unexpected EN asset currency code")
-        
-        XCTAssertEqual(nlWikiAsset.id, "NL_2023_11", "Unexpected config id")
-        XCTAssertEqual(nlWikiAsset.textHtml, "<b>Wikipedia is niet te koop.</b><br><i>Een persoonlijke boodschap van Jimmy Wales.</i><br><br>Sta je weleens stil bij de keren dat je de Wikipedia-app hebt gebruikt dit jaar? Als je dat nuttig vond, zou je dan €&nbsp;2 willen geven? De Wikimedia Foundation is afhankelijk van lezers die de technologie willen ondersteunen die Wikipedia en andere projecten mogelijk maakt. Omdat we een non-profitorganisatie zijn, bestaat er geen gevaar dat iemand ineens Wikipedia koopt en ermee aan de haal gaat. Als je vindt dat Wikipedia je dit jaar €&nbsp;2 aan kennis heeft gegeven, overweeg dan een donatie. Alvast bedankt. — <i>Jimmy Wales, oprichter van de Wikimedia Foundation</i>", "Unexpected NL asset text")
-        XCTAssertEqual(nlWikiAsset.footerHtml, "Als je doneert, ga je akkoord met ons <a href='https://foundation.wikimedia.org/wiki/Donor_privacy_policy/nl'>privacybeleid voor donateurs</a>.", "Unexpected NL asset footer")
-        XCTAssertEqual(nlWikiAsset.actions.count, 3, "Unexpected NL asset actions count")
-        
-        XCTAssertEqual(nlWikiAsset.actions[0].title, "Doneer nu", "Unexpected NL asset positive action title")
-        XCTAssertEqual(nlWikiAsset.actions[0].url, URL(string: "https://donate.wikimedia.org/?uselang=nl&appeal=JimmyQuote&utm_medium=WikipediaApp&utm_campaign=iOS&utm_source=app_2023_nlNL_iOS_control")!, "Unexpected NL asset positive action url")
-        XCTAssertEqual(nlWikiAsset.actions[1].title, "Misschien later", "Unexpected NL asset negative action title")
-        XCTAssertEqual(nlWikiAsset.actions[2].title, "Ik heb al gedoneerd", "Unexpected NL asset negative action title")
-        XCTAssertEqual(nlWikiAsset.currencyCode, "EUR", "Unexpected NL asset currency code")
+
+        WMFMockBasicService(jsonResourceName: "fundraising-campaign-get-config").performDecodableGET(request: request, completion: completion)
     }
 
-    func testFetchConfigAndLoadAssetWithInvalidCountryValidDateValidWiki() {
-        
-        let expectation = XCTestExpectation(description: "Fetch Config")
-        
-        let invalidCountry = "US"
-        let validDate = validFirstDayDate()
-        let validENProject = enProject
-        let validNLProject = nlProject
-        
-        controller.fetchConfig(countryCode: invalidCountry, currentDate: validDate) { result in
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
-                XCTFail("Failure fetching config: \(error)")
-            }
-            
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 10.0)
-        
-        let enWikiAsset = controller.loadActiveCampaignAsset(countryCode: invalidCountry, wmfProject: validENProject, currentDate: validDate)
-        let nlWikiAsset = controller.loadActiveCampaignAsset(countryCode: invalidCountry, wmfProject: validNLProject, currentDate: validDate)
-    
-        XCTAssertNil(enWikiAsset, "Expected EN Asset to be nil for invalid country")
-        XCTAssertNil(nlWikiAsset, "Expected NL Asset to be nil for invalid country")
+    func performDecodablePOST<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void) {
+        completion(.failure(WMFServiceError.unexpectedResponse))
     }
-    
-    func testFetchConfigAndLoadAssetWithValidCountryInvalidDateValidWiki() {
-        
-        let expectation = XCTestExpectation(description: "Fetch Config")
-        
-        let validCountry = "NL"
-        let invalidDate = invalidDate()
-        let validENProject = enProject
-        let validNLProject = nlProject
-        
-        controller.fetchConfig(countryCode: validCountry, currentDate: invalidDate) { result in
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
-                XCTFail("Failure fetching config: \(error)")
-            }
-            
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 10.0)
-        
-        let enWikiAsset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validENProject, currentDate: invalidDate)
-        let nlWikiAsset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validNLProject, currentDate: invalidDate)
-    
-        XCTAssertNil(enWikiAsset, "Expected EN Asset to be nil for invalid date")
-        XCTAssertNil(nlWikiAsset, "Expected NL Asset to be nil for invalid date")
-    }
-    
-    func testFetchConfigAndLoadAssetWithValidCountryValidDateInvalidWiki() {
-        
-        let expectation = XCTestExpectation(description: "Fetch Config")
-        
-        let validCountry = "NL"
-        let validDate = validFirstDayDate()
-        let invalidESProject = esProject
-        
-        controller.fetchConfig(countryCode: validCountry, currentDate: validDate) { result in
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
-                XCTFail("Failure fetching config: \(error)")
-            }
-            
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 10.0)
-        
-        let esWikiAsset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: invalidESProject, currentDate: validDate)
-        XCTAssertNil(esWikiAsset, "ES asset should be nil")
-    }
-    
-    func testFetchConfigAndLoadAssetWithNoCacheAndNoInternetConnection() {
-        WMFDataEnvironment.current.basicService = WMFMockServiceNoInternetConnection()
-        controller.service = WMFDataEnvironment.current.basicService
-        
-        let expectation = XCTestExpectation(description: "Fetch Campaign Config")
-        
-        let validCountry = "NL"
-        let validDate = validFirstDayDate()
-        let validNLProject = nlProject
-        
-        controller.fetchConfig(countryCode: validCountry, currentDate: validDate) { result in
-            switch result {
-            case .success:
-                
-                XCTFail("Unexpected success")
-                
-            case .failure:
-                break
-            }
-            
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 10.0)
-        
-        let asset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validNLProject, currentDate: validDate)
-        
-        XCTAssertNil(asset, "Expected Nil Asset")
-    }
-    
-    func testFetchConfigAndLoadAssetWithCacheAndNoInternetConnection() {
 
-        let expectation1 = XCTestExpectation(description: "Fetch Config with Internet Connection")
-        let expectation2 = XCTestExpectation(description: "Fetch Config without Internet Connection")
+    func clearCachedData() {}
 
-        var connectedAsset: WMFFundraisingCampaignConfig.WMFAsset?
-        var notConnectedAsset: WMFFundraisingCampaignConfig.WMFAsset?
-        
-        let validCountry = "NL"
-        let validDate = validFirstDayDate()
-        let validNLProject = nlProject
-        
-        // First fetch successfully to populate cache
+    private func isCampaignConfigRequest(_ request: WMFServiceRequest) -> Bool {
+        request.method == .GET &&
+            request.url?.path == "/wiki/MediaWiki:AppsCampaignConfig.json" &&
+            ["donate.wikimedia.org", "test.wikipedia.org"].contains(request.url?.host) &&
+            request.parameters?["action"] as? String == "raw"
+    }
+}
 
-        controller.fetchConfig(countryCode: validCountry, currentDate: validDate) { result in
-            switch result {
-            case .success:
-                
-                connectedAsset = self.controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: self.nlProject, currentDate: validDate)
-
-                // Drop Internet Connection
-                WMFDataEnvironment.current.basicService = WMFMockServiceNoInternetConnection()
-                self.controller.service = WMFDataEnvironment.current.basicService
-
-                // Fetch again
-                self.controller.fetchConfig(countryCode: validCountry, currentDate: validDate) { result in
-                    switch result {
-                    case .success:
-                        
-                        XCTFail("Unexpected disconnected success")
-                        
-                    case .failure:
-                        
-                        // Despite failure, we still expect to be able to load configs from cache
-                        notConnectedAsset = self.controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validNLProject, currentDate: validDate)
-                        
-                    }
-                    
-                    expectation2.fulfill()
-                }
-            case .failure:
-                XCTFail("Unexpected connected failure")
+private extension WMFFundraisingCampaignDataController {
+    func fetchConfig(countryCode: String, currentDate: Date) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            fetchConfig(countryCode: countryCode, currentDate: currentDate) { result in
+                continuation.resume(with: result)
             }
-            
-            expectation1.fulfill()
         }
-        
-        wait(for: [expectation1], timeout: 10.0)
-        wait(for: [expectation2], timeout: 10.0)
-        
-        XCTAssertNotNil(connectedAsset, "Expected Fundraising Config")
-        XCTAssertNotNil(notConnectedAsset, "Expected Fundraising Config")
-        XCTAssertEqual(connectedAsset?.id, notConnectedAsset?.id, "Expected asset campaign IDs to be equal")
-        XCTAssertEqual(connectedAsset?.textHtml, notConnectedAsset?.textHtml, "Expected asset texts to be equal")
-    }
-  
-    func testLoadHiddenAsset() {
-        let expectation = XCTestExpectation(description: "Fetch Config")
-        
-        let validCountry = "NL"
-        let validDate = validFirstDayDate()
-        let validNLProject = nlProject
-        
-        // First fetch asset with valid params
-        controller.fetchConfig(countryCode: validCountry, currentDate: validDate) { result in
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
-                XCTFail("Failure fetching config: \(error)")
-            }
-            
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 10.0)
-        
-        // Confirm valid asset loads
-        let nlWikiAsset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validNLProject, currentDate: validDate)
-        XCTAssertNotNil(nlWikiAsset, "NL asset should not be nil")
-        
-        // Mark asset as dissmissed
-        controller.markAssetAsPermanentlyHidden(asset: nlWikiAsset!)
-        
-        // Now try to load again
-        let hiddenNLWikiAsset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validNLProject, currentDate: validDate)
-        XCTAssertNil(hiddenNLWikiAsset, "Hidden NL asset should be nil")
-    }
-    
-    func testLoadMaybeLaterAssetSixHoursLater() {
-        let expectation = XCTestExpectation(description: "Fetch Config")
-        
-        let validCountry = "NL"
-        let validDate = validFirstDayDate()
-        let validNLProject = nlProject
-        
-        // First fetch asset with valid params
-        controller.fetchConfig(countryCode: validCountry, currentDate: validDate) { result in
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
-                XCTFail("Failure fetching config: \(error)")
-            }
-            
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 10.0)
-        
-        
-        // Confirm valid asset loads
-        let nlWikiAsset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validNLProject, currentDate: validDate)
-        XCTAssertNotNil(nlWikiAsset, "NL asset should not be nil")
-        
-        // Mark asset as maybe later
-        controller.markAssetAsMaybeLater(asset: nlWikiAsset!, currentDate: validDate)
-        
-        // Load Six Hours later
-        let nlWikiAssetSixHoursLater = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validNLProject, currentDate: validFirstDayPlus6HoursDate())
-        
-        XCTAssertNil(nlWikiAssetSixHoursLater, "NL asset marked as maybe later, then loaded 6 hours later should be nil")
-    }
-    
-    func testLoadMaybeLaterAssetThirtyHoursLater() {
-        let expectation = XCTestExpectation(description: "Fetch Config")
-        
-        let validCountry = "NL"
-        let validDate = validFirstDayDate()
-        let validNLProject = nlProject
-        
-        // First fetch asset with valid params
-        controller.fetchConfig(countryCode: validCountry, currentDate: validDate) { result in
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
-                XCTFail("Failure fetching config: \(error)")
-            }
-            
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 10.0)
-        
-        
-        // Confirm valid asset loads
-        let nlWikiAsset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validNLProject, currentDate: validDate)
-        XCTAssertNotNil(nlWikiAsset, "NL asset should not be nil")
-        
-        // Mark asset as maybe later
-        controller.markAssetAsMaybeLater(asset: nlWikiAsset!, currentDate: validDate)
-        
-        // Load Thirty Hours later
-        let nlWikiAssetThirtyHoursLater = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validNLProject, currentDate: validFirstDayPlus30HoursDate())
-        
-        XCTAssertNotNil(nlWikiAssetThirtyHoursLater, "NL asset marked as maybe later, then loaded 30 hours later should not be nil")
-    }
-    
-    func testLoadMaybeLaterAssetAfterCampaignEnds() {
-        let expectation = XCTestExpectation(description: "Fetch Config")
-        
-        let validCountry = "NL"
-        let validDate = validLastDayDate()
-        let validNLProject = nlProject
-        
-        // First fetch asset with valid params
-        controller.fetchConfig(countryCode: validCountry, currentDate: validDate) { result in
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
-                XCTFail("Failure fetching config: \(error)")
-            }
-            
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 10.0)
-        
-        
-        // Confirm valid asset loads
-        let nlWikiAsset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validNLProject, currentDate: validDate)
-        XCTAssertNotNil(nlWikiAsset, "NL asset should not be nil")
-        
-        // Mark asset as maybe later
-        controller.markAssetAsMaybeLater(asset: nlWikiAsset!, currentDate: validDate)
-        
-        // Load next day after campaign ends
-        let nlWikiAssetThirtyHoursLater = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: validNLProject, currentDate: validLastDayPlus30HoursDate())
-        
-        XCTAssertNil(nlWikiAssetThirtyHoursLater, "NL asset marked as maybe later, then loaded after last day of campaign should be nil")
     }
 }

--- a/WMFData/Tests/WMFDataTests/WMFWatchlistDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFWatchlistDataControllerTests.swift
@@ -1,14 +1,16 @@
-import XCTest
+import Foundation
+import Testing
 @testable import WMFData
 @testable import WMFDataMocks
 
-final class WMFWatchlistDataControllerTests: XCTestCase {
-    
+@Suite(.serialized)
+struct WMFWatchlistDataControllerTests {
+
     private let enProject = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
     private let esProject = WMFProject.wikipedia(WMFLanguage(languageCode: "es", languageVariantCode: nil))
-    
-    override func setUp() async throws {
-        WMFDataEnvironment.current.appData = WMFAppData(appLanguages:[
+
+    init() {
+        WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [
             WMFLanguage(languageCode: "en", languageVariantCode: nil),
             WMFLanguage(languageCode: "es", languageVariantCode: nil)
         ])
@@ -16,110 +18,222 @@ final class WMFWatchlistDataControllerTests: XCTestCase {
         WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
         WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
     }
-    
-    func testAllWatchlistProjects() {
+
+    @Test
+    func allWatchlistProjects() {
         let controller = WMFWatchlistDataController()
         let allProjects = controller.allWatchlistProjects()
-        XCTAssertEqual([enProject, esProject, .commons, .wikidata], allProjects)
+
+        #expect([enProject, esProject, .commons, .wikidata] == allProjects)
     }
-    
-    func testSavingAndLoadingFilterSettings() {
+
+    @Test
+    func savingAndLoadingFilterSettings() {
         let controller = WMFWatchlistDataController()
-        let filterSettingsToSave = WMFWatchlistFilterSettings(offProjects: [.wikidata, .commons], latestRevisions: .latestRevision, activity: .seenChanges, automatedContributions: .bot, significance: .minorEdits, userRegistration: .registered, offTypes: [.categoryChanges, .loggedActions])
-        controller.saveFilterSettings(filterSettingsToSave)
+        let filterSettings = WMFWatchlistFilterSettings(offProjects: [.wikidata, .commons], latestRevisions: .latestRevision, activity: .seenChanges, automatedContributions: .bot, significance: .minorEdits, userRegistration: .registered, offTypes: [.categoryChanges, .loggedActions])
+
+        controller.saveFilterSettings(filterSettings)
         let loadedFilterSettings = controller.loadFilterSettings()
-        XCTAssertEqual(filterSettingsToSave, loadedFilterSettings)
+
+        #expect(filterSettings == loadedFilterSettings)
     }
-    
-    func testOnOffWatchlistProjects() {
+
+    @Test
+    func onOffWatchlistProjects() {
         let controller = WMFWatchlistDataController()
-        let filterSettingsToSave = WMFWatchlistFilterSettings(offProjects: [.wikidata, .commons], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
-        controller.saveFilterSettings(filterSettingsToSave)
-        XCTAssertEqual(controller.onWatchlistProjects(), [enProject, esProject])
-        XCTAssertEqual(controller.offWatchlistProjects(), [.wikidata, .commons])
+        let filterSettings = WMFWatchlistFilterSettings(offProjects: [.wikidata, .commons], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
+
+        controller.saveFilterSettings(filterSettings)
+
+        #expect(controller.onWatchlistProjects() == [enProject, esProject])
+        #expect(controller.offWatchlistProjects() == [.wikidata, .commons])
     }
-    
-    func testAllOffChangeTypes() {
+
+    @Test
+    func allOffChangeTypes() {
         let controller = WMFWatchlistDataController()
-        let filterSettingsToSave = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [.categoryChanges, .pageCreations])
-        controller.saveFilterSettings(filterSettingsToSave)
-        XCTAssertEqual(controller.allChangeTypes(), [.pageEdits, .pageCreations, .categoryChanges, .wikidataEdits, .loggedActions])
-        XCTAssertEqual(controller.offChangeTypes(), [.categoryChanges, .pageCreations])
+        let filterSettings = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [.categoryChanges, .pageCreations])
+
+        controller.saveFilterSettings(filterSettings)
+
+        #expect(controller.allChangeTypes() == [.pageEdits, .pageCreations, .categoryChanges, .wikidataEdits, .loggedActions])
+        #expect(controller.offChangeTypes() == [.categoryChanges, .pageCreations])
     }
-    
-    func testActiveFilterCount1() {
+
+    @Test
+    func activeFilterCount1() {
         let controller = WMFWatchlistDataController()
-        let filterSettingsToSave = WMFWatchlistFilterSettings(offProjects: [.commons, .wikidata], latestRevisions: .notTheLatestRevision, activity: .seenChanges, automatedContributions: .bot, significance: .minorEdits, userRegistration: .registered, offTypes: [])
-        controller.saveFilterSettings(filterSettingsToSave)
-        XCTAssertEqual(controller.activeFilterCount(), 6)
+        let filterSettings = WMFWatchlistFilterSettings(offProjects: [.commons, .wikidata], latestRevisions: .notTheLatestRevision, activity: .seenChanges, automatedContributions: .bot, significance: .minorEdits, userRegistration: .registered, offTypes: [])
+
+        controller.saveFilterSettings(filterSettings)
+
+        #expect(controller.activeFilterCount() == 6)
     }
-    
-    func testActiveFilterCount2() {
+
+    @Test
+    func activeFilterCount2() {
         let controller = WMFWatchlistDataController()
-        let filterSettingsToSave = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .latestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [.categoryChanges])
-        controller.saveFilterSettings(filterSettingsToSave)
-        XCTAssertEqual(controller.activeFilterCount(), 2)
+        let filterSettings = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .latestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [.categoryChanges])
+
+        controller.saveFilterSettings(filterSettings)
+
+        #expect(controller.activeFilterCount() == 2)
     }
-    
-    func testActiveFilterCount3() {
+
+    @Test
+    func activeFilterCount3() {
         let controller = WMFWatchlistDataController()
-        let filterSettingsToSave = WMFWatchlistFilterSettings(offProjects: [.commons, .wikidata, enProject], latestRevisions: .latestRevision, activity: .unseenChanges, automatedContributions: .human, significance: .nonMinorEdits, userRegistration: .unregistered, offTypes: [.categoryChanges, .loggedActions, .pageCreations, .pageEdits, .wikidataEdits])
-        controller.saveFilterSettings(filterSettingsToSave)
-        XCTAssertEqual(controller.activeFilterCount(), 13)
+        let filterSettings = WMFWatchlistFilterSettings(offProjects: [.commons, .wikidata, enProject], latestRevisions: .latestRevision, activity: .unseenChanges, automatedContributions: .human, significance: .nonMinorEdits, userRegistration: .unregistered, offTypes: [.categoryChanges, .loggedActions, .pageCreations, .pageEdits, .wikidataEdits])
+
+        controller.saveFilterSettings(filterSettings)
+
+        #expect(controller.activeFilterCount() == 13)
     }
-    
-    func testFetchWatchlistWithDefaultFilter() {
+
+    @Test
+    func fetchWatchlistWithDefaultFilter() async throws {
         let controller = WMFWatchlistDataController()
-        
-        let expectation = XCTestExpectation(description: "Fetch Watchlist")
-        
-        var watchlistToTest: WMFWatchlist?
-        controller.fetchWatchlist { result in
-            switch result {
-            case .success(let watchlist):
-                
-                watchlistToTest = watchlist
-                
-            case .failure(let error):
-                XCTFail("Failure fetching watchlist: \(error)")
-            }
-            
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 10.0)
-        
-        guard let watchlistToTest else {
-            XCTFail("Missing watchlistToTest")
+
+        let watchlist = try await controller.fetchWatchlist()
+
+        #expect(watchlist.items.count == 82)
+        #expect(watchlist.activeFilterCount == 0)
+        #expect(watchlist.items.filter { $0.project == enProject }.count == 38)
+        #expect(watchlist.items.filter { $0.project == esProject }.count == 13)
+        #expect(watchlist.items.filter { $0.project == .wikidata }.count == 28)
+        #expect(watchlist.items.filter { $0.project == .commons }.count == 3)
+
+        let first = try #require(watchlist.items.first)
+        #expect(first.title == "Talk:Cat")
+        #expect(first.username == "CatLover 1137")
+        #expect(first.revisionID == 1157699533)
+        #expect(first.oldRevisionID == 1157699360)
+        #expect(first.isAnon == false)
+        #expect(first.isBot == false)
+        #expect(first.commentWikitext == "/* I disagree with the above comment */ Reply")
+        #expect(first.commentHtml == "<span dir=\"auto\"><span class=\"autocomment\"><a href=\"/wiki/Talk:Cat#I_disagree_with_the_above_comment\" title=\"Talk:Cat\">→‎I disagree with the above comment</a>: </span> Reply</span>")
+        #expect(first.byteLength == 4246)
+        #expect(first.oldByteLength == 4071)
+        #expect(first.project == enProject)
+        let expectedDate = try testDate()
+        #expect(first.timestamp == expectedDate)
+    }
+
+    @Test
+    func fetchWatchlistWithProjectFilter() async throws {
+        let controller = WMFWatchlistDataController()
+        let filterSettings = WMFWatchlistFilterSettings(offProjects: [enProject, esProject], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
+        controller.saveFilterSettings(filterSettings)
+
+        let watchlist = try await controller.fetchWatchlist()
+
+        #expect(watchlist.items.count == 31)
+        #expect(watchlist.activeFilterCount == 2)
+        #expect(watchlist.items.filter { $0.project == enProject }.count == 0)
+        #expect(watchlist.items.filter { $0.project == esProject }.count == 0)
+        #expect(watchlist.items.filter { $0.project == .wikidata }.count == 28)
+        #expect(watchlist.items.filter { $0.project == .commons }.count == 3)
+    }
+
+    @Test
+    func fetchWatchlistWithAllProjectsPlusOneFilter() async throws {
+        let controller = WMFWatchlistDataController()
+        let filterSettings = WMFWatchlistFilterSettings(offProjects: [enProject, esProject, .wikidata, .commons], latestRevisions: .latestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
+        controller.saveFilterSettings(filterSettings)
+
+        let watchlist = try await controller.fetchWatchlist()
+
+        #expect(watchlist.activeFilterCount == 5)
+    }
+
+    @Test
+    func fetchWatchlistWithBotsFilter() async throws {
+        let controller = WMFWatchlistDataController()
+        let filterSettings = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .bot, significance: .all, userRegistration: .all, offTypes: [])
+        controller.saveFilterSettings(filterSettings)
+
+        let watchlist = try await controller.fetchWatchlist()
+
+        #expect(watchlist.items.count == 2)
+        #expect(watchlist.activeFilterCount == 1)
+        #expect(watchlist.items.filter { $0.isBot == false }.count == 0)
+    }
+
+    @Test
+    func fetchWatchlistWithNoCacheAndNoInternetConnection() async throws {
+        WMFDataEnvironment.current.mediaWikiService = WMFMockServiceNoInternetConnection()
+        let controller = WMFWatchlistDataController()
+
+        let error = try #require(await #expect(throws: WMFDataControllerError.self) {
+            _ = try await controller.fetchWatchlist()
+        })
+
+        guard case .serviceError(let underlyingError) = error else {
+            Issue.record("Expected serviceError, got \(error)")
             return
         }
-        
-        XCTAssertEqual(watchlistToTest.items.count, 82, "Incorrect number of watchlist items returned")
-        XCTAssertEqual(watchlistToTest.activeFilterCount, 0, "Incorrect activeFilterCount")
-        
-        let enItems = watchlistToTest.items.filter { $0.project == enProject }
-        let esItems = watchlistToTest.items.filter { $0.project == esProject }
-        let wikidataItems = watchlistToTest.items.filter { $0.project == .wikidata }
-        let commonsItems = watchlistToTest.items.filter { $0.project == .commons }
-        
-        XCTAssertEqual(enItems.count, 38, "Incorrect number of EN watchlist items returned")
-        XCTAssertEqual(esItems.count, 13, "Incorrect number of ES watchlist items returned")
-        XCTAssertEqual(wikidataItems.count, 28, "Incorrect number of wikidata watchlist items returned")
-        XCTAssertEqual(commonsItems.count, 3, "Incorrect number of commons watchlist items returned")
-        
-        let first = watchlistToTest.items.first!
-        XCTAssertEqual(first.title, "Talk:Cat", "Unexpected watchlist item title property")
-        XCTAssertEqual(first.username, "CatLover 1137", "Unexpected watchlist item username property")
-        XCTAssertEqual(first.revisionID, 1157699533, "Unexpected watchlist item revisionID property")
-        XCTAssertEqual(first.oldRevisionID, 1157699360, "Unexpected watchlist item oldRevisionID property")
-        XCTAssertEqual(first.isAnon, false, "Unexpected watchlist item isAnon property")
-        XCTAssertEqual(first.isBot, false, "Unexpected watchlist item isBot property")
-        XCTAssertEqual(first.commentWikitext, "/* I disagree with the above comment */ Reply", "Unexpected watchlist item commentWikitext property")
-        XCTAssertEqual(first.commentHtml, "<span dir=\"auto\"><span class=\"autocomment\"><a href=\"/wiki/Talk:Cat#I_disagree_with_the_above_comment\" title=\"Talk:Cat\">→‎I disagree with the above comment</a>: </span> Reply</span>", "Unexpected watchlist item commentHtml property")
-        XCTAssertEqual(first.byteLength, 4246, "Unexpected watchlist item byteLength property")
-        XCTAssertEqual(first.oldByteLength, 4071, "Unexpected watchlist item oldByteLength property")
-        XCTAssertEqual(first.project, WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)))
-        
+
+        let nsError = underlyingError as NSError
+        #expect(nsError.domain == NSURLErrorDomain)
+        #expect(nsError.code == NSURLErrorNotConnectedToInternet)
+    }
+
+    @Test
+    func fetchWatchlistWithCacheAndNoInternetConnection() async throws {
+        let controller = WMFWatchlistDataController()
+        let connectedWatchlist = try await controller.fetchWatchlist()
+
+        WMFDataEnvironment.current.mediaWikiService = WMFMockServiceNoInternetConnection()
+        controller.service = WMFDataEnvironment.current.mediaWikiService
+
+        let disconnectedAndCachedWatchlist = try await controller.fetchWatchlist()
+
+        #expect(connectedWatchlist.items.count == 82)
+        #expect(disconnectedAndCachedWatchlist.items.count == 82)
+    }
+
+    @Test
+    func postWatchArticleExpiryNever() async throws {
+        let controller = WMFWatchlistDataController()
+
+        try await controller.watch(title: "Cat", project: enProject, expiry: .never)
+    }
+
+    @Test
+    func postWatchArticleExpiryDate() async throws {
+        let controller = WMFWatchlistDataController()
+
+        try await controller.watch(title: "Cat", project: enProject, expiry: .oneMonth)
+    }
+
+    @Test
+    func postUnwatchArticle() async throws {
+        let controller = WMFWatchlistDataController()
+
+        try await controller.unwatch(title: "Cat", project: enProject)
+    }
+
+    @Test
+    func postRollbackArticle() async throws {
+        let controller = WMFWatchlistDataController()
+
+        let result = try await controller.rollback(title: "Cat", project: enProject, username: "Amigao")
+
+        #expect(result.newRevisionID == 573955)
+        #expect(result.oldRevisionID == 573953)
+    }
+
+    @Test
+    func postUndoArticle() async throws {
+        let controller = WMFWatchlistDataController()
+
+        let result = try await controller.undo(title: "Cat", revisionID: 1155871225, summary: "Testing", username: "Amigao", project: enProject)
+
+        #expect(result.newRevisionID == 573989)
+        #expect(result.oldRevisionID == 573988)
+    }
+
+    private func testDate() throws -> Date {
         var dateComponents = DateComponents()
         dateComponents.year = 2023
         dateComponents.month = 5
@@ -128,296 +242,49 @@ final class WMFWatchlistDataControllerTests: XCTestCase {
         dateComponents.hour = 11
         dateComponents.minute = 37
         dateComponents.second = 31
-        
-        guard let testDate = Calendar.current.date(from: dateComponents) else {
-            XCTFail("Failure creating testDate")
-            return
-        }
-        
-        XCTAssertEqual(first.timestamp, testDate, "Unexpected watchlist item timestamp property")
+
+        return try #require(Calendar.current.date(from: dateComponents))
     }
-    
-    func testFetchWatchlistWithProjectFilter() {
-        let controller = WMFWatchlistDataController()
-        
-        let filterSettingsToSave = WMFWatchlistFilterSettings(offProjects: [enProject, esProject], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
-        controller.saveFilterSettings(filterSettingsToSave)
-        
-        let expectation = XCTestExpectation(description: "Fetch Watchlist")
-        
-        var watchlistToTest: WMFWatchlist?
-        controller.fetchWatchlist { result in
-            switch result {
-            case .success(let watchlist):
-                
-                watchlistToTest = watchlist
-                
-            case .failure(let error):
-                XCTFail("Failure fetching watchlist: \(error)")
+}
+
+private extension WMFWatchlistDataController {
+    func fetchWatchlist() async throws -> WMFWatchlist {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchWatchlist { result in
+                continuation.resume(with: result)
             }
-            
-            expectation.fulfill()
         }
-        
-        wait(for: [expectation], timeout: 10.0)
-        
-        guard let watchlistToTest else {
-            XCTFail("Missing watchlistToTest")
-            return
-        }
-        
-        XCTAssertEqual(watchlistToTest.items.count, 31, "Incorrect number of watchlist items returned")
-        XCTAssertEqual(watchlistToTest.activeFilterCount, 2, "Incorrect activeFilterCount")
-        
-        let enItems = watchlistToTest.items.filter { $0.project == enProject }
-        let esItems = watchlistToTest.items.filter { $0.project == esProject }
-        let wikidataItems = watchlistToTest.items.filter { $0.project == .wikidata }
-        let commonsItems = watchlistToTest.items.filter { $0.project == .commons }
-        
-        XCTAssertEqual(enItems.count, 0, "Incorrect number of EN watchlist items returned")
-        XCTAssertEqual(esItems.count, 0, "Incorrect number of ES watchlist items returned")
-        XCTAssertEqual(wikidataItems.count, 28, "Incorrect number of wikidata watchlist items returned")
-        XCTAssertEqual(commonsItems.count, 3, "Incorrect number of commons watchlist items returned")
     }
-    
-    func testFetchWatchlistWithAllProjectsPlusOneFilter() {
-        let controller = WMFWatchlistDataController()
-        
-        let filterSettingsToSave = WMFWatchlistFilterSettings(offProjects: [enProject, esProject, .wikidata, .commons], latestRevisions: .latestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
-        controller.saveFilterSettings(filterSettingsToSave)
-        
-        let expectation = XCTestExpectation(description: "Fetch Watchlist")
-        
-        var watchlistToTest: WMFWatchlist?
-        controller.fetchWatchlist { result in
-            switch result {
-            case .success(let watchlist):
-                
-                watchlistToTest = watchlist
-                
-            case .failure(let error):
-                XCTFail("Failure fetching watchlist: \(error)")
+
+    func watch(title: String, project: WMFProject, expiry: WMFWatchlistExpiryType) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            watch(title: title, project: project, expiry: expiry) { result in
+                continuation.resume(with: result)
             }
-            
-            expectation.fulfill()
         }
-        
-        wait(for: [expectation], timeout: 10.0)
-        
-        guard let watchlistToTest else {
-            XCTFail("Missing watchlistToTest")
-            return
-        }
-        
-        XCTAssertEqual(watchlistToTest.activeFilterCount, 5, "Incorrect activeFilterCount")
     }
-    
-    func testFetchWatchlistWithBotsFilter() {
-        let controller = WMFWatchlistDataController()
-        
-        let filterSettingsToSave = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .bot, significance: .all, userRegistration: .all, offTypes: [])
-        controller.saveFilterSettings(filterSettingsToSave)
-        
-        let expectation = XCTestExpectation(description: "Fetch Watchlist")
-        
-        var watchlistToTest: WMFWatchlist?
-        controller.fetchWatchlist { result in
-            switch result {
-            case .success(let watchlist):
-                
-                watchlistToTest = watchlist
-                
-            case .failure(let error):
-                XCTFail("Failure fetching watchlist: \(error)")
+
+    func unwatch(title: String, project: WMFProject) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            unwatch(title: title, project: project) { result in
+                continuation.resume(with: result)
             }
-            
-            expectation.fulfill()
         }
-        
-        wait(for: [expectation], timeout: 10.0)
-        
-        guard let watchlistToTest else {
-            XCTFail("Missing watchlistToTest")
-            return
-        }
-        
-        XCTAssertEqual(watchlistToTest.items.count, 2, "Incorrect number of watchlist items returned")
-        XCTAssertEqual(watchlistToTest.activeFilterCount, 1, "Incorrect activeFilterCount")
-        
-        let humanItems = watchlistToTest.items.filter { $0.isBot == false }
-        XCTAssertEqual(humanItems.count, 0)
     }
-    
-    func testFetchWatchlistWithNoCacheAndNoInternetConnection() {
-        WMFDataEnvironment.current.mediaWikiService = WMFMockServiceNoInternetConnection()
-        let controller = WMFWatchlistDataController()
-        
-        let expectation = XCTestExpectation(description: "Fetch Watchlist")
-        
-        controller.fetchWatchlist { result in
-            switch result {
-            case .success:
-                
-                XCTFail("Unexpected success")
-                
-            case .failure:
-                break
+
+    func rollback(title: String, project: WMFProject, username: String) async throws -> WMFUndoOrRollbackResult {
+        try await withCheckedThrowingContinuation { continuation in
+            rollback(title: title, project: project, username: username) { result in
+                continuation.resume(with: result)
             }
-            
-            expectation.fulfill()
         }
-        
-        wait(for: [expectation], timeout: 10.0)
     }
-    
-    func testFetchWatchlistWithCacheAndNoInternetConnection() {
-        
-        // First fetch successfully to populate cache
-        let controller = WMFWatchlistDataController()
-        
-        let expectation1 = XCTestExpectation(description: "Fetch Watchlist with Internet Connection")
-        let expectation2 = XCTestExpectation(description: "Fetch Watchlist without Internet Connection")
-        var connectedWatchlistReturned: WMFWatchlist? = nil
-        var disconnectedAndCachedWatchlistReturned: WMFWatchlist? = nil
-        
-        controller.fetchWatchlist { result in
-            switch result {
-            case .success(let watchlist1):
-                
-                connectedWatchlistReturned = watchlist1
-                
-                // Drop Internet Connection
-                WMFDataEnvironment.current.mediaWikiService = WMFMockServiceNoInternetConnection()
-                controller.service = WMFDataEnvironment.current.mediaWikiService
 
-                // Fetch again, confirm it still succeeds
-                controller.fetchWatchlist { result in
-                    switch result {
-                    case .success(let watchlist2):
-                        disconnectedAndCachedWatchlistReturned = watchlist2
-                    case .failure:
-                        XCTFail("Unexpected disconnected failure")
-                    }
-                    
-                    expectation2.fulfill()
-                }
-            case .failure:
-                XCTFail("Unexpected connected failure")
+    func undo(title: String, revisionID: UInt, summary: String, username: String, project: WMFProject) async throws -> WMFUndoOrRollbackResult {
+        try await withCheckedThrowingContinuation { continuation in
+            undo(title: title, revisionID: revisionID, summary: summary, username: username, project: project) { result in
+                continuation.resume(with: result)
             }
-            
-            expectation1.fulfill()
-        }
-        
-        wait(for: [expectation1], timeout: 10.0)
-        wait(for: [expectation2], timeout: 10.0)
-        
-        XCTAssertEqual(connectedWatchlistReturned?.items.count, 82, "Incorrect number of watchlist items initially returned")
-        XCTAssertEqual(disconnectedAndCachedWatchlistReturned?.items.count, 82, "Incorrect number of watchlist items initially returned")
-    }
-    
-    func testPostWatchArticleExpiryNever() {
-         let controller = WMFWatchlistDataController()
-
-         let expectation = XCTestExpectation(description: "Post Watch Article Expiry Never")
-
-         var resultToTest: Result<Void, Error>?
-        controller.watch(title: "Cat", project: enProject, expiry: .never) { result in
-             resultToTest = result
-             expectation.fulfill()
-         }
-
-         wait(for: [expectation], timeout: 10.0)
-
-         guard case .success = resultToTest else {
-             return XCTFail("Unexpected result")
-         }
-     }
-
-     func testPostWatchArticleExpiryDate() {
-         let controller = WMFWatchlistDataController()
-
-         let expectation = XCTestExpectation(description: "Post Watch Article Expiry Date")
-
-         var resultToTest: Result<Void, Error>?
-         controller.watch(title: "Cat", project: enProject, expiry: .oneMonth) { result in
-             resultToTest = result
-             expectation.fulfill()
-         }
-
-         wait(for: [expectation], timeout: 10.0)
-
-         guard case .success = resultToTest else {
-             return XCTFail("Unexpected result")
-         }
-     }
-
-     func testPostUnwatchArticle() {
-         let controller = WMFWatchlistDataController()
-
-         let expectation = XCTestExpectation(description: "Post Watch Unwatch Article")
-
-         var resultToTest: Result<Void, Error>?
-         controller.unwatch(title: "Cat", project: enProject) { result in
-             resultToTest = result
-             expectation.fulfill()
-         }
-
-         wait(for: [expectation], timeout: 10.0)
-
-         guard case .success = resultToTest else {
-             return XCTFail("Unexpected result")
-         }
-     }
-    
-    func testPostRollbackArticle() {
-        let controller = WMFWatchlistDataController()
-
-        let expectation = XCTestExpectation(description: "Post Rollback Article")
-
-        var resultToTest: Result<WMFUndoOrRollbackResult, Error>?
-        controller.rollback(title: "Cat", project: enProject, username: "Amigao") { result in
-            resultToTest = result
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10.0)
-
-        guard let resultToTest else {
-            return XCTFail("Unexpected result")
-        }
-        
-        switch resultToTest {
-        case .success(let result):
-            XCTAssertEqual(result.newRevisionID, 573955)
-            XCTAssertEqual(result.oldRevisionID, 573953)
-        case .failure:
-            return XCTFail("Unexpected result")
-        }
-    }
-    
-    func testPostUndoArticle() {
-        let controller = WMFWatchlistDataController()
-        
-        let expectation = XCTestExpectation(description: "Post Undo Article")
-
-        var resultToTest: Result<WMFUndoOrRollbackResult, Error>?
-        controller.undo(title: "Cat", revisionID: 1155871225, summary: "Testing", username: "Amigao", project: enProject) { result in
-            resultToTest = result
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10.0)
-        
-        guard let resultToTest else {
-            return XCTFail("Unexpected result")
-        }
-        
-        switch resultToTest {
-        case .success(let result):
-            XCTAssertEqual(result.newRevisionID, 573989)
-            XCTAssertEqual(result.oldRevisionID, 573988)
-        case .failure:
-            return XCTFail("Unexpected result")
         }
     }
 }

--- a/WikipediaUnitTests/Code/TestNetworkFixtures/WMFSearchFetcherTests.swift
+++ b/WikipediaUnitTests/Code/TestNetworkFixtures/WMFSearchFetcherTests.swift
@@ -1,73 +1,70 @@
 import Foundation
+import Testing
 @testable import Wikipedia
 @testable import WMF
-import XCTest
 
-final class WMFSearchFetcherTests: XCTestCase {
-    private var fetcher: WMFSearchFetcher!
-    private var httpClient: SearchHTTPClient!
-
-    override func setUp() {
-        super.setUp()
-
-        httpClient = SearchHTTPClient()
-        let session = Session(configuration: .current, httpClientProvider: SearchHTTPClientProvider(httpClient: httpClient))
-        fetcher = WMFSearchFetcher(session: session, configuration: .current)
-    }
-
-    override func tearDown() {
-        fetcher.cancelAllFetches()
-        fetcher = nil
-        httpClient = nil
-
-        super.tearDown()
-    }
-
-    func testNonEmptyPrefixResponse() throws {
+struct WMFSearchFetcherTests {
+    @Test
+    func nonEmptyPrefixResponse() async throws {
         let json = try jsonFixture(named: "BarackSearch")
-        httpClient.responseData = try JSONSerialization.data(withJSONObject: json)
-        let siteURL = try XCTUnwrap(URL(string: "https://en.wikipedia.org"))
+        let harness = makeHarness()
+        defer {
+            harness.fetcher.cancelAllFetches()
+        }
+        harness.httpClient.responseData = try JSONSerialization.data(withJSONObject: json)
+        let siteURL = try #require(URL(string: "https://en.wikipedia.org"))
 
-        let expectation = expectation(description: "Wait for articles")
+        let result = try await harness.fetcher.fetchArticles(forSearchTerm: "foo", siteURL: siteURL, resultLimit: 15)
 
-        fetcher.fetchArticles(forSearchTerm: "foo", siteURL: siteURL, resultLimit: 15, failure: { error in
-            XCTFail("Expected search success, got \(error)")
-            expectation.fulfill()
-        }, success: { result in
-            let query = json["query"] as? [String: Any]
-            let pages = query?["pages"] as? [String: Any]
-            XCTAssertEqual(result.results?.count, pages?.count)
-            expectation.fulfill()
-        })
-
-        waitForExpectations(timeout: 10)
-        XCTAssertTrue(httpClient.capturedRequests.containsPrefixSearchRequest)
+        let query = json["query"] as? [String: Any]
+        let pages = query?["pages"] as? [String: Any]
+        #expect(result.results?.count == pages?.count)
+        #expect(harness.httpClient.capturedRequests.containsPrefixSearchRequest)
     }
 
-    func testEmptyPrefixResponse() throws {
+    @Test
+    func emptyPrefixResponse() async throws {
         let json = try jsonFixture(named: "NoSearchResultsWithSuggestion")
-        httpClient.responseData = try JSONSerialization.data(withJSONObject: json)
-        let siteURL = try XCTUnwrap(URL(string: "https://en.wikipedia.org"))
+        let harness = makeHarness()
+        defer {
+            harness.fetcher.cancelAllFetches()
+        }
+        harness.httpClient.responseData = try JSONSerialization.data(withJSONObject: json)
+        let siteURL = try #require(URL(string: "https://en.wikipedia.org"))
 
-        let expectation = expectation(description: "Wait for articles")
+        let result = try await harness.fetcher.fetchArticles(forSearchTerm: "foo", siteURL: siteURL, resultLimit: 15)
 
-        fetcher.fetchArticles(forSearchTerm: "foo", siteURL: siteURL, resultLimit: 15, failure: { error in
-            XCTFail("Expected search success, got \(error)")
-            expectation.fulfill()
-        }, success: { result in
-            let query = json["query"] as? [String: Any]
-            let searchInfo = query?["searchinfo"] as? [String: Any]
-            XCTAssertEqual(result.searchSuggestion, searchInfo?["suggestion"] as? String)
-            XCTAssertEqual(result.results?.count, 0)
-            expectation.fulfill()
-        })
+        let query = json["query"] as? [String: Any]
+        let searchInfo = query?["searchinfo"] as? [String: Any]
+        #expect(result.searchSuggestion == searchInfo?["suggestion"] as? String)
+        #expect(result.results?.count == 0)
+        #expect(harness.httpClient.capturedRequests.containsPrefixSearchRequest)
+    }
 
-        waitForExpectations(timeout: 10)
-        XCTAssertTrue(httpClient.capturedRequests.containsPrefixSearchRequest)
+    private func makeHarness() -> (fetcher: WMFSearchFetcher, httpClient: SearchHTTPClient) {
+        let httpClient = SearchHTTPClient()
+        let session = Session(configuration: .current, httpClientProvider: SearchHTTPClientProvider(httpClient: httpClient))
+        let fetcher = WMFSearchFetcher(session: session, configuration: .current)
+        return (fetcher, httpClient)
     }
 
     private func jsonFixture(named name: String) throws -> [String: Any] {
-        let data = try XCTUnwrap(wmf_bundle().wmf_data(fromContentsOfFile: name, ofType: "json"))
-        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let data = try #require(Bundle(for: WMFSearchFetcherTestBundleToken.self).wmf_data(fromContentsOfFile: name, ofType: "json"))
+        let jsonObject = try JSONSerialization.jsonObject(with: data)
+        return try #require(jsonObject as? [String: Any])
+    }
+}
+
+private final class WMFSearchFetcherTestBundleToken {}
+
+private extension WMFSearchFetcher {
+    func fetchArticles(forSearchTerm searchTerm: String, siteURL: URL, resultLimit: UInt) async throws -> WMFSearchResults {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchArticles(forSearchTerm: searchTerm, siteURL: siteURL, resultLimit: resultLimit, failure: { error in
+                continuation.resume(throwing: error)
+            }, success: { result in
+                continuation.resume(returning: result)
+            })
+        }
     }
 }

--- a/WikipediaUnitTests/Manual Tests/ArticleCacheReadingManualTests.swift
+++ b/WikipediaUnitTests/Manual Tests/ArticleCacheReadingManualTests.swift
@@ -1,123 +1,136 @@
+import Foundation
+import Testing
 @testable import Wikipedia
 @testable import WMF
-import XCTest
 
-class ArticleCacheReadingManualTests: XCTestCase {
+@MainActor
+struct ArticleCacheReadingManualTests {
     
-    override func setUp(completion: @escaping (Error?) -> Void) {
-        ArticleTestHelpers.setup {
-            ArticleTestHelpers.pullDataFromFixtures(inBundle: self.wmf_bundle())
-            completion(nil)
+    init() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            ArticleTestHelpers.setup {
+                continuation.resume()
+            }
+        }
+
+        ArticleTestHelpers.pullDataFromFixtures(inBundle: Bundle(for: ArticleCacheReadingManualTestBundleToken.self))
+    }
+
+    private func loadResponses(
+        for basicVC: BasicCachingWebViewController,
+        expectedURLs: Set<String>
+    ) async -> [String: Data] {
+        await withCheckedContinuation { (continuation: CheckedContinuation<[String: Data], Never>) in
+            var responses: [String: Data] = [:]
+            var didResume = false
+
+            basicVC.didReceiveDataCallback = { urlSchemeTask, data in
+                guard !didResume else {
+                    return
+                }
+
+                guard let urlString = urlSchemeTask.request.url?.absoluteString else {
+                    Issue.record("Unable to determine urlString from scheme task")
+                    return
+                }
+
+                guard expectedURLs.contains(urlString) else {
+                    Issue.record("Unexpected scheme task callback")
+                    return
+                }
+
+                responses[urlString] = data
+                guard expectedURLs.allSatisfy({ responses[$0] != nil }) else {
+                    return
+                }
+
+                didResume = true
+                basicVC.didReceiveDataCallback = nil
+                continuation.resume(returning: responses)
+            }
+
+            basicVC.loadViewIfNeeded()
         }
     }
-    
-    override func tearDown() {
-        super.tearDown()
-        
-        URLCache.shared.removeAllCachedResponses()
-    }
-    
-    func testBasicNetworkNoConnectionWithCachedArticle() {
 
-       XCTFail("Reminder: these tests need to be on device and in airplane mode, otherwise they won't work. Comment out this failure once this is done and re-run.")
+    private func data(
+        from responses: [String: Data],
+        for urlString: String
+    ) throws -> Data {
+        try #require(responses[urlString], "Missing scheme task response for \(urlString)")
+    }
+
+    private func trimmedString(
+        from responses: [String: Data],
+        for urlString: String
+    ) throws -> String {
+        let data = try data(from: responses, for: urlString)
+        let string = try #require(String(data: data, encoding: .utf8))
+        return String(string.filter { !"\n\t\r".contains($0) })
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func basicNetworkNoConnectionWithCachedArticle() async throws {
+        defer {
+            URLCache.shared.removeAllCachedResponses()
+        }
+
+        try #require(Bool(false), "Reminder: these tests need to be on device and in airplane mode, otherwise they won't work. Comment out this failure once this is done and re-run.")
 
         ArticleTestHelpers.writeCachedPiecesToCachingSystem()
 
         let basicVC = BasicCachingWebViewController()
+        let htmlURLString = "app://en.wikipedia.org/api/rest_v1/page/mobile-html/United_States"
+        let imageURLString = "app://upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/960px-Flag_of_the_United_States.svg.png"
+        let cssURLString = "app://en.wikipedia.org/api/rest_v1/data/css/mobile/site"
+        let responses = await loadResponses(
+            for: basicVC,
+            expectedURLs: [
+                htmlURLString,
+                imageURLString,
+                cssURLString
+            ]
+        )
 
-        let htmlExpectation = expectation(description: "Waiting for html content to return")
-        let imageExpectation = expectation(description: "Waiting for image load to return")
-        let cssExpectation = expectation(description: "Waiting for css load to return")
-
-        basicVC.didReceiveDataCallback = { urlSchemeTask, data in
-
-            guard let urlString = urlSchemeTask.request.url?.absoluteString else {
-                XCTFail("Unable to determine urlString from scheme task")
-                return
-            }
-
-            switch urlString {
-            case "app://en.wikipedia.org/api/rest_v1/page/mobile-html/United_States":
-
-                htmlExpectation.fulfill()
-
-                if let htmlString = String(data: data, encoding: .utf8) {
-                    let trimmedHTML = String(htmlString.filter { !"\n\t\r".contains($0) })
-                    XCTAssertEqual(trimmedHTML, "<!DOCTYPE html><html><head><link rel=\"stylesheet\" href=\"//en.wikipedia.org/api/rest_v1/data/css/mobile/site\"></head><body><p>Testing Cached</p><img src=\"//upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/960px-Flag_of_the_United_States.svg.png\"></body></html>")
-                }
-
-            case "app://en.wikipedia.org/api/rest_v1/data/css/mobile/site":
-
-                cssExpectation.fulfill()
-
-                if let cssString = String(data: data, encoding: .utf8) {
-                    let trimmedCSS = String(cssString.filter { !"\n\t\r".contains($0) })
-                    XCTAssertEqual(trimmedCSS, "body {background-color: red;}", "Unexpected basic HTML content")
-                }
-            case "app://upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/960px-Flag_of_the_United_States.svg.png":
-                imageExpectation.fulfill()
-            default:
-                XCTFail("Unexpected scheme task callback")
-            }
-        }
-
-        basicVC.loadViewIfNeeded()
-
-        wait(for: [htmlExpectation], timeout: 10)
-        wait(for: [imageExpectation], timeout: 10)
-        wait(for: [cssExpectation], timeout: 10)
+        let html = try trimmedString(from: responses, for: htmlURLString)
+        #expect(html == "<!DOCTYPE html><html><head><link rel=\"stylesheet\" href=\"//en.wikipedia.org/api/rest_v1/data/css/mobile/site\"></head><body><p>Testing Cached</p><img src=\"//upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/960px-Flag_of_the_United_States.svg.png\"></body></html>")
+        _ = try data(from: responses, for: imageURLString)
+        let css = try trimmedString(from: responses, for: cssURLString)
+        #expect(css == "body {background-color: red;}", "Unexpected basic HTML content")
     }
     
-   func testVariantFallbacksUponConnectionFailure() {
+    @Test(.timeLimit(.minutes(1)))
+    func variantFallbacksUponConnectionFailure() async throws {
+        defer {
+            URLCache.shared.removeAllCachedResponses()
+        }
 
-    XCTFail("Reminder: these tests need to be on device and in airplane mode, otherwise they won't work. Comment out this failure once this is done and re-run.")
+        try #require(Bool(false), "Reminder: these tests need to be on device and in airplane mode, otherwise they won't work. Comment out this failure once this is done and re-run.")
 
-    ArticleTestHelpers.writeVariantPiecesToCachingSystem()
+        ArticleTestHelpers.writeVariantPiecesToCachingSystem()
 
         let basicVC = BasicCachingWebViewController()
         basicVC.extraHeaders = ["Accept-Language": "zh-hant"]
-        basicVC.articleURL = URL(string: "app://zh.wikipedia.org/api/rest_v1/page/mobile-html/%E7%BE%8E%E5%9B%BD")!
+        basicVC.articleURL = try #require(URL(string: "app://zh.wikipedia.org/api/rest_v1/page/mobile-html/%E7%BE%8E%E5%9B%BD"))
 
-        let htmlExpectation = expectation(description: "Waiting for html content to return")
-        let imageExpectation = expectation(description: "Waiting for image load to return")
-        let cssExpectation = expectation(description: "Waiting for css load to return")
+        let htmlURLString = "app://zh.wikipedia.org/api/rest_v1/page/mobile-html/%E7%BE%8E%E5%9B%BD"
+        let imageURLString = "app://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Flag_of_the_United_States_%28Pantone%29.svg/960px-Flag_of_the_United_States_%28Pantone%29.svg.png"
+        let cssURLString = "app://zh.wikipedia.org/api/rest_v1/data/css/mobile/site"
+        let responses = await loadResponses(
+            for: basicVC,
+            expectedURLs: [
+                htmlURLString,
+                imageURLString,
+                cssURLString
+            ]
+        )
 
-        basicVC.didReceiveDataCallback = { urlSchemeTask, data in
-
-            guard let urlString = urlSchemeTask.request.url?.absoluteString else {
-                XCTFail("Unable to determine urlString from scheme task")
-                return
-            }
-
-            switch urlString {
-            case "app://zh.wikipedia.org/api/rest_v1/page/mobile-html/%E7%BE%8E%E5%9B%BD":
-
-                htmlExpectation.fulfill()
-
-                if let htmlString = String(data: data, encoding: .utf8) {
-                    let trimmedHTML = String(htmlString.filter { !"\n\t\r".contains($0) })
-                    XCTAssertEqual(trimmedHTML, "<!DOCTYPE html><html><head><link rel=\"stylesheet\" href=\"//zh.wikipedia.org/api/rest_v1/data/css/mobile/site\"></head><body><p>美国 (美洲北部国家)</p><img src=\"//upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Flag_of_the_United_States_%28Pantone%29.svg/960px-Flag_of_the_United_States_%28Pantone%29.svg.png\"></body></html>")
-                }
-
-            case "app://zh.wikipedia.org/api/rest_v1/data/css/mobile/site":
-
-                cssExpectation.fulfill()
-
-                if let cssString = String(data: data, encoding: .utf8) {
-                    let trimmedCSS = String(cssString.filter { !"\n\t\r".contains($0) })
-                    XCTAssertEqual(trimmedCSS, "body {background-color: blue;}", "Unexpected basic HTML content")
-                }
-            case "app://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Flag_of_the_United_States_%28Pantone%29.svg/960px-Flag_of_the_United_States_%28Pantone%29.svg.png":
-                imageExpectation.fulfill()
-            default:
-                XCTFail("Unexpected scheme task callback")
-            }
-        }
-
-       basicVC.loadViewIfNeeded()
-
-        wait(for: [htmlExpectation], timeout: 10)
-        wait(for: [imageExpectation], timeout: 10)
-        wait(for: [cssExpectation], timeout: 10)
+        let html = try trimmedString(from: responses, for: htmlURLString)
+        #expect(html == "<!DOCTYPE html><html><head><link rel=\"stylesheet\" href=\"//zh.wikipedia.org/api/rest_v1/data/css/mobile/site\"></head><body><p>美国 (美洲北部国家)</p><img src=\"//upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Flag_of_the_United_States_%28Pantone%29.svg/960px-Flag_of_the_United_States_%28Pantone%29.svg.png\"></body></html>")
+        _ = try data(from: responses, for: imageURLString)
+        let css = try trimmedString(from: responses, for: cssURLString)
+        #expect(css == "body {background-color: blue;}", "Unexpected basic HTML content")
     }
 }
+
+private final class ArticleCacheReadingManualTestBundleToken {}


### PR DESCRIPTION
**Phabricator: T269478** 

### Notes
- Updating some tests away from expectation to async + Swift Testing:
  * `WMFSearchFetcherTests`
  * `ArticleCacheReadingManualTests`
  * `WMFDonateViewModelTests`
  * `WMFImageRecommendationsViewModelTests`
  * `WMFArticleDataControllerTests`
  * `WMFDeveloperSettingsDataControllerTests`
  * `WMFDonateDataControllerTests`
  * `WMFFundraisingCampaignDataControllerTests`
  * `WMFWatchlistDataControllerTests`
### Test Steps
N/A

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
N/A