### PR TITLE
T434229: Refactor choose editor sheet ahead of the editing preferences screen (1/2)

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Editors/Choose Editor/WMFChooseEditorView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Editors/Choose Editor/WMFChooseEditorView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WMFData
 
 public struct WMFChooseEditorView: View {
 
@@ -38,54 +39,9 @@ public struct WMFChooseEditorView: View {
     }
 
     private var optionsCard: some View {
-        VStack(spacing: 0) {
-            optionRow(mode: .visual, title: viewModel.visualEditingTitle, subtitle: viewModel.visualEditingSubtitle, showsExternalLinkIcon: true)
-            Divider()
-                .padding(.horizontal, 16)
-            optionRow(mode: .source, title: viewModel.sourceEditingTitle, subtitle: viewModel.sourceEditingSubtitle, showsExternalLinkIcon: false)
-        }
-        .background(
-            RoundedRectangle(cornerRadius: 32)
-                .fill(Color(uiColor: theme.chromeBackground))
-        )
-    }
-
-    private func optionRow(mode: WMFChooseEditorViewModel.EditMode, title: String, subtitle: String, showsExternalLinkIcon: Bool) -> some View {
-        Button {
+        WMFEditModeOptionsCard(selectedMode: viewModel.selectedMode) { mode in
             viewModel.selectedMode = mode
-        } label: {
-            HStack(alignment: .top, spacing: 12) {
-                VStack(alignment: .leading) {
-                    HStack(spacing: 8) {
-                        Text(title)
-                            .font(Font(WMFFont.for(.headline)))
-                            .accessibilityAddTraits(viewModel.selectedMode == mode ? [.isSelected] : [])
-
-                        if showsExternalLinkIcon, let uiImage = WMFSFSymbolIcon.for(symbol: .arrowUpForward, font: .subheadline) {
-                            Image(uiImage: uiImage)
-                        }
-                    }
-                    .foregroundColor(Color(uiColor: theme.text))
-
-                    HStack(alignment: .top, spacing: 8) {
-                        Text(subtitle)
-                            .fixedSize(horizontal: false, vertical: true)
-
-                        Spacer(minLength: 8)
-
-                        WMFCheckmarkView(isSelected: true, configuration: .init(style: .default))
-                            .opacity(viewModel.selectedMode == mode ? 1 : 0)
-                            .accessibilityHidden(true)
-                    }
-                    .font(Font(WMFFont.for(.subheadline)))
-                    .foregroundColor(Color(uiColor: theme.secondaryText))
-                }
-            }
-            .padding(16)
-            .contentShape(Rectangle())
         }
-        .buttonStyle(ChooseEditorRowButtonStyle())
-        .accessibilityElement(children: .combine)
     }
 
     private var dontShowAgainRow: some View {
@@ -105,12 +61,6 @@ public struct WMFChooseEditorView: View {
             viewModel.dontShowAgain.toggle()
         }
         .padding(.horizontal, 4)
-    }
-}
-
-private struct ChooseEditorRowButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
     }
 }
 

--- a/WMFComponents/Sources/WMFComponents/Components/Editors/Choose Editor/WMFChooseEditorViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Editors/Choose Editor/WMFChooseEditorViewModel.swift
@@ -1,20 +1,12 @@
 import Foundation
 import SwiftUI
