### PR TITLE
Run WMFData tests serially to fix global-environment race

### DIFF
--- a/Test Plans/WMFData.xctestplan
+++ b/Test Plans/WMFData.xctestplan
@@ -21,6 +21,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : false,
       "target" : {
         "containerPath" : "container:",
         "identifier" : "WMFDataTests",


### PR DESCRIPTION
## Problem
Several `WMFDataTests` suites mutate the shared `WMFDataEnvironment.current` singleton (`mediaWikiService` / `basicService` / stores) in their `setUp`/`init`. Swift Testing runs suites **in parallel by default**, so concurrently-running suites can overwrite each other's mocked services mid-test. This produces intermittent failures — e.g. `WMFWatchlistDataControllerTests.fetchWatchlistWithProjectFilter` failing with `.serviceError(unableToPullData)` when another suite swapped the global service out from under it.

## Why the obvious fixes don't work
- **`@Suite(.serialized)` per suite** (already present on several suites) only serializes tests *within* one suite — separate suites still run in parallel relative to one another. This is a **cross-suite** race.
- **`setUp`/`tearDown` snapshot-restore** can't help either: concurrent suites stomp the shared global regardless of restore.
- The target also **mixes** Swift Testing structs and XCTest classes, so a single nested `.serialized` base suite would require converting the XCTest classes — large, risky churn.

## Fix
Disable parallel execution for the whole `WMFDataTests` target in its test plan (`"parallelizable": false`). This is the documented, framework-correct way to serialize an entire target (confirmed by Swift Testing maintainers that the test-plan parallelization setting gates Swift Testing, not just XCTest).

## Verification
- Instrumented the run output: max concurrent Swift Testing tests drops from **7 → 1** (fully serial).
- Full WMFData suite passes green across repeated runs.
- The suite is small, so the serial-execution time cost is negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)