### PR TITLE
T430756: Update year to be full length

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Extensions/DateFormatter+Extensions.swift
+++ b/WMFComponents/Sources/WMFComponents/Extensions/DateFormatter+Extensions.swift
@@ -86,7 +86,7 @@ public extension DateFormatter {
         return wmfMonthDayDateFormatter.string(from: date)
     }
 
-    /// Parses a `yyyy-MM-dd` string and returns "Month Day, ’Year" e.g. `December 19, 25`
+    /// Parses a `yyyy-MM-dd` string and returns "Month Day, Year" e.g. `December 19, 2025`
     static func wmfMonthDayYearFromDailyGameDate(_ dateString: String) -> String {
         let parser = DateFormatter()
         parser.dateFormat = "yyyy-MM-dd"

--- a/WMFComponents/Sources/WMFComponents/Extensions/DateFormatter+Extensions.swift
+++ b/WMFComponents/Sources/WMFComponents/Extensions/DateFormatter+Extensions.swift
@@ -92,6 +92,6 @@ public extension DateFormatter {
         parser.dateFormat = "yyyy-MM-dd"
         parser.locale = Locale(identifier: "en_US_POSIX")
         guard let date = parser.date(from: dateString) else { return dateString }
-        return wmfMonthDayShortYearDateFormatter.string(from: date)
+        return wmfMonthDayYearDateFormatter.string(from: date)
     }
 }

--- a/Wikipedia/Code/WhichCameFirstCoordinator.swift
+++ b/Wikipedia/Code/WhichCameFirstCoordinator.swift
@@ -545,7 +545,7 @@ final class WhichCameFirstCoordinator: NSObject, Coordinator {
     // MARK: - Helpers
 
     private func formattedTodayDateString() -> String {
-        return DateFormatter.wmfMonthDayShortYearDateFormatter.string(from: Date())
+        return DateFormatter.wmfMonthDayYearDateFormatter.string(from: Date())
     }
 
     private func formattedTodayISODateString() -> String {


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T430756

### Notes
* Updates short year -> regular length for header for game

### Test Steps
1. 

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
<img width="750" height="1334" alt="simulator_screenshot_3C777CD9-70E4-467E-9A8D-F8683E32B42B" src="https://github.com/user-attachments/assets/89effd23-d999-43d0-846a-0c8eabdfcbd7" />
