### PR TITLE
T269478: Consolidate Singleton/global environment mutation

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -44,6 +44,10 @@ jobs:
           ios-version: ${{ env.IOS_VERSION }}
           simulator-name: ${{ env.SIMULATOR_NAME }}
 
+      - name: Ensure tests reset WMFData global environment state
+        if: matrix.scheme == 'WMFData'
+        run: scripts/lint-wmfdata-test-fixtures.sh
+
       - name: Test ${{ matrix.scheme }} scheme
         run: |
           echo "Running scheme: ${{ matrix.scheme }} on ${SIMULATOR_NAME} iOS ${IOS_VERSION} with Xcode ${XCODE_VERSION}"

--- a/WMFComponents/Package.swift
+++ b/WMFComponents/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
         .testTarget(
             name: "WMFComponentsTests",
             dependencies: ["WMFComponents",
+                           .product(name: "WMFDataTestSupport", package: "WMFData"),
                            .product(name: "WMFDataMocks", package: "WMFData")])
     ]
 )

--- a/WMFComponents/Tests/WMFComponentsTests/WMFDonateViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFDonateViewModelTests.swift
@@ -11,13 +11,6 @@ final class WMFDonateViewModelTests {
     private let fixture = WMFDataTestFixture()
     private let merchantID = "merchant.id"
 
-    init() async {
-        await fixture.setUp()
-        WMFDataEnvironment.current.basicService = WMFMockBasicService()
-        WMFDataEnvironment.current.serviceEnvironment = .staging
-        await fixture.resetWMFDataTestState()
-    }
-
     @Test
     func viewModelInstantiatesWithCorrectDefaultsUSD() async throws {
         let viewModel = try await makeViewModel(countryCode: "US", currencyCode: "USD", languageCode: "EN", appInstallID: nil)
@@ -212,8 +205,28 @@ final class WMFDonateViewModelTests {
     }
 
     private func makeViewModel(countryCode: String, currencyCode: String, languageCode: String, appInstallID: String? = UUID().uuidString) async throws -> WMFDonateViewModel {
-        let donateData = try await loadDonateData()
-        return try #require(WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode(currencyCode), donateConfig: donateData.donateConfig, paymentMethods: donateData.paymentMethods, countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", appInstallID: appInstallID, coordinatorDelegate: nil, loggingDelegate: nil))
+        try await withConfiguredEnvironment {
+            let donateData = try await loadDonateData()
+            return try #require(WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode(currencyCode), donateConfig: donateData.donateConfig, paymentMethods: donateData.paymentMethods, countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", appInstallID: appInstallID, coordinatorDelegate: nil, loggingDelegate: nil))
+        }
+    }
+
+    private func withConfiguredEnvironment<T>(_ operation: () async throws -> T) async rethrows -> T {
+        try await fixture.withGlobalStateLease {
+            await fixture.setUp()
+            WMFDataEnvironment.current.basicService = WMFMockBasicService()
+            WMFDataEnvironment.current.serviceEnvironment = .staging
+            await fixture.resetWMFDataTestState()
+
+            do {
+                let result = try await operation()
+                await fixture.tearDown()
+                return result
+            } catch {
+                await fixture.tearDown()
+                throw error
+            }
+        }
     }
 
     private func loadDonateData() async throws -> (donateConfig: WMFDonateConfig, paymentMethods: WMFPaymentMethods) {

--- a/WMFComponents/Tests/WMFComponentsTests/WMFDonateViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFDonateViewModelTests.swift
@@ -205,28 +205,15 @@ final class WMFDonateViewModelTests {
     }
 
     private func makeViewModel(countryCode: String, currencyCode: String, languageCode: String, appInstallID: String? = UUID().uuidString) async throws -> WMFDonateViewModel {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let donateData = try await loadDonateData()
             return try #require(WMFDonateViewModel(localizedStrings: .demoStringsForCurrencyCode(currencyCode), donateConfig: donateData.donateConfig, paymentMethods: donateData.paymentMethods, countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, merchantID: merchantID, metricsID: "enNL_2023_11_iOS", appVersion: "7.4.3", appInstallID: appInstallID, coordinatorDelegate: nil, loggingDelegate: nil))
         }
     }
 
-    private func withConfiguredEnvironment<T>(_ operation: () async throws -> T) async rethrows -> T {
-        try await fixture.withGlobalStateLease {
-            await fixture.setUp()
-            WMFDataEnvironment.current.basicService = WMFMockBasicService()
-            WMFDataEnvironment.current.serviceEnvironment = .staging
-            await fixture.resetWMFDataTestState()
-
-            do {
-                let result = try await operation()
-                await fixture.tearDown()
-                return result
-            } catch {
-                await fixture.tearDown()
-                throw error
-            }
-        }
+    private func configureEnvironment() async {
+        WMFDataEnvironment.current.basicService = WMFMockBasicService()
+        WMFDataEnvironment.current.serviceEnvironment = .staging
     }
 
     private func loadDonateData() async throws -> (donateConfig: WMFDonateConfig, paymentMethods: WMFPaymentMethods) {

--- a/WMFComponents/Tests/WMFComponentsTests/WMFDonateViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFDonateViewModelTests.swift
@@ -1,13 +1,22 @@
 import Foundation
 import Testing
+import WMFDataTestSupport
 @testable import WMFComponents
 @testable import WMFData
 @testable import WMFDataMocks
 
 @MainActor
-struct WMFDonateViewModelTests {
+final class WMFDonateViewModelTests {
 
+    private let fixture = WMFDataTestFixture()
     private let merchantID = "merchant.id"
+
+    init() async {
+        await fixture.setUp()
+        WMFDataEnvironment.current.basicService = WMFMockBasicService()
+        WMFDataEnvironment.current.serviceEnvironment = .staging
+        await fixture.resetWMFDataTestState()
+    }
 
     @Test
     func viewModelInstantiatesWithCorrectDefaultsUSD() async throws {
@@ -208,7 +217,6 @@ struct WMFDonateViewModelTests {
     }
 
     private func loadDonateData() async throws -> (donateConfig: WMFDonateConfig, paymentMethods: WMFPaymentMethods) {
-        WMFDataEnvironment.current.serviceEnvironment = .staging
         let controller = WMFDonateDataController(service: WMFMockBasicService(), sharedCacheStore: WMFMockKeyValueStore())
         try await controller.fetchConfigs(for: "US")
 

--- a/WMFComponents/Tests/WMFComponentsTests/WMFImageRecommendationsViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFImageRecommendationsViewModelTests.swift
@@ -20,34 +20,49 @@ final class WMFImageRecommendationsViewModelTests {
             WMFSurveyViewModel.OptionViewModel(text: "I don’t know this subject", apiIdentifer: "unfamiliar")
     ]
 
-    init() async {
-        await fixture.setUp()
-        WMFDataEnvironment.current.mediaWikiService = WMFMockGrowthTasksService()
-        WMFDataEnvironment.current.basicService = WMFMockBasicService()
-        await fixture.resetWMFDataTestState()
-    }
-
     @Test
     func fetchInitialImageRecommendations() async {
-        let viewModel = WMFImageRecommendationsViewModel(project: csProject, semanticContentAttribute: .forceLeftToRight, isPermanent: true, localizedStrings: localizedStrings, surveyOptions: surveyOptions, needsSuppressPosting: false)
+        await withConfiguredEnvironment {
+            let viewModel = WMFImageRecommendationsViewModel(project: csProject, semanticContentAttribute: .forceLeftToRight, isPermanent: true, localizedStrings: localizedStrings, surveyOptions: surveyOptions, needsSuppressPosting: false)
 
-        await viewModel.fetchImageRecommendationsIfNeeded()
+            await viewModel.fetchImageRecommendationsIfNeeded()
 
-        #expect(viewModel.imageRecommendations.count == 9)
-        #expect(viewModel.currentRecommendation != nil)
-        #expect(viewModel.currentRecommendation?.articleSummary != nil)
+            #expect(viewModel.imageRecommendations.count == 9)
+            #expect(viewModel.currentRecommendation != nil)
+            #expect(viewModel.currentRecommendation?.articleSummary != nil)
+        }
     }
     
     @Test
     func fetchNextImageRecommendation() async {
-        let viewModel = WMFImageRecommendationsViewModel(project: csProject, semanticContentAttribute: .forceLeftToRight, isPermanent: true, localizedStrings: localizedStrings, surveyOptions: surveyOptions, needsSuppressPosting: false)
+        await withConfiguredEnvironment {
+            let viewModel = WMFImageRecommendationsViewModel(project: csProject, semanticContentAttribute: .forceLeftToRight, isPermanent: true, localizedStrings: localizedStrings, surveyOptions: surveyOptions, needsSuppressPosting: false)
 
-        await viewModel.fetchImageRecommendationsIfNeeded()
-        await viewModel.next()
+            await viewModel.fetchImageRecommendationsIfNeeded()
+            await viewModel.next()
 
-        #expect(viewModel.imageRecommendations.count == 8)
-        #expect(viewModel.currentRecommendation != nil)
-        #expect(viewModel.currentRecommendation?.articleSummary != nil)
+            #expect(viewModel.imageRecommendations.count == 8)
+            #expect(viewModel.currentRecommendation != nil)
+            #expect(viewModel.currentRecommendation?.articleSummary != nil)
+        }
+    }
+
+    private func withConfiguredEnvironment<T>(_ operation: () async throws -> T) async rethrows -> T {
+        try await fixture.withGlobalStateLease {
+            await fixture.setUp()
+            WMFDataEnvironment.current.mediaWikiService = WMFMockGrowthTasksService()
+            WMFDataEnvironment.current.basicService = WMFMockBasicService()
+            await fixture.resetWMFDataTestState()
+
+            do {
+                let result = try await operation()
+                await fixture.tearDown()
+                return result
+            } catch {
+                await fixture.tearDown()
+                throw error
+            }
+        }
     }
 }
 

--- a/WMFComponents/Tests/WMFComponentsTests/WMFImageRecommendationsViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFImageRecommendationsViewModelTests.swift
@@ -22,7 +22,7 @@ final class WMFImageRecommendationsViewModelTests {
 
     @Test
     func fetchInitialImageRecommendations() async {
-        await withConfiguredEnvironment {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let viewModel = WMFImageRecommendationsViewModel(project: csProject, semanticContentAttribute: .forceLeftToRight, isPermanent: true, localizedStrings: localizedStrings, surveyOptions: surveyOptions, needsSuppressPosting: false)
 
             await viewModel.fetchImageRecommendationsIfNeeded()
@@ -35,7 +35,7 @@ final class WMFImageRecommendationsViewModelTests {
     
     @Test
     func fetchNextImageRecommendation() async {
-        await withConfiguredEnvironment {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let viewModel = WMFImageRecommendationsViewModel(project: csProject, semanticContentAttribute: .forceLeftToRight, isPermanent: true, localizedStrings: localizedStrings, surveyOptions: surveyOptions, needsSuppressPosting: false)
 
             await viewModel.fetchImageRecommendationsIfNeeded()
@@ -47,22 +47,9 @@ final class WMFImageRecommendationsViewModelTests {
         }
     }
 
-    private func withConfiguredEnvironment<T>(_ operation: () async throws -> T) async rethrows -> T {
-        try await fixture.withGlobalStateLease {
-            await fixture.setUp()
-            WMFDataEnvironment.current.mediaWikiService = WMFMockGrowthTasksService()
-            WMFDataEnvironment.current.basicService = WMFMockBasicService()
-            await fixture.resetWMFDataTestState()
-
-            do {
-                let result = try await operation()
-                await fixture.tearDown()
-                return result
-            } catch {
-                await fixture.tearDown()
-                throw error
-            }
-        }
+    private func configureEnvironment() async {
+        WMFDataEnvironment.current.mediaWikiService = WMFMockGrowthTasksService()
+        WMFDataEnvironment.current.basicService = WMFMockBasicService()
     }
 }
 

--- a/WMFComponents/Tests/WMFComponentsTests/WMFImageRecommendationsViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFImageRecommendationsViewModelTests.swift
@@ -1,12 +1,14 @@
 import Testing
+import WMFDataTestSupport
 @testable import WMFComponents
 @testable import WMFData
 @testable import WMFDataMocks
 
 @MainActor
 @Suite(.serialized)
-struct WMFImageRecommendationsViewModelTests {
+final class WMFImageRecommendationsViewModelTests {
     
+    private let fixture = WMFDataTestFixture()
     private let csProject = WMFProject.wikipedia(WMFLanguage(languageCode: "cs", languageVariantCode: nil))
     
     private let localizedStrings = WMFImageRecommendationsViewModel.LocalizedStrings(title: "Add image", viewArticle: "View article", onboardingStrings: WMFImageRecommendationsViewModel.LocalizedStrings.OnboardingStrings(title: "Onboarding title", firstItemTitle: "First item title", firstItemBody: "First item body", secondItemTitle: "Second item title", secondItemBody: "Second item body", thirdItemTitle: "Third item title", thirdItemBody: "Third item body", continueButton: "Continue", learnMoreButton: "Learn more"), tooltipStrings: WMFImageRecommendationsViewModel.LocalizedStrings.TooltipStrings(tooltip1Title: "Review", tooltip1Body: "Review this article to understand its topic.", tooltip2Title: "Inspect", tooltip2Body: "Inspect the image and its associated information.", tooltip3Title: "Decide", tooltip3Body: "Decide if the image helps readers understand this topic better."), surveyLocalizedStrings: WMFImageRecommendationsViewModel.LocalizedStrings.SurveyLocalizedStrings(title: "Reason", cancel: "Cancel", submit: "Submit", subtitle: "Improve", instructions: "Instructions", otherPlaceholder: "Other"), emptyLocalizedStrings: WMFImageRecommendationsViewModel.LocalizedStrings.EmptyLocalizedStrings(title: "You have no more suggested images available at this time.", subtitle: "Try coming back later.", titleFilter: nil, buttonTitle: nil, attributedFilterString: nil), errorLocalizedStrings: WMFImageRecommendationsViewModel.LocalizedStrings.ErrorLocalizedStrings(title: "Unable to load page", subtitle: "Something went wrong.", buttonTitle: "Try again"), bottomSheetTitle: "Add this image?", yesButtonTitle: "yes", noButtonTitle: "no", notSureButtonTitle: "not sure", learnMoreButtonTitle: "Learn more", tutorialButtonTitle: "Tutorial", problemWithFeatureButtonTitle: "Problem with feature")
@@ -18,9 +20,11 @@ struct WMFImageRecommendationsViewModelTests {
             WMFSurveyViewModel.OptionViewModel(text: "I don’t know this subject", apiIdentifer: "unfamiliar")
     ]
 
-    init() {
+    init() async {
+        await fixture.setUp()
         WMFDataEnvironment.current.mediaWikiService = WMFMockGrowthTasksService()
         WMFDataEnvironment.current.basicService = WMFMockBasicService()
+        await fixture.resetWMFDataTestState()
     }
 
     @Test

--- a/WMFComponents/Tests/WMFComponentsTests/WMFWatchlistFilterViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFWatchlistFilterViewModelTests.swift
@@ -1,16 +1,27 @@
 import XCTest
+import WMFDataTestSupport
 @testable import WMFComponents
 @testable import WMFData
 import WMFDataMocks
 
 final class WMFWatchlistFilterViewModelTests: XCTestCase {
 
-    override func setUpWithError() throws {
+    private let fixture = WMFDataTestFixture()
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await fixture.setUp()
         WMFDataEnvironment.current.appData = WMFAppData(appLanguages:[
             enLanguage,
             esLanguage
         ])
         WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
+        await fixture.resetWMFDataTestState()
+    }
+
+    override func tearDown() async throws {
+        await fixture.tearDown()
+        try await super.tearDown()
     }
     
     var enLanguage: WMFLanguage {

--- a/WMFComponents/Tests/WMFComponentsTests/WMFWhichCameFirstViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFWhichCameFirstViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import WMFDataTestSupport
 @testable import WMFComponents
 @testable import WMFData
 import WMFDataMocks
@@ -6,11 +7,21 @@ import WMFDataMocks
 @MainActor
 final class WMFWhichCameFirstViewModelTests: XCTestCase {
 
+    private let fixture = WMFDataTestFixture()
+
     // MARK: - Setup
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
+        try await super.setUp()
+        await fixture.setUp()
         WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [enLanguage])
         WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
+        await fixture.resetWMFDataTestState()
+    }
+
+    override func tearDown() async throws {
+        await fixture.tearDown()
+        try await super.tearDown()
     }
 
     // MARK: - Fixtures

--- a/WMFData/Package.swift
+++ b/WMFData/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -8,11 +8,13 @@ let package = Package(
     platforms: [.iOS(.v17)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
-                .library(
-                    name: "WMFData",
-                    targets: ["WMFData"]),
-                .library(name: "WMFDataMocks",
-                    targets: ["WMFDataMocks"])
+        .library(
+            name: "WMFData",
+            targets: ["WMFData"]),
+        .library(name: "WMFDataMocks",
+            targets: ["WMFDataMocks"]),
+        .library(name: "WMFDataTestSupport",
+            targets: ["WMFDataTestSupport"])
     ],
     dependencies: [
         .package(name: "WMFTestKitchen", path: "../WMFTestKitchen/")
@@ -21,18 +23,25 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-                   name: "WMFData",
-                   dependencies: [
-                    .product(name: "WMFTestKitchen", package: "WMFTestKitchen")
-                   ],
-                   path: "Sources/WMFData",
-                   resources: [.process("Resources")]),
-               .target(name: "WMFDataMocks",
-                      dependencies: ["WMFData"],
-                       path: "Sources/WMFDataMocks",
-                       resources: [.process("Resources")]),
-               .testTarget(
-                   name: "WMFDataTests",
-                   dependencies: ["WMFData", "WMFDataMocks"])
-    ]
+            name: "WMFData",
+            dependencies: [
+                .product(name: "WMFTestKitchen", package: "WMFTestKitchen")
+            ],
+            path: "Sources/WMFData",
+            resources: [.process("Resources")]),
+        .target(name: "WMFDataMocks",
+            dependencies: ["WMFData"],
+            path: "Sources/WMFDataMocks",
+            resources: [.process("Resources")]),
+        .target(name: "WMFDataTestSupport",
+            dependencies: ["WMFData"],
+            path: "Sources/WMFDataTestSupport"),
+        .testTarget(
+            name: "WMFDataTests",
+            dependencies: ["WMFData", "WMFDataMocks", "WMFDataTestSupport"])
+    ],
+    // Bumped tools-version to unlock per-target swiftSettings/swiftLanguageMode syntax.
+    // Language mode is explicitly pinned to .v5 (warnings-only) until this package
+    // completes its strict-concurrency burn-down and flips to .v6.
+    swiftLanguageModes: [.v5]
 )

--- a/WMFData/Sources/WMFData/Data Controllers/Article Tabs/WMFArticleTabsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Article Tabs/WMFArticleTabsDataController.swift
@@ -147,6 +147,12 @@ public protocol WMFArticleTabsDataControlling {
             self.experimentsDataController = nil
         }
     }
+
+    @_spi(Testing) public func reset() {
+        backgroundContext = nil
+        assignmentCache = nil
+        _coreDataStore = nil
+    }
     
     // MARK: - Experiment
 

--- a/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
@@ -237,4 +237,9 @@ public protocol WMFDeveloperSettingsDataControlling: AnyObject {
             }
         }
     }
+
+    @_spi(Testing) public func reset() {
+        featureConfig = nil
+        sharedCacheStore = WMFDataEnvironment.current.sharedCacheStore
+    }
 }

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonateDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonateDataController.swift
@@ -316,9 +316,11 @@ import Contacts
         try? self.sharedCacheStore?.remove(key: cacheDirectoryName, cacheLocalDonateHistoryFileName)
     }
 
-    // MARK: - Internal
-    
-    func reset() {
+    // MARK: - Testing
+
+    @_spi(Testing) public func reset() {
+        service = WMFDataEnvironment.current.basicService
+        sharedCacheStore = WMFDataEnvironment.current.sharedCacheStore
         donateConfig = nil
         paymentMethods = nil
     }

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFFundraisingCampaignDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFFundraisingCampaignDataController.swift
@@ -220,11 +220,15 @@ import Foundation
         mediaWikiService.perform(request: request, completion: completion)
     }
     
-    // MARK: - Internal
-    
-    func reset() {
+    // MARK: - Testing
+
+    @_spi(Testing) public func reset() {
+        service = WMFDataEnvironment.current.basicService
+        mediaWikiService = WMFDataEnvironment.current.mediaWikiService
+        sharedCacheStore = WMFDataEnvironment.current.sharedCacheStore
         activeCountryConfigs = []
         promptState = nil
+        preferencesBannerOptIns = SafeDictionary<WMFProject, Bool>()
     }
     
     // MARK: - Private

--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFImageDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFImageDataController.swift
@@ -89,6 +89,12 @@ public final class WMFImageDataController {
             }
         }
     }
+
+    @_spi(Testing) public func reset() {
+        basicService = WMFDataEnvironment.current.basicService
+        mediaWikiService = WMFDataEnvironment.current.mediaWikiService
+        imageCache.removeAllObjects()
+    }
 }
 
 private extension WMFImageDataController {

--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFOnThisDayDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFOnThisDayDataController.swift
@@ -86,6 +86,10 @@ public actor WMFOnThisDayDataController {
         return response
     }
 
+    @_spi(Testing) public func reset() {
+        responseCache = [:]
+    }
+
     // MARK: Private helpers
 
     nonisolated private func isSupported(project: WMFProject) -> Bool {

--- a/WMFData/Sources/WMFData/Data Controllers/Temp Accounts/WMFTempAccountDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Temp Accounts/WMFTempAccountDataController.swift
@@ -91,6 +91,12 @@ import Foundation
             }
         }
     }
+
+    @_spi(Testing) public func reset() {
+        mediaWikiService = WMFDataEnvironment.current.mediaWikiService
+        _primaryWikiHasTempAccountsEnabled = nil
+        wikisWithTempAccountsEnabled = []
+    }
 }
 
 private struct TempStatusResponse: Codable {

--- a/WMFData/Sources/WMFData/Environment/WMFDataEnvironment.swift
+++ b/WMFData/Sources/WMFData/Environment/WMFDataEnvironment.swift
@@ -60,3 +60,56 @@ public final class WMFDataEnvironment: ObservableObject {
         }
     }
 }
+
+@_spi(Testing) public struct WMFDataEnvironmentSnapshot {
+    fileprivate let serviceEnvironment: WMFServiceEnvironment
+    fileprivate let appContainerURL: URL?
+    fileprivate let appData: WMFAppData
+    fileprivate let mediaWikiService: WMFService?
+    fileprivate let basicService: WMFService?
+    fileprivate let userAgentUtility: (() -> String)?
+    fileprivate let appInstallIDUtility: (() -> String?)?
+    fileprivate let acceptLanguageUtility: (() -> String)?
+    fileprivate let userDefaultsStore: WMFKeyValueStore?
+    fileprivate let crossProcessUserDefaultsStore: WMFKeyValueStore?
+    fileprivate let sharedCacheStore: WMFKeyValueStore?
+    fileprivate let testKitchenClient: TestKitchenClient?
+    fileprivate let coreDataStore: WMFCoreDataStore?
+}
+
+@_spi(Testing) public extension WMFDataEnvironment {
+
+    func snapshotForTesting() -> WMFDataEnvironmentSnapshot {
+        return WMFDataEnvironmentSnapshot(
+            serviceEnvironment: serviceEnvironment,
+            appContainerURL: appContainerURL,
+            appData: appData,
+            mediaWikiService: mediaWikiService,
+            basicService: basicService,
+            userAgentUtility: userAgentUtility,
+            appInstallIDUtility: appInstallIDUtility,
+            acceptLanguageUtility: acceptLanguageUtility,
+            userDefaultsStore: userDefaultsStore,
+            crossProcessUserDefaultsStore: crossProcessUserDefaultsStore,
+            sharedCacheStore: sharedCacheStore,
+            testKitchenClient: testKitchenClient,
+            coreDataStore: coreDataStore
+        )
+    }
+
+    func restoreForTesting(_ snapshot: WMFDataEnvironmentSnapshot) {
+        serviceEnvironment = snapshot.serviceEnvironment
+        appContainerURL = snapshot.appContainerURL
+        appData = snapshot.appData
+        mediaWikiService = snapshot.mediaWikiService
+        basicService = snapshot.basicService
+        userAgentUtility = snapshot.userAgentUtility
+        appInstallIDUtility = snapshot.appInstallIDUtility
+        acceptLanguageUtility = snapshot.acceptLanguageUtility
+        userDefaultsStore = snapshot.userDefaultsStore
+        crossProcessUserDefaultsStore = snapshot.crossProcessUserDefaultsStore
+        sharedCacheStore = snapshot.sharedCacheStore
+        testKitchenClient = snapshot.testKitchenClient
+        coreDataStore = snapshot.coreDataStore
+    }
+}

--- a/WMFData/Sources/WMFDataTestSupport/WMFDataTestFixture.swift
+++ b/WMFData/Sources/WMFDataTestSupport/WMFDataTestFixture.swift
@@ -44,6 +44,26 @@ public final class WMFDataTestFixture {
         }
     }
 
+    public func withConfiguredEnvironment<T>(
+        configure: () async throws -> Void,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        try await withGlobalStateLease {
+            await setUp()
+
+            do {
+                try await configure()
+                await resetWMFDataTestState()
+                let result = try await operation()
+                await tearDown()
+                return result
+            } catch {
+                await tearDown()
+                throw error
+            }
+        }
+    }
+
     private func resetSynchronousWMFDataTestState() {
         WMFDonateDataController.shared.reset()
         WMFFundraisingCampaignDataController.shared.reset()

--- a/WMFData/Sources/WMFDataTestSupport/WMFDataTestFixture.swift
+++ b/WMFData/Sources/WMFDataTestSupport/WMFDataTestFixture.swift
@@ -1,0 +1,109 @@
+import Foundation
+@_spi(Testing) import WMFData
+
+public final class WMFDataTestFixture {
+
+    private var restoreEnvironment: (() -> Void)?
+    private var temporaryDirectories: [URL] = []
+    private var isGlobalFixtureLockHeld = false
+
+    public init() {}
+
+    deinit {
+        resetSynchronousWMFDataTestState()
+        restoreEnvironmentForTesting()
+        resetSynchronousWMFDataTestState()
+        unlockGlobalFixtureState()
+    }
+
+    public func setUp() async {
+        lockGlobalFixtureState()
+        restoreEnvironmentForTesting()
+        snapshotEnvironment()
+        await resetWMFDataTestState()
+    }
+
+    public func tearDown() async {
+        await resetWMFDataTestState()
+        restoreEnvironmentForTesting()
+        await resetWMFDataTestState()
+        unlockGlobalFixtureState()
+    }
+
+    public func resetWMFDataTestState() async {
+        resetSynchronousWMFDataTestState()
+        await WMFOnThisDayDataController.shared.reset()
+    }
+
+    private func resetSynchronousWMFDataTestState() {
+        WMFDonateDataController.shared.reset()
+        WMFFundraisingCampaignDataController.shared.reset()
+        WMFArticleTabsDataController.shared.reset()
+        WMFDeveloperSettingsDataController.shared.reset()
+        WMFImageDataController.shared.reset()
+        WMFTempAccountDataController.shared.reset()
+    }
+
+    public func makeTemporaryCoreDataStore() async throws -> WMFCoreDataStore {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        temporaryDirectories.append(temporaryDirectory)
+        return try await WMFCoreDataStore(appContainerURL: temporaryDirectory)
+    }
+
+    private func snapshotEnvironment() {
+        let snapshot = WMFDataEnvironment.current.snapshotForTesting()
+
+        restoreEnvironment = {
+            WMFDataEnvironment.current.restoreForTesting(snapshot)
+        }
+    }
+
+    private func restoreEnvironmentForTesting() {
+        restoreEnvironment?()
+        restoreEnvironment = nil
+        removeTemporaryDirectories()
+    }
+
+    private func removeTemporaryDirectories() {
+        for temporaryDirectory in temporaryDirectories {
+            try? FileManager.default.removeItem(at: temporaryDirectory)
+        }
+        temporaryDirectories = []
+    }
+
+    private func lockGlobalFixtureState() {
+        guard isGlobalFixtureLockHeld == false else {
+            return
+        }
+
+        WMFDataTestFixtureLock.shared.lock()
+        isGlobalFixtureLockHeld = true
+    }
+
+    private func unlockGlobalFixtureState() {
+        guard isGlobalFixtureLockHeld else {
+            return
+        }
+
+        isGlobalFixtureLockHeld = false
+        WMFDataTestFixtureLock.shared.unlock()
+    }
+}
+
+// Swift Testing serializes tests within a suite, but different suites can still
+// run in parallel. Fixture setup and teardown mutate process-wide WMFData
+// singletons, so fixture users need one cross-suite lease for the whole test.
+private final class WMFDataTestFixtureLock: @unchecked Sendable {
+    static let shared = WMFDataTestFixtureLock()
+
+    private let mutex = NSLock()
+
+    func lock() {
+        mutex.lock()
+    }
+
+    func unlock() {
+        mutex.unlock()
+    }
+}

--- a/WMFData/Sources/WMFDataTestSupport/WMFDataTestFixture.swift
+++ b/WMFData/Sources/WMFDataTestSupport/WMFDataTestFixture.swift
@@ -5,7 +5,6 @@ public final class WMFDataTestFixture {
 
     private var restoreEnvironment: (() -> Void)?
     private var temporaryDirectories: [URL] = []
-    private var isGlobalFixtureLockHeld = false
 
     public init() {}
 
@@ -13,11 +12,9 @@ public final class WMFDataTestFixture {
         resetSynchronousWMFDataTestState()
         restoreEnvironmentForTesting()
         resetSynchronousWMFDataTestState()
-        unlockGlobalFixtureState()
     }
 
     public func setUp() async {
-        lockGlobalFixtureState()
         restoreEnvironmentForTesting()
         snapshotEnvironment()
         await resetWMFDataTestState()
@@ -27,12 +24,24 @@ public final class WMFDataTestFixture {
         await resetWMFDataTestState()
         restoreEnvironmentForTesting()
         await resetWMFDataTestState()
-        unlockGlobalFixtureState()
     }
 
     public func resetWMFDataTestState() async {
         resetSynchronousWMFDataTestState()
         await WMFOnThisDayDataController.shared.reset()
+    }
+
+    public func withGlobalStateLease<T>(_ operation: () async throws -> T) async rethrows -> T {
+        let lease = await WMFDataTestFixtureGlobalStateLease.shared.acquire()
+
+        do {
+            let result = try await operation()
+            await lease.release()
+            return result
+        } catch {
+            await lease.release()
+            throw error
+        }
     }
 
     private func resetSynchronousWMFDataTestState() {
@@ -71,39 +80,43 @@ public final class WMFDataTestFixture {
         }
         temporaryDirectories = []
     }
-
-    private func lockGlobalFixtureState() {
-        guard isGlobalFixtureLockHeld == false else {
-            return
-        }
-
-        WMFDataTestFixtureLock.shared.lock()
-        isGlobalFixtureLockHeld = true
-    }
-
-    private func unlockGlobalFixtureState() {
-        guard isGlobalFixtureLockHeld else {
-            return
-        }
-
-        isGlobalFixtureLockHeld = false
-        WMFDataTestFixtureLock.shared.unlock()
-    }
 }
 
-// Swift Testing serializes tests within a suite, but different suites can still
-// run in parallel. Fixture setup and teardown mutate process-wide WMFData
-// singletons, so fixture users need one cross-suite lease for the whole test.
-private final class WMFDataTestFixtureLock: @unchecked Sendable {
-    static let shared = WMFDataTestFixtureLock()
+private actor WMFDataTestFixtureGlobalStateLease {
+    static let shared = WMFDataTestFixtureGlobalStateLease()
 
-    private let mutex = NSLock()
+    private var isHeld = false
+    private var waiters: [CheckedContinuation<Lease, Never>] = []
 
-    func lock() {
-        mutex.lock()
+    func acquire() async -> Lease {
+        if isHeld {
+            return await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+
+        isHeld = true
+        return Lease(owner: self)
     }
 
-    func unlock() {
-        mutex.unlock()
+    private func release() {
+        guard waiters.isEmpty else {
+            waiters.removeFirst().resume(returning: Lease(owner: self))
+            return
+        }
+
+        isHeld = false
+    }
+
+    struct Lease: Sendable {
+        private let owner: WMFDataTestFixtureGlobalStateLease
+
+        fileprivate init(owner: WMFDataTestFixtureGlobalStateLease) {
+            self.owner = owner
+        }
+
+        func release() async {
+            await owner.release()
+        }
     }
 }

--- a/WMFData/Tests/WMFDataTests/WMFArticleDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFArticleDataControllerTests.swift
@@ -12,7 +12,7 @@ final class WMFArticleDataControllerTests {
 
     @Test
     func fetchWatchStatus() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFArticleDataController()
             let request = try WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: false, needsCategories: false)
 
@@ -25,7 +25,7 @@ final class WMFArticleDataControllerTests {
 
     @Test
     func fetchWatchStatusWithRollbackRights() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFArticleDataController()
             let request = try WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: true, needsCategories: false)
 
@@ -36,26 +36,13 @@ final class WMFArticleDataControllerTests {
         }
     }
 
-    private func withConfiguredEnvironment<T>(_ operation: () async throws -> T) async rethrows -> T {
-        try await fixture.withGlobalStateLease {
-            await fixture.setUp()
-            WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [
-                WMFLanguage(languageCode: "en", languageVariantCode: nil)
-            ])
-            WMFDataEnvironment.current.mediaWikiService = WMFMockWatchlistMediaWikiService()
-            WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
-            WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
-            await fixture.resetWMFDataTestState()
-
-            do {
-                let result = try await operation()
-                await fixture.tearDown()
-                return result
-            } catch {
-                await fixture.tearDown()
-                throw error
-            }
-        }
+    private func configureEnvironment() async {
+        WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [
+            WMFLanguage(languageCode: "en", languageVariantCode: nil)
+        ])
+        WMFDataEnvironment.current.mediaWikiService = WMFMockWatchlistMediaWikiService()
+        WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
+        WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
     }
 }
 

--- a/WMFData/Tests/WMFDataTests/WMFArticleDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFArticleDataControllerTests.swift
@@ -1,20 +1,24 @@
 import Foundation
 import Testing
+import WMFDataTestSupport
 @testable import WMFData
 @testable import WMFDataMocks
 
 @Suite(.serialized)
-struct WMFArticleDataControllerTests {
+final class WMFArticleDataControllerTests {
 
+    private let fixture = WMFDataTestFixture()
     private let enProject = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
 
-    init() {
+    init() async {
+        await fixture.setUp()
         WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [
             WMFLanguage(languageCode: "en", languageVariantCode: nil)
         ])
         WMFDataEnvironment.current.mediaWikiService = WMFMockWatchlistMediaWikiService()
         WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
         WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
+        await fixture.resetWMFDataTestState()
     }
 
     @Test

--- a/WMFData/Tests/WMFDataTests/WMFArticleDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFArticleDataControllerTests.swift
@@ -10,37 +10,52 @@ final class WMFArticleDataControllerTests {
     private let fixture = WMFDataTestFixture()
     private let enProject = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
 
-    init() async {
-        await fixture.setUp()
-        WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [
-            WMFLanguage(languageCode: "en", languageVariantCode: nil)
-        ])
-        WMFDataEnvironment.current.mediaWikiService = WMFMockWatchlistMediaWikiService()
-        WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
-        WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
-        await fixture.resetWMFDataTestState()
-    }
-
     @Test
     func fetchWatchStatus() async throws {
-        let controller = WMFArticleDataController()
-        let request = try WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: false, needsCategories: false)
+        try await withConfiguredEnvironment {
+            let controller = WMFArticleDataController()
+            let request = try WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: false, needsCategories: false)
 
-        let status = try await controller.fetchArticleInfo(title: "Cat", project: enProject, request: request)
+            let status = try await controller.fetchArticleInfo(title: "Cat", project: enProject, request: request)
 
-        #expect(status.watched)
-        #expect(status.userHasRollbackRights == nil)
+            #expect(status.watched)
+            #expect(status.userHasRollbackRights == nil)
+        }
     }
 
     @Test
     func fetchWatchStatusWithRollbackRights() async throws {
-        let controller = WMFArticleDataController()
-        let request = try WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: true, needsCategories: false)
+        try await withConfiguredEnvironment {
+            let controller = WMFArticleDataController()
+            let request = try WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: true, needsRollbackRights: true, needsCategories: false)
 
-        let status = try await controller.fetchArticleInfo(title: "Cat", project: enProject, request: request)
+            let status = try await controller.fetchArticleInfo(title: "Cat", project: enProject, request: request)
 
-        #expect(status.watched == false)
-        #expect(status.userHasRollbackRights == true)
+            #expect(status.watched == false)
+            #expect(status.userHasRollbackRights == true)
+        }
+    }
+
+    private func withConfiguredEnvironment<T>(_ operation: () async throws -> T) async rethrows -> T {
+        try await fixture.withGlobalStateLease {
+            await fixture.setUp()
+            WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [
+                WMFLanguage(languageCode: "en", languageVariantCode: nil)
+            ])
+            WMFDataEnvironment.current.mediaWikiService = WMFMockWatchlistMediaWikiService()
+            WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
+            WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
+            await fixture.resetWMFDataTestState()
+
+            do {
+                let result = try await operation()
+                await fixture.tearDown()
+                return result
+            } catch {
+                await fixture.tearDown()
+                throw error
+            }
+        }
     }
 }
 

--- a/WMFData/Tests/WMFDataTests/WMFArticleTabsDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFArticleTabsDataControllerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import WMFDataTestSupport
 @testable import WMFData
 @testable import WMFDataMocks
 
@@ -9,6 +10,7 @@ final class WMFArticleTabsDataControllerTests: XCTestCase {
         case missingDataController
     }
     
+    private let fixture = WMFDataTestFixture()
     var store: WMFCoreDataStore?
     var dataController: WMFArticleTabsDataController?
     
@@ -18,15 +20,20 @@ final class WMFArticleTabsDataControllerTests: XCTestCase {
     }()
     
     override func setUp() async throws {
-        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        let store = try await WMFCoreDataStore(appContainerURL: temporaryDirectory)
+        try await super.setUp()
+        await fixture.setUp()
+        let store = try await fixture.makeTemporaryCoreDataStore()
         self.store = store
         
         WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [WMFLanguage(languageCode: "en", languageVariantCode: nil)])
+        await fixture.resetWMFDataTestState()
         
         self.dataController = WMFArticleTabsDataController(coreDataStore: store)
-        
-        try await super.setUp()
+    }
+
+    override func tearDown() async throws {
+        await fixture.tearDown()
+        try await super.tearDown()
     }
     
     func testTabsCount() async throws {

--- a/WMFData/Tests/WMFDataTests/WMFDeveloperSettingsDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFDeveloperSettingsDataControllerTests.swift
@@ -8,45 +8,58 @@ import WMFDataTestSupport
 final class WMFDeveloperSettingsDataControllerTests {
 
     private let fixture = WMFDataTestFixture()
-    private var controller: WMFDeveloperSettingsDataController!
-
-    init() async {
-        await fixture.setUp()
-        WMFDataEnvironment.current.basicService = WMFFeatureConfigRequestMockService()
-        WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
-        WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [WMFLanguage(languageCode: "en", languageVariantCode: nil)])
-        await fixture.resetWMFDataTestState()
-        controller = WMFDeveloperSettingsDataController()
-    }
 
     @Test
     func fetchFeatureConfigAndLoad() async throws {
-        try await controller.fetchFeatureConfig()
+        try await withConfiguredEnvironment { controller in
+            try await controller.fetchFeatureConfig()
 
-        let config = try #require(controller.loadFeatureConfig())
-        let yirConfig = try #require(config.common.yir(year: 2025))
+            let config = try #require(controller.loadFeatureConfig())
+            let yirConfig = try #require(config.common.yir(year: 2025))
 
-        #expect(yirConfig.year == 2025)
-        #expect(yirConfig.activeStartDateString == "2025-12-01T00:00:00Z")
-        #expect(yirConfig.activeEndDateString == "2026-02-01T00:00:00Z")
-        #expect(yirConfig.dataStartDateString == "2025-01-01T00:00:00Z")
-        #expect(yirConfig.dataEndDateString == "2025-12-01T00:00:00Z")
-        #expect(yirConfig.languages == 300)
-        #expect(yirConfig.articles == 10000000)
-        #expect(yirConfig.savedArticlesApps == 37574993)
-        #expect(yirConfig.viewsApps == 1000000000)
-        #expect(yirConfig.editsApps == 124356)
-        #expect(yirConfig.editsPerMinute == 342)
-        #expect(yirConfig.averageArticlesReadPerYear == 335)
-        #expect(yirConfig.edits == 81987181)
-        #expect(yirConfig.editsEN == 31000000)
-        #expect(yirConfig.bytesAddedEN == 1000000000)
-        #expect(yirConfig.hoursReadEN == 2423171000)
-        #expect(yirConfig.yearsReadEN == 275000)
-        #expect(yirConfig.topReadEN.count == 5)
-        #expect(yirConfig.topReadPercentages.count == 8)
-        #expect(yirConfig.hideCountryCodes.count == 22)
-        #expect(yirConfig.hideDonateCountryCodes.count == 30)
+            #expect(yirConfig.year == 2025)
+            #expect(yirConfig.activeStartDateString == "2025-12-01T00:00:00Z")
+            #expect(yirConfig.activeEndDateString == "2026-02-01T00:00:00Z")
+            #expect(yirConfig.dataStartDateString == "2025-01-01T00:00:00Z")
+            #expect(yirConfig.dataEndDateString == "2025-12-01T00:00:00Z")
+            #expect(yirConfig.languages == 300)
+            #expect(yirConfig.articles == 10000000)
+            #expect(yirConfig.savedArticlesApps == 37574993)
+            #expect(yirConfig.viewsApps == 1000000000)
+            #expect(yirConfig.editsApps == 124356)
+            #expect(yirConfig.editsPerMinute == 342)
+            #expect(yirConfig.averageArticlesReadPerYear == 335)
+            #expect(yirConfig.edits == 81987181)
+            #expect(yirConfig.editsEN == 31000000)
+            #expect(yirConfig.bytesAddedEN == 1000000000)
+            #expect(yirConfig.hoursReadEN == 2423171000)
+            #expect(yirConfig.yearsReadEN == 275000)
+            #expect(yirConfig.topReadEN.count == 5)
+            #expect(yirConfig.topReadPercentages.count == 8)
+            #expect(yirConfig.hideCountryCodes.count == 22)
+            #expect(yirConfig.hideDonateCountryCodes.count == 30)
+        }
+    }
+
+    private func withConfiguredEnvironment<T>(_ operation: (WMFDeveloperSettingsDataController) async throws -> T) async rethrows -> T {
+        try await fixture.withGlobalStateLease {
+            await fixture.setUp()
+            WMFDataEnvironment.current.basicService = WMFFeatureConfigRequestMockService()
+            WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
+            WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [WMFLanguage(languageCode: "en", languageVariantCode: nil)])
+            await fixture.resetWMFDataTestState()
+
+            let controller = WMFDeveloperSettingsDataController()
+
+            do {
+                let result = try await operation(controller)
+                await fixture.tearDown()
+                return result
+            } catch {
+                await fixture.tearDown()
+                throw error
+            }
+        }
     }
 }
 

