### PR TITLE
Fix Which Came First scoring to mark the earlier event as correct

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Games/WMFGamesDataController.swift
@@ -425,11 +425,15 @@ extension WMFGamesDataController {
                 thumbnailURL: thumbnail2
             )
 
+            // Randomize which slot each event lands in, then mark the earlier (oldest)
+            // event as correct — the game asks the user which event came first.
             let flip = Bool.random()
+            let slotA = flip ? optionB : optionA
+            let slotB = flip ? optionA : optionB
             questions.append(WMFWhichCameFirstQuestion(
-                optionA: flip ? optionB : optionA,
-                optionB: flip ? optionA : optionB,
-                correctAnswer: flip ? "B" : "A"
+                optionA: slotA,
+                optionB: slotB,
+                correctAnswer: slotA.date < slotB.date ? "A" : "B"
             ))
         }
 

--- a/WMFData/Tests/WMFDataTests/WMFGamesDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFGamesDataControllerTests.swift
@@ -141,6 +141,31 @@ final class WMFGamesDataControllerTests: XCTestCase {
         }
     }
 
+    func testCorrectAnswerPointsToEarlierEvent() {
+        // The game asks which event came first, so correctAnswer must identify the
+        // option with the earlier (oldest) date, regardless of slot randomization.
+        let eventNames = ["Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon"]
+        let events = (0...19).map { makeEvent(text: "Event \(eventNames[$0])", year: ($0 + 1) * 100) }
+
+        let questions = WMFGamesDataController.makeWhichCameFirstQuestions(
+            from: events,
+            month: 5,
+            day: 7,
+            year: 2026,
+            count: 5
+        )
+
+        XCTAssertEqual(questions.count, 5)
+        for question in questions {
+            let earlierOption = question.optionA.date < question.optionB.date ? "A" : "B"
+            XCTAssertEqual(
+                question.correctAnswer,
+                earlierOption,
+                "correctAnswer should point to the earlier event (A: \(question.optionA.date), B: \(question.optionB.date))"
+            )
+        }
+    }
+
     // MARK: - makeWhichCameFirstQuestions BC Date Filtering Tests
 
     /// Builds an event with a single page so it passes the `!pages.isEmpty` filter.


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T430754

### Notes
* correctAnswer was hard-wired to event1 (pool.removeFirst()) regardless of its date, so the game scored against an arbitrary event — often the more recent one — instead of the one that came first. Compare the two options' dates and mark the earlier (oldest) one correct.

### Test Steps
1. Play the game
2. Make sure earliest date is always the correct one

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
