### PR TITLE
T383376: Show language variant code in settings

### DIFF
--- a/Wikipedia/Code/SettingsCoordinator.swift
+++ b/Wikipedia/Code/SettingsCoordinator.swift
@@ -118,7 +118,7 @@ final class SettingsCoordinator: Coordinator, SettingsCoordinatorDelegate {
         let tempUsername = dataStore.authenticationManager.authStateTemporaryUsername
         let isTempAccount = WMFTempAccountDataController.shared.primaryWikiHasTempAccountsEnabled && dataStore.authenticationManager.authStateIsTemporary
 
-        let language = dataStore.languageLinkController.appLanguage?.languageCode.uppercased() ?? String()
+        let language = dataStore.languageLinkController.appLanguage?.contentLanguageCode.uppercased() ?? String()
 
         let viewModel = await WMFSettingsViewModel(localizedStrings: locStrings(), username: username, tempUsername: tempUsername, isTempAccount: isTempAccount, primaryLanguage: language, exploreFeedStatus: isExploreFeedOn, readingPreferenceTheme: themeName, dataController: dataController)
 
@@ -130,7 +130,7 @@ final class SettingsCoordinator: Coordinator, SettingsCoordinatorDelegate {
     }
 
     func fetchDynamicValues() -> (primaryLanguage: String, exploreFeedStatus: Bool, readingPreferenceTheme: String) {
-        let primaryLanguage = dataStore.languageLinkController.appLanguage?.languageCode.uppercased() ?? String()
+        let primaryLanguage = dataStore.languageLinkController.appLanguage?.contentLanguageCode.uppercased() ?? String()
         let exploreFeedStatus = UserDefaults.standard.defaultTabType == .explore
         let readingPreferenceTheme = UserDefaults.standard.themeDisplayName
         return (primaryLanguage: primaryLanguage, exploreFeedStatus: exploreFeedStatus, readingPreferenceTheme: readingPreferenceTheme)
@@ -492,7 +492,7 @@ final class SettingsCoordinator: Coordinator, SettingsCoordinatorDelegate {
     }
 
     func handleLanguagesDidUpdate() {
-        if let newLanguage = dataStore.languageLinkController.appLanguage?.languageCode.uppercased() {
+        if let newLanguage = dataStore.languageLinkController.appLanguage?.contentLanguageCode.uppercased() {
             settingsViewModel?.updateDynamicValues(
                 primaryLanguage: newLanguage,
                 exploreFeedStatus: UserDefaults.standard.defaultTabType == .explore,

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -1278,7 +1278,7 @@ extension WMFAppViewController {
         let tempUsername = dataStore.authenticationManager.authStateTemporaryUsername
         let isTempAccount = WMFTempAccountDataController.shared.primaryWikiHasTempAccountsEnabled &&
                             dataStore.authenticationManager.authStateIsTemporary
-        let language = dataStore.languageLinkController.appLanguage?.languageCode.uppercased() ?? String()
+        let language = dataStore.languageLinkController.appLanguage?.contentLanguageCode.uppercased() ?? String()
 
         let localizedStrings = WMFSettingsViewModel.LocalizedStrings(
             settingTitle: CommonStrings.settingsTitle,


### PR DESCRIPTION
Bug: T383376

### Notes
* This PR replaces `languageCode` with `contentLanguageCode` for the settings view model.

### Test Steps
1. Select any variant as the primary language
2. Go back to the main settings page

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
Before | After
-|-
<img width="300" src="https://github.com/user-attachments/assets/f533560b-52da-462a-baa6-cd6a7034b67e" /> | <img width="300" src="https://github.com/user-attachments/assets/a40bf7a0-6ef5-4c3a-a0e7-6c5c8629373a" />
