### PR TITLE
Feature/places coordinate deeplink

### DIFF
--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.m
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.m
@@ -62,15 +62,32 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
 + (instancetype)wmf_placesActivityWithURL:(NSURL *)activityURL {
     NSURLComponents *components = [NSURLComponents componentsWithURL:activityURL resolvingAgainstBaseURL:NO];
     NSURL *articleURL = nil;
+    NSString *latString = nil, *lonString = nil, *placeName = nil;
     for (NSURLQueryItem *item in components.queryItems) {
         if ([item.name isEqualToString:@"WMFArticleURL"]) {
             NSString *articleURLString = item.value;
             articleURL = [NSURL URLWithString:articleURLString];
             break;
+        } else if ([item.name isEqualToString:@"lat"]) {
+            latString = item.value;
+        } else if ([item.name isEqualToString:@"lon"] || [item.name isEqualToString:@"lng"] || [item.name isEqualToString:@"long"]) {
+            lonString = item.value;
+        } else if ([item.name isEqualToString:@"name"] || [item.name isEqualToString:@"title"]) {
+            placeName = item.value;
         }
     }
     NSUserActivity *activity = [self wmf_pageActivityWithName:@"Places"];
     activity.webpageURL = articleURL;
+    
+    if (latString.length > 0 && lonString.length > 0) {
+        NSMutableDictionary *userInfo = [activity.userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
+        userInfo[@"WMFPlacesLatitude"] = latString;
+        userInfo[@"WMFPlacesLongitude"] = lonString;
+        if (placeName.length > 0) {
+            userInfo[@"WMFPlacesName"] = placeName;
+        }
+        activity.userInfo = userInfo;
+    }
     return activity;
 }
 

--- a/Wikipedia/Code/PlacesViewController.swift
+++ b/Wikipedia/Code/PlacesViewController.swift
@@ -2099,6 +2099,23 @@ class PlacesViewController: ArticleLocationCollectionViewController, UISearchBar
         let searchResult = MWKSearchResult(articleID: 0, revID: 0, title: title, displayTitle: displayTitle, displayTitleHTML: displayTitleHTML, wikidataDescription: article.wikidataDescription, extract: article.snippet, thumbnailURL: article.thumbnailURL, index: nil, titleNamespace: nil, location: article.location)
         currentSearch = PlaceSearch(filter: .top, type: .location, origin: .user, sortStyle: .links, string: nil, region: region, localizedDescription: title, searchResult: searchResult, siteURL: articleURL.wmf_site)
     }
