### PR TITLE
Extend community feed to behind the tab bar

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Home/WMFHomeView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Home/WMFHomeView.swift
@@ -42,7 +42,7 @@ public struct WMFHomeView: View {
         if #available(iOS 26.0, *) {
             communityTabContent
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .ignoresSafeArea(.container, edges: .top)
+                .ignoresSafeArea(.container, edges: [.top, .bottom])
                 .safeAreaInset(edge: .top, spacing: 0) {
 
                     headerBar


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T432471

### Notes
* Extend community feed to behind the tab bar

### Test Steps
1. Run the app with the enable home flag on

### Checklist
- [x] Checked against Swift 6 strict concurrency

