### PR TITLE
T432495: Add one-time new install onboarding start event for legacy onboarding

### DIFF
--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -52,7 +52,7 @@ public enum WMFUserDefaultsKey: String {
 
     // Games dev settings
     case developerSettingsShowGamesV2 = "dev-settings-show-games-v2"
-    
+
     // Logging
     case appInstallID = "wmf-app-install-id"
     case sessionID = "wmf-session-id"
@@ -83,4 +83,7 @@ public enum WMFUserDefaultsKey: String {
     
     case randomWidgetDailyIndex = "random-widget-daily-index"
     case randomWidgetDailyDate = "random-widget-daily-date"
+
+    // Onboarding: New app install event
+    case didSendNewInstallOnboardingStartEvent = "did-send-new-install-onboarding-start-event"
 }

--- a/Wikipedia/Code/WMFWelcomeInitialViewController.swift
+++ b/Wikipedia/Code/WMFWelcomeInitialViewController.swift
@@ -61,7 +61,7 @@ class WMFWelcomeInitialViewController: ThemeableViewController {
         let didSend: Bool = (try? store.load(key: key)) ?? false
         guard !didSend else { return }
 
-        TestKitchenAdapter.shared.client.getInstrument(name: "apps-authentication")
+        TestKitchenAdapter.shared.client.getInstrument(name: "apps-open")
             .submitInteraction(action: "app_open", actionSource: "new_install_onboarding_start")
 
         try? store.save(key: key, value: true)

--- a/Wikipedia/Code/WMFWelcomeInitialViewController.swift
+++ b/Wikipedia/Code/WMFWelcomeInitialViewController.swift
@@ -1,3 +1,6 @@
+import WMFData
+import WMFTestKitchen
+
 // A lightweight way to provide iPhone X friendly constraints when using a UIPageViewController
 // is to simply embed it in a container view which uses such constraints. No need to modify the
 // UIPageViewController subclass at all. WMFWelcomeInitialViewController embeds a UIPageViewController
@@ -41,5 +44,24 @@ class WMFWelcomeInitialViewController: ThemeableViewController {
     
     override var shouldAutorotate : Bool {
         return false
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        sendNewInstallOnboardingStartEventIfNeeded()
+    }
+
+    // MARK: - App install instrumentation helper function
+    private func sendNewInstallOnboardingStartEventIfNeeded() {
+        let store = WMFDataEnvironment.current.userDefaultsStore
+        let key = WMFUserDefaultsKey.didSendNewInstallOnboardingStartEvent.rawValue
+
+        let didSend: Bool? = try? store?.load(key: key)
+        guard didSend != true else { return }
+        try? store?.save(key: key, value: true)
+
+        TestKitchenAdapter.shared.client.getInstrument(name: "apps-authentication")
+            .submitInteraction(action: "app_open", actionSource: "new_install_onboarding_start")
     }
 }

--- a/Wikipedia/Code/WMFWelcomeInitialViewController.swift
+++ b/Wikipedia/Code/WMFWelcomeInitialViewController.swift
@@ -54,14 +54,16 @@ class WMFWelcomeInitialViewController: ThemeableViewController {
 
     // MARK: - App install instrumentation helper function
     private func sendNewInstallOnboardingStartEventIfNeeded() {
-        let store = WMFDataEnvironment.current.userDefaultsStore
+        guard let store = WMFDataEnvironment.current.userDefaultsStore else { return }
+
         let key = WMFUserDefaultsKey.didSendNewInstallOnboardingStartEvent.rawValue
 
-        let didSend: Bool? = try? store?.load(key: key)
-        guard didSend != true else { return }
-        try? store?.save(key: key, value: true)
+        let didSend: Bool = (try? store.load(key: key)) ?? false
+        guard !didSend else { return }
 
         TestKitchenAdapter.shared.client.getInstrument(name: "apps-authentication")
             .submitInteraction(action: "app_open", actionSource: "new_install_onboarding_start")
+
+        try? store.save(key: key, value: true)
     }
 }


### PR DESCRIPTION
**Phabricator:** 
T432495


### Notes
- Add one-time new install onboarding start event for legacy onboarding

### Test Steps
1. delete the app install
2. reinstall the app and run
3. check debugger for: `new_install_onboarding_start`

then rerun the app:
1. check debugger for: `new_install_onboarding_start` (this time it should NOT show up)

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
``` 
🧑‍🍳TestKitchen: Scheduling event to be sent to /analytics/product_metrics/app/base/2.0.0:

$schema: /analytics/product_metrics/app/base/2.0.0
action: app_open
action_source: new_install_onboarding_start
agent: {
    "app_install_id" = "DC4E9546-5593-4802-856B-F4D307ACA50F";
    "app_theme" = default;
    "app_version" = 0;
    "app_version_name" = "WikipediaApp/8.3.0.0";
    "client_platform" = ios;
    "client_platform_family" = app;
    "device_family" = Phone;
    "device_language" = "en-CA";
    "release_status" = debug;
}
dt: 2026-07-21T19:43:37.319Z
instrument_name: apps-authentication
mediawiki: {
    database = enwiki;
}
meta: {
    stream = "product_metrics.app_base";
}
performer: {
    "is_logged_in" = 0;
    "is_temp" = 0;
    "language_groups" = en;
    "language_primary" = en;
    "session_id" = 6c2516adaca6715292c3;
}
``` 