### PR TITLE
DI-001: Add handling places deeplink with coordinates, add tests

### DIFF
--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.m
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.m
@@ -61,15 +61,27 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
 
 + (instancetype)wmf_placesActivityWithURL:(NSURL *)activityURL {
     NSURLComponents *components = [NSURLComponents componentsWithURL:activityURL resolvingAgainstBaseURL:NO];
+    NSString *latitude = nil;
+    NSString *longitude = nil;
     NSURL *articleURL = nil;
     for (NSURLQueryItem *item in components.queryItems) {
-        if ([item.name isEqualToString:@"WMFArticleURL"]) {
+        if ([item.name isEqualToString:@"latitude"]) {
+            latitude = item.value;
+        } else if ([item.name isEqualToString:@"longitude"]) {
+            longitude = item.value;
+        } else if ([item.name isEqualToString:@"WMFArticleURL"]) {
             NSString *articleURLString = item.value;
             articleURL = [NSURL URLWithString:articleURLString];
-            break;
         }
     }
     NSUserActivity *activity = [self wmf_pageActivityWithName:@"Places"];
+    if (latitude && longitude) {
+        NSMutableDictionary *userInfo = [activity.userInfo mutableCopy];
+        userInfo[@"latitude"] = latitude;
+        userInfo[@"longitude"] = longitude;
+        activity.userInfo = userInfo;
+        return activity;
+    }
     activity.webpageURL = articleURL;
     return activity;
 }

--- a/Wikipedia/Code/PlacesViewController.swift
+++ b/Wikipedia/Code/PlacesViewController.swift
@@ -2088,6 +2088,17 @@ class PlacesViewController: ArticleLocationCollectionViewController, UISearchBar
         recenterOnUserLocation(self)
     }
 
+    @objc public func showCoordinate(_ coordinate: CLLocationCoordinate2D) {
+        guard view != nil else { // force view instantiation
+            return
+        }
+
+        let span = MKCoordinateSpan(latitudeDelta: 0.6, longitudeDelta: 0.6)
+        let region = MKCoordinateRegion(center: coordinate, span: span)
+
+        currentSearch = PlaceSearch(filter: .top, type: .location, origin: .system, sortStyle: .links, string: nil, region: region, localizedDescription: nil, searchResult: nil, siteURL: nil)
+    }
+
     @objc public func showArticleURL(_ articleURL: URL) {
         guard let article = dataStore.fetchArticle(with: articleURL), let title = articleURL.wmf_title,
               view != nil else { // force view instantiation

--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -1206,7 +1206,15 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
             dismissPresentedViewControllers()
             selectedIndex = WMFAppTabType.places.rawValue
             currentTabNavigationController?.popToRootViewController(animated: animated)
-            if let articleURL = activity.wmf_linkURL() {
+            if
+                let latitudeStr = activity.userInfo?["latitude"] as? String,
+                let longitudeStr = activity.userInfo?["longitude"] as? String,
+                let latitude = Double(latitudeStr),
+                let longitude = Double(longitudeStr) {
+                let coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+                placesViewController.updateViewModeToMap()
+                placesViewController.showCoordinate(coordinate)
+            } else if let articleURL = activity.wmf_linkURL() {
                 placesViewController.updateViewModeToMap()
                 placesViewController.showArticleURL(articleURL)
             }

--- a/WikipediaUnitTests/Code/NSUserActivity+WMFExtensionsTest.m
+++ b/WikipediaUnitTests/Code/NSUserActivity+WMFExtensionsTest.m
@@ -45,4 +45,28 @@
                           @"https://en.wikipedia.org/w/index.php?search=dog&title=Special:Search&fulltext=1");
 }
 
+- (void)testPlacesCoordinateURL {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?latitude=52.3547498&longitude=4.8339215&name=Amsterdam"];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertEqualObjects(activity.userInfo[@"latitude"], @"52.3547498");
+    XCTAssertEqualObjects(activity.userInfo[@"longitude"], @"4.8339215");
+    XCTAssertNil(activity.webpageURL);
+}
+
+- (void)testPlacesURLWithoutParams {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places"];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertNil(activity.webpageURL);
+}
+
+- (void)testPlacesArticleURL {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?WMFArticleURL=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FFoo"];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertEqualObjects(activity.webpageURL.absoluteString, @"https://en.wikipedia.org/wiki/Foo");
+    XCTAssertNil(activity.userInfo[@"latitude"]);
+}
+
 @end


### PR DESCRIPTION
**Phabricator:** 

### Notes
* add deeplink handling to places tab with coordinates
* add tests

### Test Steps
1. Install Wikipedia app
2. Call URL with format wikipedia://places?latitude=45.3547498&longitude=1.8339215
3. The app should open Places tab with focus on the location with the coordinates from the link

### Screenshots/Videos
https://github.com/user-attachments/assets/0993d541-bd11-45e4-9c6d-a73acaf9fabc

