### PR TITLE
Add WMFRelatedPagesDataController

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFRelatedPagesDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFRelatedPagesDataController.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+public actor WMFRelatedPagesDataController {
+
+    public static let shared = WMFRelatedPagesDataController()
+
+    private var service: WMFService? {
+        WMFDataEnvironment.current.basicService
+    }
+
+    private init() {}
+
+    public struct WMFRelatedPage: Sendable {
+        public let pageid: Int
+        public let title: String
+        public let description: String?
+        public let thumbnailURL: URL?
+        public let extract: String?
+    }
+
+    // MARK: - Response Models
+
+    private struct Response: Codable {
+        let query: Query?
+
+        struct Query: Codable {
+            let pages: [Page]?
+        }
+
+        struct Page: Codable {
+            let pageid: Int
+            let title: String
+            let description: String?
+            let thumbnail: Thumbnail?
+            let extract: String?
+
+            struct Thumbnail: Codable {
+                let source: String?
+            }
+        }
+    }
+
+    // MARK: - Public API
+
+    public func fetchRelatedPages(title: String, project: WMFProject) async throws -> [WMFRelatedPage] {
+        guard let service else {
+            throw WMFDataControllerError.basicServiceUnavailable
+        }
+
+        guard let url = URL.mediaWikiAPIURL(project: project) else {
+            throw WMFDataControllerError.failureCreatingRequestURL
+        }
+
+        let parameters: [String: Any] = [
+            "action": "query",
+            "format": "json",
+            "formatversion": "2",
+            "generator": "search",
+            "gsrsearch": "morelike:\(title)",
+            "gsrnamespace": "0",
+            "gsrlimit": "20",
+            "gsrqiprofile": "classic_noboostlinks",
+            "prop": "pageimages|description|info|extracts",
+            "piprop": "thumbnail",
+            "pithumbsize": "160",
+            "pilimit": "20",
+            "exintro": "1",
+            "explaintext": "1",
+            "inprop": "varianttitles",
+            "maxage": "86400",
+            "smaxage": "86400",
+            "origin": "*"
+        ]
+
+        let request = WMFBasicServiceRequest(url: url, method: .GET, languageVariantCode: project.languageVariantCode, parameters: parameters, acceptType: .json)
+
+        let response: Response = try await withCheckedThrowingContinuation { continuation in
+            service.performDecodableGET(request: request) { (result: Result<Response, Error>) in
+                switch result {
+                case .success(let response):
+                    continuation.resume(returning: response)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+
+        guard let pages = response.query?.pages else {
+            return []
+        }
+
+        return pages.map { page in
+            let thumbnailURL = page.thumbnail?.source.flatMap { URL(string: $0) }
+            return WMFRelatedPage(
+                pageid: page.pageid,
+                title: page.title,
+                description: page.description,
+                thumbnailURL: thumbnailURL,
+                extract: page.extract
+            )
+        }
+    }
+}

--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFRelatedPagesDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFRelatedPagesDataController.swift
@@ -4,11 +4,11 @@ public actor WMFRelatedPagesDataController {
 
     public static let shared = WMFRelatedPagesDataController()
 
-    private var service: WMFService? {
-        WMFDataEnvironment.current.basicService
-    }
+    private let service: WMFService?
 
-    private init() {}
+    public init(basicService: WMFService? = WMFDataEnvironment.current.basicService) {
+        self.service = basicService
+    }
 
     public struct WMFRelatedPage: Sendable {
         public let pageid: Int

--- a/WMFData/Sources/WMFDataMocks/Resources/related-pages-get.json
+++ b/WMFData/Sources/WMFDataMocks/Resources/related-pages-get.json
@@ -1,0 +1,78 @@
+{
+  "batchcomplete": true,
+  "continue": {
+    "gsroffset": 20,
+    "continue": "gsroffset||"
+  },
+  "query": {
+    "pages": [
+      {
+        "pageid": 586558,
+        "ns": 0,
+        "title": "Trap–neuter–return",
+        "index": 6,
+        "thumbnail": {
+          "source": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Feral_cat%2C_sterilized_through_a_Trap-Neuter-Return_program.jpg/250px-Feral_cat%2C_sterilized_through_a_Trap-Neuter-Return_program.jpg",
+          "width": 160,
+          "height": 120
+        },
+        "description": "Strategy for controlling feral animal populations",
+        "descriptionsource": "local",
+        "contentmodel": "wikitext",
+        "pagelanguage": "en",
+        "pagelanguagehtmlcode": "en",
+        "pagelanguagedir": "ltr",
+        "touched": "2026-05-31T02:54:18Z",
+        "lastrevid": 1356989886,
+        "length": 101656,
+        "varianttitles": {
+          "en": "Trap–neuter–return"
+        },
+        "extract": "Trap–neuter–return (TNR), also known as trap–neuter–release, is a controversial method that attempts to manage populations of feral cats."
+      },
+      {
+        "pageid": 629216,
+        "ns": 0,
+        "title": "Purr",
+        "index": 7,
+        "description": "Fluttering vocalization",
+        "descriptionsource": "local",
+        "contentmodel": "wikitext",
+        "pagelanguage": "en",
+        "pagelanguagehtmlcode": "en",
+        "pagelanguagedir": "ltr",
+        "touched": "2026-06-21T21:49:54Z",
+        "lastrevid": 1353803747,
+        "length": 16020,
+        "varianttitles": {
+          "en": "Purr"
+        },
+        "extract": "A purr or whirr is a tonal fluttering sound made by some species of felids, including both larger, wild cats and the domestic cat (Felis catus)."
+      },
+      {
+        "pageid": 895672,
+        "ns": 0,
+        "title": "Feral cat",
+        "index": 1,
+        "thumbnail": {
+          "source": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Feral_cat_1.JPG/250px-Feral_cat_1.JPG",
+          "width": 160,
+          "height": 107
+        },
+        "description": "Unowned or untamed domestic cat in the outdoors",
+        "descriptionsource": "local",
+        "contentmodel": "wikitext",
+        "pagelanguage": "en",
+        "pagelanguagehtmlcode": "en",
+        "pagelanguagedir": "ltr",
+        "touched": "2026-06-20T00:20:46Z",
+        "lastrevid": 1358802933,
+        "length": 88006,
+        "varianttitles": {
+          "en": "Feral cat"
+        },
+        "extract": "A feral cat or stray cat is an unowned domestic cat (Felis catus) that lives freely outdoors and avoids human contact."
+      }
+    ]
+  }
+}

--- a/WMFData/Tests/WMFDataTests/WMFRelatedPagesDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFRelatedPagesDataControllerTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import WMFData
+@testable import WMFDataMocks
+
+@Suite(.serialized)
+struct WMFRelatedPagesDataControllerTests {
+
+    private let project = WMFProject.wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
+
+    private func makeController() -> WMFRelatedPagesDataController {
+        let mockService = WMFMockBasicService(jsonResourceName: "related-pages-get")
+        return WMFRelatedPagesDataController(basicService: mockService)
+    }
+
+    @Test
+    func fetchRelatedPagesReturnsCorrectCount() async throws {
+        let controller = makeController()
+        let pages = try await controller.fetchRelatedPages(title: "Cat", project: project)
+        #expect(pages.count == 3)
+    }
+
+    @Test
+    func fetchRelatedPagesDeserializesFirstPage() async throws {
+        let controller = makeController()
+        let pages = try await controller.fetchRelatedPages(title: "Cat", project: project)
+
+        let first = try #require(pages.first)
+        #expect(first.pageid == 586558)
+        #expect(first.title == "Trap–neuter–return")
+        #expect(first.description == "Strategy for controlling feral animal populations")
+        #expect(first.thumbnailURL == URL(string: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Feral_cat%2C_sterilized_through_a_Trap-Neuter-Return_program.jpg/250px-Feral_cat%2C_sterilized_through_a_Trap-Neuter-Return_program.jpg"))
+        #expect(first.extract?.hasPrefix("Trap–neuter–return (TNR)") == true)
+    }
+
+    @Test
+    func fetchRelatedPagesDeserializesPageWithoutThumbnail() async throws {
+        let controller = makeController()
+        let pages = try await controller.fetchRelatedPages(title: "Cat", project: project)
+
+        // Purr has no thumbnail in the response
+        let purr = try #require(pages.first(where: { $0.pageid == 629216 }))
+        #expect(purr.title == "Purr")
+        #expect(purr.description == "Fluttering vocalization")
+        #expect(purr.thumbnailURL == nil)
+    }
+
+    @Test
+    func fetchRelatedPagesDeserializesAllTitles() async throws {
+        let controller = makeController()
+        let pages = try await controller.fetchRelatedPages(title: "Cat", project: project)
+
+        #expect(pages.map(\.title) == ["Trap–neuter–return", "Purr", "Feral cat"])
+    }
+}


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T413371

### Notes
Creating a related pages data controller + tests. We will use this when fetching related interest articles in the For You tab.

🤖 Mostly generated with Claude Sonnet 4.6

### Test Steps
1. Ensure unit tests pass

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
