### PR TITLE
T269478: Fix full UI test plan prebuilt run invocation

### DIFF
--- a/.github/workflows/run_full_ui_test_plan.yml
+++ b/.github/workflows/run_full_ui_test_plan.yml
@@ -159,7 +159,6 @@ jobs:
         run: |
           echo "Running WikipediaUITests ${UI_TEST_CONFIGURATION} on ${SIMULATOR_NAME} iOS ${IOS_VERSION} with Xcode ${XCODE_VERSION}"
           xcodebuild test-without-building \
-            -scheme WikipediaUITests \
             -only-test-configuration "${UI_TEST_CONFIGURATION}" \
             -destination "${{ steps.simulator.outputs.destination }}" \
             -testProductsPath "WikipediaUITests.xctestproducts" \


### PR DESCRIPTION
**Phabricator: T269478**

### Notes
* Remove the remaining `-scheme WikipediaUITests` selector from the full UI test plan `test-without-building` step.
* `-testProductsPath` materializes an `.xctestrun`; Xcode rejects combining that with `-scheme`, `-project`, or `-workspace`.

### Test Steps
N/A

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
N/A