### PR TITLE
Fix campaign modal

### DIFF
--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -521,13 +521,7 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
     /// If any higher-priority modal is shown, the games announcement is deferred to the next launch.
     /// Only one modal is ever presented per appearance.
     private func presentModalsIfNeeded() {
-
-        // fall back to year in review or fundraising
-        guard let navigationController else {
-            presentYearInReviewAnnouncementOrFundraisingOrGamesIfNeeded()
-            return
-        }
-
+        presentYearInReviewAnnouncementOrFundraisingOrGamesIfNeeded()
     }
 
     /// Called at the tail of the modal chain (after RC, YIR, and fundraising have all declined).

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -619,15 +619,6 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
             })
         }
     }
-    
-    private func presentYearInReviewAnnouncementOrTooltipsOrGamesIfNeeded() {
-        if needsYearInReviewAnnouncement() {
-            updateProfileButton()
-            presentYearInReviewAnnouncement()
-        } else {
-            perform(#selector(listenForTooltips), with: nil, afterDelay: 2.0)
-        }
-    }
 
     @objc private func wButtonTapped(_ sender: UIButton) {
         wTip.invalidate(reason: .actionPerformed)


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
Fixes a regression with the campaign modal. When removing the reading challenge feature announcement (https://github.com/wikimedia/wikipedia-ios/pull/6009), we accidentally removed all modal announcements on articles. This restores them.

I also discovered an unused method, this PR cleans that out.

We need this fix in order to test and complete https://phabricator.wikimedia.org/T415791.

### Test Steps
(These are test steps against our Test Wiki campaign modal, which is currently on version 3)
1. In WMFFundraisingCampaignDataController, change the [current version to 3](https://github.com/wikimedia/wikipedia-ios/blob/8ce6e2c803e6a1dcef1b9657b017b426aea6d89e/WMFData/Sources/WMFData/Data%20Controllers/Donor%20Experience/WMFFundraisingCampaignDataController.swift#L467) so that it correctly deserializes the Test Wiki campaign.
2. Run the app in Xcode on the Staging scheme in simulator. The Staging scheme is set up to point to the Test Wiki config.


<img width="488" height="56" alt="Screenshot 2026-07-23 at 11 25 56 AM" src="https://github.com/user-attachments/assets/bcdc6c50-61c6-40c1-8009-c9a7090dda4f" />

3. When you land on Explore, background the app, foreground, then pull to refresh on Explore. This ensures the fundraising config is fetched.
4. Visit an article on EN Wikipedia. You should see a campaign modal appear:

<img width="553" height="1054" alt="Screenshot 2026-07-23 at 12 07 03 PM" src="https://github.com/user-attachments/assets/d771e21a-7c60-4dfa-a1ac-ebb758cd379c" />

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
