### PR TITLE
Recover 2026 Reading Challenge completion 

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Reading Challenge/WMFReadingChallengeCompletionDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Reading Challenge/WMFReadingChallengeCompletionDataController.swift
@@ -1,0 +1,159 @@
+import Foundation
+import CoreData
+
+/// Recovers whether a user completed the 2026 Reading Challenge (a 25 day reading streak between
+/// May 11, 2026 and June 18, 2026) and persists the result to a durable user defaults flag.
+///
+/// The Reading Challenge feature was removed from the app in July 2026. While it shipped, the only
+/// record of completion was a boolean the Reading Challenge widget extension wrote into the shared
+/// app group. That value still exists on device (the removal deleted the key definitions, not the
+/// stored values), but it was only ever written by the widget's timeline provider — users who
+/// completed the challenge without the widget installed have nothing recorded.
+///
+/// Recovery therefore combines two signals:
+/// 1. The legacy `reading-challenge-user-completed` boolean in the shared app group. Authoritative
+///    when present.
+/// 2. A recomputation of the longest consecutive-day reading streak inside the challenge window,
+///    using locally stored page views. This covers users the widget never flagged.
+///
+/// Known limitation: page views are the only local record of daily reading, so a user who cleared
+/// their reading history will be recovered as not completed unless the legacy widget flag is set.
+public actor WMFReadingChallengeCompletionDataController {
+
+    public static let shared = WMFReadingChallengeCompletionDataController()
+
+    // MARK: - Challenge configuration
+
+    /// Restored from the removed `ReadingChallengeStateConfig`.
+    private static let streakGoal = 25
+
+    private static var challengeStartDate: Date {
+        return DateComponents(calendar: .current, year: 2026, month: 5, day: 11).date
+            ?? Date(timeIntervalSince1970: 1778457600)
+    }
+
+    private static var challengeEndDate: Date {
+        return DateComponents(calendar: .current, year: 2026, month: 6, day: 18, hour: 23, minute: 59, second: 59).date
+            ?? Date(timeIntervalSince1970: 1781827199)
+    }
+
+    // MARK: - Legacy storage
+
+    /// These keys were removed from `WMFUserDefaultsKey` along with the feature, but the values
+    /// themselves were never cleared from the shared app group, so they are still readable.
+    private static let legacySharedGroupID = "group.org.wikimedia.wikipedia"
+    private static let legacyUserCompletedKey = "reading-challenge-user-completed"
+
+    // MARK: - Properties
+
+    nonisolated(unsafe) private let userDefaultsStore: WMFKeyValueStore?
+    nonisolated(unsafe) private let legacyDefaults: UserDefaults?
+    private let injectedCoreDataStore: WMFCoreDataStore?
+
+    // MARK: - Lifecycle
+
+    init(userDefaultsStore: WMFKeyValueStore? = nil, legacyDefaults: UserDefaults? = nil, coreDataStore: WMFCoreDataStore? = nil) {
+        self.userDefaultsStore = userDefaultsStore ?? WMFDataEnvironment.current.userDefaultsStore
+        self.legacyDefaults = legacyDefaults ?? UserDefaults(suiteName: WMFReadingChallengeCompletionDataController.legacySharedGroupID)
+        self.injectedCoreDataStore = coreDataStore
+    }
+
+    // MARK: - Public
+
+    /// Whether the user completed the 2026 Reading Challenge. Only meaningful once
+    /// `recoverCompletionIfNeeded()` has succeeded, which can be checked via
+    /// `didRecoverReadingChallenge2026Completion()`.
+    public nonisolated func didCompleteReadingChallenge2026() -> Bool {
+        return (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.completedReadingChallenge2026.rawValue)) ?? false
+    }
+
+    /// Whether recovery has already run to completion. Recovery is a one time operation.
+    public nonisolated func didRecoverReadingChallenge2026Completion() -> Bool {
+        return (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.didRecoverReadingChallenge2026Completion.rawValue)) ?? false
+    }
+
+    /// Determines whether the user completed the 2026 Reading Challenge and saves the result to
+    /// user defaults. No-ops once recovery has succeeded.
+    ///
+    /// Throws if page views are unavailable (for example, Core Data is not set up yet) so that the
+    /// caller can retry on a later app launch. The recovery flag is only saved on success.
+    public func recoverCompletionIfNeeded() async throws {
+
+        guard !didRecoverReadingChallenge2026Completion() else {
+            return
+        }
+
+        if legacyWidgetRecordedCompletion() {
+            save(didComplete: true)
+            return
+        }
+
+        let longestStreak = try await longestStreakDuringChallenge()
+        save(didComplete: longestStreak >= Self.streakGoal)
+    }
+
+    // MARK: - Private
+
+    private nonisolated func legacyWidgetRecordedCompletion() -> Bool {
+        return legacyDefaults?.bool(forKey: Self.legacyUserCompletedKey) ?? false
+    }
+
+    private nonisolated func save(didComplete: Bool) {
+        try? userDefaultsStore?.save(key: WMFUserDefaultsKey.completedReadingChallenge2026.rawValue, value: didComplete)
+        try? userDefaultsStore?.save(key: WMFUserDefaultsKey.didRecoverReadingChallenge2026Completion.rawValue, value: true)
+    }
+
+    /// Longest run of consecutive calendar days with at least one page view, bounded by the
+    /// challenge window. The original feature evaluated the user's *current* streak whenever the
+    /// widget refreshed; retroactively, the longest streak within the window is the equivalent of
+    /// what the challenge asked for ("complete a 25-day reading streak while the challenge is live").
+    private func longestStreakDuringChallenge() async throws -> Int {
+
+        guard let coreDataStore = injectedCoreDataStore ?? WMFDataEnvironment.current.coreDataStore else {
+            throw WMFDataControllerError.coreDataStoreUnavailable
+        }
+
+        let calendar = Calendar.current
+        let startDate = calendar.startOfDay(for: Self.challengeStartDate)
+        let endDate = Self.challengeEndDate
+
+        let backgroundContext = try coreDataStore.newBackgroundContext
+
+        return try await backgroundContext.perform {
+
+            let fetchRequest: NSFetchRequest<CDPageView> = CDPageView.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "timestamp >= %@ && timestamp <= %@", startDate as NSDate, endDate as NSDate)
+            let pageViews = try backgroundContext.fetch(fetchRequest)
+
+            var daysWithRead = Set<DateComponents>()
+            for pageView in pageViews {
+                guard let timestamp = pageView.timestamp else { continue }
+                daysWithRead.insert(calendar.dateComponents([.year, .month, .day], from: timestamp))
+            }
+
+            guard !daysWithRead.isEmpty else {
+                return 0
+            }
+
+            var longestStreak = 0
+            var currentStreak = 0
+            var cursor = startDate
+            let lastDay = calendar.startOfDay(for: endDate)
+
+            while cursor <= lastDay {
+                let components = calendar.dateComponents([.year, .month, .day], from: cursor)
+                if daysWithRead.contains(components) {
+                    currentStreak += 1
+                    longestStreak = max(longestStreak, currentStreak)
+                } else {
+                    currentStreak = 0
+                }
+
+                guard let nextDay = calendar.date(byAdding: .day, value: 1, to: cursor) else { break }
+                cursor = nextDay
+            }
+
+            return longestStreak
+        }
+    }
+}

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -47,6 +47,10 @@ public enum WMFUserDefaultsKey: String {
 
     case allowGestureZoomArticleWebview = "allow-gesture-zoom-article-webview"
 
+    // Reading Challenge 2026 (feature removed, see WMFReadingChallengeCompletionDataController)
+    case completedReadingChallenge2026 = "completed-reading-challenge-2026"
+    case didRecoverReadingChallenge2026Completion = "did-recover-reading-challenge-2026-completion"
+
     // Games announcement
     case hasSeenGamesAnnouncement = "has-seen-games-announcement"
     case needsDailyGameFeedRefresh = "needs-daily-game-feed-refresh"

--- a/WMFData/Tests/WMFDataTests/WMFReadingChallengeCompletionDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFReadingChallengeCompletionDataControllerTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import WMFData
+@testable import WMFDataMocks
+
+final class WMFReadingChallengeCompletionDataControllerTests: XCTestCase {
+
+    enum TestsError: Error {
+        case missingStore
+        case missingDataController
+    }
+
+    private var store: WMFCoreDataStore?
+    private var pageViewsDataController: WMFPageViewsDataController?
+    private var userDefaultsStore: WMFMockKeyValueStore?
+    private var legacyDefaults: UserDefaults?
+
+    private lazy var enProject: WMFProject = {
+        return .wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
+    }()
+
+    /// First day of the 2026 Reading Challenge window.
+    private lazy var challengeStartDate: Date = {
+        return DateComponents(calendar: .current, year: 2026, month: 5, day: 11, hour: 12).date!
+    }()
+
+    override func setUp() async throws {
+
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let store = try await WMFCoreDataStore(appContainerURL: temporaryDirectory)
+        self.store = store
+        self.pageViewsDataController = try WMFPageViewsDataController(coreDataStore: store)
+
+        self.userDefaultsStore = WMFMockKeyValueStore()
+
+        // A throwaway suite so tests never read or write the real shared app group.
+        let legacyDefaults = UserDefaults(suiteName: "org.wikimedia.wikipedia.tests.\(UUID().uuidString)")
+        self.legacyDefaults = legacyDefaults
+
+        try await super.setUp()
+    }
+
+    private func dataController() throws -> WMFReadingChallengeCompletionDataController {
+        guard let store, let userDefaultsStore, let legacyDefaults else {
+            throw TestsError.missingStore
+        }
+
+        return WMFReadingChallengeCompletionDataController(userDefaultsStore: userDefaultsStore, legacyDefaults: legacyDefaults, coreDataStore: store)
+    }
+
+    /// Adds a page view on each of `days` consecutive days, starting `offsetFromStart` days into the challenge window.
+    private func addPageViews(days: Int, offsetFromStart: Int = 0) async throws {
+        guard let pageViewsDataController else {
+            throw TestsError.missingDataController
+        }
+
+        let calendar = Calendar.current
+        for day in 0..<days {
+            guard let timestamp = calendar.date(byAdding: .day, value: offsetFromStart + day, to: challengeStartDate) else {
+                continue
+            }
+            _ = try await pageViewsDataController.addPageView(title: "Cat_\(offsetFromStart)_\(day)", namespaceID: 0, project: enProject, previousPageViewObjectID: nil, timestamp: timestamp)
+        }
+    }
+
+    func testRecoveryFlagsCompletionForTwentyFiveDayStreak() async throws {
+        let dataController = try dataController()
+        try await addPageViews(days: 25)
+
+        try await dataController.recoverCompletionIfNeeded()
+
+        XCTAssertTrue(dataController.didCompleteReadingChallenge2026())
+        XCTAssertTrue(dataController.didRecoverReadingChallenge2026Completion())
+    }
+
+    func testRecoveryDoesNotFlagCompletionForShortStreak() async throws {
+        let dataController = try dataController()
+        try await addPageViews(days: 24)
+
+        try await dataController.recoverCompletionIfNeeded()
+
+        XCTAssertFalse(dataController.didCompleteReadingChallenge2026())
+        XCTAssertTrue(dataController.didRecoverReadingChallenge2026Completion())
+    }
+
+    func testRecoveryDoesNotFlagCompletionForBrokenStreak() async throws {
+        let dataController = try dataController()
+
+        // 20 days, a one day gap, then 20 more days: 40 reading days but no 25 day streak.
+        try await addPageViews(days: 20)
+        try await addPageViews(days: 20, offsetFromStart: 21)
+
+        try await dataController.recoverCompletionIfNeeded()
+
+        XCTAssertFalse(dataController.didCompleteReadingChallenge2026())
+    }
+
+    func testRecoveryDoesNotCountReadingOutsideChallengeWindow() async throws {
+        let dataController = try dataController()
+
+        // Streak starts 20 days before the challenge window opens, so only 5 days land inside it.
+        try await addPageViews(days: 25, offsetFromStart: -20)
+
+        try await dataController.recoverCompletionIfNeeded()
+
+        XCTAssertFalse(dataController.didCompleteReadingChallenge2026())
+    }
+
+    func testRecoveryHonorsLegacyWidgetCompletionFlag() async throws {
+        let dataController = try dataController()
+
+        // No page views at all — the legacy widget flag is the only signal.
+        legacyDefaults?.set(true, forKey: "reading-challenge-user-completed")
+
+        try await dataController.recoverCompletionIfNeeded()
+
+        XCTAssertTrue(dataController.didCompleteReadingChallenge2026())
+    }
+
+    func testRecoveryOnlyRunsOnce() async throws {
+        let dataController = try dataController()
+
+        try await dataController.recoverCompletionIfNeeded()
+        XCTAssertFalse(dataController.didCompleteReadingChallenge2026())
+
+        // Page views arriving after recovery has run should not change the saved flag.
+        try await addPageViews(days: 25)
+        try await dataController.recoverCompletionIfNeeded()
+
+        XCTAssertFalse(dataController.didCompleteReadingChallenge2026())
+    }
+}

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -664,9 +664,21 @@ extension WMFAppViewController {
             do {
                 WMFDataEnvironment.current.coreDataStore = try await WMFCoreDataStore()
                 await self.migrateSavedArticleInfoWithBackgroundTask()
+                await self.recoverReadingChallenge2026Completion()
             } catch let error {
                 DDLogError("Error setting up WMFCoreDataStore: \(error)")
             }
+        }
+    }
+
+    /// Determines whether the user completed the (since removed) 2026 Reading Challenge and saves it
+    /// to user defaults. No-ops after it succeeds once. Retries on the next launch if it throws,
+    /// which is why the error is logged rather than surfaced.
+    private func recoverReadingChallenge2026Completion() async {
+        do {
+            try await WMFReadingChallengeCompletionDataController.shared.recoverCompletionIfNeeded()
+        } catch let error {
+            DDLogError("Error recovering 2026 Reading Challenge completion: \(error)")
         }
     }
 


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T433435

### Notes
* Saves the completion of the reading challenge into a user defaults flag, so we can reuse it in YiR

### Test Steps
1. Run the `reading-challenge-test` branch - it mocks the completed state. Add the widget to see the completion.
2. Switch to this PR's branch and install the app.
3. Verify through breakpoints when launching the app that it saves the state
4. Make sure the added test passes

### Checklist
- [ ] Checked against Swift 6 strict concurrency
