### PR TITLE
T388081: Send wiki and real user_editcount in all EditAttemptStep events

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFArticleDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFArticleDataController.swift
@@ -12,15 +12,18 @@ public final class WMFArticleDataController {
         let needsWatchedStatus: Bool
         let needsRollbackRights: Bool
         let needsCategories: Bool
-        
-        public init(needsWatchedStatus: Bool, needsRollbackRights: Bool, needsCategories: Bool) throws {
+        let needsUserInfo: Bool
+
+        public init(needsWatchedStatus: Bool, needsRollbackRights: Bool, needsCategories: Bool, needsUserInfo: Bool = false) throws {
             self.needsWatchedStatus = needsWatchedStatus
             self.needsRollbackRights = needsRollbackRights
             self.needsCategories = needsCategories
-            
+            self.needsUserInfo = needsUserInfo
+
             guard needsWatchedStatus == true ||
                     needsRollbackRights == true ||
-                    needsCategories == true else {
+                    needsCategories == true ||
+                    needsUserInfo == true else {
                 throw WMFServiceError.invalidRequest
             }
         }
@@ -44,22 +47,49 @@ public final class WMFArticleDataController {
             }
 
             struct UserInfo: Codable {
+                let id: Int?
                 let name: String
-                let rights: [String]
+                let anon: Bool?
+                let temp: Bool?
+                let rights: [String]?
+                let groups: [String]?
+                let editcount: UInt64?
+                let blockid: UInt64?
+                let blockpartial: Bool?
+                let registrationdate: String?
+            }
+
+            struct GlobalUserInfo: Codable {
+                let id: Int?
             }
 
             let pages: [Page]
             let userinfo: UserInfo?
+            let globaluserinfo: GlobalUserInfo?
         }
 
         let query: Query
     }
-    
+
+    /// Info about the current user on the article's wiki, as returned with the article info request.
+    public struct WMFArticleUserInfo {
+        public let userID: Int
+        public let globalUserID: Int?
+        public let name: String
+        public let groups: [String]
+        public let editCount: UInt64
+        public let isBlocked: Bool
+        public let isIP: Bool
+        public let isTemp: Bool
+        public let registrationDateString: String?
+    }
+
     public struct WMFArticleInfoResponse {
         public let watched: Bool
         public let watchlistExpiry: Date?
         public let userHasRollbackRights: Bool?
         public let categories: [String]
+        public let userInfo: WMFArticleUserInfo?
     }
 
     
@@ -102,7 +132,10 @@ public final class WMFArticleDataController {
             parameters["cllimit"] = "500"
         }
 
-        if request.needsRollbackRights {
+        if request.needsUserInfo {
+            parameters["meta"] = "userinfo|globaluserinfo"
+            parameters["uiprop"] = "rights|groups|blockinfo|editcount|registrationdate"
+        } else if request.needsRollbackRights {
             parameters["meta"] = "userinfo"
             parameters["uiprop"] = "rights"
         }
@@ -123,7 +156,7 @@ public final class WMFArticleDataController {
                 }
 
                 let watched = firstPage.watched ?? false
-                let userHasRollbackRights = response.query.userinfo?.rights.contains("rollback")
+                let userHasRollbackRights = response.query.userinfo?.rights?.contains("rollback")
                  
                 var watchlistExpiry: Date? = nil
                 if let watchlistExpiryString = firstPage.watchlistexpiry {
@@ -137,7 +170,24 @@ public final class WMFArticleDataController {
                     }
                  }
 
-                 let status = WMFArticleInfoResponse(watched: watched, watchlistExpiry: watchlistExpiry, userHasRollbackRights: userHasRollbackRights, categories: categoryTitles)
+                 var articleUserInfo: WMFArticleUserInfo? = nil
+                 if let userinfo = response.query.userinfo, let userID = userinfo.id {
+                     let blockPartial = userinfo.blockpartial ?? false
+                     let isBlocked = userinfo.blockid != nil && !blockPartial
+                     articleUserInfo = WMFArticleUserInfo(
+                         userID: userID,
+                         globalUserID: response.query.globaluserinfo?.id,
+                         name: userinfo.name,
+                         groups: userinfo.groups ?? [],
+                         editCount: userinfo.editcount ?? 0,
+                         isBlocked: isBlocked,
+                         isIP: userinfo.anon ?? false,
+                         isTemp: userinfo.temp ?? false,
+                         registrationDateString: userinfo.registrationdate
+                     )
+                 }
+
+                 let status = WMFArticleInfoResponse(watched: watched, watchlistExpiry: watchlistExpiry, userHasRollbackRights: userHasRollbackRights, categories: categoryTitles, userInfo: articleUserInfo)
                  completion(.success(status))
              case .failure(let error):
                  completion(.failure(WMFDataControllerError.serviceError(error)))

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -719,7 +719,10 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
         }
 
         let needsCategories = !isMainPage
-        guard let request = try? WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: self.dataStore.authenticationManager.authStateIsPermanent, needsRollbackRights: false, needsCategories: needsCategories) else {
+        let authenticationManager = self.dataStore.authenticationManager
+        let isPermanent = authenticationManager.authStateIsPermanent
+        let needsUserInfo = isPermanent && authenticationManager.permanentUser(siteURL: siteURL) == nil
+        guard let request = try? WMFArticleDataController.ArticleInfoRequest(needsWatchedStatus: isPermanent, needsRollbackRights: false, needsCategories: needsCategories, needsUserInfo: needsUserInfo) else {
             self.needsWatchButton = false
             self.needsUnwatchHalfButton = false
             self.needsUnwatchFullButton = false
@@ -735,6 +738,22 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
             case .success(let info):
 
                 DispatchQueue.main.async {
+                    // Seed the user cache with this wiki's user info, so EditAttemptStep events carry the correct per-wiki user_id and edit count without an extra fetch.
+                    if let userInfo = info.userInfo {
+                        let user = WMFCurrentUser(
+                            userID: userInfo.userID,
+                            globalUserID: userInfo.globalUserID ?? 0,
+                            name: userInfo.name,
+                            groups: userInfo.groups,
+                            editCount: userInfo.editCount,
+                            isBlocked: userInfo.isBlocked,
+                            isIP: userInfo.isIP,
+                            isTemp: userInfo.isTemp,
+                            registrationDateString: userInfo.registrationDateString
+                        )
+                        self.dataStore.authenticationManager.seedUserCacheIfNeeded(user: user, siteURL: siteURL)
+                    }
+
                     self.needsWatchButton = !info.watched
                     self.needsUnwatchHalfButton = info.watched && info.watchlistExpiry != nil
                     self.needsUnwatchFullButton = info.watched && info.watchlistExpiry == nil

--- a/Wikipedia/Code/EditAttemptFunnel.swift
+++ b/Wikipedia/Code/EditAttemptFunnel.swift
@@ -58,7 +58,7 @@ public final class EditAttemptFunnel {
         let resolvedProject = project ?? WikimediaProject(siteURL: pageURL)
         let currentUser = MWKDataStore.shared().authenticationManager.permanentUser(siteURL: pageURL)
         let userId = currentUser?.userID ?? 0
-        let editCount = Int(currentUser?.globalEditCount ?? 0)
+        let editCount = Int(currentUser?.editCount ?? 0)
 
         let appInstallID: String? = try? WMFDataEnvironment.current.crossProcessUserDefaultsStore?.load(key: WMFUserDefaultsKey.appInstallID.rawValue)
 

--- a/Wikipedia/Code/EditAttemptFunnel.swift
+++ b/Wikipedia/Code/EditAttemptFunnel.swift
@@ -56,7 +56,11 @@ public final class EditAttemptFunnel {
         let platform = UIDevice.current.userInterfaceIdiom == .pad ? "tablet" : "phone"
 
         let resolvedProject = project ?? WikimediaProject(siteURL: pageURL)
-        let currentUser = MWKDataStore.shared().authenticationManager.permanentUser(siteURL: pageURL)
+        let authenticationManager = MWKDataStore.shared().authenticationManager
+        let currentUser = authenticationManager.permanentUser(siteURL: pageURL)
+        if currentUser == nil {
+            authenticationManager.hydrateUserCacheIfNeeded(siteURL: pageURL)
+        }
         let userId = currentUser?.userID ?? 0
         let editCount = Int(currentUser?.editCount ?? 0)
 

--- a/Wikipedia/Code/EditAttemptFunnel.swift
+++ b/Wikipedia/Code/EditAttemptFunnel.swift
@@ -58,7 +58,7 @@ public final class EditAttemptFunnel {
         let resolvedProject = project ?? WikimediaProject(siteURL: pageURL)
         let currentUser = MWKDataStore.shared().authenticationManager.permanentUser(siteURL: pageURL)
         let userId = currentUser?.userID ?? 0
-        let editCount = Int(currentUser?.editCount ?? 0)
+        let editCount = Int(currentUser?.globalEditCount ?? 0)
 
         let appInstallID: String? = try? WMFDataEnvironment.current.crossProcessUserDefaultsStore?.load(key: WMFUserDefaultsKey.appInstallID.rawValue)
 

--- a/Wikipedia/Code/EditAttemptFunnel.swift
+++ b/Wikipedia/Code/EditAttemptFunnel.swift
@@ -8,6 +8,7 @@ public final class EditAttemptFunnel {
     private struct EventContainer: EventInterface {
         static let schema: EventPlatformClient.Schema = .editAttempt
         let event: Event
+        let wiki: String?
     }
 
     private struct Event: Codable {
@@ -26,7 +27,6 @@ public final class EditAttemptFunnel {
         let page_title: String?
         let page_ns: Int?
         let revision_id: Int?
-        let wiki_id: String?
         let dt: Date
     }
 
@@ -55,13 +55,33 @@ public final class EditAttemptFunnel {
         let integrationID = "app-ios"
         let platform = UIDevice.current.userInterfaceIdiom == .pad ? "tablet" : "phone"
 
-        let userId = getUserID(pageURL: pageURL)
-        
+        let resolvedProject = project ?? WikimediaProject(siteURL: pageURL)
+        let currentUser = MWKDataStore.shared().authenticationManager.permanentUser(siteURL: pageURL)
+        let userId = currentUser?.userID ?? 0
+        let editCount = Int(currentUser?.editCount ?? 0)
+
         let appInstallID: String? = try? WMFDataEnvironment.current.crossProcessUserDefaultsStore?.load(key: WMFUserDefaultsKey.appInstallID.rawValue)
 
-        let event = Event(action: action, editing_session_id: "", app_install_id: appInstallID, editor_interface: editorInterface, integration: integrationID, is_anon: isAnon, mw_version: "", platform: platform, user_editcount: 0, user_id: userId, user_is_temp: isTemp, version: 1, page_title: pageURL.wmf_title, page_ns: pageURL.namespace?.rawValue, revision_id: revisionId, wiki_id: project?.notificationsApiWikiIdentifier, dt: Date())
+        let event = Event(
+            action: action,
+            editing_session_id: "",
+            app_install_id: appInstallID,
+            editor_interface: editorInterface,
+            integration: integrationID,
+            is_anon: isAnon,
+            mw_version: "",
+            platform: platform,
+            user_editcount: editCount,
+            user_id: userId,
+            user_is_temp: isTemp,
+            version: 1,
+            page_title: pageURL.wmf_title,
+            page_ns: pageURL.namespace?.rawValue,
+            revision_id: revisionId,
+            dt: Date()
+        )
 
-        let container = EventContainer(event: event)
+        let container = EventContainer(event: event, wiki: resolvedProject?.notificationsApiWikiIdentifier)
         EventPlatformClient.shared.submit(stream: .editAttempt, event: container, needsMinimal: true)
     }
 
@@ -88,9 +108,4 @@ public final class EditAttemptFunnel {
     func logAbort(pageURL: URL) {
         logEvent(pageURL: pageURL, action: .abort)
     }
-
-    fileprivate func getUserID(pageURL: URL) -> Int {
-        MWKDataStore.shared().authenticationManager.permanentUser(siteURL: pageURL)?.userID ?? 0
-    }
-
 }

--- a/Wikipedia/Code/WMFAuthenticationManager.swift
+++ b/Wikipedia/Code/WMFAuthenticationManager.swift
@@ -265,19 +265,8 @@ import WMFTestKitchen
                         guard !(error is URLError) else {
                             // Connection error, assume login would have been successful
                             
-                            let user = WMFCurrentUser(
-                                userID: 0,
-                                globalUserID: 0,
-                                name: userName,
-                                groups: [],
-                                editCount: 0,
-                                globalEditCount: 0,
-                                isBlocked: false,
-                                isIP: false,
-                                isTemp: false,
-                                registrationDateString: nil
-                            )
-
+                            let user = WMFCurrentUser(userID: 0, globalUserID: 0, name: userName, groups: [], editCount: 0, isBlocked: false, isIP: false, isTemp: false, registrationDateString: nil)
+                            
                             if let host = siteURL.host {
                                 self.currentUserCache[host] = user
                             }
@@ -347,19 +336,8 @@ import WMFTestKitchen
                 guard !(error is URLError) else {
                     // If connection error, assume login would have been successful
                     
-                    let user = WMFCurrentUser(
-                        userID: 0,
-                        globalUserID: 0,
-                        name: userName,
-                        groups: [],
-                        editCount: 0,
-                        globalEditCount: 0,
-                        isBlocked: false,
-                        isIP: false,
-                        isTemp: false,
-                        registrationDateString: nil
-                    )
-
+                    let user = WMFCurrentUser(userID: 0, globalUserID: 0, name: userName, groups: [], editCount: 0, isBlocked: false, isIP: false, isTemp: false, registrationDateString: nil)
+                    
                     if let host = siteURL.host {
                         self.currentUserCache[host] = user
                     }

--- a/Wikipedia/Code/WMFAuthenticationManager.swift
+++ b/Wikipedia/Code/WMFAuthenticationManager.swift
@@ -62,6 +62,7 @@ import WMFTestKitchen
     fileprivate let currentUserFetcher: WMFCurrentUserFetcher
     
     private var currentUserCache: [SiteURLHost: WMFCurrentUser] = [:]
+    private var hydratingHosts: Set<SiteURLHost> = []
     
     @objc public var authStateTemporaryUsername: String? {
         if authStateIsTemporary {
@@ -113,10 +114,37 @@ import WMFTestKitchen
         guard user.authState == .permanent else {
             return nil
         }
-        
         return user
     }
-    
+
+    /// Stores the given user in the cache for the given site if the cache has no entry for that host. Use this when another API call already contains the user information, so the cache gets filled without an extra fetch.
+    public func seedUserCacheIfNeeded(user: WMFCurrentUser, siteURL: URL) {
+        guard let host = siteURL.host, currentUserCache[host] == nil else {
+            return
+        }
+        currentUserCache[host] = user
+    }
+
+    /// Fetches and caches the current user for the given site if the cache has no entry for that host. This call does not block. Callers get the cached value on a later lookup.
+    public func hydrateUserCacheIfNeeded(siteURL: URL) {
+        guard let host = siteURL.host,
+              currentUserCache[host] == nil,
+              !hydratingHosts.contains(host) else {
+            return
+        }
+        hydratingHosts.insert(host)
+        currentUserFetcher.fetch(siteURL: siteURL, success: { user in
+            DispatchQueue.main.async {
+                self.currentUserCache[host] = user
+                self.hydratingHosts.remove(host)
+            }
+        }, failure: { _ in
+            DispatchQueue.main.async {
+                self.hydratingHosts.remove(host)
+            }
+        })
+    }
+
     /// Loops through all current user objects across the various siteURLs we have cached, and returns the username of the first username with authState == .permanent
     @objc public var authStatePermanentUsername: String? {
         

--- a/Wikipedia/Code/WMFAuthenticationManager.swift
+++ b/Wikipedia/Code/WMFAuthenticationManager.swift
@@ -265,8 +265,19 @@ import WMFTestKitchen
                         guard !(error is URLError) else {
                             // Connection error, assume login would have been successful
                             
-                            let user = WMFCurrentUser(userID: 0, globalUserID: 0, name: userName, groups: [], editCount: 0, isBlocked: false, isIP: false, isTemp: false, registrationDateString: nil)
-                            
+                            let user = WMFCurrentUser(
+                                userID: 0,
+                                globalUserID: 0,
+                                name: userName,
+                                groups: [],
+                                editCount: 0,
+                                globalEditCount: 0,
+                                isBlocked: false,
+                                isIP: false,
+                                isTemp: false,
+                                registrationDateString: nil
+                            )
+
                             if let host = siteURL.host {
                                 self.currentUserCache[host] = user
                             }
@@ -336,8 +347,19 @@ import WMFTestKitchen
                 guard !(error is URLError) else {
                     // If connection error, assume login would have been successful
                     
-                    let user = WMFCurrentUser(userID: 0, globalUserID: 0, name: userName, groups: [], editCount: 0, isBlocked: false, isIP: false, isTemp: false, registrationDateString: nil)
-                    
+                    let user = WMFCurrentUser(
+                        userID: 0,
+                        globalUserID: 0,
+                        name: userName,
+                        groups: [],
+                        editCount: 0,
+                        globalEditCount: 0,
+                        isBlocked: false,
+                        isIP: false,
+                        isTemp: false,
+                        registrationDateString: nil
+                    )
+
                     if let host = siteURL.host {
                         self.currentUserCache[host] = user
                     }

--- a/Wikipedia/Code/WMFCurrentUserFetcher.swift
+++ b/Wikipedia/Code/WMFCurrentUserFetcher.swift
@@ -24,7 +24,18 @@ public enum WMFUserFetcherError: LocalizedError {
     @objc public let isBlocked: Bool
     @objc public let authState: AuthState
     @objc public let registrationDateString: String?
-    init(userID: Int, globalUserID: Int, name: String, groups: [String], editCount: UInt64, isBlocked: Bool, isIP: Bool, isTemp: Bool, registrationDateString: String?) {
+
+    public init(
+        userID: Int,
+        globalUserID: Int,
+        name: String,
+        groups: [String],
+        editCount: UInt64,
+        isBlocked: Bool,
+        isIP: Bool,
+        isTemp: Bool,
+        registrationDateString: String?
+    ) {
         assert(!(isTemp && isIP), "Invalid values. A user cannot both be IP and Temp.")
         self.userID = userID
         self.globalUserID = globalUserID

--- a/Wikipedia/Code/WMFCurrentUserFetcher.swift
+++ b/Wikipedia/Code/WMFCurrentUserFetcher.swift
@@ -21,16 +21,30 @@ public enum WMFUserFetcherError: LocalizedError {
     @objc public let name: String
     @objc public let groups: [String]
     @objc public let editCount: UInt64
+    @objc public let globalEditCount: UInt64
     @objc public let isBlocked: Bool
     @objc public let authState: AuthState
     @objc public let registrationDateString: String?
-    init(userID: Int, globalUserID: Int, name: String, groups: [String], editCount: UInt64, isBlocked: Bool, isIP: Bool, isTemp: Bool, registrationDateString: String?) {
+
+    init(
+        userID: Int,
+        globalUserID: Int,
+        name: String,
+        groups: [String],
+        editCount: UInt64,
+        globalEditCount: UInt64,
+        isBlocked: Bool,
+        isIP: Bool,
+        isTemp: Bool,
+        registrationDateString: String?
+    ) {
         assert(!(isTemp && isIP), "Invalid values. A user cannot both be IP and Temp.")
         self.userID = userID
         self.globalUserID = globalUserID
         self.name = name
         self.groups = groups
         self.editCount = editCount
+        self.globalEditCount = globalEditCount
         self.isBlocked = isBlocked
         if isIP {
             self.authState = .ip
@@ -49,6 +63,7 @@ public class WMFCurrentUserFetcher: Fetcher {
             "action": "query",
             "meta": "userinfo|globaluserinfo",
             "uiprop": "groups|blockinfo|editcount|registrationdate",
+            "guiprop": "editcount",
             "format": "json"
         ]
         
@@ -73,6 +88,7 @@ public class WMFCurrentUserFetcher: Fetcher {
             let isTemp = userinfo["temp"] != nil
             
             let editCount = userinfo["editcount"] as? UInt64 ?? 0
+            let globalEditCount = globalUserInfo["editcount"] as? UInt64 ?? 0
             let registrationDateString = userinfo["registrationdate"] as? String
             
             var isBlocked = false
@@ -84,7 +100,20 @@ public class WMFCurrentUserFetcher: Fetcher {
             }
             
             let groups = userinfo["groups"] as? [String] ?? []
-            success(WMFCurrentUser.init(userID: userID, globalUserID: globalUserID, name: userName, groups: groups, editCount: editCount, isBlocked: isBlocked, isIP: isIP, isTemp: isTemp, registrationDateString: registrationDateString))
+            success(
+                WMFCurrentUser.init(
+                    userID: userID,
+                    globalUserID: globalUserID,
+                    name: userName,
+                    groups: groups,
+                    editCount: editCount,
+                    globalEditCount: globalEditCount,
+                    isBlocked: isBlocked,
+                    isIP: isIP,
+                    isTemp: isTemp,
+                    registrationDateString: registrationDateString
+                )
+            )
         }
     }
 }

--- a/Wikipedia/Code/WMFCurrentUserFetcher.swift
+++ b/Wikipedia/Code/WMFCurrentUserFetcher.swift
@@ -21,30 +21,16 @@ public enum WMFUserFetcherError: LocalizedError {
     @objc public let name: String
     @objc public let groups: [String]
     @objc public let editCount: UInt64
-    @objc public let globalEditCount: UInt64
     @objc public let isBlocked: Bool
     @objc public let authState: AuthState
     @objc public let registrationDateString: String?
-
-    init(
-        userID: Int,
-        globalUserID: Int,
-        name: String,
-        groups: [String],
-        editCount: UInt64,
-        globalEditCount: UInt64,
-        isBlocked: Bool,
-        isIP: Bool,
-        isTemp: Bool,
-        registrationDateString: String?
-    ) {
+    init(userID: Int, globalUserID: Int, name: String, groups: [String], editCount: UInt64, isBlocked: Bool, isIP: Bool, isTemp: Bool, registrationDateString: String?) {
         assert(!(isTemp && isIP), "Invalid values. A user cannot both be IP and Temp.")
         self.userID = userID
         self.globalUserID = globalUserID
         self.name = name
         self.groups = groups
         self.editCount = editCount
-        self.globalEditCount = globalEditCount
         self.isBlocked = isBlocked
         if isIP {
             self.authState = .ip
@@ -63,7 +49,6 @@ public class WMFCurrentUserFetcher: Fetcher {
             "action": "query",
             "meta": "userinfo|globaluserinfo",
             "uiprop": "groups|blockinfo|editcount|registrationdate",
-            "guiprop": "editcount",
             "format": "json"
         ]
         
@@ -88,7 +73,6 @@ public class WMFCurrentUserFetcher: Fetcher {
             let isTemp = userinfo["temp"] != nil
             
             let editCount = userinfo["editcount"] as? UInt64 ?? 0
-            let globalEditCount = globalUserInfo["editcount"] as? UInt64 ?? 0
             let registrationDateString = userinfo["registrationdate"] as? String
             
             var isBlocked = false
@@ -100,20 +84,7 @@ public class WMFCurrentUserFetcher: Fetcher {
             }
             
             let groups = userinfo["groups"] as? [String] ?? []
-            success(
-                WMFCurrentUser.init(
-                    userID: userID,
-                    globalUserID: globalUserID,
-                    name: userName,
-                    groups: groups,
-                    editCount: editCount,
-                    globalEditCount: globalEditCount,
-                    isBlocked: isBlocked,
-                    isIP: isIP,
-                    isTemp: isTemp,
-                    registrationDateString: registrationDateString
-                )
-            )
+            success(WMFCurrentUser.init(userID: userID, globalUserID: globalUserID, name: userName, groups: groups, editCount: editCount, isBlocked: isBlocked, isIP: isIP, isTemp: isTemp, registrationDateString: registrationDateString))
         }
     }
 }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T388081

### Notes
* Send wiki and real user_editcount in all EditAttemptStep events
	* The EditAttemptStep funnel sent the wiki value only as event.wiki_id (a key the schema doesnt define), so it never reached the dataset and only for saveSuccess, all other events omitted it. user_editcount was hardcoded to 0. Send the top level wiki field the schema defines (matching android's), derived from pageURL for all actions, drop the dead wiki_id field and populate the user_editcount with cached user info response


### Test Steps
1. log with an account that has prior edits and run an edit flow on any article (plus a second flow cancelling out of the editor)
2. search for the EPC debug logs, confirm EditAttemptStep action (init, saveIntent, saveSuccess, abort) carries a top level `wiki` field (sibling of event), a real `user_editaccount`. and no `wiki_id` inside `event`.

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos


<img width="1662" height="1000" alt="appended-images-2026-07-31-19-39-16" src="https://github.com/user-attachments/assets/ff117a12-9f18-46a3-ba89-e7e44b64a764" />

user on editing on their primary language:
<img width="1042" height="941" alt="appended-images-2026-08-07-20-14-58-testwiki-primary" src="https://github.com/user-attachments/assets/8025cb39-6086-4ac8-99a3-5f183d40aace" />


user editing on a different wiki than the primary language:

<img width="1020" height="455" alt="appended-images-2026-08-07-21-23-52" src="https://github.com/user-attachments/assets/f40ef8e7-458b-454a-9582-0bc11e9717d4" />