+import WMFData
 import WMFNativeLocalizations
 
 @MainActor
 public final class WMFChooseEditorViewModel: ObservableObject {
 
-    public enum EditMode {
-        case visual
-        case source
-    }
-
     let title = WMFLocalizedString("choose-editor-title", value: "Choose how to edit", comment: "Title of sheet allowing the user to choose between visual and source editing")
-    let visualEditingTitle = WMFLocalizedString("choose-editor-visual-title", value: "Visual editing", comment: "Title of the visual editing option in the choose editor sheet")
-    let visualEditingSubtitle = WMFLocalizedString("choose-editor-visual-subtitle", value: "Make changes directly to the page you see. Opens in your browser.", comment: "Subtitle of the visual editing option in the choose editor sheet")
-    let sourceEditingTitle = WMFLocalizedString("choose-editor-source-title", value: "Source editing", comment: "Title of the source editing option in the choose editor sheet")
-    let sourceEditingSubtitle = WMFLocalizedString("choose-editor-source-subtitle", value: "Make changes using markup. Stays in the app.", comment: "Subtitle of the source editing option in the choose editor sheet")
     let dontShowAgainTitle = WMFLocalizedString("choose-editor-dont-show-again", value: "Don't show this again. This default can be changed later in Settings.", comment: "Title of checkbox in the choose editor sheet that suppresses the sheet for future edits")
     let dontShowAgainAccessibilityHint = WMFLocalizedString(
         "choose-editor-dont-show-hint",
@@ -23,15 +15,15 @@ public final class WMFChooseEditorViewModel: ObservableObject {
     )
     let continueTitle = CommonStrings.continueButton
 
-    @Published var selectedMode: EditMode
+    @Published var selectedMode: WMFEditMode
     @Published var dontShowAgain: Bool = false
 
-    let didTapContinue: @MainActor @Sendable (EditMode, _ dontShowAgain: Bool) -> Void
+    let didTapContinue: @MainActor @Sendable (WMFEditMode, _ dontShowAgain: Bool) -> Void
     let didTapClose: @MainActor @Sendable () -> Void
 
     public init(
-        initialMode: EditMode = .visual,
-        didTapContinue: @escaping @MainActor @Sendable (EditMode, Bool) -> Void,
+        initialMode: WMFEditMode = .visual,
+        didTapContinue: @escaping @MainActor @Sendable (WMFEditMode, Bool) -> Void,
         didTapClose: @escaping @MainActor @Sendable () -> Void
     ) {
         self.selectedMode = initialMode

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/WMFEditModeCopy.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/WMFEditModeCopy.swift
@@ -1,0 +1,28 @@
+import Foundation
+import WMFData
+import WMFNativeLocalizations
+
+enum WMFEditModeCopy {
+
+    static let visualEditingTitle = WMFLocalizedString("choose-editor-visual-title", value: "Visual editing", comment: "Title of the visual editing option in the choose editor sheet")
+    static let visualEditingSubtitle = WMFLocalizedString("choose-editor-visual-subtitle", value: "Make changes directly to the page you see. Opens in your browser.", comment: "Subtitle of the visual editing option in the choose editor sheet")
+    static let sourceEditingTitle = WMFLocalizedString("choose-editor-source-title", value: "Source editing", comment: "Title of the source editing option in the choose editor sheet")
+    static let sourceEditingSubtitle = WMFLocalizedString("choose-editor-source-subtitle", value: "Make changes using markup. Stays in the app.", comment: "Subtitle of the source editing option in the choose editor sheet")
+}
+
+extension WMFEditMode {
+
+    var localizedTitle: String {
+        switch self {
+        case .visual: return WMFEditModeCopy.visualEditingTitle
+        case .source: return WMFEditModeCopy.sourceEditingTitle
+        }
+    }
+
+    var localizedSubtitle: String {
+        switch self {
+        case .visual: return WMFEditModeCopy.visualEditingSubtitle
+        case .source: return WMFEditModeCopy.sourceEditingSubtitle
+        }
+    }
+}

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/WMFEditModeOptionsCard.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/WMFEditModeOptionsCard.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+import WMFData
+
+struct WMFEditModeOptionsCard: View {
+
+    @ObservedObject var appEnvironment = WMFAppEnvironment.current
+
+    var theme: WMFTheme { appEnvironment.theme }
+
+    private let selectedMode: WMFEditMode
+    private let showsExternalLinkIcon: Bool
+    private let cornerRadius: CGFloat
+    private let didSelect: (WMFEditMode) -> Void
+
+    init(selectedMode: WMFEditMode, showsExternalLinkIcon: Bool = true, cornerRadius: CGFloat = 32, didSelect: @escaping (WMFEditMode) -> Void) {
+        self.selectedMode = selectedMode
+        self.showsExternalLinkIcon = showsExternalLinkIcon
+        self.cornerRadius = cornerRadius
+        self.didSelect = didSelect
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            optionRow(mode: .visual)
+            Divider()
+                .padding(.horizontal, 16)
+            optionRow(mode: .source)
+        }
+        .background(
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(Color(uiColor: theme.chromeBackground))
+        )
+    }
+
+    private func optionRow(mode: WMFEditMode) -> some View {
+        Button {
+            didSelect(mode)
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading) {
+                    HStack(spacing: 8) {
+                        Text(mode.localizedTitle)
+                            .font(Font(WMFFont.for(.headline)))
+                            .accessibilityAddTraits(selectedMode == mode ? [.isSelected] : [])
+
+                        if showsExternalLinkIcon, mode == .visual, let uiImage = WMFSFSymbolIcon.for(symbol: .arrowUpForward, font: .subheadline) {
+                            Image(uiImage: uiImage)
+                        }
+                    }
+                    .foregroundColor(Color(uiColor: theme.text))
+
+                    HStack(alignment: .top, spacing: 8) {
+                        Text(mode.localizedSubtitle)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Spacer(minLength: 8)
+
+                        WMFCheckmarkView(isSelected: true, configuration: .init(style: .default))
+                            .opacity(selectedMode == mode ? 1 : 0)
+                            .accessibilityHidden(true)
+                    }
+                    .font(Font(WMFFont.for(.subheadline)))
+                    .foregroundColor(Color(uiColor: theme.secondaryText))
+                }
+            }
+            .padding(16)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(WMFEditModeRowButtonStyle())
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct WMFEditModeRowButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+    }
+}

--- a/WMFComponents/Tests/WMFComponentsTests/Editors/Choose Editor/WMFChooseEditorViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/Editors/Choose Editor/WMFChooseEditorViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import WMFData
 @testable import WMFComponents
 
 @MainActor
@@ -16,7 +17,7 @@ final class WMFChooseEditorViewModelTests: XCTestCase {
     }
 
     func testTappedContinuePassesSelectionAndCheckboxState() {
-        var receivedMode: WMFChooseEditorViewModel.EditMode?
+        var receivedMode: WMFEditMode?
         var receivedDontShowAgain: Bool?
         let viewModel = WMFChooseEditorViewModel(didTapContinue: { mode, dontShowAgain in
             receivedMode = mode

--- a/Wikipedia/Code/ChooseEditorSheetCoordinator.swift
+++ b/Wikipedia/Code/ChooseEditorSheetCoordinator.swift
@@ -1,17 +1,22 @@
 import UIKit
 import SwiftUI
 import WMFComponents
+import WMFData
 import WMFNativeLocalizations
 
 final class ChooseEditorSheetCoordinator: Coordinator {
 
     var navigationController: UINavigationController
     private let theme: Theme
-    private let didChoose: (WMFChooseEditorViewModel.EditMode, _ dontShowAgain: Bool) -> Void
+    private let didChoose: (WMFEditMode, _ dontShowAgain: Bool) -> Void
 
     private weak var sheetNavigationController: WMFComponentNavigationController?
 
-    init(navigationController: UINavigationController, theme: Theme, didChoose: @escaping (WMFChooseEditorViewModel.EditMode, Bool) -> Void) {
+    init(
+        navigationController: UINavigationController,
+        theme: Theme,
+        didChoose: @escaping (WMFEditMode, Bool) -> Void
+    ) {
         self.navigationController = navigationController
         self.theme = theme
         self.didChoose = didChoose


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T434229

### Notes
* Refactor choose editor sheet ahead of the editing preferences screen
	* replaces duplicate EditMode with WMFData's WMFEditMode, and extracts the option copy and the options card so the editing preferences settings screen can reuse them.


### Test Steps
1. Just guaranteeing modal still works the same way.

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
- no visual changes.