### PR TITLE
Add year to game nav bar header dates

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Games/Splash Screen/WMFGamesSplashScreenViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Splash Screen/WMFGamesSplashScreenViewModel.swift
@@ -11,7 +11,7 @@ public final class WMFGamesSplashScreenViewModel: ObservableObject {
 
     /// SF Symbol name or custom icon name for the game icon displayed above the title.
     public let icon: UIImage?
-    /// The date label shown in the navigation bar (e.g. "January 6").
+    /// The date label shown in the navigation bar (e.g. "January 6, 25").
     @Published public var dateString: String?
 
     public let title: String

--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstViewController.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstViewController.swift
@@ -63,7 +63,7 @@ public final class WMFWhichCameFirstHostingController: WMFComponentHostingContro
 
     private func configureNavigationBar() {
         let titleConfig = WMFNavigationBarTitleConfig(
-            title: DateFormatter.wmfMonthDayFromDailyGameDate(viewModel.date),
+            title: DateFormatter.wmfMonthDayYearFromDailyGameDate(viewModel.date),
             customView: nil,
             alignment: .centerCompact
         )

--- a/WMFComponents/Sources/WMFComponents/Extensions/DateFormatter+Extensions.swift
+++ b/WMFComponents/Sources/WMFComponents/Extensions/DateFormatter+Extensions.swift
@@ -44,6 +44,15 @@ public extension DateFormatter {
         return dateFormatter
     }()
 
+    /// Month and Day and two-digit Year: e.g. `August 22, 25`
+    static var wmfMonthDayShortYearDateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeStyle = .none
+        dateFormatter.locale = .current
+        dateFormatter.setLocalizedDateFormatFromTemplate("MMMM d yy")
+        return dateFormatter
+    }()
+
     /// Smart formatter for "Last Read" dates:
     /// - If the date is today → show time (e.g. `2:48 PM`)
     /// - Otherwise → show month and day (e.g. `August 22`)
@@ -75,5 +84,14 @@ public extension DateFormatter {
         parser.locale = Locale(identifier: "en_US_POSIX")
         guard let date = parser.date(from: dateString) else { return dateString }
         return wmfMonthDayDateFormatter.string(from: date)
+    }
+
+    /// Parses a `yyyy-MM-dd` string and returns "Month Day, ’Year" e.g. `December 19, 25`
+    static func wmfMonthDayYearFromDailyGameDate(_ dateString: String) -> String {
+        let parser = DateFormatter()
+        parser.dateFormat = "yyyy-MM-dd"
+        parser.locale = Locale(identifier: "en_US_POSIX")
+        guard let date = parser.date(from: dateString) else { return dateString }
+        return wmfMonthDayShortYearDateFormatter.string(from: date)
     }
 }

--- a/Wikipedia/Code/WhichCameFirstCoordinator.swift
+++ b/Wikipedia/Code/WhichCameFirstCoordinator.swift
@@ -539,9 +539,7 @@ final class WhichCameFirstCoordinator: NSObject, Coordinator {
     // MARK: - Helpers
 
     private func formattedTodayDateString() -> String {
-        let formatter = DateFormatter()
-        formatter.setLocalizedDateFormatFromTemplate("MMMMd")
-        return formatter.string(from: Date())
+        return DateFormatter.wmfMonthDayShortYearDateFormatter.string(from: Date())
     }
 
     private func formattedTodayISODateString() -> String {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T430756

### Notes
* Clicking on an older date from the archive could be confusing
* Added a short year date to make it look better in smaller devices

### Test Steps
1. Play the game, current or archive
2. Make sure the view title displays the year
3. Also check splash screen

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
