### PR TITLE
T427936: Support hCaptcha in DiscussionTools API edits

### DIFF
--- a/WMFData/Sources/WMFData/Models/Developer Settings/WMFFeatureConfigResponse.swift
+++ b/WMFData/Sources/WMFData/Models/Developer Settings/WMFFeatureConfigResponse.swift
@@ -115,6 +115,7 @@ public struct WMFFeatureConfigResponse: Codable {
             public let reportapi: String
             public let sentry: Bool
             public let apiKey: String
+            public let editApiKey: String?
         }
     }
     

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -1317,6 +1317,7 @@
 		834CC34D21075B7600F62818 /* UITabBar+Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834CC34A21075B7600F62818 /* UITabBar+Theme.swift */; };
 		834F47F42833D91F00F86C80 /* RemoteNotificationFilterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834F47F32833D91F00F86C80 /* RemoteNotificationFilterType.swift */; };
 		835021BA2CD1496E00D0CB5E /* SinglePageWebViewParseDonationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835021B92CD1495900D0CB5E /* SinglePageWebViewParseDonationTests.swift */; };
+		A427936B0000000000000002 /* TalkPageFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A427936A0000000000000001 /* TalkPageFetcherTests.swift */; };
 		8350FC4C20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8350FC4B20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift */; };
 		8350FC4D20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8350FC4B20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift */; };
 		8350FC4E20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8350FC4B20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift */; };
@@ -3580,6 +3581,7 @@
 		834CC34A21075B7600F62818 /* UITabBar+Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBar+Theme.swift"; sourceTree = "<group>"; };
 		834F47F32833D91F00F86C80 /* RemoteNotificationFilterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationFilterType.swift; sourceTree = "<group>"; };
 		835021B92CD1495900D0CB5E /* SinglePageWebViewParseDonationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinglePageWebViewParseDonationTests.swift; sourceTree = "<group>"; };
+		A427936A0000000000000001 /* TalkPageFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageFetcherTests.swift; sourceTree = "<group>"; };
 		8350FC4B20DA937B00C19D60 /* ArticleLocationAuthorizationCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleLocationAuthorizationCollectionViewCell.swift; sourceTree = "<group>"; };
 		83510B0628F4CF6400B6235B /* TalkPageErrorStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageErrorStateView.swift; sourceTree = "<group>"; };
 		8351CE7720D4424100E32FC1 /* CollectionViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewHeader.swift; sourceTree = "<group>"; };
@@ -7280,6 +7282,7 @@
 				679FA102242E64FC0095F3C6 /* Article Tests */,
 				8330533223F0388E00123141 /* DataStoreTests.swift */,
 				835021B92CD1495900D0CB5E /* SinglePageWebViewParseDonationTests.swift */,
+				A427936A0000000000000001 /* TalkPageFetcherTests.swift */,
 				D8BDA8C01E71C0760031F4BF /* WMFBlocksKitTests.m */,
 				B39427411E71F79700D3146D /* NSDictionaryBlocksKitTest.m */,
 				B39427421E71F79700D3146D /* NSSetBlocksKitTest.m */,
@@ -9457,6 +9460,7 @@
 				67DAEDEF27E8FB63005CF9B6 /* NotificationsCenterDetailViewModelThanksTests.swift in Sources */,
 				67DAEDF127E8FB63005CF9B6 /* NotificationsCenterDetailViewModelEditMilestoneTests.swift in Sources */,
 				835021BA2CD1496E00D0CB5E /* SinglePageWebViewParseDonationTests.swift in Sources */,
