### PR TITLE
T355134: Fix blank Top Read widget

### DIFF
--- a/WMF Framework/Widget/Models/WidgetTopRead.swift
+++ b/WMF Framework/Widget/Models/WidgetTopRead.swift
@@ -66,6 +66,10 @@ public struct WidgetTopRead: Codable {
     public var dateString: String?
     public var elements: [Article]
 
+    /// Runtime-only (excluded from `CodingKeys`): true when served from cache as a fallback, so
+    /// the widget timeline can schedule an earlier retry for fresh content.
+    public var isFromCacheFallback: Bool = false
+
     public var topFourElements: [Article] {
         return Array(elements.prefix(4))
     }

--- a/WMF Framework/Widget/WidgetController.swift
+++ b/WMF Framework/Widget/WidgetController.swift
@@ -267,7 +267,11 @@ public extension WidgetController {
 
         fetcher.fetchFeaturedContent(forDate: Date(), siteURL: widgetCache.settings.siteURL, languageCode: widgetCache.settings.languageCode, languageVariantCode: widgetCache.settings.languageVariantCode) { result in
             switch result {
-            case .success(let featuredContent):
+            case .success(var featuredContent):
+                if featuredContent.topRead == nil {
+                    // Carry the previous top read over so this save doesn't destroy the top read widget's fallback.
+                    featuredContent.topRead = widgetCache.featuredContent?.topRead
+                }
                 widgetCache.featuredContent = featuredContent
                 self.sharedCache.saveCache(widgetCache)
                 performCompletion(result: .success(featuredContent))
@@ -300,10 +304,14 @@ public extension WidgetController {
             return
         }
 
-        fetchFeaturedContent { result in
+        let cachedTopRead = widgetCache.featuredContent?.topRead
+
+        // Judge the cache by the top read's own date, not its fetch date. A same-day cache
+        // saved without current most-read data must not short-circuit the network.
+        fetchFeaturedContent(useCacheIfAvailable: topReadIsCurrent(cachedTopRead)) { result in
             switch result {
             case .success(var featuredContent):
-                if var topRead = featuredContent.topRead {
+                if var topRead = featuredContent.topRead, self.topReadIsCurrent(topRead) {
                     // Fetch images, if available, for the top four elements
                     let group = DispatchGroup()
                     for (index, element) in topRead.topFourElements.enumerated() {
@@ -334,15 +342,61 @@ public extension WidgetController {
                             performCompletion(result: .failure(.contentFailure))
                         }
                     }
+                } else if var fallbackTopRead = featuredContent.topRead ?? cachedTopRead {
+                    // Serve the most recent top read available instead of leaving the widget empty.
+                    fallbackTopRead.isFromCacheFallback = true
+                    performCompletion(result: .success(fallbackTopRead))
                 } else {
-                    widgetCache.featuredContent = nil
-                    self.sharedCache.saveCache(widgetCache)
                     performCompletion(result: .failure(.contentFailure))
                 }
             case .failure(let error):
-                performCompletion(result: .failure(error))
+                if var fallbackTopRead = cachedTopRead {
+                    fallbackTopRead.isFromCacheFallback = true
+                    performCompletion(result: .success(fallbackTopRead))
+                } else {
+                    performCompletion(result: .failure(error))
+                }
             }
         }
+    }
+
+    /// Most-read data for a feed day is published a few hours after that day begins in UTC.
+    /// Returns the moment the data for the local date's feed should become available
+    /// (randomized within 03:00–03:30 UTC), or nil if that moment has already passed.
+    static func expectedTopReadPublicationDate(after date: Date, calendar: Calendar = .current) -> Date? {
+        guard let utcTimeZone = TimeZone(identifier: "UTC") else {
+            return nil
+        }
+        var utcCalendar = Calendar(identifier: .gregorian)
+        utcCalendar.timeZone = utcTimeZone
+
+        var localGregorianCalendar = Calendar(identifier: .gregorian)
+        localGregorianCalendar.timeZone = calendar.timeZone
+
+        var publicationComponents = localGregorianCalendar.dateComponents([.year, .month, .day], from: date)
+        publicationComponents.hour = 3
+        publicationComponents.minute = .random(in: 0..<30)
+
+        guard let publicationDate = utcCalendar.date(from: publicationComponents), publicationDate > date else {
+            return nil
+        }
+
+        return publicationDate
+    }
+
+    /// A top read is current when it covers the day before the local date, which is the most recent day
+    /// the pageviews pipeline can have published data for.
+    func topReadIsCurrent(_ topRead: WidgetTopRead?, now: Date = Date(), calendar: Calendar = .current) -> Bool {
+        guard let dateString = topRead?.dateString,
+              let yesterday = calendar.date(byAdding: .day, value: -1, to: now) else {
+            return false
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = calendar.timeZone
+        return dateString.hasPrefix(formatter.string(from: yesterday))
     }
 
     // MARK: - Fetch Featured Article Widget Content

--- a/WMF Framework/Widget/WidgetController.swift
+++ b/WMF Framework/Widget/WidgetController.swift
@@ -426,7 +426,8 @@ public extension WidgetController {
             return
         }
 
-        fetchFeaturedContent { result in
+        // A same-day cache saved without a featured article must not short-circuit the network.
+        fetchFeaturedContent(useCacheIfAvailable: widgetCache.featuredContent?.featuredArticle != nil) { result in
             switch result {
             case .success(var featuredContent):
                 if let featuredArticleThumbnailImageSource = featuredContent.featuredArticle?.thumbnailImageSource {
@@ -446,8 +447,7 @@ public extension WidgetController {
                         self.sharedCache.saveCache(widgetCache)
                         performCompletion(result: .success(featureArticle))
                     } else {
-                        widgetCache.featuredContent = nil
-                        self.sharedCache.saveCache(widgetCache)
+                        // Leave the shared cache intact for the other widgets.
                         performCompletion(result: .failure(.contentFailure))
                     }
                 }
@@ -479,7 +479,8 @@ public extension WidgetController {
             return
         }
 
-        fetchFeaturedContent { result in
+        // A same-day cache saved without a picture of the day must not short-circuit the network.
+        fetchFeaturedContent(useCacheIfAvailable: widgetCache.featuredContent?.pictureOfTheDay != nil) { result in
             switch result {
             case .success(var featuredContent):
                 // Portrait images deliver far more pixels for the same requested width;
@@ -520,8 +521,7 @@ public extension WidgetController {
                         }
                     }
                 } else {
-                    widgetCache.featuredContent = nil
-                    self.sharedCache.saveCache(widgetCache)
+                    // Leave the shared cache intact for the other widgets.
                     performCompletion(result: .failure(.contentFailure))
                 }
             case .failure(let error):

--- a/WMF Framework/Widget/WidgetController.swift
+++ b/WMF Framework/Widget/WidgetController.swift
@@ -361,8 +361,10 @@ public extension WidgetController {
     }
 
     /// Most-read data for a feed day is published a few hours after that day begins in UTC.
+    /// The daily loads usually complete around 02:30 UTC, but there is no guaranteed completion
+    /// time and they can be delayed by days.
     /// Returns the moment the data for the local date's feed should become available
-    /// (randomized within 03:00–03:30 UTC), or nil if that moment has already passed.
+    /// (randomized within 03:30–04:00 UTC), or nil if that moment has already passed.
     static func expectedTopReadPublicationDate(after date: Date, calendar: Calendar = .current) -> Date? {
         guard let utcTimeZone = TimeZone(identifier: "UTC") else {
             return nil
@@ -375,7 +377,7 @@ public extension WidgetController {
 
         var publicationComponents = localGregorianCalendar.dateComponents([.year, .month, .day], from: date)
         publicationComponents.hour = 3
-        publicationComponents.minute = .random(in: 0..<30)
+        publicationComponents.minute = .random(in: 30..<60)
 
         guard let publicationDate = utcCalendar.date(from: publicationComponents), publicationDate > date else {
             return nil

--- a/Widgets/Widgets/PictureOfTheDayWidget.swift
+++ b/Widgets/Widgets/PictureOfTheDayWidget.swift
@@ -27,8 +27,29 @@ final class PictureOfTheDayData {
 
     // MARK: Properties
 
-    static var sampleEntry: PictureOfTheDayEntry {
-        return PictureOfTheDayEntry(date: Date(), kind: .sample, image: UIImage(named: "PictureOfTheYear_2019"), imageDescription:  PictureOfTheDayWidget.LocalizedStrings.sampleEntryDescription)
+    static func sampleEntry(targetSize: CGSize) -> PictureOfTheDayEntry {
+        return PictureOfTheDayEntry(date: Date(), kind: .sample, image: sampleImage(fitting: targetSize), imageDescription:  PictureOfTheDayWidget.LocalizedStrings.sampleEntryDescription)
+    }
+
+    /// The bundled sample is 800×533 (426k px), which exceeds WidgetKit's archival cap on iPad
+    /// (~423k px observed) — the image is silently dropped and gallery previews render gray.
+    /// Scale it down to the family's render size, like real content.
+    private static func sampleImage(fitting targetSize: CGSize) -> UIImage? {
+        guard let image = UIImage(named: "PictureOfTheYear_2019") else {
+            return nil
+        }
+
+        let scale = min(targetSize.width / image.size.width, targetSize.height / image.size.height, 1)
+        guard scale < 1 else {
+            return image
+        }
+
+        let scaledSize = CGSize(width: (image.size.width * scale).rounded(.down), height: (image.size.height * scale).rounded(.down))
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        return UIGraphicsImageRenderer(size: scaledSize, format: format).image { _ in
+            image.draw(in: CGRect(origin: .zero, size: scaledSize))
+        }
     }
     
     static var placeholderEntry: PictureOfTheDayEntry {
@@ -56,7 +77,7 @@ final class PictureOfTheDayData {
                 let entry = PictureOfTheDayEntry(date: Date(), kind: .entry, contentURL: groupURL, image: image, imageDescription: description, licenseCode: license)
                 completion(entry)
             } else {
-                completion(PictureOfTheDayData.sampleEntry)
+                completion(PictureOfTheDayData.sampleEntry(targetSize: targetSize))
             }
         }
     }

--- a/Widgets/Widgets/TopReadWidget.swift
+++ b/Widgets/Widgets/TopReadWidget.swift
@@ -73,7 +73,15 @@ final class TopReadData {
                     rankedElements.append(displayElement)
                 }
 
-                completion(TopReadEntry(date: Date(), rankedElements: rankedElements, groupURL: groupURL, contentLayoutDirection: layoutDirection))
+                completion(
+                    TopReadEntry(
+                        date: Date(),
+                        rankedElements: rankedElements,
+                        groupURL: groupURL,
+                        contentLayoutDirection: layoutDirection,
+                        isFromCacheFallback: topReadContent.isFromCacheFallback
+                    )
+                )
             case .failure:
                 completion(self.placeholder)
             }
@@ -101,6 +109,7 @@ struct TopReadEntry: TimelineEntry {
     var rankedElements: [RankedElement] = Array(repeating: RankedElement.init(title: "–", description: "–", image: nil, viewCounts: [.init(floatLiteral: 0)]), count: 4)
     var groupURL: URL? = nil
     var contentLayoutDirection: LayoutDirection = .leftToRight
+    var isFromCacheFallback: Bool = false
 }
 
 // MARK: - TimelineProvider
@@ -126,10 +135,16 @@ struct TopReadProvider: TimelineProvider {
             let nextUpdate: Date
             let currentDate = Date()
 
-            // Schedule an earlier refresh if this is placeholder content or not valid for today
-            if entry.isPlaceholder || !(entry.date as NSDate).wmf_UTCDateIsTodayLocal() {
-                let components = DateComponents(hour: 2)
-                nextUpdate = Calendar.current.date(byAdding: components, to: currentDate) ?? currentDate
+            // Schedule an earlier refresh if this is placeholder content, content served from
+            // cache as a fallback, or not valid for today
+            if entry.isPlaceholder || entry.isFromCacheFallback || !(entry.date as NSDate).wmf_UTCDateIsTodayLocal() {
+                if let publicationDate = WidgetController.expectedTopReadPublicationDate(after: currentDate) {
+                    // Today's most-read data can't exist yet; retry when it should be published.
+                    nextUpdate = publicationDate
+                } else {
+                    let components = DateComponents(hour: 2)
+                    nextUpdate = Calendar.current.date(byAdding: components, to: currentDate) ?? currentDate
+                }
             } else {
                 nextUpdate = currentDate.randomDateShortlyAfterMidnight() ?? currentDate
             }

--- a/WikipediaUnitTests/Code/WidgetSampleContentTests.swift
+++ b/WikipediaUnitTests/Code/WidgetSampleContentTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import WMF
 
 class WidgetSampleContentTests: XCTestCase {
 
@@ -32,5 +33,100 @@ class WidgetSampleContentTests: XCTestCase {
         XCTAssertNotNil(articles[0].viewHistory)
         XCTAssertNotNil(articles[0].views)
         XCTAssertNil(articles[1].viewHistory, "article without view_history should decode with nil history")
+    }
+
+    // MARK: - Top Read cache fallback
+
+    func testTopReadCacheFallbackFlagIsNotPersisted() throws {
+        var topRead = try topRead(dateString: "2026-07-27Z")
+        XCTAssertFalse(topRead.isFromCacheFallback, "decoded content should never be marked as fallback")
+
+        topRead.isFromCacheFallback = true
+        let roundTripped = try JSONDecoder().decode(WidgetTopRead.self, from: JSONEncoder().encode(topRead))
+        XCTAssertFalse(roundTripped.isFromCacheFallback, "isFromCacheFallback is runtime-only and must not survive the cache round-trip")
+    }
+
+    func testTopReadIsCurrentUsesLocalDate() throws {
+        // 15:00 UTC on Jul 28 is already 01:00 on Jul 29 in Sydney, so Sydney's "yesterday"
+        // is Jul 28 while UTC's is still Jul 27.
+        let now = try utcDate(year: 2026, month: 7, day: 28, hour: 15, minute: 0)
+        let sydney = calendar(timeZoneIdentifier: "Australia/Sydney")
+        XCTAssertTrue(WidgetController.shared.topReadIsCurrent(try topRead(dateString: "2026-07-28Z"), now: now, calendar: sydney))
+        XCTAssertFalse(WidgetController.shared.topReadIsCurrent(try topRead(dateString: "2026-07-27Z"), now: now, calendar: sydney))
+
+        // At the same instant it is 09:00 on Jul 28 in Calgary, where Jul 27 is current.
+        let calgary = calendar(timeZoneIdentifier: "America/Edmonton")
+        XCTAssertTrue(WidgetController.shared.topReadIsCurrent(try topRead(dateString: "2026-07-27Z"), now: now, calendar: calgary))
+    }
+
+    func testTopReadIsNotCurrentForOlderOrMissingData() throws {
+        let now = try utcDate(year: 2026, month: 7, day: 28, hour: 15, minute: 0)
+        let calgary = calendar(timeZoneIdentifier: "America/Edmonton")
+        XCTAssertFalse(WidgetController.shared.topReadIsCurrent(try topRead(dateString: "2026-07-26Z"), now: now, calendar: calgary))
+        XCTAssertFalse(WidgetController.shared.topReadIsCurrent(try topRead(dateString: nil), now: now, calendar: calgary))
+        XCTAssertFalse(WidgetController.shared.topReadIsCurrent(nil, now: now, calendar: calgary))
+    }
+
+    // MARK: - Top Read publication date
+
+    func testExpectedTopReadPublicationDateEastOfUTC() throws {
+        // Midnight in Sydney (UTC+10) on Jul 29 is 14:00 UTC on Jul 28; the local date's
+        // most-read data is only published within 03:00–03:30 UTC on Jul 29.
+        let sydneyMidnight = try utcDate(year: 2026, month: 7, day: 28, hour: 14, minute: 5)
+        let publication = try XCTUnwrap(
+            WidgetController.expectedTopReadPublicationDate(
+                after: sydneyMidnight,
+                calendar: calendar(timeZoneIdentifier: "Australia/Sydney")
+            )
+        )
+        XCTAssertGreaterThanOrEqual(publication, try utcDate(year: 2026, month: 7, day: 29, hour: 3, minute: 0))
+        XCTAssertLessThan(publication, try utcDate(year: 2026, month: 7, day: 29, hour: 3, minute: 30))
+    }
+
+    func testExpectedTopReadPublicationDateWestOfUTCAfterPublication() throws {
+        // Midnight in Calgary (UTC-6) on Jul 28 is 06:10 UTC, past the 03:00–03:30 UTC
+        // publication window for the local date — the data should already exist.
+        let calgaryMidnight = try utcDate(year: 2026, month: 7, day: 28, hour: 6, minute: 10)
+        XCTAssertNil(
+            WidgetController.expectedTopReadPublicationDate(
+                after: calgaryMidnight,
+                calendar: calendar(timeZoneIdentifier: "America/Edmonton")
+            )
+        )
+    }
+
+    func testExpectedTopReadPublicationDateNonGregorianCalendar() throws {
+        // A Buddhist-calendar year (2569) must not be reinterpreted as a Gregorian year.
+        var buddhistBangkok = Calendar(identifier: .buddhist)
+        buddhistBangkok.timeZone = try XCTUnwrap(TimeZone(identifier: "Asia/Bangkok"))
+
+        let beforePublication = try utcDate(year: 2026, month: 7, day: 28, hour: 1, minute: 0)
+        let publication = try XCTUnwrap(
+            WidgetController.expectedTopReadPublicationDate(after: beforePublication, calendar: buddhistBangkok)
+        )
+        XCTAssertLessThan(publication.timeIntervalSince(beforePublication), 60 * 60 * 24, "publication date should be within a day, not centuries away")
+
+        let afterPublication = try utcDate(year: 2026, month: 7, day: 28, hour: 14, minute: 5)
+        XCTAssertNil(WidgetController.expectedTopReadPublicationDate(after: afterPublication, calendar: buddhistBangkok))
+    }
+
+    // MARK: - Helpers
+
+    private func topRead(dateString: String?) throws -> WidgetTopRead {
+        let dateField = dateString.map { "\"date\": \"\($0)\"," } ?? ""
+        let json = "{\(dateField)\"articles\": []}"
+        return try JSONDecoder().decode(WidgetTopRead.self, from: Data(json.utf8))
+    }
+
+    private func calendar(timeZoneIdentifier: String) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: timeZoneIdentifier) ?? .current
+        return calendar
+    }
+
+    private func utcDate(year: Int, month: Int, day: Int, hour: Int, minute: Int) throws -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        return try XCTUnwrap(calendar.date(from: DateComponents(year: year, month: month, day: day, hour: hour, minute: minute)))
     }
 }

--- a/WikipediaUnitTests/Code/WidgetSampleContentTests.swift
+++ b/WikipediaUnitTests/Code/WidgetSampleContentTests.swift
@@ -71,7 +71,7 @@ class WidgetSampleContentTests: XCTestCase {
 
     func testExpectedTopReadPublicationDateEastOfUTC() throws {
         // Midnight in Sydney (UTC+10) on Jul 29 is 14:00 UTC on Jul 28; the local date's
-        // most-read data is only published within 03:00–03:30 UTC on Jul 29.
+        // most-read data is only published within 03:30–04:00 UTC on Jul 29.
         let sydneyMidnight = try utcDate(year: 2026, month: 7, day: 28, hour: 14, minute: 5)
         let publication = try XCTUnwrap(
             WidgetController.expectedTopReadPublicationDate(
@@ -79,12 +79,12 @@ class WidgetSampleContentTests: XCTestCase {
                 calendar: calendar(timeZoneIdentifier: "Australia/Sydney")
             )
         )
-        XCTAssertGreaterThanOrEqual(publication, try utcDate(year: 2026, month: 7, day: 29, hour: 3, minute: 0))
-        XCTAssertLessThan(publication, try utcDate(year: 2026, month: 7, day: 29, hour: 3, minute: 30))
+        XCTAssertGreaterThanOrEqual(publication, try utcDate(year: 2026, month: 7, day: 29, hour: 3, minute: 30))
+        XCTAssertLessThan(publication, try utcDate(year: 2026, month: 7, day: 29, hour: 4, minute: 0))
     }
 
     func testExpectedTopReadPublicationDateWestOfUTCAfterPublication() throws {
-        // Midnight in Calgary (UTC-6) on Jul 28 is 06:10 UTC, past the 03:00–03:30 UTC
+        // Midnight in Calgary (UTC-6) on Jul 28 is 06:10 UTC, past the 03:30–04:00 UTC
         // publication window for the local date — the data should already exist.
         let calgaryMidnight = try utcDate(year: 2026, month: 7, day: 28, hour: 6, minute: 10)
         XCTAssertNil(


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T355134
https://phabricator.wikimedia.org/T339127


### Notes
* The Top Read widget rendered blank placeholders whenever a refresh couldn't produce current most-read data. This happens routinely, for two reasons:
  * **Structural (east of UTC):** most-read data for a feed day is only published ~2–2.5h after that day begins in UTC (measured on two consecutive days), and `feed/featured/{date}` for a "future" UTC date omits `mostread` entirely. Devices east of UTC request their local date at local midnight, so the widget had nothing to show from midnight until early afternoon (Sydney: ~12.5h) — every day. All other feed parts (TFA, POTD, news, OTD) are curated ahead of time and exist for future dates; only most-read is computed retrospectively.
  * **Transient (everywhere):** any network failure during a scheduled refresh also produced placeholders, ignoring valid cached content on disk.
* On top of that, the widget cache was actively cleared when a response lacked `mostread` (or TFA/POTD in the sibling widgets), destroying content the other widgets still needed (introduced in #5045 to fix a stuck-placeholder  bug where a same-day cache without content short-circuited the network all day).
* Fix, in three commits:
  1. `WidgetController` serves the most recent cached top read (marked runtime-only as `isFromCacheFallback`) when fresh data is unavailable or the fetch fails, carries the previous top read over when saving feed  responses without one, and judges top read cache freshness by the data's own date (`topReadIsCurrent`) instead of the cache's fetch date. The Top Read timeline retries at the expected publication moment (randomized within 03:30–04:00 UTC on the local date) when today's data can't exist yet, and every 2h after that — or for transient failures — until current data arrives.
  2. Featured Article and Picture of the Day replace the #5045 cache invalidation with a presence-based cache bypass — same protection against the stuck-placeholder bug, without wiping the shared cache.
  3. Unit tests: fallback flag cache round-trip, date-based freshness across timezones, and publication scheduling (including non-Gregorian device calendars, e.g. Thai Buddhist).
* Worst case for the user is now "yesterday's top read for a few hours" instead of a blank widget — for a product that is inherently day-behind (rankings only exist for closed UTC days), that's a one-day-older ranking, not missing content.

* Also fixes gray Picture of the Day previews in the widget gallery: the bundled sample image (800×533, 426,400 px) exceeds WidgetKit's archival cap on iPad (~422,840 px), so it was silently dropped ("Widget archival failed due to image being too large"). The sample is now downsampled to the family's render size, like real content. Verified on the iPad simulator —  all three sizes render the sample image.
Earlier commits already established render-size downsampling for every other image path:
- dd565293f9 (Featured Article thumbnail),
- 10941f8af9 (Top Read row thumbnails), 
- 055ba0024c and 31519d673f (POTD network images) 
- but the POTD *sample* only got a fixed-size downscale in ded5790c5b.

<img width="80%" alt="appended-images-2026-07-29-19-21-24" src="https://github.com/user-attachments/assets/527e2ab0-0133-44c0-a32c-585cd3201fa3" />



### Test Steps
1. Run the app once so the widget cache is populated, and add the Top Read widget (any size) to the home screen.
2. Simulate a feed response without most-read data: set the device/simulator timezone to `Australia/Sydney` and the time to shortly after local midnight (or temporarily change `if var topRead = featuredContent.topRead, self.topReadIsCurrent(topRead)` to `, false` in `WidgetController`), then reload the widget (remove/re-add or background refresh).
3. Before this change: blank placeholder rows. After: the previous day's top read renders.
4. Simulate a network failure (Airplane Mode) and reload — cached content renders instead of placeholders.

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
the issue was top read showing up like the snapshot below when user's timezone changed day, but the list isn't ready yet:
<img width="60%" alt="IMG_2289" src="https://github.com/user-attachments/assets/fd55364e-1085-4aa1-a1c5-9b5fa45ed5b1" />

now when the data for the following day isn't available it keeps the current cached info and schedules the fetch for the time we expect the top read to be available.

On timing: the daily most-read loads normally complete around 02:30 UTC — which matches what I measured on two consecutive days (≤02:10 and 02:24–02:29 UTC) — but there is no guaranteed completion time and the loads can be delayed, sometimes by days. So the widget targets 03:30 UTC (jittered up to 04:00 to spread requests) and keeps retrying every 2h if the data is still missing, showing the previous day's ranking in the meantime.

Note: the widget does not display the date of the ranking (Explore labels it "Yesterday"), so a multi-day pipeline delay shows an older ranking without saying so. That is pre-existing and out of scope here — worth a separate ticket.

<img width="60%" alt="IMG_2321" src="https://github.com/user-attachments/assets/fefae65d-6323-4636-b188-97a4fb40bd49" />


