### PR TITLE
Fix game_end close button logging

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstViewController.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstViewController.swift
@@ -92,7 +92,7 @@ public final class WMFWhichCameFirstHostingController: WMFComponentHostingContro
     }
 
     @objc private func tappedClose() {
-        viewModel.didTapExitDuringPlay?(viewModel.currentIndex + 1)
+        viewModel.didTapExitDuringPlay?(viewModel.currentIndex + 1, viewModel.phase == .complete)
         dismiss(animated: true)
     }
 }

--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstViewModel.swift
@@ -136,7 +136,7 @@ public final class WMFWhichCameFirstViewModel: ObservableObject, Identifiable {
     /// Slide becomes visible. Index is 1-based (game_play_1 … game_play_5).
     public var didImpressionSlide: (@MainActor @Sendable (_ slideIndex: Int) -> Void)?
     /// Taps the exit button during gameplay. Index is 1-based.
-    public var didTapExitDuringPlay: (@MainActor @Sendable (_ slideIndex: Int) -> Void)?
+    public var didTapExitDuringPlay: (@MainActor @Sendable (_ slideIndex: Int, _ isComplete: Bool) -> Void)?
     /// Taps Submit on a question. Index is 1-based.
     public var didSubmitAnswer: (@MainActor @Sendable (_ slideIndex: Int) -> Void)?
     /// Last question is answered and the game transitions to complete.

--- a/Wikipedia/Code/WhichCameFirstCoordinator.swift
+++ b/Wikipedia/Code/WhichCameFirstCoordinator.swift
@@ -186,8 +186,13 @@ final class WhichCameFirstCoordinator: NSObject, Coordinator {
         viewModel.didImpressionSlide = { [weak self] slideIndex in
             self?.logImpression(actionSource: "game_play", actionSubtype: "game_play_\(slideIndex)")
         }
-        viewModel.didTapExitDuringPlay = { [weak self] slideIndex in
-            self?.logClick(actionSource: "game_play", actionSubtype: "game_play_\(slideIndex)", elementId: "exit_button")
+        viewModel.didTapExitDuringPlay = { [weak self] slideIndex, isComplete in
+            if isComplete {
+                self?.logClick(actionSource: "game_end", elementId: "exit_button")
+            } else {
+                self?.logClick(actionSource: "game_play", actionSubtype: "game_play_\(slideIndex)", elementId: "exit_button")
+            }
+            
         }
         viewModel.didSubmitAnswer = { [weak self] slideIndex in
             self?.logClick(actionSource: "game_play", actionSubtype: "game_play_\(slideIndex)", elementId: "answer_submit")


### PR DESCRIPTION
**Phabricator:** N/A

See https://wikimedia.slack.com/archives/CEKKLRDT2/p1782323789524689

### Notes
The close button on the results view was logging incorrectly.

### Test Steps
1. Tap close button on results view.
2. Console should print action = click, element_id = exit_button, action_source = game_end

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