+    
+    @objc public func showCoordinate(latitude: CLLocationDegrees, longitude: CLLocationDegrees, name: String?) {
+        guard view != nil else { // force view instantiation
+            return
+        }
+        guard CLLocationCoordinate2DIsValid(CLLocationCoordinate2D(latitude: latitude, longitude: longitude)),
+              (-90.0...90.0).contains(latitude),
+              (-180.0...180.0).contains(longitude) else {
+            return
+        }
+        let location = CLLocation(latitude: latitude, longitude: longitude)
+        // Make sure we're on the map view (caller normally has already done this).
+        updateViewModeToMap()
+        // Clear any in-flight search so the centered location's default search takes effect.
+        currentSearch = nil
+        zoomAndPanMapView(toLocation: location)
+    }
 
     fileprivate func searchForFirstSearchSuggestion() {
         if !searchSuggestionController.searches[PlaceSearchSuggestionController.completionSection].isEmpty {

--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -1206,7 +1206,16 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
             dismissPresentedViewControllers()
             selectedIndex = WMFAppTabType.places.rawValue
             currentTabNavigationController?.popToRootViewController(animated: animated)
-            if let articleURL = activity.wmf_linkURL() {
+            
+            let userInfo = activity.userInfo
+            let latString = (userInfo?["WMFPlacesLatitude"] as? String) ?? (userInfo?["WMFPlacesLatitude"] as? NSNumber)?.stringValue
+            let lonString = (userInfo?["WMFPlacesLongitude"] as? String) ?? (userInfo?["WMFPlacesLongitude"] as? NSNumber)?.stringValue
+            if let latString, let lonString,
+               let lat = Double(latString), let lon = Double(lonString) {
+                let name = userInfo?["WMFPlacesName"] as? String
+                placesViewController.updateViewModeToMap()
+                placesViewController.showCoordinate(latitude: lat, longitude: lon, name: name)
+            } else if let articleURL = activity.wmf_linkURL() {
                 placesViewController.updateViewModeToMap()
                 placesViewController.showArticleURL(articleURL)
             }

--- a/WikipediaUnitTests/Code/NSUserActivity+WMFExtensionsTest.m
+++ b/WikipediaUnitTests/Code/NSUserActivity+WMFExtensionsTest.m
@@ -45,4 +45,29 @@
                           @"https://en.wikipedia.org/w/index.php?search=dog&title=Special:Search&fulltext=1");
 }
 
+- (void)testPlacesURLWithoutCoordinates {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places"];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertNil(activity.userInfo[@"WMFPlacesLatitude"]);
+    XCTAssertNil(activity.userInfo[@"WMFPlacesLongitude"]);
+}
+
+- (void)testPlacesURLWithCoordinatesAndName {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?lat=52.3676&lon=4.9041&name=Amsterdam"];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertEqualObjects(activity.userInfo[@"WMFPlacesLatitude"], @"52.3676");
+    XCTAssertEqualObjects(activity.userInfo[@"WMFPlacesLongitude"], @"4.9041");
+    XCTAssertEqualObjects(activity.userInfo[@"WMFPlacesName"], @"Amsterdam");
+}
+
+- (void)testPlacesURLWithLngAlias {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?lat=-33.8688&lng=151.2093"];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertEqualObjects(activity.userInfo[@"WMFPlacesLatitude"], @"-33.8688");
+    XCTAssertEqualObjects(activity.userInfo[@"WMFPlacesLongitude"], @"151.2093");
+}
+
 @end

--- a/docs/url_schemes.md
+++ b/docs/url_schemes.md
@@ -2,13 +2,13 @@
 
 The URL scheme is `wikipedia://`. The following URLs are currently handled:
 
-| Feature            | Format                                   | Example                                  |
-| ------------------ | ---------------------------------------- | ---------------------------------------- |
-| Article            | wikipedia://[site]/wiki/[page_id]        | wikipedia://en.wikipedia.org/wiki/Red    |
-|                    | https://[[site]/wiki/[page_id]           | https://en.wikipedia.org/wiki/Red        |
-| Content            | wikipedia://content                      | wikipedia://content/on-this-day/wikipedia.org/en/2024/08/15                                         |
-| Explore            | wikipedia://explore                      |                                          |
-| History            | wikipedia://history                      |                                          |
-| Places             | wikipedia://places[?WMFArticleURL=]      | wikipedia://places/?WMFArticleURL=https://en.wikipedia.org/wiki/Dallas
-                                         |
-| Saved pages        | wikipedia://saved                        |                                          |
+| Feature            | Format                                     | Example                                                                 |
+| ------------------ | -------------------------------------------| ------------------------------------------------------------------------|
+| Article            | wikipedia://[site]/wiki/[page_id]          | wikipedia://en.wikipedia.org/wiki/Red                                   |
+|                    | https://[[site]/wiki/[page_id]             | https://en.wikipedia.org/wiki/Red                                       |
+| Content            | wikipedia://content                        | wikipedia://content/on-this-day/wikipedia.org/en/2024/08/15             |
+| Explore            | wikipedia://explore                        |                                                                         |
+| History            | wikipedia://history                        |                                                                         |
+| Places             | wikipedia://places[?WMFArticleURL=]        | wikipedia://places/?WMFArticleURL=https://en.wikipedia.org/wiki/Dallas  |
+| Places(coordinate) | wikipedia://places?lat=..&lon=..[&name=..] | wikipedia://places?lat=52.3676&lon=4.9041&name=Amsterdam                |
+| Saved pages        | wikipedia://saved                          |                                                                         |


### PR DESCRIPTION
## What changed

The Wikipedia app already supports `wikipedia://places?WMFArticleURL=…` for opening the Places tab on a specific article. This branch extends the same route so that an external caller can supply raw coordinates instead:

```
wikipedia://places?lat=<latitude>&lon=<longitude>[&name=<name>]
```

When opened with this URL the app:

1. Switches to the Places tab.
2. Centers the map on the supplied coordinate.
3. Runs the default nearby-articles search there — instead of falling back to the device's current location.

## Manual smoke test

After building both the modified Wikipedia app and the PlacesApp:

1. Launch Wikipedia once so its URL scheme is registered.
2. From Safari or Note app, paste and tap `wikipedia://places?lat=52.3676&lon=4.9041&name=Amsterdam` 
3. Wikipedia should be opened on the Places tab and centered on that location.
