### PR TITLE
T424240: Keep image gallery buttons dark

### DIFF
--- a/Wikipedia/Code/WMFImageGalleryViewController.m
+++ b/Wikipedia/Code/WMFImageGalleryViewController.m
@@ -125,6 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
     } else {
         self.overlayView.topCoverBackgroundColor = [UIColor blackColor];
         self.overlayView.navigationBar.backgroundColor = [UIColor clearColor];
+        self.overlayView.navigationBar.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
 
         UIBarButtonItem *share = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"share"] style:UIBarButtonItemStylePlain target:self action:@selector(didTapShareButton)];
         share.tintColor = [UIColor whiteColor];


### PR DESCRIPTION
**T424240**

### Notes
This PR locks the image gallery's navbar to a dark interface style, keeping the button icons legible.

### Test Steps
1. Put the device in light mode
2. Enable "Reduce Transparency"
3. Open any image in the app

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots
Before |  After
-|-
<img width="300" src="https://github.com/user-attachments/assets/4aeeb8e8-a2e2-4734-874d-26b7ee00808a" /> | <img width="300" src="https://github.com/user-attachments/assets/e4690ec5-3cce-46ee-a02a-a12650d6bfae" />

