### PR TITLE
Run WMFComponents tests serially to fix global-environment race

### DIFF
--- a/Test Plans/WMFComponents.xctestplan
+++ b/Test Plans/WMFComponents.xctestplan
@@ -16,6 +16,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : false,
       "target" : {
         "containerPath" : "container:",
         "identifier" : "WMFComponentsTests",


### PR DESCRIPTION
Companion to the WMFData serialization fix (#5965), applying the same one-line change to the WMFComponents test target.

## Problem
Several `WMFComponentsTests` suites mutate the shared `WMFDataEnvironment.current` singleton (mocked services/stores): `WMFImageRecommendationsViewModelTests`, `WMFWatchlistFilterViewModelTests`, `WMFDonateViewModelTests`, `WMFWhichCameFirstViewModelTests`. Swift Testing runs suites **in parallel by default**, so concurrently-running suites can overwrite each other's global state mid-test — the same cross-suite race fixed for WMFData in #5965.

## Fix
Disable parallel execution for the `WMFComponentsTests` target in its test plan (`"parallelizable": false`). Per-suite `.serialized` cannot fix a cross-suite race; the test-plan toggle is the documented way to serialize an entire target (and it gates Swift Testing, not just XCTest).

## Verification
- Instrumented the run output: max concurrent Swift Testing tests drops from **8 → 1** (fully serial).
- Full WMFComponents suite passes green across repeated runs.
- Negligible time cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)