### PR TITLE
Integrate hCaptcha into the Login flow.

### DIFF
--- a/Wikipedia/Code/WMFAccountLoginLogoutFetcher.swift
+++ b/Wikipedia/Code/WMFAccountLoginLogoutFetcher.swift
@@ -25,6 +25,7 @@ public enum WMFAccountLoginError: LocalizedError {
     case wrongPassword(MediaWikiMessage?)
     case wrongToken(MediaWikiMessage?)
     case captchaRequired(String?, MediaWikiMessage?)
+    case hCaptchaRequired(String?, MediaWikiMessage?)
     case authManagerInfoRequired(MediaWikiMessage?, [String: Any])
     case failedToParseAuthManagerInfo(MediaWikiMessage?)
     case invalidSiteURL
@@ -41,6 +42,8 @@ public enum WMFAccountLoginError: LocalizedError {
              .authManagerInfoRequired(let message, _):
             return message?.text
         case .captchaRequired(_, let message):
+            return message?.text
+        case .hCaptchaRequired(_, let message):
             return message?.text
         case .wrongToken:
             return WMFLocalizedString("field-alert-token-invalid", value:"Invalid code", comment:"Alert shown if token is not correct")
@@ -62,6 +65,8 @@ public enum WMFAccountLoginError: LocalizedError {
             return message?.code
         case .captchaRequired(_, let message):
             return message?.code
+        case .hCaptchaRequired(_, let message):
+            return message?.code
         case .cannotExtractLoginStatus:
             return nil
         case .invalidSiteURL:
@@ -81,7 +86,7 @@ public typealias Username = String
 
 public class WMFAccountLoginLogoutFetcher: Fetcher {
     
-    public func login(username: String, password: String, retypePassword: String?, oathToken: String?, emailAuthCode: String?, captchaID: String?, captchaWord: String?, siteURL: URL, reattemptOn401Response: Bool = false, attempt: Int = 0, newModule: String? = nil, success: @escaping (Username) -> Void, failure: @escaping WMFErrorHandler) {
+    public func login(username: String, password: String, retypePassword: String?, oathToken: String?, emailAuthCode: String?, captchaID: String?, captchaWord: String?, hCaptchaToken: String? = nil, siteURL: URL, reattemptOn401Response: Bool = false, attempt: Int = 0, newModule: String? = nil, success: @escaping (Username) -> Void, failure: @escaping WMFErrorHandler) {
         
         let attempt = attempt + 1
 
@@ -112,7 +117,8 @@ public class WMFAccountLoginLogoutFetcher: Fetcher {
         if let captchaID = captchaID {
             parameters["captchaId"] = captchaID
         }
-        if let captchaWord = captchaWord {
+        // The hCaptcha token is submitted in the same `captchaWord` field the classic captcha solution uses.
+        if let captchaWord = hCaptchaToken ?? captchaWord {
             parameters["captchaWord"] = captchaWord
         }
         
@@ -158,6 +164,28 @@ public class WMFAccountLoginLogoutFetcher: Fetcher {
                         case .success(let authInfo):
                             guard let requests = authInfo["requests"] as? [[String: Any]] else {
                                 failure(WMFAccountLoginError.failedToParseAuthManagerInfo(message))
+                                return
+                            }
+
+                            // If the failure is captcha-related and the server offers an hCaptcha challenge, prompt for hCaptcha.
+                            let hCaptchaRequest = requests.first { request in
+                                guard let id = (request["id"] as? String)?.lowercased(),
+                                      id.contains("captcha"),
+                                      let metadata = request["metadata"] as? [String: Any],
+                                      let type = (metadata["type"] as? String)?.lowercased(),
+                                      type.contains("hcaptcha") else {
+                                    return false
+                                }
+                                return true
+                            }
+
+                            if let hCaptchaRequest,
+                               let messageCode,
+                               messageCode.lowercased().contains("captcha"),
+                               !messageCode.lowercased().contains("error") {
+                                // `metadata.key` is the hCaptcha site key to use for this challenge.
+                                let siteKey = (hCaptchaRequest["metadata"] as? [String: Any])?["key"] as? String
+                                failure(WMFAccountLoginError.hCaptchaRequired(siteKey, message))
                                 return
                             }
 
@@ -227,7 +255,7 @@ public class WMFAccountLoginLogoutFetcher: Fetcher {
                        allowedModules.contains("totp"),
                        attempt == 1 {
                         // repeat call once, passing in "newModule=totp" https://phabricator.wikimedia.org/T399654#11133473
-                        login(username: username, password: password, retypePassword: retypePassword, oathToken: oathToken, emailAuthCode: emailAuthCode, captchaID: captchaID, captchaWord: captchaWord, siteURL: siteURL, attempt: attempt, newModule: "totp", success: success, failure: failure)
+                        login(username: username, password: password, retypePassword: retypePassword, oathToken: oathToken, emailAuthCode: emailAuthCode, captchaID: captchaID, captchaWord: captchaWord, hCaptchaToken: hCaptchaToken, siteURL: siteURL, attempt: attempt, newModule: "totp", success: success, failure: failure)
                         return
                     }
 

--- a/Wikipedia/Code/WMFAuthenticationManager.swift
+++ b/Wikipedia/Code/WMFAuthenticationManager.swift
@@ -178,16 +178,17 @@ import WMFTestKitchen
     ///   - oathToken: Two factor password required if user's account has 2FA enabled. Optional.
     ///   - captchaID: CaptchaID if login requiers captcha information
     ///   - captchaWord: CaptchaWord if login requiers captcha information
+    ///   - hCaptchaToken: hCaptcha token if login requires an hCaptcha challenge to be solved
     ///   - reattemptOn401Response: Attempts login again if response http is 401.
     ///   - completion: Completion handler with current user object upon success
-    public func login(username: String, password: String, retypePassword: String?, oathToken: String?, emailAuthCode: String?, captchaID: String?, captchaWord: String?, reattemptOn401Response: Bool = false, completion: @escaping (Result<WMFCurrentUser, Error>) -> Void) {
+    public func login(username: String, password: String, retypePassword: String?, oathToken: String?, emailAuthCode: String?, captchaID: String?, captchaWord: String?, hCaptchaToken: String? = nil, reattemptOn401Response: Bool = false, completion: @escaping (Result<WMFCurrentUser, Error>) -> Void) {
         guard let siteURL = loginSiteURL else {
             DispatchQueue.main.async {
                 completion(.failure(LoginError.missingLoginURL))
             }
             return
         }
-        accountLoginLogoutFetcher.login(username: username, password: password, retypePassword: retypePassword, oathToken: oathToken, emailAuthCode: emailAuthCode, captchaID: captchaID, captchaWord: captchaWord, siteURL: siteURL, reattemptOn401Response: reattemptOn401Response, success: {username in
+        accountLoginLogoutFetcher.login(username: username, password: password, retypePassword: retypePassword, oathToken: oathToken, emailAuthCode: emailAuthCode, captchaID: captchaID, captchaWord: captchaWord, hCaptchaToken: hCaptchaToken, siteURL: siteURL, reattemptOn401Response: reattemptOn401Response, success: {username in
 
             // Upon successful login, try fetching userinfo to populate user cache
             self.currentUserFetcher.fetch(siteURL: siteURL, success: { user in

--- a/Wikipedia/Code/WMFHCaptchaViewController.swift
+++ b/Wikipedia/Code/WMFHCaptchaViewController.swift
@@ -35,7 +35,11 @@ class WMFHCaptchaViewController: ThemeableViewController {
     // MARK: - HCaptcha
     var hCaptcha: HCaptcha?
     var captchaWebView: WKWebView?
-    
+
+    /// Site key provided by the server (via authmanagerinfo `metadata.key`) for this challenge.
+    /// When set, it takes precedence over the site key in the remote feature config.
+    var siteKey: String?
+
     var successAction: ((String) -> Void)?
     var errorAction: ((Error) -> Void)?
 
@@ -110,7 +114,7 @@ class WMFHCaptchaViewController: ThemeableViewController {
                       return
                   }
             
-            let apiKey = WMFDeveloperSettingsDataController.shared.forceHCaptchaChallenge ? "45205f58-be1c-40f0-b286-07a4498ea3da" : config.apiKey
+            let apiKey = WMFDeveloperSettingsDataController.shared.forceHCaptchaChallenge ? "45205f58-be1c-40f0-b286-07a4498ea3da" : (siteKey ?? config.apiKey)
             hCaptcha = try HCaptcha(apiKey: apiKey,
                                      baseURL: baseURL,
                                      jsSrc: jsSrc,

--- a/Wikipedia/Code/WMFLoginViewController.storyboard
+++ b/Wikipedia/Code/WMFLoginViewController.storyboard
@@ -144,6 +144,13 @@
                                                             <action selector="loginButtonTappedWithSender:" destination="mbm-n6-GWW" eventType="touchUpInside" id="hfj-DJ-2AQ"/>
                                                         </connections>
                                                     </button>
+                                                    <textView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" text="`" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Hc1-Fp-tv0" userLabel="hCaptcha Fine Print Text View">
+                                                        <rect key="frame" x="0.0" y="463" width="288" height="0.0"/>
+                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                        <color key="textColor" systemColor="labelColor"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                    </textView>
                                                 </subviews>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="288" id="KRB-WU-5eu"/>
@@ -182,6 +189,7 @@
                         <outlet property="captchaContainer" destination="DZK-nT-oqo" id="huS-0D-XXz"/>
                         <outlet property="createAccountButton" destination="jiW-Cg-oL3" id="Yk9-jI-doe"/>
                         <outlet property="forgotPasswordButton" destination="LDv-H3-IXL" id="qIN-wb-OOS"/>
+                        <outlet property="hcaptchaFinePrintTextView" destination="Hc1-Fp-tv0" id="Hc2-Fp-ou0"/>
                         <outlet property="loginButton" destination="d0a-BA-vwt" id="A3V-ih-aBb"/>
                         <outlet property="passwordAlertLabel" destination="HxZ-Ry-50e" id="rW0-Ht-vIF"/>
                         <outlet property="passwordField" destination="kVb-lx-d6C" id="CMg-WD-j0S"/>

--- a/Wikipedia/Code/WMFLoginViewController.swift
+++ b/Wikipedia/Code/WMFLoginViewController.swift
@@ -5,6 +5,7 @@ import WMFData
 import CocoaLumberjackSwift
 import WMFNativeLocalizations
 import WMFTestKitchen
+import HCaptcha
 
 class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFCaptchaViewControllerDelegate, Themeable, WMFNavigationBarConfiguring {
     // SINGLETONTODO
@@ -20,6 +21,7 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
     @IBOutlet fileprivate var titleLabel: UILabel!
     @IBOutlet weak var scrollContainerTopConstraint: NSLayoutConstraint!
     @IBOutlet fileprivate var captchaContainer: UIView!
+    @IBOutlet var hcaptchaFinePrintTextView: UITextView!
     @IBOutlet fileprivate var loginButton: WMFAuthButton!
     @IBOutlet weak var scrollContainer: UIView!
 
@@ -45,6 +47,9 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
     
     fileprivate lazy var captchaViewController: WMFCaptchaViewController? = WMFCaptchaViewController.wmf_initialViewControllerFromClassStoryboard()
     private let loginInfoFetcher = WMFAuthLoginInfoFetcher()
+
+    private var hCaptchaToken: String?
+    private var hCaptchaFinePrintText: String?
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
@@ -237,7 +242,7 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
             return
         }
 
-        dataStore.authenticationManager.login(username: username, password: password, retypePassword: nil, oathToken: nil, emailAuthCode: nil, captchaID: captchaViewController?.captcha?.classicInfo?.captchaID, captchaWord: captchaViewController?.solution) { [weak self] (loginResult) in
+        dataStore.authenticationManager.login(username: username, password: password, retypePassword: nil, oathToken: nil, emailAuthCode: nil, captchaID: captchaViewController?.captcha?.classicInfo?.captchaID, captchaWord: captchaViewController?.solution, hCaptchaToken: hCaptchaToken) { [weak self] (loginResult) in
 
             guard let self else { return }
 
@@ -268,6 +273,9 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
             case .failure(let error):
                 self.setViewControllerUserInteraction(enabled: true)
 
+                // hCaptcha tokens are single-use, so discard the previous one on any failure.
+                self.hCaptchaToken = nil
+
                 // Captcha's appear to be one-time, so always try to get a new one on failure.
                 self.getCaptcha()
 
@@ -286,6 +294,10 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
                         return
                     case .needsEmailAuthToken:
                         self.showTwoFactorViewController(isEmailAuth: true)
+                        return
+                    case .hCaptchaRequired(let siteKey, _):
+                        WMFToastManager.sharedInstance.dismissCurrentToast()
+                        self.displayHCaptcha(siteKey: siteKey)
                         return
                     case .statusNotPass:
                         self.passwordField.text = nil
@@ -411,14 +423,101 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
         let siteURL = dataStore.primarySiteURL
         loginInfoFetcher.fetchLoginInfoForSiteURL(siteURL!, success: { info in
             DispatchQueue.main.async { [weak self] in
-                
+
                 guard let self else { return }
-                
-                self.captchaViewController?.captcha = info.captcha
+
+                if info.captcha?.classicInfo != nil {
+                    self.captchaViewController?.captcha = info.captcha
+                    self.hcaptchaFinePrintTextView.isHidden = true
+                } else if (info.captcha?.hCaptchaInfo?.needsHCaptcha) ?? false {
+                    // hCaptcha challenge is presented on demand from the login failure handler; here we only surface the required fine print.
+                    self.captchaViewController?.captcha = nil
+                    self.fetchAndSetupHCaptchaFinePrint()
+                } else {
+                    self.captchaViewController?.captcha = nil
+                    self.hcaptchaFinePrintTextView.isHidden = true
+                }
                 self.updatePasswordFieldReturnKeyType()
                 self.enableProgressiveButtonIfNecessary()
             }
         }, failure: captchaFailure)
+    }
+
+    private func setupHCaptchaFinePrintText() {
+        guard let hCaptchaFinePrintText,
+              !hCaptchaFinePrintText.isEmpty else {
+            return
+        }
+        hcaptchaFinePrintTextView.delegate = self
+        hcaptchaFinePrintTextView.isEditable = false
+        hcaptchaFinePrintTextView.isSelectable = true
+        hcaptchaFinePrintTextView.backgroundColor = .clear
+
+        let font = WMFFont.for(.caption1)
+        let boldFont = WMFFont.for(.semiboldCaption1)
+        let color = theme.colors.secondaryText
+        let linkColor = theme.colors.link
+        let styles = HtmlUtils.Styles(font: font, boldFont: boldFont, italicsFont: font, boldItalicsFont: font, linkFont: boldFont, color: color, linkColor: linkColor, lineSpacing: 1)
+        if let attributedText = try? HtmlUtils.nsAttributedStringFromHtml(hCaptchaFinePrintText, styles: styles) {
+            hcaptchaFinePrintTextView.attributedText = attributedText
+        } else {
+            hcaptchaFinePrintTextView.text = hCaptchaFinePrintText
+        }
+    }
+
+    private func fetchAndSetupHCaptchaFinePrint() {
+        let appLanguage = dataStore.languageLinkController.appLanguage
+        Task { [weak self] in
+
+            guard let self else { return }
+
+            let languageCode = appLanguage?.languageCode ?? "en"
+            let languageVariantCode = appLanguage?.languageVariantCode
+            let project = WMFProject.wikipedia(WMFLanguage(languageCode: languageCode, languageVariantCode: languageVariantCode))
+            do {
+                let finePrintText = try await MessagesDataController().fetchMessages(keys: ["hcaptcha-privacy-policy"], parseLinks: true, project: project).first?.content
+
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.hCaptchaFinePrintText = finePrintText
+                    self.setupHCaptchaFinePrintText()
+                    self.hcaptchaFinePrintTextView.isHidden = false
+                }
+            } catch {
+                self.hcaptchaFinePrintTextView.isHidden = true
+            }
+
+            self.enableProgressiveButtonIfNecessary()
+        }
+    }
+
+    private func displayHCaptcha(siteKey: String?) {
+        let hcaptchaVC = WMFHCaptchaViewController()
+        hcaptchaVC.authInstrument = authInstrument
+        hcaptchaVC.siteKey = siteKey
+        hcaptchaVC.theme = theme
+        hcaptchaVC.modalTransitionStyle = .crossDissolve
+        hcaptchaVC.modalPresentationStyle = .overFullScreen
+
+        hcaptchaVC.successAction = { token in
+            hcaptchaVC.dismiss(animated: true) { [weak self] in
+                self?.hCaptchaToken = token
+                self?.save()
+            }
+        }
+
+        hcaptchaVC.errorAction = { error in
+            hcaptchaVC.dismiss(animated: true) { [weak self] in
+                self?.hCaptchaToken = nil
+                self?.setViewControllerUserInteraction(enabled: true)
+                self?.enableProgressiveButtonIfNecessary()
+                WMFToastManager.sharedInstance.showErrorAlert(error, sticky: true, dismissPreviousToasts: true)
+            }
+        }
+
+        present(hcaptchaVC, animated: true) {
+            hcaptchaVC.validate()
+        }
     }
 
     func captchaReloadPushed(_ sender: AnyObject) {
@@ -481,5 +580,21 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
         passwordAlertLabel.textColor = theme.colors.error
         scrollContainer.backgroundColor = theme.colors.paperBackground
         captchaViewController?.apply(theme: theme)
+        setupHCaptchaFinePrintText()
+    }
+}
+
+extension WMFLoginViewController: UITextViewDelegate {
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange) -> Bool {
+        if URL.absoluteString.contains("privacy") {
+            authInstrument.submitInteraction(action: "click", elementId: "hcaptcha_privacy_link")
+        } else if URL.absoluteString.contains("terms") {
+            authInstrument.submitInteraction(action: "click", elementId: "hcaptcha_tos_link")
+        }
+        let config = SinglePageWebViewController.StandardConfig(url: URL, useSimpleNavigationBar: true)
+        let inAppWebView = SinglePageWebViewController(configType: .standard(config), theme: theme)
+        let navVC = WMFComponentNavigationController(rootViewController: inAppWebView, modalPresentationStyle: .pageSheet)
+        present(navVC, animated: true)
+        return false
     }
 }

--- a/Wikipedia/Code/WMFLoginViewController.swift
+++ b/Wikipedia/Code/WMFLoginViewController.swift
@@ -5,7 +5,6 @@ import WMFData
 import CocoaLumberjackSwift
 import WMFNativeLocalizations
 import WMFTestKitchen
-import HCaptcha
 
 class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFCaptchaViewControllerDelegate, Themeable, WMFNavigationBarConfiguring {
     // SINGLETONTODO
@@ -467,7 +466,7 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
 
     private func fetchAndSetupHCaptchaFinePrint() {
         let appLanguage = dataStore.languageLinkController.appLanguage
-        Task { [weak self] in
+        Task { @MainActor [weak self] in
 
             guard let self else { return }
 
@@ -477,12 +476,9 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
             do {
                 let finePrintText = try await MessagesDataController().fetchMessages(keys: ["hcaptcha-privacy-policy"], parseLinks: true, project: project).first?.content
 
-                Task { @MainActor [weak self] in
-                    guard let self else { return }
-                    self.hCaptchaFinePrintText = finePrintText
-                    self.setupHCaptchaFinePrintText()
-                    self.hcaptchaFinePrintTextView.isHidden = false
-                }
+                self.hCaptchaFinePrintText = finePrintText
+                self.setupHCaptchaFinePrintText()
+                self.hcaptchaFinePrintTextView.isHidden = finePrintText?.isEmpty != false
             } catch {
                 self.hcaptchaFinePrintTextView.isHidden = true
             }
@@ -499,15 +495,15 @@ class WMFLoginViewController: WMFScrollViewController, UITextFieldDelegate, WMFC
         hcaptchaVC.modalTransitionStyle = .crossDissolve
         hcaptchaVC.modalPresentationStyle = .overFullScreen
 
-        hcaptchaVC.successAction = { token in
-            hcaptchaVC.dismiss(animated: true) { [weak self] in
+        hcaptchaVC.successAction = { [weak hcaptchaVC, weak self] token in
+            hcaptchaVC?.dismiss(animated: true) {
                 self?.hCaptchaToken = token
                 self?.save()
             }
         }
 
-        hcaptchaVC.errorAction = { error in
-            hcaptchaVC.dismiss(animated: true) { [weak self] in
+        hcaptchaVC.errorAction = { [weak hcaptchaVC, weak self] error in
+            hcaptchaVC?.dismiss(animated: true) {
                 self?.hCaptchaToken = nil
                 self?.setViewControllerUserInteraction(enabled: true)
                 self?.enableProgressiveButtonIfNecessary()


### PR DESCRIPTION
Mirror the account-creation hCaptcha wiring for login: when a login attempt fails with a captcha-related message code and the server offers an hCaptcha challenge (via authmanagerinfo), present the hCaptcha overlay, then resubmit the login with the resulting token in the captchaWord field.

https://phabricator.wikimedia.org/T430799