### PR TITLE
T269478: Remove extra assert to fix non-english lang tests

### DIFF
--- a/WikipediaUITests/ArticleControlsUITests.swift
+++ b/WikipediaUITests/ArticleControlsUITests.swift
@@ -184,7 +184,6 @@ final class ArticleControlsUITests: XCTestCase {
             .explore
             .assertVisible(file: file, line: line)
             .openFirstArticle(file: file, line: line)
-            .assertLoadedArticle(named: articleControlsFixture.primaryArticleTitle, file: file, line: line)
     }
 
     private func openArticle(file: StaticString = #filePath, line: UInt = #line) -> ArticleRobot {


### PR DESCRIPTION
**Phabricator: T269478** 

### Notes
* Remove extra assert to fix non-english lang tests

### Test Steps
N/A

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
N/A