+				A427936B0000000000000002 /* TalkPageFetcherTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Wikipedia/Code/TalkPageDataController.swift
+++ b/Wikipedia/Code/TalkPageDataController.swift
@@ -27,6 +27,8 @@ class TalkPageDataController {
     
     enum TalkPageError: Error {
         case unableToDetermineWikimediaProject
+        /// `siteKey` is server-dictated (nil falls back to the configured key).
+        case hCaptchaRequired(siteKey: String?, forceShowCaptcha: Bool)
     }
     
     // MARK: Public
@@ -76,18 +78,18 @@ class TalkPageDataController {
 
     }
     
-    func postReply(commentId: String, comment: String, completion: @escaping (Result<Void, Error>) -> Void) {
-        
-        talkPageFetcher.postReply(talkPageTitle: pageTitle, siteURL: siteURL, commentId: commentId, comment: comment.signed) { result in
+    func postReply(commentId: String, comment: String, hCaptchaToken: String? = nil, forceShowCaptcha: Bool = false, completion: @escaping (Result<Void, Error>) -> Void) {
+
+        talkPageFetcher.postReply(talkPageTitle: pageTitle, siteURL: siteURL, commentId: commentId, comment: comment.signed, hCaptchaToken: hCaptchaToken, forceShowCaptcha: forceShowCaptcha) { result in
             DispatchQueue.main.async {
                 completion(result)
             }
         }
     }
-    
-    func postTopic(topicTitle: String, topicBody: String, completion: @escaping (Result<Void, Error>) -> Void) {
-        
-        talkPageFetcher.postTopic(talkPageTitle: pageTitle, siteURL: siteURL, topicTitle: topicTitle, topicBody: topicBody.signed) { result in
+
+    func postTopic(topicTitle: String, topicBody: String, hCaptchaToken: String? = nil, forceShowCaptcha: Bool = false, completion: @escaping (Result<Void, Error>) -> Void) {
+
+        talkPageFetcher.postTopic(talkPageTitle: pageTitle, siteURL: siteURL, topicTitle: topicTitle, topicBody: topicBody.signed, hCaptchaToken: hCaptchaToken, forceShowCaptcha: forceShowCaptcha) { result in
             DispatchQueue.main.async {
                 completion(result)
             }

--- a/Wikipedia/Code/TalkPageFetcher.swift
+++ b/Wikipedia/Code/TalkPageFetcher.swift
@@ -186,13 +186,13 @@ class TalkPageFetcher: Fetcher {
         }
     }
     
-    func postReply(talkPageTitle: String, siteURL: URL, commentId: String, comment: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    func postReply(talkPageTitle: String, siteURL: URL, commentId: String, comment: String, hCaptchaToken: String? = nil, forceShowCaptcha: Bool = false, completion: @escaping (Result<Void, Error>) -> Void) {
         guard let title = talkPageTitle.denormalizedPageTitle else {
             completion(.failure(RequestError.invalidParameters))
             return
         }
-        
-        let params = ["action": "discussiontoolsedit",
+
+        var params = ["action": "discussiontoolsedit",
                       "paction": "addcomment",
                       "page": title,
                       "matags": WMFEditTag.appTalkReply.rawValue,
@@ -200,54 +200,84 @@ class TalkPageFetcher: Fetcher {
                       "formatversion" : "2",
                       "commentid": commentId,
                       "wikitext": comment
-                      
         ]
-        
+
+        addHCaptchaParams(to: &params, hCaptchaToken: hCaptchaToken, forceShowCaptcha: forceShowCaptcha)
+
         performTokenizedMediaWikiAPIPOST(to: siteURL, with: params, reattemptLoginOn401Response: false) { result, httpResponse, error in
             self.evaluateResponse(error, result, completion: completion)
         }
     }
-    
-    func postTopic(talkPageTitle: String, siteURL: URL, topicTitle: String, topicBody: String, completion: @escaping (Result<Void, Error>) -> Void) {
-        
+
+    func postTopic(talkPageTitle: String, siteURL: URL, topicTitle: String, topicBody: String, hCaptchaToken: String? = nil, forceShowCaptcha: Bool = false, completion: @escaping (Result<Void, Error>) -> Void) {
+
         guard let title = talkPageTitle.denormalizedPageTitle else {
             completion(.failure(RequestError.invalidParameters))
             return
         }
-        
-        let params = ["action": "discussiontoolsedit",
+
+        var params = ["action": "discussiontoolsedit",
                       "paction": "addtopic",
                       "page": title,
                       "matags": WMFEditTag.appTalkTopic.rawValue,
                       "format": "json",
                       "formatversion" : "2",
                       "sectiontitle": topicTitle,
-                      "wikitext": topicBody        ]
-        
+                      "wikitext": topicBody
+        ]
+
+        addHCaptchaParams(to: &params, hCaptchaToken: hCaptchaToken, forceShowCaptcha: forceShowCaptcha)
+
         performTokenizedMediaWikiAPIPOST(to: siteURL, with: params, reattemptLoginOn401Response: false) { result, httpResponse, error in
             self.evaluateResponse(error, result, completion: completion)
         }
     }
-    
-    fileprivate func evaluateResponse(_ error: Error?, _ result: [String : Any]?, completion: @escaping (Result<Void, Error>) -> Void) {
+
+    /// Token must be lowercase `captchaword` — the only form `discussiontoolsedit` forwards.
+    private func addHCaptchaParams(to params: inout [String: String], hCaptchaToken: String?, forceShowCaptcha: Bool) {
+        guard let hCaptchaToken else {
+            return
+        }
+        params["captchaword"] = hCaptchaToken
+        if forceShowCaptcha {
+            params["wgConfirmEditForceShowCaptcha"] = "1"
+        }
+    }
+
+    func evaluateResponse(_ error: Error?, _ result: [String : Any]?, completion: @escaping (Result<Void, Error>) -> Void) {
         if let error = error {
             completion(.failure(error))
             return
         }
-        
+
         if let resultError = result?["error"] as? [String: Any],
            let info = resultError["info"] as? String {
             completion(.failure(RequestError.api(info)))
             return
         }
-        
+
+        // A "success" without newrevid published nothing.
         guard let discussionToolsEdit = result?["discussiontoolsedit"] as? [String: Any],
               let discussionToolsEditResult = discussionToolsEdit["result"] as? String,
-              discussionToolsEditResult == "success" else {
+              discussionToolsEditResult == "success",
+              let newRevID = discussionToolsEdit["newrevid"] as? Int,
+              newRevID > 0 else {
+
+            if let discussionToolsEdit = result?["discussiontoolsedit"] as? [String: Any],
+               let edit = discussionToolsEdit["edit"] as? [String: Any],
+               let captcha = edit["captcha"] as? [String: Any],
+               let type = captcha["type"] as? String,
+               type == "hcaptcha" {
+                let siteKey = captcha["key"] as? String
+                let forceShowCaptcha = (captcha["error"] as? String) == "forceshowcaptcha"
+                completion(.failure(TalkPageDataController.TalkPageError.hCaptchaRequired(siteKey: siteKey, forceShowCaptcha: forceShowCaptcha)))
+                return
+            }
+
             completion(.failure(RequestError.unexpectedResponse))
             return
         }
-        
+
         completion(.success(()))
     }
     

--- a/Wikipedia/Code/TalkPageReplyComposeContentView.swift
+++ b/Wikipedia/Code/TalkPageReplyComposeContentView.swift
@@ -1,5 +1,6 @@
 import WMFComponents
 import WMF
+import WMFData
 import WMFNativeLocalizations
 
 class TalkPageReplyComposeContentView: SetupView {
@@ -127,6 +128,9 @@ class TalkPageReplyComposeContentView: SetupView {
     private let wikiHasTempAccounts: Bool?
     private let tappedIPTempButtonAction: () -> Void
 
+    // Localized "protected by hCaptcha" notice (HTML), appended to the fine print once fetched.
+    private var hCaptchaFinePrintHTML: String?
+
     // MARK: Lifecycle
 
     init(commentViewModel: TalkPageCellCommentViewModel, theme: Theme, linkDelegate: TalkPageTextViewLinkHandling, authenticationManager: WMFAuthenticationManager?, wikiHasTempAccounts: Bool?, tappedIPTempButtonAction: @escaping () -> Void) {
@@ -155,6 +159,7 @@ class TalkPageReplyComposeContentView: SetupView {
         setupPlaceholderLabel()
         updateFonts()
         apply(theme: theme)
+        fetchHCaptchaFinePrint()
 
         guard let semanticContentAttribute = commentViewModel.cellViewModel?.viewModel?.semanticContentAttribute else {
             return
@@ -382,7 +387,32 @@ class TalkPageReplyComposeContentView: SetupView {
             "</a>"
         )
 
-        return NSAttributedString.attributedStringFromHtml(substitutedString, styles: styles)
+        let attributedString = NSMutableAttributedString(attributedString: NSAttributedString.attributedStringFromHtml(substitutedString, styles: styles))
+
+        if let hCaptchaFinePrintHTML, !hCaptchaFinePrintHTML.isEmpty {
+            attributedString.append(NSAttributedString(string: "\n"))
+            attributedString.append(NSAttributedString.attributedStringFromHtml(hCaptchaFinePrintHTML, styles: styles))
+        }
+
+        return attributedString
+    }
+
+    /// Fetches the localized "protected by hCaptcha" notice and appends it to the fine print.
+    /// Best-effort: a failed fetch leaves the existing Terms/license text unchanged.
+    private func fetchHCaptchaFinePrint() {
+        guard let talkPageURL = commentViewModel.talkPageURL else {
+            return
+        }
+        let project = WMFProject.wikipedia(WMFLanguage(languageCode: talkPageURL.wmf_languageCode ?? "en", languageVariantCode: talkPageURL.wmf_languageVariantCode))
+        Task { [weak self] in
+            let html = try? await MessagesDataController().fetchMessages(keys: ["hcaptcha-privacy-policy"], parseLinks: true, project: project).first?.content
+            guard let html, !html.isEmpty else { return }
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.hCaptchaFinePrintHTML = html
+                self.finePrintTextView.attributedText = self.licenseTitleTextViewAttributedString
+            }
+        }
     }
 
     private var styles: HtmlUtils.Styles {

--- a/Wikipedia/Code/TalkPageTopicComposeViewController.swift
+++ b/Wikipedia/Code/TalkPageTopicComposeViewController.swift
@@ -1,5 +1,6 @@
 import WMFComponents
 import WMF
+import WMFData
 import WMFNativeLocalizations
 
 protocol TalkPageTopicComposeViewControllerDelegate: AnyObject {
@@ -28,6 +29,9 @@ class TalkPageTopicComposeViewController: ThemeableViewController, WMFNavigation
     let viewModel: TalkPageTopicComposeViewModel
 
     internal var preselectedTextRange = UITextRange()
+
+    // Localized "protected by hCaptcha" notice (HTML), appended to the fine print once fetched.
+    private var hCaptchaFinePrintHTML: String?
 
     private lazy var safeAreaBackgroundView: UIView = {
         let view = UIView(frame: .zero)
@@ -187,6 +191,7 @@ class TalkPageTopicComposeViewController: ThemeableViewController, WMFNavigation
         setupContainerStackView()
         updateFonts()
         apply(theme: theme)
+        fetchHCaptchaFinePrint()
 
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillChangeFrame(_:)), name: UIWindow.keyboardWillChangeFrameNotification, object: nil)
 
@@ -485,7 +490,29 @@ class TalkPageTopicComposeViewController: ThemeableViewController, WMFNavigation
 
         let styles = HtmlUtils.Styles(font: WMFFont.for(.caption1, compatibleWith: traitCollection), boldFont: WMFFont.for(.boldCaption1, compatibleWith: traitCollection), italicsFont: WMFFont.for(.italicCaption1, compatibleWith: traitCollection), boldItalicsFont: WMFFont.for(.boldCaption1, compatibleWith: traitCollection), color: theme.colors.primaryText, linkColor: theme.colors.link, lineSpacing: 3)
 
-        return NSAttributedString.attributedStringFromHtml(substitutedString, styles: styles)
+        let attributedString = NSMutableAttributedString(attributedString: NSAttributedString.attributedStringFromHtml(substitutedString, styles: styles))
+
+        if let hCaptchaFinePrintHTML, !hCaptchaFinePrintHTML.isEmpty {
+            attributedString.append(NSAttributedString(string: "\n"))
+            attributedString.append(NSAttributedString.attributedStringFromHtml(hCaptchaFinePrintHTML, styles: styles))
+        }
+
+        return attributedString
+    }
+
+    /// Fetches the localized "protected by hCaptcha" notice and appends it to the fine print.
+    /// Best-effort: a failed fetch leaves the existing Terms/license text unchanged.
+    private func fetchHCaptchaFinePrint() {
+        let project = WMFProject.wikipedia(WMFLanguage(languageCode: viewModel.siteURL.wmf_languageCode ?? "en", languageVariantCode: viewModel.siteURL.wmf_languageVariantCode))
+        Task { [weak self] in
+            let html = try? await MessagesDataController().fetchMessages(keys: ["hcaptcha-privacy-policy"], parseLinks: true, project: project).first?.content
+            guard let html, !html.isEmpty else { return }
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.hCaptchaFinePrintHTML = html
+                self.finePrintTextView.attributedText = self.licenseTitleTextViewAttributedString
+            }
+        }
     }
 
     private func evaluatePublishButtonEnabledState() {

--- a/Wikipedia/Code/TalkPageViewController.swift
+++ b/Wikipedia/Code/TalkPageViewController.swift
@@ -1135,6 +1135,19 @@ extension TalkPageViewController: TalkPageReplyComposeDelegate {
 
     func tappedPublish(text: String, commentViewModel: TalkPageCellCommentViewModel) {
 
+        if let talkPageURL = viewModel.getTalkPageURL(encoded: false) {
+            EditAttemptFunnel.shared.logSaveAttempt(pageURL: talkPageURL)
+        }
+
+        if let lastViewDidAppearDate = lastViewDidAppearDate {
+            TalkPagesFunnel.shared.logTappedPublishNewTopicOrInlineReply(routingSource: viewModel.source, project: viewModel.project, talkPageType: viewModel.pageType, lastViewDidAppearDate: lastViewDidAppearDate)
+        }
+
+        publishReply(text: text, commentViewModel: commentViewModel)
+    }
+
+    private func publishReply(text: String, commentViewModel: TalkPageCellCommentViewModel, hCaptchaToken: String? = nil, forceShowCaptcha: Bool = false) {
+
         var wasIP = false
         if let wikiHasTempAccounts = viewModel.wikiHasTempAccounts, !viewModel.authenticationManager.authStateIsPermanent && wikiHasTempAccounts {
             if !viewModel.authenticationManager.authStateIsTemporary {
@@ -1142,18 +1155,10 @@ extension TalkPageViewController: TalkPageReplyComposeDelegate {
             }
         }
 
-        if let talkPageURL = viewModel.getTalkPageURL(encoded: false) {
-            EditAttemptFunnel.shared.logSaveAttempt(pageURL: talkPageURL)
-        }
-
         let oldCellViewModel = commentViewModel.cellViewModel
         let oldCommentViewModels = oldCellViewModel?.allCommentViewModels
 
-        if let lastViewDidAppearDate = lastViewDidAppearDate {
-            TalkPagesFunnel.shared.logTappedPublishNewTopicOrInlineReply(routingSource: viewModel.source, project: viewModel.project, talkPageType: viewModel.pageType, lastViewDidAppearDate: lastViewDidAppearDate)
-        }
-
-        viewModel.postReply(commentId: commentViewModel.commentId, comment: text) { [weak self] result in
+        viewModel.postReply(commentId: commentViewModel.commentId, comment: text, hCaptchaToken: hCaptchaToken, forceShowCaptcha: forceShowCaptcha) { [weak self] result in
 
             guard let self else {
                 return
@@ -1195,6 +1200,15 @@ extension TalkPageViewController: TalkPageReplyComposeDelegate {
                     }
                 }
             case .failure(let error):
+                if case TalkPageDataController.TalkPageError.hCaptchaRequired(let siteKey, let forceShowCaptcha) = error {
+                    self.presentHCaptchaChallenge(on: self, siteKey: siteKey, forceShowCaptcha: forceShowCaptcha, onSuccess: { [weak self] token in
+                        self?.publishReply(text: text, commentViewModel: commentViewModel, hCaptchaToken: token, forceShowCaptcha: forceShowCaptcha)
+                    }, onError: { [weak self] in
+                        self?.replyComposeController.isLoading = false
+                    })
+                    return
+                }
+
                 DDLogError("Failure publishing reply: \(error)")
                 self.replyComposeController.isLoading = false
                 if let talkPageURL = self.viewModel.getTalkPageURL(encoded: false) {
@@ -1224,12 +1238,54 @@ extension TalkPageViewController: TalkPageReplyComposeDelegate {
         viewController.present(alert, animated: true)
     }
 
+    /// Presents an hCaptcha challenge, reporting the token via `onSuccess` (to retry) or `onError`.
+    fileprivate func presentHCaptchaChallenge(on presenter: UIViewController, siteKey: String?, forceShowCaptcha: Bool, onSuccess: @escaping (String) -> Void, onError: @escaping () -> Void) {
+        let hcaptchaVC = WMFHCaptchaViewController()
+        hcaptchaVC.theme = theme
+        if forceShowCaptcha {
+            hcaptchaVC.siteKey = siteKey
+        } else {
+            let editApiKey = WMFDeveloperSettingsDataController.shared.loadFeatureConfig()?.ios.hCaptcha?.editApiKey
+            hcaptchaVC.siteKey = editApiKey?.isEmpty == false ? editApiKey : nil
+        }
+        hcaptchaVC.modalTransitionStyle = .crossDissolve
+        hcaptchaVC.modalPresentationStyle = .overFullScreen
+
+        hcaptchaVC.successAction = { [weak hcaptchaVC] token in
+            guard let hcaptchaVC else { return }
+            hcaptchaVC.dismiss(animated: true) {
+                onSuccess(token)
+            }
+        }
+
+        hcaptchaVC.errorAction = { [weak hcaptchaVC] error in
+            guard let hcaptchaVC else { return }
+            hcaptchaVC.dismiss(animated: true) {
+                WMFToastManager.sharedInstance.showErrorAlert(error, sticky: true, dismissPreviousToasts: true)
+                onError()
+            }
+        }
+
+        presenter.present(hcaptchaVC, animated: true) {
+            hcaptchaVC.validate()
+        }
+    }
+
 }
 
 // MARK: Extensions
 
 extension TalkPageViewController: TalkPageTopicComposeViewControllerDelegate {
     func tappedPublish(topicTitle: String, topicBody: String, composeViewController: TalkPageTopicComposeViewController) {
+
+        if let lastViewDidAppearDate = lastViewDidAppearDate {
+            TalkPagesFunnel.shared.logTappedPublishNewTopicOrInlineReply(routingSource: viewModel.source, project: viewModel.project, talkPageType: viewModel.pageType, lastViewDidAppearDate: lastViewDidAppearDate)
+        }
+
+        publishTopic(topicTitle: topicTitle, topicBody: topicBody, composeViewController: composeViewController)
+    }
+
+    private func publishTopic(topicTitle: String, topicBody: String, composeViewController: TalkPageTopicComposeViewController, hCaptchaToken: String? = nil, forceShowCaptcha: Bool = false) {
 
         var wasIP = false
         if let wikiHasTempAccounts = viewModel.wikiHasTempAccounts, !viewModel.authenticationManager.authStateIsPermanent && wikiHasTempAccounts {
@@ -1238,11 +1294,7 @@ extension TalkPageViewController: TalkPageTopicComposeViewControllerDelegate {
             }
         }
 
-        if let lastViewDidAppearDate = lastViewDidAppearDate {
-            TalkPagesFunnel.shared.logTappedPublishNewTopicOrInlineReply(routingSource: viewModel.source, project: viewModel.project, talkPageType: viewModel.pageType, lastViewDidAppearDate: lastViewDidAppearDate)
-        }
-
-        viewModel.postTopic(topicTitle: topicTitle, topicBody: topicBody) { [weak self] result in
+        viewModel.postTopic(topicTitle: topicTitle, topicBody: topicBody, hCaptchaToken: hCaptchaToken, forceShowCaptcha: forceShowCaptcha) { [weak self] result in
 
             guard let self else { return }
 
@@ -1282,6 +1334,14 @@ extension TalkPageViewController: TalkPageTopicComposeViewControllerDelegate {
                     }
                 }
             case .failure(let error):
+                if case TalkPageDataController.TalkPageError.hCaptchaRequired(let siteKey, let forceShowCaptcha) = error {
+                    self.presentHCaptchaChallenge(on: composeViewController, siteKey: siteKey, forceShowCaptcha: forceShowCaptcha, onSuccess: { [weak self] token in
+                        self?.publishTopic(topicTitle: topicTitle, topicBody: topicBody, composeViewController: composeViewController, hCaptchaToken: token, forceShowCaptcha: forceShowCaptcha)
+                    }, onError: {
+                        composeViewController.setupNavigationBar(isPublishing: false)
+                    })
+                    return
+                }
 
                 DDLogError("Failure publishing topic: \(error)")
                 composeViewController.setupNavigationBar(isPublishing: false)

--- a/Wikipedia/Code/TalkPageViewModel.swift
+++ b/Wikipedia/Code/TalkPageViewModel.swift
@@ -129,12 +129,12 @@ final class TalkPageViewModel {
         }
     }
 
-    func postTopic(topicTitle: String, topicBody: String, completion: @escaping (Result<Void, Error>) -> Void) {
-        dataController.postTopic(topicTitle: topicTitle, topicBody: topicBody, completion: completion)
+    func postTopic(topicTitle: String, topicBody: String, hCaptchaToken: String? = nil, forceShowCaptcha: Bool = false, completion: @escaping (Result<Void, Error>) -> Void) {
+        dataController.postTopic(topicTitle: topicTitle, topicBody: topicBody, hCaptchaToken: hCaptchaToken, forceShowCaptcha: forceShowCaptcha, completion: completion)
     }
-    
-    func postReply(commentId: String, comment: String, completion: @escaping (Result<Void, Error>) -> Void) {
-        dataController.postReply(commentId: commentId, comment: comment, completion: completion)
+
+    func postReply(commentId: String, comment: String, hCaptchaToken: String? = nil, forceShowCaptcha: Bool = false, completion: @escaping (Result<Void, Error>) -> Void) {
+        dataController.postReply(commentId: commentId, comment: comment, hCaptchaToken: hCaptchaToken, forceShowCaptcha: forceShowCaptcha, completion: completion)
     }
     
 

--- a/Wikipedia/Code/WMFHCaptchaViewController.swift
+++ b/Wikipedia/Code/WMFHCaptchaViewController.swift
@@ -36,8 +36,9 @@ class WMFHCaptchaViewController: ThemeableViewController {
     var hCaptcha: HCaptcha?
     var captchaWebView: WKWebView?
 
-    /// Site key provided by the server (via authmanagerinfo `metadata.key`) for this challenge.
-    /// When set, it takes precedence over the site key in the remote feature config.
+    /// Explicit site key for this challenge — either server-provided (via authmanagerinfo
+    /// `metadata.key`) or the app's own key for a specific action. When set, it overrides the
+    /// default site key in the remote feature config.
     var siteKey: String?
 
     var successAction: ((String) -> Void)?

--- a/WikipediaUnitTests/Code/TalkPageFetcherTests.swift
+++ b/WikipediaUnitTests/Code/TalkPageFetcherTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import Wikipedia
+@testable import WMF
+
+final class TalkPageFetcherTests: XCTestCase {
+
+    /// `evaluateResponse` is pure, so no network is needed.
+    private func evaluate(_ result: [String: Any]?) -> Result<Void, Error> {
+        let session = Session(configuration: .current)
+        let fetcher = TalkPageFetcher(session: session, configuration: .current)
+        var captured: Result<Void, Error>!
+        fetcher.evaluateResponse(nil, result) { captured = $0 }
+        return captured
+    }
+
+    func testSuccessWithNewRevIDSucceeds() {
+        let result = evaluate(["discussiontoolsedit": ["result": "success", "newrevid": 12345]])
+        guard case .success = result else {
+            return XCTFail("Expected success, got \(result)")
+        }
+    }
+
+    func testSuccessWithoutNewRevIDIsNotSuccess() {
+        let result = evaluate(["discussiontoolsedit": ["result": "success"]])
+        guard case .failure = result else {
+            return XCTFail("Expected failure when newrevid is missing")
+        }
+    }
+
+    func testHCaptchaChallengeReturnsHCaptchaRequiredWithSiteKey() {
+        // Response shape from T427887.
+        let result = evaluate([
+            "discussiontoolsedit": [
+                "result": "error",
+                "edit": [
+                    "result": "Failure",
+                    "captcha": [
+                        "type": "hcaptcha",
+                        "mime": "application/javascript",
+                        "key": "5d0c670e-a5f4-4258-ad16-1f42792c9c62",
+                        "error": "missing-token"
+                    ]
+                ]
+            ]
+        ])
+        guard case .failure(let error) = result,
+              case TalkPageDataController.TalkPageError.hCaptchaRequired(let siteKey, let forceShowCaptcha) = error else {
+            return XCTFail("Expected hCaptchaRequired, got \(result)")
+        }
+        XCTAssertEqual(siteKey, "5d0c670e-a5f4-4258-ad16-1f42792c9c62")
+        XCTAssertFalse(forceShowCaptcha)
+    }
+
+    func testForceShowCaptchaChallengeSetsForceShowFlag() {
+        // AbuseFilter "showcaptcha": always-challenge sitekey + error=forceshowcaptcha.
+        let result = evaluate([
+            "discussiontoolsedit": [
+                "result": "error",
+                "edit": [
+                    "result": "Failure",
+                    "captcha": [
+                        "type": "hcaptcha",
+                        "key": "always-challenge-key",
+                        "error": "forceshowcaptcha"
+                    ]
+                ]
+            ]
+        ])
+        guard case .failure(let error) = result,
+              case TalkPageDataController.TalkPageError.hCaptchaRequired(let siteKey, let forceShowCaptcha) = error else {
+            return XCTFail("Expected hCaptchaRequired, got \(result)")
+        }
+        XCTAssertEqual(siteKey, "always-challenge-key")
+        XCTAssertTrue(forceShowCaptcha)
+    }
+
+    func testTopLevelAPIErrorReturnsAPIError() {
+        let result = evaluate(["error": ["info": "Some API error", "code": "badtoken"]])
+        guard case .failure(let error) = result, case RequestError.api = error else {
+            return XCTFail("Expected RequestError.api, got \(result)")
+        }
+    }
+
+    func testNonCaptchaFailureReturnsUnexpectedResponse() {
+        let result = evaluate(["discussiontoolsedit": ["result": "error", "edit": ["result": "Failure"]]])
+        guard case .failure(let error) = result, case RequestError.unexpectedResponse = error else {
+            return XCTFail("Expected unexpectedResponse, got \(result)")
+        }
+    }
+}


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T427936

Why:

- Talk-page replies and new topics posted via discussiontoolsedit should support hCaptcha.

What:

- Detect the challenge in TalkPageFetcher, surfacing the server suggested sitekey and always-challenge flag
- present the existing WMFHCaptchaViewController (adding siteKeyOverride so the token is solved against the key the server verifies)
- resubmit the edit with the token as `captchaword`, plus wgConfirmEditForceShowCaptcha when an interactive always-challenge is required

Assisted-by: Claude Opus 4.8