### PR TITLE
Skill to wrap a feature with a setting in the developer menu

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -522,3 +522,7 @@ All new code must comply with Swift 6 strict concurrency. The following rules ap
 
 - When interfacing with legacy Objective-C or non-`Sendable` types, isolate the interaction inside `@MainActor` blocks or within an actor boundary.
 - Do not widen the surface area of `@preconcurrency` imports. Confine them to the specific file or extension where the legacy type is used.
+
+### Skills
+
+@.github/skills/ios-dev-setting/SKILL.md

--- a/.github/skills/ios-dev-setting/SKILL.md
+++ b/.github/skills/ios-dev-setting/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: ios-dev-setting
+description: Add a new boolean developer setting toggle to the Wikipedia iOS app. Use when the user asks to "add a developer setting", "add a dev setting", "add a debug toggle", or "add a feature flag" to the iOS app.
+version: 0.1.0
+---
+
+# Add an iOS Developer Setting
+
+Adds a boolean toggle to the Developer Settings panel. Requires four edits across three packages.
+
+## Before starting
+
+Run `git log -1 --stat` to inspect the most recent commit. If it introduced a discrete feature or behavior change, ask the user:
+
+> "Should I gate the feature from the last commit (`<commit subject>`) behind this developer setting?"
+
+If yes, identify the call site automatically from the diff (`git show HEAD`) rather than asking the user for it.
+
+If no (or if the last commit is unrelated), ask the user for these before starting:
+- **camelCase name** — e.g. `allowGestureZoomArticleWebview`
+- **kebab-case UserDefaults key** — e.g. `allow-gesture-zoom-article-webview`
+- **UI label** — e.g. `"Allow pinch to zoom when reading articles"`
+- **Call site** — which file and what behavior to gate
+
+## 1. `WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift`
+
+Add a case to `WMFUserDefaultsKey`:
+
+```swift
+case myNewSetting = "my-new-setting"
+```
+
+## 2. `WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift`
+
+Add a `public var` property (default `false`):
+
+```swift
+public var myNewSetting: Bool {
+    get { (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.myNewSetting.rawValue)) ?? false }
+    set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.myNewSetting.rawValue, value: newValue) }
+}
+```
+
+## 3. `WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift`
+
+In `setupFormViewModel()`, instantiate and add to the items array:
+
+```swift
+let myNewSetting = WMFFormItemSelectViewModel(title: "Human-readable label", isSelected: WMFDeveloperSettingsDataController.shared.myNewSetting)
+```
+
+In `setupSubscribers()`, wire via Combine:
+
+```swift
+myNewSetting.$isSelected
+    .sink { isSelected in WMFDeveloperSettingsDataController.shared.myNewSetting = isSelected }
+    .store(in: &subscribers)
+```
+
+## 4. Call site
+
+```swift
+if WMFDeveloperSettingsDataController.shared.myNewSetting {
+    // enable behavior
+}
+```
+
+## Verify
+
+Build in this order (see `CLAUDE.md` for full build commands):
+
+```bash
+xcodebuild -scheme WMFData ...
+xcodebuild -scheme WMFComponents ...
+xcodebuild -scheme Wikipedia ...
+```
+
+## Reference
+
+Commit `1b4617f947a6772cdf77d5297ff9305f337cf116` is a complete example (`allowGestureZoomArticleWebview` gating `ignoresViewportScaleLimits` in `ArticleViewController.swift`).


### PR DESCRIPTION
**Phabricator:** 

This PR is a developer tool and does not add any user facing feature to the app. Please let me know if I should create a Phabricator for this.

### Notes
* This adds a skill that allows AI coding tools to wrap a feature with a developer setting menu.
* By default, the most recent commit is interpreted as the feature to wrap but there are instructions to allow the developer to provide more details when using it
* I have only tested this with Claude Code. 

### Test Steps

1. Develop a feature
2. Commit the feature locally
3. In Claude Code, ask to add a feature flag.
4. Claude Code should pick up the newest commit as a feature and go through the various steps to create a developer settings flag, add the toggle in the developer setting menu and wrap the feature with a conditional.

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
