### PR TITLE
Which Came First - other event choice fixes

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
@@ -320,24 +320,29 @@ extension WMFGamesDataController {
     // Internal rather than private so it can be unit tested directly (e.g. BC date filtering).
     static func makeWhichCameFirstQuestions(from events: [WMFOnThisDayEvent], month: Int, day: Int, year: Int, count: Int) -> [WMFWhichCameFirstQuestion] {
         let calendar = Calendar(identifier: .gregorian)
+        
         // Exclude BC/BCE events (negative or zero years) — the Gregorian calendar has no year 0, so any year < 1 is BC.
         // Exclude future events (year > current year).
         // Exclude events whose text contains a standalone number (1–4 digits) — it could reveal the answer year.
-        // Deduplicate by year (keep first event per year, matching Android's distinctBy { year }).
+        
         let yearInTextRegex = try? NSRegularExpression(pattern: "\\b\\d{1,4}\\b")
         var pool = events.filter { event in
             guard !event.pages.isEmpty && event.year > 0 && event.year <= year else { return false }
             let range = NSRange(event.text.startIndex..., in: event.text)
             return yearInTextRegex?.firstMatch(in: event.text, range: range) == nil
         }.sorted { $0.year < $1.year }
+        
+        // Deduplicate by year (keep first event per year, matching Android's distinctBy { year }).
         pool = pool.reduce(into: [WMFOnThisDayEvent]()) { acc, event in
             if acc.last?.year != event.year { acc.append(event) }
         }
+        
         // Shuffle with a date-seeded RNG so question order is consistent for the same day,
         // matching Android's Random(month * 100 + day) seeded shuffle.
         let rng = GKMersenneTwisterRandomSource(seed: UInt64(month * 100 + day))
         guard let shuffled = rng.arrayByShufflingObjects(in: pool) as? [WMFOnThisDayEvent] else { return [] }
         pool = shuffled
+        
         var questions: [WMFWhichCameFirstQuestion] = []
 
         func makeDate(year: Int) -> Date {

--- a/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
@@ -318,8 +318,14 @@ extension WMFGamesDataController {
     static func makeWhichCameFirstQuestions(from events: [WMFOnThisDayEvent], month: Int, day: Int, count: Int) -> [WMFWhichCameFirstQuestion] {
         let calendar = Calendar(identifier: .gregorian)
         // Exclude BC/BCE events (negative or zero years) — the Gregorian calendar has no year 0, so any year < 1 is BC.
+        // Exclude events whose text contains a standalone number (1–4 digits) — it could reveal the answer year.
         // Deduplicate by year (keep first event per year, matching Android's distinctBy { year }).
-        var pool = events.filter { !$0.pages.isEmpty && $0.year > 0 }.sorted { $0.year < $1.year }
+        let yearInTextRegex = try? NSRegularExpression(pattern: "\\b\\d{1,4}\\b")
+        var pool = events.filter { event in
+            guard !event.pages.isEmpty && event.year > 0 else { return false }
+            let range = NSRange(event.text.startIndex..., in: event.text)
+            return yearInTextRegex?.firstMatch(in: event.text, range: range) == nil
+        }.sorted { $0.year < $1.year }
         pool = pool.reduce(into: [WMFOnThisDayEvent]()) { acc, event in
             if acc.last?.year != event.year { acc.append(event) }
         }

--- a/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreData
+import GameplayKit
 
 public class WMFGamesDataController {
 
@@ -329,6 +330,11 @@ extension WMFGamesDataController {
         pool = pool.reduce(into: [WMFOnThisDayEvent]()) { acc, event in
             if acc.last?.year != event.year { acc.append(event) }
         }
+        // Shuffle with a date-seeded RNG so question order is consistent for the same day,
+        // matching Android's Random(month * 100 + day) seeded shuffle.
+        let rng = GKMersenneTwisterRandomSource(seed: UInt64(month * 100 + day))
+        guard let shuffled = rng.arrayByShufflingObjects(in: pool) as? [WMFOnThisDayEvent] else { return [] }
+        pool = shuffled
         var questions: [WMFWhichCameFirstQuestion] = []
 
         func makeDate(year: Int) -> Date {

--- a/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
@@ -321,13 +321,16 @@ extension WMFGamesDataController {
     static func makeWhichCameFirstQuestions(from events: [WMFOnThisDayEvent], month: Int, day: Int, year: Int, count: Int) -> [WMFWhichCameFirstQuestion] {
         let calendar = Calendar(identifier: .gregorian)
         
-        // Exclude BC/BCE events (negative or zero years) — the Gregorian calendar has no year 0, so any year < 1 is BC.
-        // Exclude future events (year > current year).
-        // Exclude events whose text contains a standalone number (1–4 digits) — it could reveal the answer year.
-        
+
+        // Filter out events that we don't want to consider
         let yearInTextRegex = try? NSRegularExpression(pattern: "\\b\\d{1,4}\\b")
         var pool = events.filter { event in
+            
+            // Exclude BC/BCE events (negative or zero years)
+            // Exclude future events (year > current year)
             guard !event.pages.isEmpty && event.year > 0 && event.year <= year else { return false }
+            
+            // Exclude events whose text contains a standalone number (1–4 digits) — it could reveal the answer year.
             let range = NSRange(event.text.startIndex..., in: event.text)
             return yearInTextRegex?.firstMatch(in: event.text, range: range) == nil
         }.sorted { $0.year < $1.year }

--- a/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
@@ -318,7 +318,11 @@ extension WMFGamesDataController {
     static func makeWhichCameFirstQuestions(from events: [WMFOnThisDayEvent], month: Int, day: Int, count: Int) -> [WMFWhichCameFirstQuestion] {
         let calendar = Calendar(identifier: .gregorian)
         // Exclude BC/BCE events (negative or zero years) — the Gregorian calendar has no year 0, so any year < 1 is BC.
+        // Deduplicate by year (keep first event per year, matching Android's distinctBy { year }).
         var pool = events.filter { !$0.pages.isEmpty && $0.year > 0 }.sorted { $0.year < $1.year }
+        pool = pool.reduce(into: [WMFOnThisDayEvent]()) { acc, event in
+            if acc.last?.year != event.year { acc.append(event) }
+        }
         var questions: [WMFWhichCameFirstQuestion] = []
 
         func makeDate(year: Int) -> Date {

--- a/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
@@ -270,13 +270,14 @@ extension WMFGamesDataController {
 
         let components = date.split(separator: "-")
         guard components.count == 3,
+              let year = Int(components[0]),
               let month = Int(components[1]),
               let day = Int(components[2]) else {
             return false
         }
 
         let response = try await onThisDayDataController.fetchOnThisDay(project: project, month: month, day: day)
-        let questions = Self.makeWhichCameFirstQuestions(from: response.events, month: month, day: day, count: Self.whichCameFirstQuestionCount)
+        let questions = Self.makeWhichCameFirstQuestions(from: response.events, month: month, day: day, year: year, count: Self.whichCameFirstQuestionCount)
         return questions.count == Self.whichCameFirstQuestionCount
     }
 
@@ -296,13 +297,14 @@ extension WMFGamesDataController {
 
         let components = date.split(separator: "-")
         guard components.count == 3,
+              let year = Int(components[0]),
               let month = Int(components[1]),
               let day = Int(components[2]) else {
             throw CustomError.missingIdentifier
         }
 
         let response = try await onThisDayDataController.fetchOnThisDay(project: project, month: month, day: day)
-        let questions = Self.makeWhichCameFirstQuestions(from: response.events, month: month, day: day, count: Self.whichCameFirstQuestionCount)
+        let questions = Self.makeWhichCameFirstQuestions(from: response.events, month: month, day: day, year: year, count: Self.whichCameFirstQuestionCount)
 
         guard questions.count == Self.whichCameFirstQuestionCount else {
             throw CustomError.insufficientQuestions
@@ -316,14 +318,15 @@ extension WMFGamesDataController {
     }
 
     // Internal rather than private so it can be unit tested directly (e.g. BC date filtering).
-    static func makeWhichCameFirstQuestions(from events: [WMFOnThisDayEvent], month: Int, day: Int, count: Int) -> [WMFWhichCameFirstQuestion] {
+    static func makeWhichCameFirstQuestions(from events: [WMFOnThisDayEvent], month: Int, day: Int, year: Int, count: Int) -> [WMFWhichCameFirstQuestion] {
         let calendar = Calendar(identifier: .gregorian)
         // Exclude BC/BCE events (negative or zero years) — the Gregorian calendar has no year 0, so any year < 1 is BC.
+        // Exclude future events (year > current year).
         // Exclude events whose text contains a standalone number (1–4 digits) — it could reveal the answer year.
         // Deduplicate by year (keep first event per year, matching Android's distinctBy { year }).
         let yearInTextRegex = try? NSRegularExpression(pattern: "\\b\\d{1,4}\\b")
         var pool = events.filter { event in
-            guard !event.pages.isEmpty && event.year > 0 else { return false }
+            guard !event.pages.isEmpty && event.year > 0 && event.year <= year else { return false }
             let range = NSRange(event.text.startIndex..., in: event.text)
             return yearInTextRegex?.firstMatch(in: event.text, range: range) == nil
         }.sorted { $0.year < $1.year }
@@ -466,11 +469,12 @@ extension WMFGamesDataController {
 
         let components = date.split(separator: "-")
         guard components.count == 3,
+              let year = Int(components[0]),
               let month = Int(components[1]),
               let day = Int(components[2]) else { return nil }
 
         let response = try await onThisDayDataController.fetchOnThisDay(project: project, month: month, day: day)
-        let questions = Self.makeWhichCameFirstQuestions(from: response.events, month: month, day: day, count: 1)
+        let questions = Self.makeWhichCameFirstQuestions(from: response.events, month: month, day: day, year: year, count: 1)
         guard let first = questions.first else { return nil }
         return (first.optionA, first.optionB)
     }

--- a/WMFData/Tests/WMFDataTests/WMFGamesDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFGamesDataControllerTests.swift
@@ -189,6 +189,29 @@ final class WMFGamesDataControllerTests: XCTestCase {
         }
     }
 
+    func testPoolFiltersEventsWithYearInText() {
+        // Events whose text contains a standalone number should be excluded from the pool.
+        let eventsWithYearInText = [
+            makeEvent(text: "Something happened in 1492", year: 100),
+            makeEvent(text: "The 42nd event occurred", year: 200),
+            makeEvent(text: "Event from year 800", year: 300)
+        ]
+        let cleanEvents = (1...10).map { makeEvent(text: "Clean event \($0)", year: $0 * 100 + 400) }
+
+        let questions = WMFGamesDataController.makeWhichCameFirstQuestions(
+            from: eventsWithYearInText + cleanEvents,
+            month: 5,
+            day: 7,
+            count: 5
+        )
+
+        let filteredTitles = Set(eventsWithYearInText.map { $0.text })
+        for question in questions {
+            XCTAssertFalse(filteredTitles.contains(question.optionA.title), "Event with number in text leaked into optionA: \(question.optionA.title)")
+            XCTAssertFalse(filteredTitles.contains(question.optionB.title), "Event with number in text leaked into optionB: \(question.optionB.title)")
+        }
+    }
+
     func testPoolDeduplicatesByYear() {
         // Two events with the same year — only one should enter the pool, so both
         // questions must use distinct years for their paired options.

--- a/WMFData/Tests/WMFDataTests/WMFGamesDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFGamesDataControllerTests.swift
@@ -157,13 +157,13 @@ final class WMFGamesDataControllerTests: XCTestCase {
 
     func testQuestionsExcludeBCEvents() {
         let bcEvents = [
-            makeEvent(text: "BC Event 500", year: -500),
-            makeEvent(text: "BC Event 100", year: -100),
-            makeEvent(text: "BC Event 1", year: -1)
+            makeEvent(text: "Battle of Thermopylae", year: -500),
+            makeEvent(text: "Founding of Rome", year: -100),
+            makeEvent(text: "Julius Caesar born", year: -1)
         ]
-        // Year 0 does not exist in the Gregorian calendar; treat it as BC and exclude it too.
         let yearZeroEvent = makeEvent(text: "Year Zero Event", year: 0)
-        let adEvents = (1...20).map { makeEvent(text: "AD Event \($0)", year: $0 * 100) }
+        let adEventTitles = ["Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon"]
+        let adEvents = (0...19).map { makeEvent(text: "AD Event \(adEventTitles[$0])", year: ($0 + 1) * 100) }
 
         let events = bcEvents + [yearZeroEvent] + adEvents
 
@@ -171,6 +171,7 @@ final class WMFGamesDataControllerTests: XCTestCase {
             from: events,
             month: 5,
             day: 7,
+            year: 2026,
             count: 5
         )
 
@@ -190,27 +191,33 @@ final class WMFGamesDataControllerTests: XCTestCase {
     }
 
     func testQuestionsAreDeterministicForSameDate() {
-        let events = (1...30).map { makeEvent(text: "Event \($0)", year: $0 * 50) }
+        let events = (1...30).map { makeEvent(text: "Event \(["Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon","Phi","Chi","Psi","Omega","Ares","Zeus","Hera","Athena","Apollo","Hermes"][$0 - 1])", year: $0 * 50) }
 
-        let first = WMFGamesDataController.makeWhichCameFirstQuestions(from: events, month: 5, day: 7, count: 5)
-        let second = WMFGamesDataController.makeWhichCameFirstQuestions(from: events, month: 5, day: 7, count: 5)
+        let first = WMFGamesDataController.makeWhichCameFirstQuestions(from: events, month: 5, day: 7, year: 2026, count: 5)
+        let second = WMFGamesDataController.makeWhichCameFirstQuestions(from: events, month: 5, day: 7, year: 2026, count: 5)
 
-        XCTAssertEqual(first.map { $0.optionA.title }, second.map { $0.optionA.title }, "Same date should always produce the same question order")
+        // Compare the unordered pair of titles per question — optionA/B assignment uses Bool.random()
+        // so we can't compare positionally, but the paired events themselves must be identical.
+        let firstPairs = first.map { Set([$0.optionA.title, $0.optionB.title]) }
+        let secondPairs = second.map { Set([$0.optionA.title, $0.optionB.title]) }
+        XCTAssertEqual(firstPairs, secondPairs, "Same date should always produce the same question pairings")
     }
 
     func testPoolFiltersEventsWithYearInText() {
         // Events whose text contains a standalone number should be excluded from the pool.
         let eventsWithYearInText = [
             makeEvent(text: "Something happened in 1492", year: 100),
-            makeEvent(text: "The 42nd event occurred", year: 200),
-            makeEvent(text: "Event from year 800", year: 300)
+            makeEvent(text: "An event occurred in 42 AD", year: 200),
+            makeEvent(text: "Event from the year 800", year: 300)
         ]
-        let cleanEvents = (1...10).map { makeEvent(text: "Clean event \($0)", year: $0 * 100 + 400) }
+        let cleanEventNames = ["Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa"]
+        let cleanEvents = (0...9).map { makeEvent(text: "Clean event \(cleanEventNames[$0])", year: ($0 + 1) * 100 + 400) }
 
         let questions = WMFGamesDataController.makeWhichCameFirstQuestions(
             from: eventsWithYearInText + cleanEvents,
             month: 5,
             day: 7,
+            year: 2026,
             count: 5
         )
 
@@ -221,27 +228,51 @@ final class WMFGamesDataControllerTests: XCTestCase {
         }
     }
 
+    func testPoolFiltersEventsBeyondCurrentYear() {
+        let pastEventNames = ["Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa"]
+        let currentYearEvents = (0...9).map { makeEvent(text: "Past event \(pastEventNames[$0])", year: ($0 + 1) * 100) }
+        let futureEvents = [
+            makeEvent(text: "Future event Alpha", year: 2100),
+            makeEvent(text: "Future event Beta", year: 2200)
+        ]
+
+        let questions = WMFGamesDataController.makeWhichCameFirstQuestions(
+            from: currentYearEvents + futureEvents,
+            month: 5,
+            day: 7,
+            year: 2026,
+            count: 5
+        )
+
+        let futureTitles = Set(futureEvents.map { $0.text })
+        for question in questions {
+            XCTAssertFalse(futureTitles.contains(question.optionA.title), "Future event leaked into optionA: \(question.optionA.title)")
+            XCTAssertFalse(futureTitles.contains(question.optionB.title), "Future event leaked into optionB: \(question.optionB.title)")
+        }
+    }
+
     func testPoolDeduplicatesByYear() {
         // Two events with the same year — only one should enter the pool, so both
         // questions must use distinct years for their paired options.
         let events = [
-            makeEvent(text: "Event A year 100", year: 100),
-            makeEvent(text: "Event B year 100", year: 100),
-            makeEvent(text: "Event C year 200", year: 200),
-            makeEvent(text: "Event D year 300", year: 300),
-            makeEvent(text: "Event E year 400", year: 400),
-            makeEvent(text: "Event F year 500", year: 500),
-            makeEvent(text: "Event G year 600", year: 600),
-            makeEvent(text: "Event H year 700", year: 700),
-            makeEvent(text: "Event I year 800", year: 800),
-            makeEvent(text: "Event J year 900", year: 900),
-            makeEvent(text: "Event K year 1000", year: 1000)
+            makeEvent(text: "Event Alpha", year: 100),
+            makeEvent(text: "Event Beta", year: 100),
+            makeEvent(text: "Event Gamma", year: 200),
+            makeEvent(text: "Event Delta", year: 300),
+            makeEvent(text: "Event Epsilon", year: 400),
+            makeEvent(text: "Event Zeta", year: 500),
+            makeEvent(text: "Event Eta", year: 600),
+            makeEvent(text: "Event Theta", year: 700),
+            makeEvent(text: "Event Iota", year: 800),
+            makeEvent(text: "Event Kappa", year: 900),
+            makeEvent(text: "Event Lambda", year: 1000)
         ]
 
         let questions = WMFGamesDataController.makeWhichCameFirstQuestions(
             from: events,
             month: 5,
             day: 7,
+            year: 2026,
             count: 5
         )
 
@@ -260,12 +291,13 @@ final class WMFGamesDataControllerTests: XCTestCase {
     }
 
     func testAllBCEventsProduceNoQuestions() {
-        let bcEvents = (1...20).map { makeEvent(text: "BC Event \($0)", year: -$0 * 100) }
+        let bcEvents = (1...20).map { makeEvent(text: "BC Event \(["Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon"][$0 - 1])", year: -$0 * 100) }
 
         let questions = WMFGamesDataController.makeWhichCameFirstQuestions(
             from: bcEvents,
             month: 5,
             day: 7,
+            year: 2026,
             count: 5
         )
 

--- a/WMFData/Tests/WMFDataTests/WMFGamesDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFGamesDataControllerTests.swift
@@ -189,6 +189,44 @@ final class WMFGamesDataControllerTests: XCTestCase {
         }
     }
 
+    func testPoolDeduplicatesByYear() {
+        // Two events with the same year — only one should enter the pool, so both
+        // questions must use distinct years for their paired options.
+        let events = [
+            makeEvent(text: "Event A year 100", year: 100),
+            makeEvent(text: "Event B year 100", year: 100),
+            makeEvent(text: "Event C year 200", year: 200),
+            makeEvent(text: "Event D year 300", year: 300),
+            makeEvent(text: "Event E year 400", year: 400),
+            makeEvent(text: "Event F year 500", year: 500),
+            makeEvent(text: "Event G year 600", year: 600),
+            makeEvent(text: "Event H year 700", year: 700),
+            makeEvent(text: "Event I year 800", year: 800),
+            makeEvent(text: "Event J year 900", year: 900),
+            makeEvent(text: "Event K year 1000", year: 1000)
+        ]
+
+        let questions = WMFGamesDataController.makeWhichCameFirstQuestions(
+            from: events,
+            month: 5,
+            day: 7,
+            count: 5
+        )
+
+        // Collect every year used across all questions.
+        var usedYears: [Int] = []
+        for question in questions {
+            let calendar = Calendar(identifier: .gregorian)
+            let yearA = calendar.component(.year, from: question.optionA.date)
+            let yearB = calendar.component(.year, from: question.optionB.date)
+            usedYears.append(contentsOf: [yearA, yearB])
+        }
+
+        // After dedup, year 100 appears only once in the pool, so it can appear at most once.
+        let year100Count = usedYears.filter { $0 == 100 }.count
+        XCTAssertLessThanOrEqual(year100Count, 1, "Year 100 should appear at most once across all questions after year deduplication")
+    }
+
     func testAllBCEventsProduceNoQuestions() {
         let bcEvents = (1...20).map { makeEvent(text: "BC Event \($0)", year: -$0 * 100) }
 

--- a/WMFData/Tests/WMFDataTests/WMFGamesDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFGamesDataControllerTests.swift
@@ -189,6 +189,15 @@ final class WMFGamesDataControllerTests: XCTestCase {
         }
     }
 
+    func testQuestionsAreDeterministicForSameDate() {
+        let events = (1...30).map { makeEvent(text: "Event \($0)", year: $0 * 50) }
+
+        let first = WMFGamesDataController.makeWhichCameFirstQuestions(from: events, month: 5, day: 7, count: 5)
+        let second = WMFGamesDataController.makeWhichCameFirstQuestions(from: events, month: 5, day: 7, count: 5)
+
+        XCTAssertEqual(first.map { $0.optionA.title }, second.map { $0.optionA.title }, "Same date should always produce the same question order")
+    }
+
     func testPoolFiltersEventsWithYearInText() {
         // Events whose text contains a standalone number should be excluded from the pool.
         let eventsWithYearInText = [


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
When looking at the Games algorithm for https://github.com/wikimedia/wikipedia-ios/pull/5992, I noticed events were sorted by year and paired off with the earliest dates first. This led me to more comparisons and other differences were found. Adding suggested fixes here to match Android more.

- Don't allow multiple events in the same year
- Filter out events with the year in the text, which may provide a hint.
- Randomize events before choosing pairs (don't start with the earliest events)
- Exclude future events

### Test Steps
1. Ensure unit tests pass
2. Play the game, you might see more modern events randomly picked now

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