--- a/WMFData/Tests/WMFDataTests/WMFDeveloperSettingsDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFDeveloperSettingsDataControllerTests.swift
@@ -1,17 +1,21 @@
 import Foundation
 import Testing
+import WMFDataTestSupport
 @testable import WMFData
 @testable import WMFDataMocks
 
 @Suite(.serialized)
-struct WMFDeveloperSettingsDataControllerTests {
+final class WMFDeveloperSettingsDataControllerTests {
 
-    private let controller: WMFDeveloperSettingsDataController
+    private let fixture = WMFDataTestFixture()
+    private var controller: WMFDeveloperSettingsDataController!
 
-    init() {
+    init() async {
+        await fixture.setUp()
         WMFDataEnvironment.current.basicService = WMFFeatureConfigRequestMockService()
         WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
         WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [WMFLanguage(languageCode: "en", languageVariantCode: nil)])
+        await fixture.resetWMFDataTestState()
         controller = WMFDeveloperSettingsDataController()
     }
 

--- a/WMFData/Tests/WMFDataTests/WMFDeveloperSettingsDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFDeveloperSettingsDataControllerTests.swift
@@ -11,7 +11,9 @@ final class WMFDeveloperSettingsDataControllerTests {
 
     @Test
     func fetchFeatureConfigAndLoad() async throws {
-        try await withConfiguredEnvironment { controller in
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let controller = WMFDeveloperSettingsDataController()
+
             try await controller.fetchFeatureConfig()
 
             let config = try #require(controller.loadFeatureConfig())
@@ -41,25 +43,10 @@ final class WMFDeveloperSettingsDataControllerTests {
         }
     }
 
-    private func withConfiguredEnvironment<T>(_ operation: (WMFDeveloperSettingsDataController) async throws -> T) async rethrows -> T {
-        try await fixture.withGlobalStateLease {
-            await fixture.setUp()
-            WMFDataEnvironment.current.basicService = WMFFeatureConfigRequestMockService()
-            WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
-            WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [WMFLanguage(languageCode: "en", languageVariantCode: nil)])
-            await fixture.resetWMFDataTestState()
-
-            let controller = WMFDeveloperSettingsDataController()
-
-            do {
-                let result = try await operation(controller)
-                await fixture.tearDown()
-                return result
-            } catch {
-                await fixture.tearDown()
-                throw error
-            }
-        }
+    private func configureEnvironment() async {
+        WMFDataEnvironment.current.basicService = WMFFeatureConfigRequestMockService()
+        WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
+        WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [WMFLanguage(languageCode: "en", languageVariantCode: nil)])
     }
 }
 

--- a/WMFData/Tests/WMFDataTests/WMFDonateDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFDonateDataControllerTests.swift
@@ -11,7 +11,6 @@ struct WMFDonateDataControllerTests {
 
     init() {
         controller = WMFDonateDataController(service: WMFDonateRequestMockService(), sharedCacheStore: WMFMockKeyValueStore())
-        controller.reset()
     }
 
     @Test

--- a/WMFData/Tests/WMFDataTests/WMFFeedDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFFeedDataControllerTests.swift
@@ -5,6 +5,7 @@ import XCTest
 
 final class WMFFeedDataControllerTests: XCTestCase {
 
+    private let basicService = WMFMockBasicService(jsonResourceName: "feed-featured-2025-12-11-get")
     private let enProject = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
 
     private var fixtureDate: Date {
@@ -15,13 +16,8 @@ final class WMFFeedDataControllerTests: XCTestCase {
         return Calendar(identifier: .gregorian).date(from: components)!
     }
 
-    override func setUp() async throws {
-        try await super.setUp()
-        WMFDataEnvironment.current.basicService = WMFMockBasicService(jsonResourceName: "feed-featured-2025-12-11-get")
-    }
-
     private func fetchFixture() async throws -> WMFFeedAPIResponse {
-        try await WMFFeedDataController().fetchFeed(project: enProject, date: fixtureDate)
+        try await WMFFeedDataController(basicService: basicService).fetchFeed(project: enProject, date: fixtureDate)
     }
 
     // MARK: - Fetch

--- a/WMFData/Tests/WMFDataTests/WMFFundraisingCampaignDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFFundraisingCampaignDataControllerTests.swift
@@ -15,7 +15,7 @@ final class WMFFundraisingCampaignDataControllerTests {
 
     @Test
     func fetchConfigAndLoadAssetWithValidCountryValidDateValidWiki() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let validCountry = "NL"
             let validDate = try validFirstDayDate()
 
@@ -48,7 +48,7 @@ final class WMFFundraisingCampaignDataControllerTests {
 
     @Test
     func fetchConfigAndLoadAssetWithInvalidCountryValidDateValidWiki() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let invalidCountry = "US"
             let validDate = try validFirstDayDate()
 
@@ -61,7 +61,7 @@ final class WMFFundraisingCampaignDataControllerTests {
 
     @Test
     func fetchConfigAndLoadAssetWithValidCountryInvalidDateValidWiki() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let validCountry = "NL"
             let invalidDate = try invalidDate()
 
@@ -74,7 +74,7 @@ final class WMFFundraisingCampaignDataControllerTests {
 
     @Test
     func fetchConfigAndLoadAssetWithValidCountryValidDateInvalidWiki() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let validCountry = "NL"
             let validDate = try validFirstDayDate()
 
@@ -86,7 +86,7 @@ final class WMFFundraisingCampaignDataControllerTests {
 
     @Test
     func fetchConfigAndLoadAssetWithNoCacheAndNoInternetConnection() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             controller.service = WMFMockServiceNoInternetConnection()
 
             let validCountry = "NL"
@@ -105,7 +105,7 @@ final class WMFFundraisingCampaignDataControllerTests {
 
     @Test
     func fetchConfigAndLoadAssetWithCacheAndNoInternetConnection() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let validCountry = "NL"
             let validDate = try validFirstDayDate()
 
@@ -128,7 +128,7 @@ final class WMFFundraisingCampaignDataControllerTests {
 
     @Test
     func loadHiddenAsset() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let validCountry = "NL"
             let validDate = try validFirstDayDate()
 
@@ -144,7 +144,7 @@ final class WMFFundraisingCampaignDataControllerTests {
 
     @Test
     func loadMaybeLaterAssetSixHoursLater() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let validCountry = "NL"
             let validDate = try validFirstDayDate()
 
@@ -160,7 +160,7 @@ final class WMFFundraisingCampaignDataControllerTests {
 
     @Test
     func loadMaybeLaterAssetThirtyHoursLater() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let validCountry = "NL"
             let validDate = try validFirstDayDate()
 
@@ -176,7 +176,7 @@ final class WMFFundraisingCampaignDataControllerTests {
 
     @Test
     func loadMaybeLaterAssetAfterCampaignEnds() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let validCountry = "NL"
             let validDate = try validLastDayDate()
 
@@ -190,23 +190,10 @@ final class WMFFundraisingCampaignDataControllerTests {
         }
     }
 
-    private func withConfiguredEnvironment<T>(_ operation: () async throws -> T) async rethrows -> T {
-        try await fixture.withGlobalStateLease {
-            await fixture.setUp()
-            WMFDataEnvironment.current.basicService = WMFFundraisingCampaignRequestMockService()
-            WMFDataEnvironment.current.serviceEnvironment = .staging
-            WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
-            await fixture.resetWMFDataTestState()
-
-            do {
-                let result = try await operation()
-                await fixture.tearDown()
-                return result
-            } catch {
-                await fixture.tearDown()
-                throw error
-            }
-        }
+    private func configureEnvironment() async {
+        WMFDataEnvironment.current.basicService = WMFFundraisingCampaignRequestMockService()
+        WMFDataEnvironment.current.serviceEnvironment = .staging
+        WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
     }
 
     private func validFirstDayDate() throws -> Date {

--- a/WMFData/Tests/WMFDataTests/WMFFundraisingCampaignDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFFundraisingCampaignDataControllerTests.swift
@@ -1,21 +1,24 @@
 import Foundation
 import Testing
+import WMFDataTestSupport
 @testable import WMFData
 @testable import WMFDataMocks
 
 @Suite(.serialized)
-struct WMFFundraisingCampaignDataControllerTests {
+final class WMFFundraisingCampaignDataControllerTests {
 
+    private let fixture = WMFDataTestFixture()
     private let enProject = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
     private let esProject = WMFProject.wikipedia(WMFLanguage(languageCode: "es", languageVariantCode: nil))
     private let nlProject = WMFProject.wikipedia(WMFLanguage(languageCode: "nl", languageVariantCode: nil))
-    private let controller: WMFFundraisingCampaignDataController
+    private let controller = WMFFundraisingCampaignDataController.shared
 
-    init() {
-        controller = WMFFundraisingCampaignDataController.shared
-        controller.reset()
-        controller.service = WMFFundraisingCampaignRequestMockService()
-        controller.sharedCacheStore = WMFMockKeyValueStore()
+    init() async {
+        await fixture.setUp()
+        WMFDataEnvironment.current.basicService = WMFFundraisingCampaignRequestMockService()
+        WMFDataEnvironment.current.serviceEnvironment = .staging
+        WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
+        await fixture.resetWMFDataTestState()
     }
 
     @Test

--- a/WMFData/Tests/WMFDataTests/WMFFundraisingCampaignDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFFundraisingCampaignDataControllerTests.swift
@@ -13,169 +13,200 @@ final class WMFFundraisingCampaignDataControllerTests {
     private let nlProject = WMFProject.wikipedia(WMFLanguage(languageCode: "nl", languageVariantCode: nil))
     private let controller = WMFFundraisingCampaignDataController.shared
 
-    init() async {
-        await fixture.setUp()
-        WMFDataEnvironment.current.basicService = WMFFundraisingCampaignRequestMockService()
-        WMFDataEnvironment.current.serviceEnvironment = .staging
-        WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
-        await fixture.resetWMFDataTestState()
-    }
-
     @Test
     func fetchConfigAndLoadAssetWithValidCountryValidDateValidWiki() async throws {
-        let validCountry = "NL"
-        let validDate = try validFirstDayDate()
+        try await withConfiguredEnvironment {
+            let validCountry = "NL"
+            let validDate = try validFirstDayDate()
 
-        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+            try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
 
-        let enWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: enProject, currentDate: validDate))
-        let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
+            let enWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: enProject, currentDate: validDate))
+            let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
 
-        #expect(enWikiAsset.id == "NL_2023_11")
-        #expect(enWikiAsset.textHtml == "<b>Wikipedia is not for sale.</b><br><i>A personal appeal from Jimmy Wales</i><br><br>Today I humbly ask you to reflect on the number of times you have used the Wikipedia app this year, the value you’ve gotten from it, and whether you’re able to give €2 back. The Wikimedia Foundation relies on readers to support the technology that makes Wikipedia and our other projects possible. Being a nonprofit means there is no danger that someone will buy Wikipedia and turn it into their personal playground. If Wikipedia has given you €2 worth of knowledge this year, please give back. Thank you. — <i>Jimmy Wales, founder, Wikimedia Foundation</i>")
-        #expect(enWikiAsset.footerHtml == "By donating, you agree to our <a href='https://foundation.wikimedia.org/wiki/Donor_privacy_policy/en'>donor policy</a>.")
-        #expect(enWikiAsset.actions.count == 3)
-        #expect(enWikiAsset.actions[0].title == "Donate now")
-        #expect(enWikiAsset.actions[0].url == URL(string: "https://donate.wikimedia.org/?uselang=en&appeal=JimmyQuote&utm_medium=WikipediaApp&utm_campaign=iOS&utm_source=app_2023_enNL_iOS_control"))
-        #expect(enWikiAsset.actions[1].title == "Maybe later")
-        #expect(enWikiAsset.actions[2].title == "I already donated")
-        #expect(enWikiAsset.currencyCode == "EUR")
+            #expect(enWikiAsset.id == "NL_2023_11")
+            #expect(enWikiAsset.textHtml == "<b>Wikipedia is not for sale.</b><br><i>A personal appeal from Jimmy Wales</i><br><br>Today I humbly ask you to reflect on the number of times you have used the Wikipedia app this year, the value you’ve gotten from it, and whether you’re able to give €2 back. The Wikimedia Foundation relies on readers to support the technology that makes Wikipedia and our other projects possible. Being a nonprofit means there is no danger that someone will buy Wikipedia and turn it into their personal playground. If Wikipedia has given you €2 worth of knowledge this year, please give back. Thank you. — <i>Jimmy Wales, founder, Wikimedia Foundation</i>")
+            #expect(enWikiAsset.footerHtml == "By donating, you agree to our <a href='https://foundation.wikimedia.org/wiki/Donor_privacy_policy/en'>donor policy</a>.")
+            #expect(enWikiAsset.actions.count == 3)
+            #expect(enWikiAsset.actions[0].title == "Donate now")
+            #expect(enWikiAsset.actions[0].url == URL(string: "https://donate.wikimedia.org/?uselang=en&appeal=JimmyQuote&utm_medium=WikipediaApp&utm_campaign=iOS&utm_source=app_2023_enNL_iOS_control"))
+            #expect(enWikiAsset.actions[1].title == "Maybe later")
+            #expect(enWikiAsset.actions[2].title == "I already donated")
+            #expect(enWikiAsset.currencyCode == "EUR")
 
-        #expect(nlWikiAsset.id == "NL_2023_11")
-        #expect(nlWikiAsset.textHtml == "<b>Wikipedia is niet te koop.</b><br><i>Een persoonlijke boodschap van Jimmy Wales.</i><br><br>Sta je weleens stil bij de keren dat je de Wikipedia-app hebt gebruikt dit jaar? Als je dat nuttig vond, zou je dan €&nbsp;2 willen geven? De Wikimedia Foundation is afhankelijk van lezers die de technologie willen ondersteunen die Wikipedia en andere projecten mogelijk maakt. Omdat we een non-profitorganisatie zijn, bestaat er geen gevaar dat iemand ineens Wikipedia koopt en ermee aan de haal gaat. Als je vindt dat Wikipedia je dit jaar €&nbsp;2 aan kennis heeft gegeven, overweeg dan een donatie. Alvast bedankt. — <i>Jimmy Wales, oprichter van de Wikimedia Foundation</i>")
-        #expect(nlWikiAsset.footerHtml == "Als je doneert, ga je akkoord met ons <a href='https://foundation.wikimedia.org/wiki/Donor_privacy_policy/nl'>privacybeleid voor donateurs</a>.")
-        #expect(nlWikiAsset.actions.count == 3)
-        #expect(nlWikiAsset.actions[0].title == "Doneer nu")
-        #expect(nlWikiAsset.actions[0].url == URL(string: "https://donate.wikimedia.org/?uselang=nl&appeal=JimmyQuote&utm_medium=WikipediaApp&utm_campaign=iOS&utm_source=app_2023_nlNL_iOS_control"))
-        #expect(nlWikiAsset.actions[1].title == "Misschien later")
-        #expect(nlWikiAsset.actions[2].title == "Ik heb al gedoneerd")
-        #expect(nlWikiAsset.currencyCode == "EUR")
+            #expect(nlWikiAsset.id == "NL_2023_11")
+            #expect(nlWikiAsset.textHtml == "<b>Wikipedia is niet te koop.</b><br><i>Een persoonlijke boodschap van Jimmy Wales.</i><br><br>Sta je weleens stil bij de keren dat je de Wikipedia-app hebt gebruikt dit jaar? Als je dat nuttig vond, zou je dan €&nbsp;2 willen geven? De Wikimedia Foundation is afhankelijk van lezers die de technologie willen ondersteunen die Wikipedia en andere projecten mogelijk maakt. Omdat we een non-profitorganisatie zijn, bestaat er geen gevaar dat iemand ineens Wikipedia koopt en ermee aan de haal gaat. Als je vindt dat Wikipedia je dit jaar €&nbsp;2 aan kennis heeft gegeven, overweeg dan een donatie. Alvast bedankt. — <i>Jimmy Wales, oprichter van de Wikimedia Foundation</i>")
+            #expect(nlWikiAsset.footerHtml == "Als je doneert, ga je akkoord met ons <a href='https://foundation.wikimedia.org/wiki/Donor_privacy_policy/nl'>privacybeleid voor donateurs</a>.")
+            #expect(nlWikiAsset.actions.count == 3)
+            #expect(nlWikiAsset.actions[0].title == "Doneer nu")
+            #expect(nlWikiAsset.actions[0].url == URL(string: "https://donate.wikimedia.org/?uselang=nl&appeal=JimmyQuote&utm_medium=WikipediaApp&utm_campaign=iOS&utm_source=app_2023_nlNL_iOS_control"))
+            #expect(nlWikiAsset.actions[1].title == "Misschien later")
+            #expect(nlWikiAsset.actions[2].title == "Ik heb al gedoneerd")
+            #expect(nlWikiAsset.currencyCode == "EUR")
+        }
     }
 
     @Test
     func fetchConfigAndLoadAssetWithInvalidCountryValidDateValidWiki() async throws {
-        let invalidCountry = "US"
-        let validDate = try validFirstDayDate()
+        try await withConfiguredEnvironment {
+            let invalidCountry = "US"
+            let validDate = try validFirstDayDate()
 
-        try await controller.fetchConfig(countryCode: invalidCountry, currentDate: validDate)
+            try await controller.fetchConfig(countryCode: invalidCountry, currentDate: validDate)
 
-        #expect(controller.loadActiveCampaignAsset(countryCode: invalidCountry, wmfProject: enProject, currentDate: validDate) == nil)
-        #expect(controller.loadActiveCampaignAsset(countryCode: invalidCountry, wmfProject: nlProject, currentDate: validDate) == nil)
+            #expect(controller.loadActiveCampaignAsset(countryCode: invalidCountry, wmfProject: enProject, currentDate: validDate) == nil)
+            #expect(controller.loadActiveCampaignAsset(countryCode: invalidCountry, wmfProject: nlProject, currentDate: validDate) == nil)
+        }
     }
 
     @Test
     func fetchConfigAndLoadAssetWithValidCountryInvalidDateValidWiki() async throws {
-        let validCountry = "NL"
-        let invalidDate = try invalidDate()
+        try await withConfiguredEnvironment {
+            let validCountry = "NL"
+            let invalidDate = try invalidDate()
 
-        try await controller.fetchConfig(countryCode: validCountry, currentDate: invalidDate)
+            try await controller.fetchConfig(countryCode: validCountry, currentDate: invalidDate)
 
-        #expect(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: enProject, currentDate: invalidDate) == nil)
-        #expect(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: invalidDate) == nil)
+            #expect(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: enProject, currentDate: invalidDate) == nil)
+            #expect(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: invalidDate) == nil)
+        }
     }
 
     @Test
     func fetchConfigAndLoadAssetWithValidCountryValidDateInvalidWiki() async throws {
-        let validCountry = "NL"
-        let validDate = try validFirstDayDate()
+        try await withConfiguredEnvironment {
+            let validCountry = "NL"
+            let validDate = try validFirstDayDate()
 
-        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+            try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
 
-        #expect(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: esProject, currentDate: validDate) == nil)
+            #expect(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: esProject, currentDate: validDate) == nil)
+        }
     }
 
     @Test
     func fetchConfigAndLoadAssetWithNoCacheAndNoInternetConnection() async throws {
-        controller.service = WMFMockServiceNoInternetConnection()
+        try await withConfiguredEnvironment {
+            controller.service = WMFMockServiceNoInternetConnection()
 
-        let validCountry = "NL"
-        let validDate = try validFirstDayDate()
+            let validCountry = "NL"
+            let validDate = try validFirstDayDate()
 
-        let error = try #require(await #expect(throws: NSError.self) {
-            try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
-        })
-        #expect(error.domain == NSURLErrorDomain)
-        #expect(error.code == NSURLErrorNotConnectedToInternet)
+            let error = try #require(await #expect(throws: NSError.self) {
+                try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+            })
+            #expect(error.domain == NSURLErrorDomain)
+            #expect(error.code == NSURLErrorNotConnectedToInternet)
 
-        let asset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate)
-        #expect(asset == nil)
+            let asset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate)
+            #expect(asset == nil)
+        }
     }
 
     @Test
     func fetchConfigAndLoadAssetWithCacheAndNoInternetConnection() async throws {
-        let validCountry = "NL"
-        let validDate = try validFirstDayDate()
+        try await withConfiguredEnvironment {
+            let validCountry = "NL"
+            let validDate = try validFirstDayDate()
 
-        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
-        let connectedAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
-
-        controller.service = WMFMockServiceNoInternetConnection()
-
-        let error = try #require(await #expect(throws: NSError.self) {
             try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
-        })
-        #expect(error.domain == NSURLErrorDomain)
-        #expect(error.code == NSURLErrorNotConnectedToInternet)
+            let connectedAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
 
-        let notConnectedAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
-        #expect(connectedAsset.id == notConnectedAsset.id)
-        #expect(connectedAsset.textHtml == notConnectedAsset.textHtml)
+            controller.service = WMFMockServiceNoInternetConnection()
+
+            let error = try #require(await #expect(throws: NSError.self) {
+                try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+            })
+            #expect(error.domain == NSURLErrorDomain)
+            #expect(error.code == NSURLErrorNotConnectedToInternet)
+
+            let notConnectedAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
+            #expect(connectedAsset.id == notConnectedAsset.id)
+            #expect(connectedAsset.textHtml == notConnectedAsset.textHtml)
+        }
     }
 
     @Test
     func loadHiddenAsset() async throws {
-        let validCountry = "NL"
-        let validDate = try validFirstDayDate()
+        try await withConfiguredEnvironment {
+            let validCountry = "NL"
+            let validDate = try validFirstDayDate()
 
-        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+            try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
 
-        let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
-        controller.markAssetAsPermanentlyHidden(asset: nlWikiAsset)
+            let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
+            controller.markAssetAsPermanentlyHidden(asset: nlWikiAsset)
 
-        let hiddenNLWikiAsset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate)
-        #expect(hiddenNLWikiAsset == nil)
+            let hiddenNLWikiAsset = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate)
+            #expect(hiddenNLWikiAsset == nil)
+        }
     }
 
     @Test
     func loadMaybeLaterAssetSixHoursLater() async throws {
-        let validCountry = "NL"
-        let validDate = try validFirstDayDate()
+        try await withConfiguredEnvironment {
+            let validCountry = "NL"
+            let validDate = try validFirstDayDate()
 
-        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+            try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
 
-        let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
-        controller.markAssetAsMaybeLater(asset: nlWikiAsset, currentDate: validDate)
+            let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
+            controller.markAssetAsMaybeLater(asset: nlWikiAsset, currentDate: validDate)
 
-        let nlWikiAssetSixHoursLater = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: try validFirstDayPlus6HoursDate())
-        #expect(nlWikiAssetSixHoursLater == nil)
+            let nlWikiAssetSixHoursLater = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: try validFirstDayPlus6HoursDate())
+            #expect(nlWikiAssetSixHoursLater == nil)
+        }
     }
 
     @Test
     func loadMaybeLaterAssetThirtyHoursLater() async throws {
-        let validCountry = "NL"
-        let validDate = try validFirstDayDate()
+        try await withConfiguredEnvironment {
+            let validCountry = "NL"
+            let validDate = try validFirstDayDate()
 
-        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+            try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
 
-        let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
-        controller.markAssetAsMaybeLater(asset: nlWikiAsset, currentDate: validDate)
+            let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
+            controller.markAssetAsMaybeLater(asset: nlWikiAsset, currentDate: validDate)
 
-        let nlWikiAssetThirtyHoursLater = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: try validFirstDayPlus30HoursDate())
-        #expect(nlWikiAssetThirtyHoursLater != nil)
+            let nlWikiAssetThirtyHoursLater = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: try validFirstDayPlus30HoursDate())
+            #expect(nlWikiAssetThirtyHoursLater != nil)
+        }
     }
 
     @Test
     func loadMaybeLaterAssetAfterCampaignEnds() async throws {
-        let validCountry = "NL"
-        let validDate = try validLastDayDate()
+        try await withConfiguredEnvironment {
+            let validCountry = "NL"
+            let validDate = try validLastDayDate()
 
-        try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
+            try await controller.fetchConfig(countryCode: validCountry, currentDate: validDate)
 
-        let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
-        controller.markAssetAsMaybeLater(asset: nlWikiAsset, currentDate: validDate)
+            let nlWikiAsset = try #require(controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: validDate))
+            controller.markAssetAsMaybeLater(asset: nlWikiAsset, currentDate: validDate)
 
-        let nlWikiAssetThirtyHoursLater = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: try validLastDayPlus30HoursDate())
-        #expect(nlWikiAssetThirtyHoursLater == nil)
+            let nlWikiAssetThirtyHoursLater = controller.loadActiveCampaignAsset(countryCode: validCountry, wmfProject: nlProject, currentDate: try validLastDayPlus30HoursDate())
+            #expect(nlWikiAssetThirtyHoursLater == nil)
+        }
+    }
+
+    private func withConfiguredEnvironment<T>(_ operation: () async throws -> T) async rethrows -> T {
+        try await fixture.withGlobalStateLease {
+            await fixture.setUp()
+            WMFDataEnvironment.current.basicService = WMFFundraisingCampaignRequestMockService()
+            WMFDataEnvironment.current.serviceEnvironment = .staging
+            WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
+            await fixture.resetWMFDataTestState()
+
+            do {
+                let result = try await operation()
+                await fixture.tearDown()
+                return result
+            } catch {
+                await fixture.tearDown()
+                throw error
+            }
+        }
     }
 
     private func validFirstDayDate() throws -> Date {

--- a/WMFData/Tests/WMFDataTests/WMFGamesDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFGamesDataControllerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import WMFDataTestSupport
 @testable import WMFData
 @testable import WMFDataMocks
 
@@ -6,6 +7,7 @@ final class WMFGamesDataControllerTests: XCTestCase {
 
     // MARK: - Properties
 
+    private let fixture = WMFDataTestFixture()
     var store: WMFCoreDataStore?
     var dataController: WMFGamesDataController?
 
@@ -23,17 +25,22 @@ final class WMFGamesDataControllerTests: XCTestCase {
     // MARK: - Setup
 
     override func setUp() async throws {
-        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        let store = try await WMFCoreDataStore(appContainerURL: temporaryDirectory)
+        try await super.setUp()
+        await fixture.setUp()
+        let store = try await fixture.makeTemporaryCoreDataStore()
         self.store = store
 
         WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [
             WMFLanguage(languageCode: "en", languageVariantCode: nil)
         ])
+        await fixture.resetWMFDataTestState()
 
         self.dataController = WMFGamesDataController(coreDataStore: store)
+    }
 
-        try await super.setUp()
+    override func tearDown() async throws {
+        await fixture.tearDown()
+        try await super.tearDown()
     }
 
     // MARK: - Helper Factories

--- a/WMFData/Tests/WMFDataTests/WMFGrowthTasksDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFGrowthTasksDataControllerTests.swift
@@ -1,16 +1,20 @@
 import Testing
+import WMFDataTestSupport
 @testable import WMFData
 @testable import WMFDataMocks
 
 @Suite(.serialized)
-struct WMFGrowthTasksDataControllerTests {
+final class WMFGrowthTasksDataControllerTests {
 
+    private let fixture = WMFDataTestFixture()
     private let csProject = WMFProject.wikipedia(WMFLanguage(languageCode: "cs", languageVariantCode: nil))
     private let enProject = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
 
-    init() {
+    init() async {
+        await fixture.setUp()
         WMFDataEnvironment.current.mediaWikiService = WMFMockGrowthTasksService()
         WMFDataEnvironment.current.basicService = WMFMockBasicService()
+        await fixture.resetWMFDataTestState()
     }
 
     @Test

--- a/WMFData/Tests/WMFDataTests/WMFGrowthTasksDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFGrowthTasksDataControllerTests.swift
@@ -12,7 +12,7 @@ final class WMFGrowthTasksDataControllerTests {
 
     @Test
     func fetchImageRecommendationCombinedForTasks() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFGrowthTasksDataController(project: csProject)
 
             let imageRecommendations = try await controller.imageRecommendationsCombined()
@@ -23,7 +23,7 @@ final class WMFGrowthTasksDataControllerTests {
 
     @Test
     func parseImageRecommendationsCombined() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFGrowthTasksDataController(project: enProject)
 
             let imageRecommendations = try await controller.imageRecommendationsCombined()
@@ -63,7 +63,7 @@ final class WMFGrowthTasksDataControllerTests {
 
     @Test
     func fetchArticleSummary() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFArticleSummaryDataController.shared
 
             let articleSummary = try await controller.fetchArticleSummary(project: csProject, title: "Novela (právo)")
@@ -74,22 +74,9 @@ final class WMFGrowthTasksDataControllerTests {
         }
     }
 
-    private func withConfiguredEnvironment<T>(_ operation: () async throws -> T) async rethrows -> T {
-        try await fixture.withGlobalStateLease {
-            await fixture.setUp()
-            WMFDataEnvironment.current.mediaWikiService = WMFMockGrowthTasksService()
-            WMFDataEnvironment.current.basicService = WMFMockBasicService()
-            await fixture.resetWMFDataTestState()
-
-            do {
-                let result = try await operation()
-                await fixture.tearDown()
-                return result
-            } catch {
-                await fixture.tearDown()
-                throw error
-            }
-        }
+    private func configureEnvironment() async {
+        WMFDataEnvironment.current.mediaWikiService = WMFMockGrowthTasksService()
+        WMFDataEnvironment.current.basicService = WMFMockBasicService()
     }
 }
 

--- a/WMFData/Tests/WMFDataTests/WMFGrowthTasksDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFGrowthTasksDataControllerTests.swift
@@ -10,69 +10,86 @@ final class WMFGrowthTasksDataControllerTests {
     private let csProject = WMFProject.wikipedia(WMFLanguage(languageCode: "cs", languageVariantCode: nil))
     private let enProject = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
 
-    init() async {
-        await fixture.setUp()
-        WMFDataEnvironment.current.mediaWikiService = WMFMockGrowthTasksService()
-        WMFDataEnvironment.current.basicService = WMFMockBasicService()
-        await fixture.resetWMFDataTestState()
-    }
-
     @Test
     func fetchImageRecommendationCombinedForTasks() async throws {
-        let controller = WMFGrowthTasksDataController(project: csProject)
+        try await withConfiguredEnvironment {
+            let controller = WMFGrowthTasksDataController(project: csProject)
 
-        let imageRecommendations = try await controller.imageRecommendationsCombined()
+            let imageRecommendations = try await controller.imageRecommendationsCombined()
 
-        #expect(imageRecommendations.isEmpty == false)
+            #expect(imageRecommendations.isEmpty == false)
+        }
     }
 
     @Test
     func parseImageRecommendationsCombined() async throws {
-        let controller = WMFGrowthTasksDataController(project: enProject)
+        try await withConfiguredEnvironment {
+            let controller = WMFGrowthTasksDataController(project: enProject)
 
-        let imageRecommendations = try await controller.imageRecommendationsCombined()
-        let firstImageRecommendation = try #require(imageRecommendations.first)
+            let imageRecommendations = try await controller.imageRecommendationsCombined()
+            let firstImageRecommendation = try #require(imageRecommendations.first)
 
-        #expect(firstImageRecommendation.pageid == 6706133)
-        #expect(firstImageRecommendation.title == "Juan de Salmerón")
-        #expect(firstImageRecommendation.growthimagesuggestiondata?.count == 1)
+            #expect(firstImageRecommendation.pageid == 6706133)
+            #expect(firstImageRecommendation.title == "Juan de Salmerón")
+            #expect(firstImageRecommendation.growthimagesuggestiondata?.count == 1)
 
-        let firstImageSuggestionData = try #require(firstImageRecommendation.growthimagesuggestiondata?.first)
-        #expect(firstImageSuggestionData.titleText == "Juan de Salmerón")
-        #expect(firstImageSuggestionData.titleNamespace == 0)
-        #expect(firstImageSuggestionData.images.count == 1)
+            let firstImageSuggestionData = try #require(firstImageRecommendation.growthimagesuggestiondata?.first)
+            #expect(firstImageSuggestionData.titleText == "Juan de Salmerón")
+            #expect(firstImageSuggestionData.titleNamespace == 0)
+            #expect(firstImageSuggestionData.images.count == 1)
 
-        let firstImageData = try #require(firstImageSuggestionData.images.first)
-        #expect(firstImageData.image == "Juan_de_Salmerón.JPG")
-        #expect(firstImageData.displayFilename == "Juan de Salmerón.JPG")
-        #expect(firstImageData.source == "wikipedia")
-        #expect(firstImageData.projects.count == 1)
+            let firstImageData = try #require(firstImageSuggestionData.images.first)
+            #expect(firstImageData.image == "Juan_de_Salmerón.JPG")
+            #expect(firstImageData.displayFilename == "Juan de Salmerón.JPG")
+            #expect(firstImageData.source == "wikipedia")
+            #expect(firstImageData.projects.count == 1)
 
-        let imageMetadata = firstImageData.metadata
-        #expect(imageMetadata.descriptionUrl == "https://commons.wikimedia.org/wiki/File:Juan_de_Salmer%C3%B3n.JPG")
-        #expect(imageMetadata.thumbUrl == "//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Juan_de_Salmer%C3%B3n.JPG/120px-Juan_de_Salmer%C3%B3n.JPG")
-        #expect(imageMetadata.fullUrl == "//upload.wikimedia.org/wikipedia/commons/d/d0/Juan_de_Salmer%C3%B3n.JPG")
-        #expect(imageMetadata.originalWidth == 764)
-        #expect(imageMetadata.originalHeight == 1090)
-        #expect(imageMetadata.mediaType == "BITMAP")
-        #expect(imageMetadata.description == "El Licenciado Juan de Salmerón, fundador de Puebla")
-        #expect(imageMetadata.author == "<a href=\"//commons.wikimedia.org/wiki/User:Gusvel\" title=\"User:Gusvel\">Gusvel</a>")
-        #expect(imageMetadata.license == "CC BY-SA 4.0")
-        #expect(imageMetadata.date == "2010-10-19")
-        #expect(imageMetadata.categories.count == 1)
-        #expect(imageMetadata.reason == "Used in the same article in Spanish Wikipedia.")
-        #expect(imageMetadata.contentLanguageName == "English")
+            let imageMetadata = firstImageData.metadata
+            #expect(imageMetadata.descriptionUrl == "https://commons.wikimedia.org/wiki/File:Juan_de_Salmer%C3%B3n.JPG")
+            #expect(imageMetadata.thumbUrl == "//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Juan_de_Salmer%C3%B3n.JPG/120px-Juan_de_Salmer%C3%B3n.JPG")
+            #expect(imageMetadata.fullUrl == "//upload.wikimedia.org/wikipedia/commons/d/d0/Juan_de_Salmer%C3%B3n.JPG")
+            #expect(imageMetadata.originalWidth == 764)
+            #expect(imageMetadata.originalHeight == 1090)
+            #expect(imageMetadata.mediaType == "BITMAP")
+            #expect(imageMetadata.description == "El Licenciado Juan de Salmerón, fundador de Puebla")
+            #expect(imageMetadata.author == "<a href=\"//commons.wikimedia.org/wiki/User:Gusvel\" title=\"User:Gusvel\">Gusvel</a>")
+            #expect(imageMetadata.license == "CC BY-SA 4.0")
+            #expect(imageMetadata.date == "2010-10-19")
+            #expect(imageMetadata.categories.count == 1)
+            #expect(imageMetadata.reason == "Used in the same article in Spanish Wikipedia.")
+            #expect(imageMetadata.contentLanguageName == "English")
+        }
     }
 
     @Test
     func fetchArticleSummary() async throws {
-        let controller = WMFArticleSummaryDataController.shared
+        try await withConfiguredEnvironment {
+            let controller = WMFArticleSummaryDataController.shared
 
-        let articleSummary = try await controller.fetchArticleSummary(project: csProject, title: "Novela (právo)")
+            let articleSummary = try await controller.fetchArticleSummary(project: csProject, title: "Novela (právo)")
 
-        #expect(articleSummary.displayTitle == "<span class=\"mw-page-title-main\">Novela (právo)</span>")
-        #expect(articleSummary.description == "změna zákona")
-        #expect(articleSummary.extractHtml == "<p><b>Novelou</b> se nazývá takový právní předpis, kterým se mění či doplňuje, cizím slovem <i>novelizuje</i>, jiný právní předpis. Novely jsou vydávány buď jako samostatné právní předpisy nebo jsou připojeny k jiným předpisům zpravidla na jejich konec. Název se odvozuje od výrazu „Novellae“, což je sbírka nařízení císaře Justiniána I. z let 534–569, která byla zařazena do souboru římského práva Corpus iuris civilis jako dodatek. Odlišným od novelizace je výraz „novace“, který má místo v soukromém právu, kde jde o novace závazků.</p>")
+            #expect(articleSummary.displayTitle == "<span class=\"mw-page-title-main\">Novela (právo)</span>")
+            #expect(articleSummary.description == "změna zákona")
+            #expect(articleSummary.extractHtml == "<p><b>Novelou</b> se nazývá takový právní předpis, kterým se mění či doplňuje, cizím slovem <i>novelizuje</i>, jiný právní předpis. Novely jsou vydávány buď jako samostatné právní předpisy nebo jsou připojeny k jiným předpisům zpravidla na jejich konec. Název se odvozuje od výrazu „Novellae“, což je sbírka nařízení císaře Justiniána I. z let 534–569, která byla zařazena do souboru římského práva Corpus iuris civilis jako dodatek. Odlišným od novelizace je výraz „novace“, který má místo v soukromém právu, kde jde o novace závazků.</p>")
+        }
+    }
+
+    private func withConfiguredEnvironment<T>(_ operation: () async throws -> T) async rethrows -> T {
+        try await fixture.withGlobalStateLease {
+            await fixture.setUp()
+            WMFDataEnvironment.current.mediaWikiService = WMFMockGrowthTasksService()
+            WMFDataEnvironment.current.basicService = WMFMockBasicService()
+            await fixture.resetWMFDataTestState()
+
+            do {
+                let result = try await operation()
+                await fixture.tearDown()
+                return result
+            } catch {
+                await fixture.tearDown()
+                throw error
+            }
+        }
     }
 }
 

--- a/WMFData/Tests/WMFDataTests/WMFUserDefaultsStoreTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFUserDefaultsStoreTests.swift
@@ -15,7 +15,27 @@ final class WMFUserDefaultsStoreTests: XCTestCase {
         }
     }
 
-    let userDefaultsStore = WMFUserDefaultsStore()
+    private var defaultsSuiteName: String!
+    private var defaults: UserDefaults!
+    private var userDefaultsStore: WMFUserDefaultsStore!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        defaultsSuiteName = "WMFUserDefaultsStoreTests-\(UUID().uuidString)"
+        defaults = try XCTUnwrap(UserDefaults(suiteName: defaultsSuiteName))
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        userDefaultsStore = WMFUserDefaultsStore(defaults: defaults)
+    }
+
+    override func tearDownWithError() throws {
+        defaults?.removePersistentDomain(forName: defaultsSuiteName)
+        userDefaultsStore = nil
+        defaults = nil
+        defaultsSuiteName = nil
+
+        try super.tearDownWithError()
+    }
     
     func testLoadAndSaveSingleKeyString() throws {
         let testStringToSave = "String Test"

--- a/WMFData/Tests/WMFDataTests/WMFWatchlistDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFWatchlistDataControllerTests.swift
@@ -1,15 +1,18 @@
 import Foundation
 import Testing
+import WMFDataTestSupport
 @testable import WMFData
 @testable import WMFDataMocks
 
 @Suite(.serialized)
-struct WMFWatchlistDataControllerTests {
+final class WMFWatchlistDataControllerTests {
 
+    private let fixture = WMFDataTestFixture()
     private let enProject = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
     private let esProject = WMFProject.wikipedia(WMFLanguage(languageCode: "es", languageVariantCode: nil))
 
-    init() {
+    init() async {
+        await fixture.setUp()
         WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [
             WMFLanguage(languageCode: "en", languageVariantCode: nil),
             WMFLanguage(languageCode: "es", languageVariantCode: nil)
@@ -17,6 +20,7 @@ struct WMFWatchlistDataControllerTests {
         WMFDataEnvironment.current.mediaWikiService = WMFMockWatchlistMediaWikiService()
         WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
         WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
+        await fixture.resetWMFDataTestState()
     }
 
     @Test
@@ -161,8 +165,8 @@ struct WMFWatchlistDataControllerTests {
 
     @Test
     func fetchWatchlistWithNoCacheAndNoInternetConnection() async throws {
-        WMFDataEnvironment.current.mediaWikiService = WMFMockServiceNoInternetConnection()
         let controller = WMFWatchlistDataController()
+        controller.service = WMFMockServiceNoInternetConnection()
 
         let error = try #require(await #expect(throws: WMFDataControllerError.self) {
             _ = try await controller.fetchWatchlist()
@@ -183,8 +187,7 @@ struct WMFWatchlistDataControllerTests {
         let controller = WMFWatchlistDataController()
         let connectedWatchlist = try await controller.fetchWatchlist()
 
-        WMFDataEnvironment.current.mediaWikiService = WMFMockServiceNoInternetConnection()
-        controller.service = WMFDataEnvironment.current.mediaWikiService
+        controller.service = WMFMockServiceNoInternetConnection()
 
         let disconnectedAndCachedWatchlist = try await controller.fetchWatchlist()
 

--- a/WMFData/Tests/WMFDataTests/WMFWatchlistDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFWatchlistDataControllerTests.swift
@@ -13,7 +13,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func allWatchlistProjects() async {
-        await withConfiguredEnvironment {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
             let allProjects = controller.allWatchlistProjects()
 
@@ -23,7 +23,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func savingAndLoadingFilterSettings() async {
-        await withConfiguredEnvironment {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
             let filterSettings = WMFWatchlistFilterSettings(offProjects: [.wikidata, .commons], latestRevisions: .latestRevision, activity: .seenChanges, automatedContributions: .bot, significance: .minorEdits, userRegistration: .registered, offTypes: [.categoryChanges, .loggedActions])
 
@@ -36,7 +36,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func onOffWatchlistProjects() async {
-        await withConfiguredEnvironment {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
             let filterSettings = WMFWatchlistFilterSettings(offProjects: [.wikidata, .commons], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
 
@@ -49,7 +49,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func allOffChangeTypes() async {
-        await withConfiguredEnvironment {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
             let filterSettings = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [.categoryChanges, .pageCreations])
 
@@ -62,7 +62,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func activeFilterCount1() async {
-        await withConfiguredEnvironment {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
             let filterSettings = WMFWatchlistFilterSettings(offProjects: [.commons, .wikidata], latestRevisions: .notTheLatestRevision, activity: .seenChanges, automatedContributions: .bot, significance: .minorEdits, userRegistration: .registered, offTypes: [])
 
@@ -74,7 +74,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func activeFilterCount2() async {
-        await withConfiguredEnvironment {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
             let filterSettings = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .latestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [.categoryChanges])
 
@@ -86,7 +86,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func activeFilterCount3() async {
-        await withConfiguredEnvironment {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
             let filterSettings = WMFWatchlistFilterSettings(offProjects: [.commons, .wikidata, enProject], latestRevisions: .latestRevision, activity: .unseenChanges, automatedContributions: .human, significance: .nonMinorEdits, userRegistration: .unregistered, offTypes: [.categoryChanges, .loggedActions, .pageCreations, .pageEdits, .wikidataEdits])
 
@@ -98,7 +98,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func fetchWatchlistWithDefaultFilter() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
 
             let watchlist = try await controller.fetchWatchlist()
@@ -129,7 +129,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func fetchWatchlistWithProjectFilter() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
             let filterSettings = WMFWatchlistFilterSettings(offProjects: [enProject, esProject], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
             controller.saveFilterSettings(filterSettings)
@@ -147,7 +147,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func fetchWatchlistWithAllProjectsPlusOneFilter() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
             let filterSettings = WMFWatchlistFilterSettings(offProjects: [enProject, esProject, .wikidata, .commons], latestRevisions: .latestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
             controller.saveFilterSettings(filterSettings)
@@ -160,7 +160,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func fetchWatchlistWithBotsFilter() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
             let filterSettings = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .bot, significance: .all, userRegistration: .all, offTypes: [])
             controller.saveFilterSettings(filterSettings)
@@ -175,7 +175,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func fetchWatchlistWithNoCacheAndNoInternetConnection() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
             controller.service = WMFMockServiceNoInternetConnection()
 
@@ -196,7 +196,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func fetchWatchlistWithCacheAndNoInternetConnection() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
             let connectedWatchlist = try await controller.fetchWatchlist()
 
@@ -211,7 +211,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func postWatchArticleExpiryNever() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
 
             try await controller.watch(title: "Cat", project: enProject, expiry: .never)
@@ -220,7 +220,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func postWatchArticleExpiryDate() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
 
             try await controller.watch(title: "Cat", project: enProject, expiry: .oneMonth)
@@ -229,7 +229,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func postUnwatchArticle() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
 
             try await controller.unwatch(title: "Cat", project: enProject)
@@ -238,7 +238,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func postRollbackArticle() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
 
             let result = try await controller.rollback(title: "Cat", project: enProject, username: "Amigao")
@@ -250,7 +250,7 @@ final class WMFWatchlistDataControllerTests {
 
     @Test
     func postUndoArticle() async throws {
-        try await withConfiguredEnvironment {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let controller = WMFWatchlistDataController()
 
             let result = try await controller.undo(title: "Cat", revisionID: 1155871225, summary: "Testing", username: "Amigao", project: enProject)
@@ -260,27 +260,14 @@ final class WMFWatchlistDataControllerTests {
         }
     }
 
-    private func withConfiguredEnvironment<T>(_ operation: () async throws -> T) async rethrows -> T {
-        try await fixture.withGlobalStateLease {
-            await fixture.setUp()
-            WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [
-                WMFLanguage(languageCode: "en", languageVariantCode: nil),
-                WMFLanguage(languageCode: "es", languageVariantCode: nil)
-            ])
-            WMFDataEnvironment.current.mediaWikiService = WMFMockWatchlistMediaWikiService()
-            WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
-            WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
-            await fixture.resetWMFDataTestState()
-
-            do {
-                let result = try await operation()
-                await fixture.tearDown()
-                return result
-            } catch {
-                await fixture.tearDown()
-                throw error
-            }
-        }
+    private func configureEnvironment() async {
+        WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [
+            WMFLanguage(languageCode: "en", languageVariantCode: nil),
+            WMFLanguage(languageCode: "es", languageVariantCode: nil)
+        ])
+        WMFDataEnvironment.current.mediaWikiService = WMFMockWatchlistMediaWikiService()
+        WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
+        WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
     }
 
     private func testDate() throws -> Date {

--- a/WMFData/Tests/WMFDataTests/WMFWatchlistDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFWatchlistDataControllerTests.swift
@@ -11,229 +11,276 @@ final class WMFWatchlistDataControllerTests {
     private let enProject = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
     private let esProject = WMFProject.wikipedia(WMFLanguage(languageCode: "es", languageVariantCode: nil))
 
-    init() async {
-        await fixture.setUp()
-        WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [
-            WMFLanguage(languageCode: "en", languageVariantCode: nil),
-            WMFLanguage(languageCode: "es", languageVariantCode: nil)
-        ])
-        WMFDataEnvironment.current.mediaWikiService = WMFMockWatchlistMediaWikiService()
-        WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
-        WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
-        await fixture.resetWMFDataTestState()
+    @Test
+    func allWatchlistProjects() async {
+        await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
+            let allProjects = controller.allWatchlistProjects()
+
+            #expect([enProject, esProject, .commons, .wikidata] == allProjects)
+        }
     }
 
     @Test
-    func allWatchlistProjects() {
-        let controller = WMFWatchlistDataController()
-        let allProjects = controller.allWatchlistProjects()
+    func savingAndLoadingFilterSettings() async {
+        await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
+            let filterSettings = WMFWatchlistFilterSettings(offProjects: [.wikidata, .commons], latestRevisions: .latestRevision, activity: .seenChanges, automatedContributions: .bot, significance: .minorEdits, userRegistration: .registered, offTypes: [.categoryChanges, .loggedActions])
 
-        #expect([enProject, esProject, .commons, .wikidata] == allProjects)
+            controller.saveFilterSettings(filterSettings)
+            let loadedFilterSettings = controller.loadFilterSettings()
+
+            #expect(filterSettings == loadedFilterSettings)
+        }
     }
 
     @Test
-    func savingAndLoadingFilterSettings() {
-        let controller = WMFWatchlistDataController()
-        let filterSettings = WMFWatchlistFilterSettings(offProjects: [.wikidata, .commons], latestRevisions: .latestRevision, activity: .seenChanges, automatedContributions: .bot, significance: .minorEdits, userRegistration: .registered, offTypes: [.categoryChanges, .loggedActions])
+    func onOffWatchlistProjects() async {
+        await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
+            let filterSettings = WMFWatchlistFilterSettings(offProjects: [.wikidata, .commons], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
 
-        controller.saveFilterSettings(filterSettings)
-        let loadedFilterSettings = controller.loadFilterSettings()
+            controller.saveFilterSettings(filterSettings)
 
-        #expect(filterSettings == loadedFilterSettings)
+            #expect(controller.onWatchlistProjects() == [enProject, esProject])
+            #expect(controller.offWatchlistProjects() == [.wikidata, .commons])
+        }
     }
 
     @Test
-    func onOffWatchlistProjects() {
-        let controller = WMFWatchlistDataController()
-        let filterSettings = WMFWatchlistFilterSettings(offProjects: [.wikidata, .commons], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
+    func allOffChangeTypes() async {
+        await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
+            let filterSettings = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [.categoryChanges, .pageCreations])
 
-        controller.saveFilterSettings(filterSettings)
+            controller.saveFilterSettings(filterSettings)
 
-        #expect(controller.onWatchlistProjects() == [enProject, esProject])
-        #expect(controller.offWatchlistProjects() == [.wikidata, .commons])
+            #expect(controller.allChangeTypes() == [.pageEdits, .pageCreations, .categoryChanges, .wikidataEdits, .loggedActions])
+            #expect(controller.offChangeTypes() == [.categoryChanges, .pageCreations])
+        }
     }
 
     @Test
-    func allOffChangeTypes() {
-        let controller = WMFWatchlistDataController()
-        let filterSettings = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [.categoryChanges, .pageCreations])
+    func activeFilterCount1() async {
+        await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
+            let filterSettings = WMFWatchlistFilterSettings(offProjects: [.commons, .wikidata], latestRevisions: .notTheLatestRevision, activity: .seenChanges, automatedContributions: .bot, significance: .minorEdits, userRegistration: .registered, offTypes: [])
 
-        controller.saveFilterSettings(filterSettings)
+            controller.saveFilterSettings(filterSettings)
 
-        #expect(controller.allChangeTypes() == [.pageEdits, .pageCreations, .categoryChanges, .wikidataEdits, .loggedActions])
-        #expect(controller.offChangeTypes() == [.categoryChanges, .pageCreations])
+            #expect(controller.activeFilterCount() == 6)
+        }
     }
 
     @Test
-    func activeFilterCount1() {
-        let controller = WMFWatchlistDataController()
-        let filterSettings = WMFWatchlistFilterSettings(offProjects: [.commons, .wikidata], latestRevisions: .notTheLatestRevision, activity: .seenChanges, automatedContributions: .bot, significance: .minorEdits, userRegistration: .registered, offTypes: [])
+    func activeFilterCount2() async {
+        await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
+            let filterSettings = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .latestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [.categoryChanges])
 
-        controller.saveFilterSettings(filterSettings)
+            controller.saveFilterSettings(filterSettings)
 
-        #expect(controller.activeFilterCount() == 6)
+            #expect(controller.activeFilterCount() == 2)
+        }
     }
 
     @Test
-    func activeFilterCount2() {
-        let controller = WMFWatchlistDataController()
-        let filterSettings = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .latestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [.categoryChanges])
+    func activeFilterCount3() async {
+        await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
+            let filterSettings = WMFWatchlistFilterSettings(offProjects: [.commons, .wikidata, enProject], latestRevisions: .latestRevision, activity: .unseenChanges, automatedContributions: .human, significance: .nonMinorEdits, userRegistration: .unregistered, offTypes: [.categoryChanges, .loggedActions, .pageCreations, .pageEdits, .wikidataEdits])
 
-        controller.saveFilterSettings(filterSettings)
+            controller.saveFilterSettings(filterSettings)
 
-        #expect(controller.activeFilterCount() == 2)
-    }
-
-    @Test
-    func activeFilterCount3() {
-        let controller = WMFWatchlistDataController()
-        let filterSettings = WMFWatchlistFilterSettings(offProjects: [.commons, .wikidata, enProject], latestRevisions: .latestRevision, activity: .unseenChanges, automatedContributions: .human, significance: .nonMinorEdits, userRegistration: .unregistered, offTypes: [.categoryChanges, .loggedActions, .pageCreations, .pageEdits, .wikidataEdits])
-
-        controller.saveFilterSettings(filterSettings)
-
-        #expect(controller.activeFilterCount() == 13)
+            #expect(controller.activeFilterCount() == 13)
+        }
     }
 
     @Test
     func fetchWatchlistWithDefaultFilter() async throws {
-        let controller = WMFWatchlistDataController()
+        try await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
 
-        let watchlist = try await controller.fetchWatchlist()
+            let watchlist = try await controller.fetchWatchlist()
 
-        #expect(watchlist.items.count == 82)
-        #expect(watchlist.activeFilterCount == 0)
-        #expect(watchlist.items.filter { $0.project == enProject }.count == 38)
-        #expect(watchlist.items.filter { $0.project == esProject }.count == 13)
-        #expect(watchlist.items.filter { $0.project == .wikidata }.count == 28)
-        #expect(watchlist.items.filter { $0.project == .commons }.count == 3)
+            #expect(watchlist.items.count == 82)
+            #expect(watchlist.activeFilterCount == 0)
+            #expect(watchlist.items.filter { $0.project == enProject }.count == 38)
+            #expect(watchlist.items.filter { $0.project == esProject }.count == 13)
+            #expect(watchlist.items.filter { $0.project == .wikidata }.count == 28)
+            #expect(watchlist.items.filter { $0.project == .commons }.count == 3)
 
-        let first = try #require(watchlist.items.first)
-        #expect(first.title == "Talk:Cat")
-        #expect(first.username == "CatLover 1137")
-        #expect(first.revisionID == 1157699533)
-        #expect(first.oldRevisionID == 1157699360)
-        #expect(first.isAnon == false)
-        #expect(first.isBot == false)
-        #expect(first.commentWikitext == "/* I disagree with the above comment */ Reply")
-        #expect(first.commentHtml == "<span dir=\"auto\"><span class=\"autocomment\"><a href=\"/wiki/Talk:Cat#I_disagree_with_the_above_comment\" title=\"Talk:Cat\">→‎I disagree with the above comment</a>: </span> Reply</span>")
-        #expect(first.byteLength == 4246)
-        #expect(first.oldByteLength == 4071)
-        #expect(first.project == enProject)
-        let expectedDate = try testDate()
-        #expect(first.timestamp == expectedDate)
+            let first = try #require(watchlist.items.first)
+            #expect(first.title == "Talk:Cat")
+            #expect(first.username == "CatLover 1137")
+            #expect(first.revisionID == 1157699533)
+            #expect(first.oldRevisionID == 1157699360)
+            #expect(first.isAnon == false)
+            #expect(first.isBot == false)
+            #expect(first.commentWikitext == "/* I disagree with the above comment */ Reply")
+            #expect(first.commentHtml == "<span dir=\"auto\"><span class=\"autocomment\"><a href=\"/wiki/Talk:Cat#I_disagree_with_the_above_comment\" title=\"Talk:Cat\">→‎I disagree with the above comment</a>: </span> Reply</span>")
+            #expect(first.byteLength == 4246)
+            #expect(first.oldByteLength == 4071)
+            #expect(first.project == enProject)
+            let expectedDate = try testDate()
+            #expect(first.timestamp == expectedDate)
+        }
     }
 
     @Test
     func fetchWatchlistWithProjectFilter() async throws {
-        let controller = WMFWatchlistDataController()
-        let filterSettings = WMFWatchlistFilterSettings(offProjects: [enProject, esProject], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
-        controller.saveFilterSettings(filterSettings)
+        try await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
+            let filterSettings = WMFWatchlistFilterSettings(offProjects: [enProject, esProject], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
+            controller.saveFilterSettings(filterSettings)
 
-        let watchlist = try await controller.fetchWatchlist()
+            let watchlist = try await controller.fetchWatchlist()
 
-        #expect(watchlist.items.count == 31)
-        #expect(watchlist.activeFilterCount == 2)
-        #expect(watchlist.items.filter { $0.project == enProject }.count == 0)
-        #expect(watchlist.items.filter { $0.project == esProject }.count == 0)
-        #expect(watchlist.items.filter { $0.project == .wikidata }.count == 28)
-        #expect(watchlist.items.filter { $0.project == .commons }.count == 3)
+            #expect(watchlist.items.count == 31)
+            #expect(watchlist.activeFilterCount == 2)
+            #expect(watchlist.items.filter { $0.project == enProject }.count == 0)
+            #expect(watchlist.items.filter { $0.project == esProject }.count == 0)
+            #expect(watchlist.items.filter { $0.project == .wikidata }.count == 28)
+            #expect(watchlist.items.filter { $0.project == .commons }.count == 3)
+        }
     }
 
     @Test
     func fetchWatchlistWithAllProjectsPlusOneFilter() async throws {
-        let controller = WMFWatchlistDataController()
-        let filterSettings = WMFWatchlistFilterSettings(offProjects: [enProject, esProject, .wikidata, .commons], latestRevisions: .latestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
-        controller.saveFilterSettings(filterSettings)
+        try await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
+            let filterSettings = WMFWatchlistFilterSettings(offProjects: [enProject, esProject, .wikidata, .commons], latestRevisions: .latestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
+            controller.saveFilterSettings(filterSettings)
 
-        let watchlist = try await controller.fetchWatchlist()
+            let watchlist = try await controller.fetchWatchlist()
 
-        #expect(watchlist.activeFilterCount == 5)
+            #expect(watchlist.activeFilterCount == 5)
+        }
     }
 
     @Test
     func fetchWatchlistWithBotsFilter() async throws {
-        let controller = WMFWatchlistDataController()
-        let filterSettings = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .bot, significance: .all, userRegistration: .all, offTypes: [])
-        controller.saveFilterSettings(filterSettings)
+        try await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
+            let filterSettings = WMFWatchlistFilterSettings(offProjects: [], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .bot, significance: .all, userRegistration: .all, offTypes: [])
+            controller.saveFilterSettings(filterSettings)
 
-        let watchlist = try await controller.fetchWatchlist()
+            let watchlist = try await controller.fetchWatchlist()
 
-        #expect(watchlist.items.count == 2)
-        #expect(watchlist.activeFilterCount == 1)
-        #expect(watchlist.items.filter { $0.isBot == false }.count == 0)
+            #expect(watchlist.items.count == 2)
+            #expect(watchlist.activeFilterCount == 1)
+            #expect(watchlist.items.filter { $0.isBot == false }.count == 0)
+        }
     }
 
     @Test
     func fetchWatchlistWithNoCacheAndNoInternetConnection() async throws {
-        let controller = WMFWatchlistDataController()
-        controller.service = WMFMockServiceNoInternetConnection()
+        try await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
+            controller.service = WMFMockServiceNoInternetConnection()
 
-        let error = try #require(await #expect(throws: WMFDataControllerError.self) {
-            _ = try await controller.fetchWatchlist()
-        })
+            let error = try #require(await #expect(throws: WMFDataControllerError.self) {
+                _ = try await controller.fetchWatchlist()
+            })
 
-        guard case .serviceError(let underlyingError) = error else {
-            Issue.record("Expected serviceError, got \(error)")
-            return
+            guard case .serviceError(let underlyingError) = error else {
+                Issue.record("Expected serviceError, got \(error)")
+                return
+            }
+
+            let nsError = underlyingError as NSError
+            #expect(nsError.domain == NSURLErrorDomain)
+            #expect(nsError.code == NSURLErrorNotConnectedToInternet)
         }
-
-        let nsError = underlyingError as NSError
-        #expect(nsError.domain == NSURLErrorDomain)
-        #expect(nsError.code == NSURLErrorNotConnectedToInternet)
     }
 
     @Test
     func fetchWatchlistWithCacheAndNoInternetConnection() async throws {
-        let controller = WMFWatchlistDataController()
-        let connectedWatchlist = try await controller.fetchWatchlist()
+        try await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
+            let connectedWatchlist = try await controller.fetchWatchlist()
 
-        controller.service = WMFMockServiceNoInternetConnection()
+            controller.service = WMFMockServiceNoInternetConnection()
 
-        let disconnectedAndCachedWatchlist = try await controller.fetchWatchlist()
+            let disconnectedAndCachedWatchlist = try await controller.fetchWatchlist()
 
-        #expect(connectedWatchlist.items.count == 82)
-        #expect(disconnectedAndCachedWatchlist.items.count == 82)
+            #expect(connectedWatchlist.items.count == 82)
+            #expect(disconnectedAndCachedWatchlist.items.count == 82)
+        }
     }
 
     @Test
     func postWatchArticleExpiryNever() async throws {
-        let controller = WMFWatchlistDataController()
+        try await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
 
-        try await controller.watch(title: "Cat", project: enProject, expiry: .never)
+            try await controller.watch(title: "Cat", project: enProject, expiry: .never)
+        }
     }
 
     @Test
     func postWatchArticleExpiryDate() async throws {
-        let controller = WMFWatchlistDataController()
+        try await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
 
-        try await controller.watch(title: "Cat", project: enProject, expiry: .oneMonth)
+            try await controller.watch(title: "Cat", project: enProject, expiry: .oneMonth)
+        }
     }
 
     @Test
     func postUnwatchArticle() async throws {
-        let controller = WMFWatchlistDataController()
+        try await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
 
-        try await controller.unwatch(title: "Cat", project: enProject)
+            try await controller.unwatch(title: "Cat", project: enProject)
+        }
     }
 
     @Test
     func postRollbackArticle() async throws {
-        let controller = WMFWatchlistDataController()
+        try await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
 
-        let result = try await controller.rollback(title: "Cat", project: enProject, username: "Amigao")
+            let result = try await controller.rollback(title: "Cat", project: enProject, username: "Amigao")
 
-        #expect(result.newRevisionID == 573955)
-        #expect(result.oldRevisionID == 573953)
+            #expect(result.newRevisionID == 573955)
+            #expect(result.oldRevisionID == 573953)
+        }
     }
 
     @Test
     func postUndoArticle() async throws {
-        let controller = WMFWatchlistDataController()
+        try await withConfiguredEnvironment {
+            let controller = WMFWatchlistDataController()
 
-        let result = try await controller.undo(title: "Cat", revisionID: 1155871225, summary: "Testing", username: "Amigao", project: enProject)
+            let result = try await controller.undo(title: "Cat", revisionID: 1155871225, summary: "Testing", username: "Amigao", project: enProject)
 
-        #expect(result.newRevisionID == 573989)
-        #expect(result.oldRevisionID == 573988)
+            #expect(result.newRevisionID == 573989)
+            #expect(result.oldRevisionID == 573988)
+        }
+    }
+
+    private func withConfiguredEnvironment<T>(_ operation: () async throws -> T) async rethrows -> T {
+        try await fixture.withGlobalStateLease {
+            await fixture.setUp()
+            WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [
+                WMFLanguage(languageCode: "en", languageVariantCode: nil),
+                WMFLanguage(languageCode: "es", languageVariantCode: nil)
+            ])
+            WMFDataEnvironment.current.mediaWikiService = WMFMockWatchlistMediaWikiService()
+            WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
+            WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
+            await fixture.resetWMFDataTestState()
+
+            do {
+                let result = try await operation()
+                await fixture.tearDown()
+                return result
+            } catch {
+                await fixture.tearDown()
+                throw error
+            }
+        }
     }
 
     private func testDate() throws -> Date {

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -707,6 +707,7 @@
 		67A0699F2D417C4A00290D70 /* UIViewController+ProfileButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A0699D2D417C4000290D70 /* UIViewController+ProfileButton.swift */; };
 		67A069A02D417C4A00290D70 /* UIViewController+ProfileButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A0699D2D417C4000290D70 /* UIViewController+ProfileButton.swift */; };
 		67A18A162FAD100100000001 /* WMFComponents in Frameworks */ = {isa = PBXBuildFile; productRef = 67A18A172FAD100100000001 /* WMFComponents */; };
+		7D8C00212FCF000000000021 /* WMFDataTestFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8C00202FCF000000000020 /* WMFDataTestFixture.swift */; };
 		67A417DE2FBFD9E100C0DE01 /* ArticleImageGalleryUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A417DF2FBFD9E100C0DE01 /* ArticleImageGalleryUITests.swift */; };
 		67A486872BEAE0D6001D3FF9 /* WMFAnnouncementsContentSource+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A486862BEAE0D6001D3FF9 /* WMFAnnouncementsContentSource+Extensions.swift */; };
 		67A486A42BEBF3C5001D3FF9 /* MagicWord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A486A32BEBF3C5001D3FF9 /* MagicWord.swift */; };
@@ -3159,6 +3160,7 @@
 		67146033243B8B4F008CE885 /* AnnouncementType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementType.swift; sourceTree = "<group>"; };
 		6714D6CA245A2B9700CE5A4A /* ArticleCacheReadingManualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCacheReadingManualTests.swift; sourceTree = "<group>"; };
 		6714D6CC245A2C1D00CE5A4A /* ArticleTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleTestHelpers.swift; sourceTree = "<group>"; };
+		7D8C00202FCF000000000020 /* WMFDataTestFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WMFDataTestFixture.swift; path = WMFData/Sources/WMFDataTestSupport/WMFDataTestFixture.swift; sourceTree = SOURCE_ROOT; };
 		67165C5F2ECFD3E60078098D /* DatabasePopulationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabasePopulationViewModel.swift; sourceTree = "<group>"; };
 		67165C632ECFD4030078098D /* DatabasePopulationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabasePopulationView.swift; sourceTree = "<group>"; };
 		671AC2552226FB9B005B37F8 /* ReadingThemesControlsProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingThemesControlsProtocols.swift; sourceTree = "<group>"; };
@@ -7204,6 +7206,7 @@
 				BC62AE611C58FC810064C589 /* NSProcessInfo+WMFTestEnvironment.m */,
 				BCD320081C6EC6BC00317D08 /* NSTimeZone+WMFTestingUtils.h */,
 				BCD320091C6EC6BC00317D08 /* NSTimeZone+WMFTestingUtils.m */,
+				7D8C00202FCF000000000020 /* WMFDataTestFixture.swift */,
 				6714D6CC245A2C1D00CE5A4A /* ArticleTestHelpers.swift */,
 			);
 			name = Utilities;
@@ -9430,6 +9433,7 @@
 				67C6F77327E2E78800B9C864 /* NotificationsCenterCellViewModelWikidataConnectionTests.swift in Sources */,
 				67C6F77627E2E78800B9C864 /* NotificationsCenterCellViewModelMentionTests.swift in Sources */,
 				B0E809351C0D1A2F0065EBC0 /* WMFGeometryTests.m in Sources */,
+				7D8C00212FCF000000000021 /* WMFDataTestFixture.swift in Sources */,
 				6714D6CD245A2C1D00CE5A4A /* ArticleTestHelpers.swift in Sources */,
 				B0E8090B1C0D18D90065EBC0 /* NSString+FormattedAttributedStringTests.m in Sources */,
 				D8396D1B22CF7052005625D8 /* WMFArticleTests.swift in Sources */,

--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -101,6 +101,7 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
     private var router: ViewControllerRouter?
     
     private var isUpdatingDefaultTab: Bool = false
+    private var rootTabAccessibilityIdentifiers: [String?] = []
 
     // MARK: - init / deinit
     
@@ -373,11 +374,15 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
         let nav3 = rootNavigationController(with: savedViewController)
         let nav4 = rootNavigationController(with: activityTabViewController)
         let nav5 = rootNavigationController(with: searchTabViewController)
+        let rootNavigationControllers = [nav1, nav2, nav3, nav4, nav5]
+        rootTabAccessibilityIdentifiers = rootNavigationControllers.map { nav in
+            nav.viewControllers.first?.tabBarItem.accessibilityIdentifier
+        }
 
         if #available(iOS 18.0, *) {
             // A magic fix for https://phabricator.wikimedia.org/T403896
             var potentialTabs: [UITab] = []
-            for nav in [nav1, nav2, nav3, nav4, nav5] {
+            for nav in rootNavigationControllers {
                 guard let rootVC = nav.viewControllers.first,
                       let title = rootVC.title,
                       let image = rootVC.tabBarItem.image else { continue }
@@ -396,6 +401,7 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
 
         // This should be called all the time for backward compatibility
         setViewControllers([nav1, nav2, nav3, nav4, nav5], animated: false)
+        applyRootTabAccessibilityIdentifiers()
 
         updateUserInterfaceStyleOfNavigationControllersForCurrentTheme()
 
@@ -412,6 +418,12 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
         let navigationController = WMFComponentNavigationController(rootViewController: rootViewController, modalPresentationStyle: .overFullScreen, customBarBackgroundColor: nil)
         navigationController.delegate = self
         return navigationController
+    }
+
+    private func applyRootTabAccessibilityIdentifiers() {
+        for (tabBarItem, identifier) in zip(tabBar.items ?? [], rootTabAccessibilityIdentifiers) {
+            tabBarItem.accessibilityIdentifier = identifier
+        }
     }
 
     private func setupReadingListsHelpers() {

--- a/WikipediaUITests/ArticleControlsUITests.swift
+++ b/WikipediaUITests/ArticleControlsUITests.swift
@@ -184,7 +184,6 @@ final class ArticleControlsUITests: XCTestCase {
             .explore
             .assertVisible(file: file, line: line)
             .openFirstArticle(file: file, line: line)
-            .assertLoadedArticle(named: articleControlsFixture.primaryArticleTitle, file: file, line: line)
     }
 
     private func openArticle(file: StaticString = #filePath, line: UInt = #line) -> ArticleRobot {

--- a/WikipediaUITests/ExploreUITests.swift
+++ b/WikipediaUITests/ExploreUITests.swift
@@ -40,6 +40,13 @@ final class ExploreUITests: XCTestCase {
             .tapRootTab(.search)
     }
 
+    func testExploreBottomTabsExposeAccessibilityIdentifiers() throws {
+        launchWikipediaAppRobot(onboardingState: .completed)
+            .explore
+            .assertVisible()
+            .assertRootTabAccessibilityIdentifiersSurfaced()
+    }
+
     func testExploreSearchShowsResult() throws {
         let searchTerm = exploreSearchTerm
 

--- a/WikipediaUITests/Robots/ArticleRobot.swift
+++ b/WikipediaUITests/Robots/ArticleRobot.swift
@@ -331,10 +331,10 @@ extension ArticleRobot {
 extension ArticleRobot {
     @discardableResult
     func openLeadImageGallery(file: StaticString = #filePath, line: UInt = #line) -> ImageGalleryRobot {
-        base.assertExists(leadImage, timeout: 60, description: "article lead image", file: file, line: line)
+        base.assertVisible(leadImage, timeout: 60, description: "article lead image", file: file, line: line)
         base.tapCenter(of: leadImage, file: file, line: line)
         return ImageGalleryRobot(base: base)
-            .assertVisible(file: file, line: line)
+            .assertVisible(timeout: 60, file: file, line: line)
     }
 
     @discardableResult

--- a/WikipediaUITests/Robots/ExploreRobot.swift
+++ b/WikipediaUITests/Robots/ExploreRobot.swift
@@ -130,13 +130,18 @@ extension ExploreRobot {
 
         switch tab {
         case .search:
-            base.assertExists(
-                searchView,
-                timeout: 15,
-                description: "Search view",
-                file: file,
-                line: line
-            )
+            if !searchView.waitForExistence(timeout: 15) {
+                let retryButton = rootTabButton(for: tab)
+                base.assertVisible(retryButton, timeout: 5, description: tab.description, file: file, line: line)
+                base.tapCenter(of: retryButton, file: file, line: line)
+                base.assertExists(
+                    searchView,
+                    timeout: 15,
+                    description: "Search view",
+                    file: file,
+                    line: line
+                )
+            }
         case .places:
             base.assertSelected(button, timeout: 10, description: tab.description, file: file, line: line)
             dismissPlacesLocationPromptIfNeeded(file: file, line: line)

--- a/WikipediaUITests/Robots/ExploreRobot.swift
+++ b/WikipediaUITests/Robots/ExploreRobot.swift
@@ -15,7 +15,7 @@ struct ExploreRobot: ScreenshotCapturingRobot {
 // MARK: - Root tabs
 
 extension ExploreRobot {
-    enum RootTab {
+    enum RootTab: CaseIterable {
         case activity
         case explore
         case places
@@ -52,20 +52,6 @@ extension ExploreRobot {
             }
         }
 
-        var index: Int {
-            switch self {
-            case .explore:
-                return 0
-            case .places:
-                return 1
-            case .saved:
-                return 2
-            case .activity:
-                return 3
-            case .search:
-                return 4
-            }
-        }
     }
 }
 
@@ -79,6 +65,20 @@ extension ExploreRobot {
             file: file,
             line: line
         )
+        return self
+    }
+
+    @discardableResult
+    func assertRootTabAccessibilityIdentifiersSurfaced(file: StaticString = #filePath, line: UInt = #line) -> Self {
+        for tab in RootTab.allCases {
+            base.assertExists(
+                base.app.buttons[tab.accessibilityIdentifier],
+                timeout: 15,
+                description: "\(tab.description) accessibility identifier",
+                file: file,
+                line: line
+            )
+        }
         return self
     }
 }
@@ -105,12 +105,7 @@ extension ExploreRobot {
 
     @discardableResult
     func openSearch(file: StaticString = #filePath, line: UInt = #line) -> SearchRobot {
-        let identifiedButton = rootTabButton(for: .search)
-        let searchButton = identifiedButton.waitForExistence(timeout: 5)
-            ? identifiedButton
-            : searchTabButtonFallback()
-        base.assertVisible(searchButton, timeout: 15, description: "Search tab button", file: file, line: line)
-        searchButton.tap()
+        tapRootTab(.search, file: file, line: line)
         return SearchRobot(base: base, configuration: configuration).assertVisible(file: file, line: line)
     }
 
@@ -129,26 +124,26 @@ extension ExploreRobot {
 
     @discardableResult
     func tapRootTab(_ tab: RootTab, file: StaticString = #filePath, line: UInt = #line) -> Self {
-        let identifiedButton = rootTabButton(for: tab)
-        let button = identifiedButton.waitForExistence(timeout: 5)
-            ? identifiedButton
-            : base.app.tabBars.buttons.element(boundBy: tab.index)
+        let button = rootTabButton(for: tab)
         base.assertVisible(button, timeout: 15, description: tab.description, file: file, line: line)
-        button.tap()
-        if tab == .search {
+        base.tapCenter(of: button, file: file, line: line)
+
+        switch tab {
+        case .search:
             base.assertExists(
-                base.app.otherElements[AccessibilityIdentifiers.Search.view],
+                searchView,
                 timeout: 15,
                 description: "Search view",
                 file: file,
                 line: line
             )
-        } else {
+        case .places:
             base.assertSelected(button, timeout: 10, description: tab.description, file: file, line: line)
-            if tab == .places {
-                dismissPlacesLocationPromptIfNeeded(file: file, line: line)
-            }
+            dismissPlacesLocationPromptIfNeeded(file: file, line: line)
+        default:
+            base.assertSelected(button, timeout: 10, description: tab.description, file: file, line: line)
         }
+
         return self
     }
 }
@@ -160,8 +155,8 @@ private extension ExploreRobot {
         base.app.buttons.matching(identifier: tab.accessibilityIdentifier).firstMatch
     }
 
-    func searchTabButtonFallback() -> XCUIElement {
-        base.app.tabBars.buttons.element(boundBy: 4)
+    var searchView: XCUIElement {
+        base.app.otherElements[AccessibilityIdentifiers.Search.view]
     }
 
     func dismissPlacesLocationPromptIfNeeded(file: StaticString = #filePath, line: UInt = #line) {

--- a/WikipediaUITests/Robots/ImageGalleryRobot.swift
+++ b/WikipediaUITests/Robots/ImageGalleryRobot.swift
@@ -10,10 +10,10 @@ struct ImageGalleryRobot: ScreenshotCapturingRobot {
 
 extension ImageGalleryRobot {
     @discardableResult
-    func assertVisible(file: StaticString = #filePath, line: UInt = #line) -> Self {
+    func assertVisible(timeout: TimeInterval = 15, file: StaticString = #filePath, line: UInt = #line) -> Self {
         base.assertExists(
             base.app.otherElements[AccessibilityIdentifiers.ImageGallery.view],
-            timeout: 15,
+            timeout: timeout,
             file: file,
             line: line
         )

--- a/WikipediaUnitTests/ArticleTestHelpers.swift
+++ b/WikipediaUnitTests/ArticleTestHelpers.swift
@@ -88,9 +88,24 @@ class ArticleTestHelpers {
     static func tearDownNetworkFixtures() {
         UserDefaults.standard.removeObject(forKey: TestNetworkFixtureInterceptor.profileKey)
         TestNetworkFixtureHTTPClient.resetFixtures()
+        tearDown()
+    }
+
+    static func tearDown() {
+        resetSharedState()
+    }
+
+    private static func resetSharedState() {
+        fixtureData = nil
+        cacheController = nil
+        dataStore?.session.teardown()
+        dataStore?.removeFolderAtBasePath()
+        dataStore = nil
+        URLCache.shared.removeAllCachedResponses()
     }
 
     static func setup(completion: @escaping () -> Void) {
+        resetSharedState()
         MWKDataStore.createTemporaryDataStore(completion: { dataStore in
             
             let tempPath = WMFRandomTemporaryPath()!

--- a/WikipediaUnitTests/Code/ArticlePeekPreviewViewControllerTests.swift
+++ b/WikipediaUnitTests/Code/ArticlePeekPreviewViewControllerTests.swift
@@ -5,23 +5,22 @@ import XCTest
 
 class ArticlePeekPreviewViewControllerTests: XCTestCase {
 
-    private var dataStore: MWKDataStore!
-    private var articleTabsCoreDataStore: WMFCoreDataStore?
+    private let fixture = WMFDataTestFixture()
 
-    override func setUp(completion: @escaping (Error?) -> Void) {
-        MWKDataStore.createTemporaryDataStore { dataStore in
-            self.dataStore = dataStore
-            completion(nil)
+    override func setUp() async throws {
+        try await super.setUp()
+        await fixture.setUp()
+        await withCheckedContinuation { continuation in
+            ArticleTestHelpers.setup {
+                continuation.resume()
+            }
         }
     }
 
-    override func tearDown() {
-        super.tearDown()
-        WMFArticleTabsDataController.shared.backgroundContext = nil
-        WMFDataEnvironment.current.coreDataStore = nil
-        articleTabsCoreDataStore = nil
-        dataStore.removeFolderAtBasePath()
-        dataStore = nil
+    override func tearDown() async throws {
+        ArticleTestHelpers.tearDown()
+        await fixture.tearDown()
+        try await super.tearDown()
     }
 
     func testContextMenuItemsIncludeExpectedArticleActions() throws {
@@ -93,6 +92,7 @@ class ArticlePeekPreviewViewControllerTests: XCTestCase {
 
     private func makePreviewController() throws -> (controller: ArticlePeekPreviewViewController, delegate: ArticlePreviewingDelegateMock, articleURL: URL) {
         let articleURL = try XCTUnwrap(URL(string: "https://en.wikipedia.org/wiki/Canis"))
+        let dataStore = try XCTUnwrap(ArticleTestHelpers.dataStore)
         let article = try XCTUnwrap(dataStore.fetchOrCreateArticle(with: articleURL))
         let delegate = ArticlePreviewingDelegateMock()
         let controller = ArticlePeekPreviewViewController(
@@ -110,13 +110,11 @@ class ArticlePeekPreviewViewControllerTests: XCTestCase {
     }
 
     private func prepareArticleTabsDataController() async throws -> WMFArticleTabsDataController {
-        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
-        let coreDataStore = try await WMFCoreDataStore(appContainerURL: temporaryDirectory)
-        articleTabsCoreDataStore = coreDataStore
+        let coreDataStore = try await fixture.makeTemporaryCoreDataStore()
 
         WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [WMFLanguage(languageCode: "en", languageVariantCode: nil)])
         WMFDataEnvironment.current.coreDataStore = coreDataStore
+        await fixture.resetWMFDataTestState()
 
         let articleTabsDataController = WMFArticleTabsDataController.shared
         articleTabsDataController.backgroundContext = nil
@@ -149,4 +147,3 @@ private enum ArticleContextMenuTitle {
     static let saveForLater = "Save for later"
     static let share = "Share\u{2026}"
 }
-

--- a/WikipediaUnitTests/Code/Notifications Tests/NotificationsCenterViewModelTests.swift
+++ b/WikipediaUnitTests/Code/Notifications Tests/NotificationsCenterViewModelTests.swift
@@ -22,6 +22,7 @@ class NotificationsCenterViewModelTests: XCTestCase {
 
     private var data: Data!
     private var networkModels: [RemoteNotificationsAPIController.NotificationsResult.Notification]!
+    private var previousDefaultTimeZone: TimeZone?
 
     var dataStore: MWKDataStore!
 
@@ -40,6 +41,7 @@ class NotificationsCenterViewModelTests: XCTestCase {
             self.dataStore = dataStore
             
             if let gmtTimeZone = TimeZone(abbreviation: "GMT") {
+                self.previousDefaultTimeZone = NSTimeZone.default
                 NSTimeZone.default = gmtTimeZone
             }
             
@@ -86,7 +88,13 @@ class NotificationsCenterViewModelTests: XCTestCase {
     }
     
     override func tearDown(completion: @escaping (Error?) -> Void) {
-        NSTimeZone.resetSystemTimeZone()
+        if let previousDefaultTimeZone {
+            NSTimeZone.default = previousDefaultTimeZone
+        } else {
+            NSTimeZone.resetSystemTimeZone()
+        }
+
+        previousDefaultTimeZone = nil
         completion(nil)
     }
     

--- a/WikipediaUnitTests/Code/TestNetworkFixtures/TestNetworkFixtureInterceptorTests.swift
+++ b/WikipediaUnitTests/Code/TestNetworkFixtures/TestNetworkFixtureInterceptorTests.swift
@@ -4,9 +4,14 @@ import Testing
 import WMFData
 
 @Suite(.serialized)
-struct TestNetworkFixtureInterceptorTests {
-    init() {
+final class TestNetworkFixtureInterceptorTests {
+
+    private let fixture = WMFDataTestFixture()
+
+    init() async {
+        await fixture.setUp()
         resetSharedFixtureState()
+        await fixture.resetWMFDataTestState()
     }
 
     @Test

--- a/WikipediaUnitTests/Manual Tests/ArticleCacheReadingManualTests.swift
+++ b/WikipediaUnitTests/Manual Tests/ArticleCacheReadingManualTests.swift
@@ -4,7 +4,7 @@ import Testing
 @testable import WMF
 
 @MainActor
-struct ArticleCacheReadingManualTests {
+final class ArticleCacheReadingManualTests {
     
     init() async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
@@ -14,6 +14,10 @@ struct ArticleCacheReadingManualTests {
         }
 
         ArticleTestHelpers.pullDataFromFixtures(inBundle: Bundle(for: ArticleCacheReadingManualTestBundleToken.self))
+    }
+
+    deinit {
+        ArticleTestHelpers.tearDown()
     }
 
     private func loadResponses(

--- a/scripts/lint-wmfdata-test-fixtures.sh
+++ b/scripts/lint-wmfdata-test-fixtures.sh
@@ -42,20 +42,14 @@ while IFS= read -r file; do
       ;;
   esac
 
-  uses_xctest_fixture=0
-  if grep -q "WMFDataEnvironmentResettingTestCase" "$file" &&
-    grep -q "try await super.setUp()" "$file"; then
-    uses_xctest_fixture=1
-  fi
-
-  uses_swift_testing_fixture=0
+  uses_fixture=0
   if grep -q "WMFDataTestFixture" "$file" &&
     grep -Eq "await[[:space:]]+[[:alnum:]_]+\\.setUp\\(\\)" "$file"; then
-    uses_swift_testing_fixture=1
+    uses_fixture=1
   fi
 
-  if [ "$uses_xctest_fixture" -ne 1 ] && [ "$uses_swift_testing_fixture" -ne 1 ]; then
-    echo "error: $file mutates WMFDataEnvironment.current but does not use WMFDataEnvironmentResettingTestCase or WMFDataTestFixture setup" >&2
+  if [ "$uses_fixture" -ne 1 ]; then
+    echo "error: $file mutates WMFDataEnvironment.current but does not use WMFDataTestFixture setup" >&2
     failed=1
   fi
 

--- a/scripts/lint-wmfdata-test-fixtures.sh
+++ b/scripts/lint-wmfdata-test-fixtures.sh
@@ -1,16 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if ! command -v ast-grep >/dev/null 2>&1; then
-  echo "error: ast-grep is required to lint WMFData test fixture usage" >&2
-  exit 1
-fi
-
-if ! command -v ruby >/dev/null 2>&1; then
-  echo "error: ruby is required to parse ast-grep JSON output" >&2
-  exit 1
-fi
-
 paths=("$@")
 if [ "${#paths[@]}" -eq 0 ]; then
   paths=(
@@ -23,13 +13,13 @@ fi
 matches_file="$(mktemp)"
 trap 'rm -f "$matches_file"' EXIT
 
-ast-grep run \
-  --lang swift \
-  --pattern 'WMFDataEnvironment.current.$PROPERTY = $VALUE' \
-  --json=stream \
-  "${paths[@]}" \
-  | ruby -rjson -ne 'puts JSON.parse($_).fetch("file")' \
-  | sort -u > "$matches_file"
+assignment_pattern='WMFDataEnvironment\.current\.[[:alnum:]_]+[[:space:]]*=[[:space:]]*[^=]'
+
+if command -v rg >/dev/null 2>&1; then
+  rg -l --glob '*.swift' "$assignment_pattern" "${paths[@]}" || true
+else
+  grep -RIlE --include='*.swift' "$assignment_pattern" "${paths[@]}" || true
+fi | sort -u > "$matches_file"
 
 failed=0
 

--- a/scripts/lint-wmfdata-test-fixtures.sh
+++ b/scripts/lint-wmfdata-test-fixtures.sh
@@ -34,7 +34,8 @@ while IFS= read -r file; do
 
   uses_fixture=0
   if grep -q "WMFDataTestFixture" "$file" &&
-    grep -Eq "await[[:space:]]+[[:alnum:]_]+\\.setUp\\(\\)" "$file"; then
+    (grep -Eq "await[[:space:]]+[[:alnum:]_]+\\.setUp\\(\\)" "$file" ||
+      grep -Eq "[[:alnum:]_]+\\.withConfiguredEnvironment\\(" "$file"); then
     uses_fixture=1
   fi
 
@@ -43,7 +44,8 @@ while IFS= read -r file; do
     failed=1
   fi
 
-  if ! grep -q "resetWMFDataTestState()" "$file"; then
+  if ! grep -q "resetWMFDataTestState()" "$file" &&
+    ! grep -Eq "[[:alnum:]_]+\\.withConfiguredEnvironment\\(" "$file"; then
     echo "error: $file mutates WMFDataEnvironment.current but does not call resetWMFDataTestState()" >&2
     failed=1
   fi

--- a/scripts/lint-wmfdata-test-fixtures.sh
+++ b/scripts/lint-wmfdata-test-fixtures.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v ast-grep >/dev/null 2>&1; then
+  echo "error: ast-grep is required to lint WMFData test fixture usage" >&2
+  exit 1
+fi
+
+if ! command -v ruby >/dev/null 2>&1; then
+  echo "error: ruby is required to parse ast-grep JSON output" >&2
+  exit 1
+fi
+
+paths=("$@")
+if [ "${#paths[@]}" -eq 0 ]; then
+  paths=(
+    "WMFData/Tests/WMFDataTests"
+    "WMFComponents/Tests/WMFComponentsTests"
+    "WikipediaUnitTests"
+  )
+fi
+
+matches_file="$(mktemp)"
+trap 'rm -f "$matches_file"' EXIT
+
+ast-grep run \
+  --lang swift \
+  --pattern 'WMFDataEnvironment.current.$PROPERTY = $VALUE' \
+  --json=stream \
+  "${paths[@]}" \
+  | ruby -rjson -ne 'puts JSON.parse($_).fetch("file")' \
+  | sort -u > "$matches_file"
+
+failed=0
+
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+
+  case "$file" in
+    *WMFDataTestFixture.swift|WikipediaUnitTests/ArticleTestHelpers.swift)
+      continue
+      ;;
+  esac
+
+  uses_xctest_fixture=0
+  if grep -q "WMFDataEnvironmentResettingTestCase" "$file" &&
+    grep -q "try await super.setUp()" "$file"; then
+    uses_xctest_fixture=1
+  fi
+
+  uses_swift_testing_fixture=0
+  if grep -q "WMFDataTestFixture" "$file" &&
+    grep -Eq "await[[:space:]]+[[:alnum:]_]+\\.setUp\\(\\)" "$file"; then
+    uses_swift_testing_fixture=1
+  fi
+
+  if [ "$uses_xctest_fixture" -ne 1 ] && [ "$uses_swift_testing_fixture" -ne 1 ]; then
+    echo "error: $file mutates WMFDataEnvironment.current but does not use WMFDataEnvironmentResettingTestCase or WMFDataTestFixture setup" >&2
+    failed=1
+  fi
+
+  if ! grep -q "resetWMFDataTestState()" "$file"; then
+    echo "error: $file mutates WMFDataEnvironment.current but does not call resetWMFDataTestState()" >&2
+    failed=1
+  fi
+done < "$matches_file"
+
+if [ "$failed" -ne 0 ]; then
+  exit "$failed"
+fi
+
+echo "WMFData environment-mutating tests use reset fixtures."


### PR DESCRIPTION
**Phabricator: T269478** 

### Notes
* Consolidate Singleton/global environment mutation setup/reset logic into `WMFDataTestFixture` where possible
* Add lint that checks to make sure global environment mutation is reset correctly

### Test Steps
N/A

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
N/A