### PR TITLE
ABN-Amro: Show location using universal link with coordinates

### DIFF
--- a/WMF Framework/NSUserActivity+Extensions.swift
+++ b/WMF Framework/NSUserActivity+Extensions.swift
@@ -1,6 +1,15 @@
 import Foundation
+import CoreLocation
 
 public extension NSUserActivity {
+    var wmf_placesCoordinate: CLLocationCoordinate2D? {
+        guard let lat = userInfo?["WMFPlacesLatitude"] as? NSNumber,
+              let lon = userInfo?["WMFPlacesLongitude"] as? NSNumber else {
+            return nil
+        }
+        return CLLocationCoordinate2D(latitude: lat.doubleValue, longitude: lon.doubleValue)
+    }
+
     @objc var shouldSkipOnboarding: Bool {
         guard let path = webpageURL?.wikiResourcePath,
               let languageCode = webpageURL?.wmf_languageCode else {

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -501,6 +501,9 @@
 		675826782D68D10B002B0EE7 /* LinkCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675826772D68D108002B0EE7 /* LinkCoordinator.swift */; };
 		675826792D68D10B002B0EE7 /* LinkCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675826772D68D108002B0EE7 /* LinkCoordinator.swift */; };
 		6758267A2D68D10B002B0EE7 /* LinkCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675826772D68D108002B0EE7 /* LinkCoordinator.swift */; };
+		E319AC54A5FC45F79CBE9EEA /* VisualEditorReturnJourney.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205753DD2B61458DA0A0971D /* VisualEditorReturnJourney.swift */; };
+		A4FC3D151A834C1599B44FEF /* VisualEditorReturnJourney.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205753DD2B61458DA0A0971D /* VisualEditorReturnJourney.swift */; };
+		CDC9E2BAE50D4C8880EEDEC3 /* VisualEditorReturnJourney.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205753DD2B61458DA0A0971D /* VisualEditorReturnJourney.swift */; };
 		675826802D68F543002B0EE7 /* MWKLanguageLinkController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6758267F2D68F543002B0EE7 /* MWKLanguageLinkController+Extensions.swift */; };
 		675826822D693953002B0EE7 /* RandomArticleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675826812D69394E002B0EE7 /* RandomArticleCoordinator.swift */; };
 		675826832D693953002B0EE7 /* RandomArticleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675826812D69394E002B0EE7 /* RandomArticleCoordinator.swift */; };
@@ -1498,6 +1501,7 @@
 		83B5DF9B29F6C7E300F8329D /* EditAttemptFunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B5DF9829F6C7E300F8329D /* EditAttemptFunnel.swift */; };
 		83B87ECC1F71431F00F342F1 /* ArticleCollectionViewCell+ListDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B87EC61F713BC200F342F1 /* ArticleCollectionViewCell+ListDisplay.swift */; };
 		83BBBE5623F56F9400AD0994 /* LocaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BBBE5523F56F9400AD0994 /* LocaleTests.swift */; };
+		77C367D052E2441FA4BA9479 /* VisualEditorReturnJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CC0C9EA6734DCA8BB96684 /* VisualEditorReturnJourneyTests.swift */; };
 		83C0656B23D23220001821BC /* TableOfContentsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C0656A23D23220001821BC /* TableOfContentsItem.swift */; };
 		83C0656C23D23220001821BC /* TableOfContentsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C0656A23D23220001821BC /* TableOfContentsItem.swift */; };
 		83C0656D23D23220001821BC /* TableOfContentsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C0656A23D23220001821BC /* TableOfContentsItem.swift */; };
@@ -3202,6 +3206,7 @@
 		67563DA12EFAF69400042C53 /* WMFLocalizations */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = WMFLocalizations; sourceTree = "<group>"; };
 		675826732D68CEB8002B0EE7 /* ArticleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCoordinator.swift; sourceTree = "<group>"; };
 		675826772D68D108002B0EE7 /* LinkCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkCoordinator.swift; sourceTree = "<group>"; };
+		205753DD2B61458DA0A0971D /* VisualEditorReturnJourney.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEditorReturnJourney.swift; sourceTree = "<group>"; };
 		6758267F2D68F543002B0EE7 /* MWKLanguageLinkController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MWKLanguageLinkController+Extensions.swift"; sourceTree = "<group>"; };
 		675826812D69394E002B0EE7 /* RandomArticleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomArticleCoordinator.swift; sourceTree = "<group>"; };
 		675A3D6A2A21600100F9B653 /* MediaWikiFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaWikiFetcher.swift; sourceTree = "<group>"; };
@@ -3668,6 +3673,7 @@
 		83B5DF9829F6C7E300F8329D /* EditAttemptFunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttemptFunnel.swift; sourceTree = "<group>"; };
 		83B87EC61F713BC200F342F1 /* ArticleCollectionViewCell+ListDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleCollectionViewCell+ListDisplay.swift"; sourceTree = "<group>"; };
 		83BBBE5523F56F9400AD0994 /* LocaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleTests.swift; sourceTree = "<group>"; };
+		77CC0C9EA6734DCA8BB96684 /* VisualEditorReturnJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEditorReturnJourneyTests.swift; sourceTree = "<group>"; };
 		83C0656A23D23220001821BC /* TableOfContentsItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableOfContentsItem.swift; sourceTree = "<group>"; };
 		83C06881292EC85700DF1403 /* TalkPageFormattingToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageFormattingToolbarView.swift; sourceTree = "<group>"; };
 		83C06886292EE5C600DF1403 /* TalkPageFormattingToolbarViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkPageFormattingToolbarViewDelegate.swift; sourceTree = "<group>"; };
@@ -6348,6 +6354,7 @@
 				FACE0000000000000000FE01 /* HomeCoordinator.swift */,
 				FACE0000000000000000FE11 /* HomeFeedSettingsCoordinator.swift */,
 				675826772D68D108002B0EE7 /* LinkCoordinator.swift */,
+				205753DD2B61458DA0A0971D /* VisualEditorReturnJourney.swift */,
 				3717C38B2CAB2A0700978DB2 /* YearInReviewCoordinator.swift */,
 				830795262C9DE91900E453BD /* LoginCoordinator.swift */,
 				830795222C9DB3BA00E453BD /* LogoutCoordinatorDelegate.swift */,
@@ -7292,6 +7299,7 @@
 				D864D68B1DA3EA3800B86934 /* NumberFormatterExtrasTests.swift */,
 				D858A7DE1DA6A04A009C3DEB /* WMFDateCalculationTests.m */,
 				83BBBE5523F56F9400AD0994 /* LocaleTests.swift */,
+				77CC0C9EA6734DCA8BB96684 /* VisualEditorReturnJourneyTests.swift */,
 				D84649AC1D4514F7009DB4A0 /* WMFTaskGroupTests.m */,
 				B0E809041C0D18A00065EBC0 /* CircularBitwiseRotationTests.m */,
 				B0E809081C0D18BC0065EBC0 /* NSString+WMFHTMLParsingTests.m */,
@@ -9431,6 +9439,7 @@
 				D8EC64031D007B1F00C286EE /* WMFLinkParsingTests.m in Sources */,
 				B0E809131C0D19090065EBC0 /* WMFDateFormatterTests.m in Sources */,
 				83BBBE5623F56F9400AD0994 /* LocaleTests.swift in Sources */,
+				77C367D052E2441FA4BA9479 /* VisualEditorReturnJourneyTests.swift in Sources */,
 				B39427451E71F79700D3146D /* NSSetBlocksKitTest.m in Sources */,
 				B0E808B91C0D17160065EBC0 /* WMFHTTPHangingProtocol.m in Sources */,
 				BC52D0F71C207D3300F625A9 /* TWNStringsTests.m in Sources */,
@@ -9989,6 +9998,7 @@
 				83F1095F23D09F80003F3E9E /* ArticleViewController+Tooltips.swift in Sources */,
 				67FBE335297056EB00A2E4AD /* TalkPageArchivesFetcher.swift in Sources */,
 				675826782D68D10B002B0EE7 /* LinkCoordinator.swift in Sources */,
+				E319AC54A5FC45F79CBE9EEA /* VisualEditorReturnJourney.swift in Sources */,
 				D8E6FF6C24056AC300686272 /* ArticleViewController+ContextMenu.swift in Sources */,
 				7A2432BE1FCF401900FB4BA5 /* CreateReadingListViewController.swift in Sources */,
 				7A0DE50020CEEC760032AB57 /* ExploreFeedSettingsViewController.swift in Sources */,
@@ -10571,6 +10581,7 @@
 				D8CE252E1E698E2400DAE2E0 /* WMFArticleRevisionFetcher.m in Sources */,
 				00E75B5F27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift in Sources */,
 				675826792D68D10B002B0EE7 /* LinkCoordinator.swift in Sources */,
+				A4FC3D151A834C1599B44FEF /* VisualEditorReturnJourney.swift in Sources */,
 				D8CE252F1E698E2400DAE2E0 /* WMFArticleLanguagesSectionHeader.m in Sources */,
 				83C0656C23D23220001821BC /* TableOfContentsItem.swift in Sources */,
 				D8CE25351E698E2400DAE2E0 /* WMFTwoFactorPasswordViewController.swift in Sources */,
@@ -11120,6 +11131,7 @@
 				6798332B22C3F2950073CE6F /* UITextView+Extensions.swift in Sources */,
 				7A5A0545225FBE0500BBEAC1 /* InsertMediaSearchResultCollectionViewCell.swift in Sources */,
 				6758267A2D68D10B002B0EE7 /* LinkCoordinator.swift in Sources */,
+				CDC9E2BAE50D4C8880EEDEC3 /* VisualEditorReturnJourney.swift in Sources */,
 				D8EC3E1E1E9BDA35006712EB /* WMFChangePasswordViewController.swift in Sources */,
 				00E75B5E27EB874A00A45B78 /* NotificationsCenterDetailViewController.swift in Sources */,
 				83C0656D23D23220001821BC /* TableOfContentsItem.swift in Sources */,

--- a/Wikipedia/Code/ArticleCoordinator.swift
+++ b/Wikipedia/Code/ArticleCoordinator.swift
@@ -160,8 +160,21 @@ final class ArticleCoordinator: NSObject, Coordinator, ArticleTabCoordinating {
     var tabIdentifier: UUID?
     var tabItemIdentifier: UUID?
     var needsFocusOnSearch: Bool
-    
-    init(navigationController: UINavigationController, articleURL: URL, dataStore: MWKDataStore, theme: Theme, needsAnimation: Bool = true, source: ArticleSource, isRestoringState: Bool = false, previousPageViewObjectID: NSManagedObjectID? = nil, tabConfig: ArticleTabConfig = .appendArticleAndAssignCurrentTab, needsFocusOnSearch: Bool = false) {
+    private let revisionID: UInt64?
+
+    init(
+        navigationController: UINavigationController,
+        articleURL: URL,
+        dataStore: MWKDataStore,
+        theme: Theme,
+        needsAnimation: Bool = true,
+        source: ArticleSource,
+        isRestoringState: Bool = false,
+        previousPageViewObjectID: NSManagedObjectID? = nil,
+        tabConfig: ArticleTabConfig = .appendArticleAndAssignCurrentTab,
+        needsFocusOnSearch: Bool = false,
+        revisionID: UInt64? = nil
+    ) {
         self.navigationController = navigationController
         self.articleURL = articleURL
         self.dataStore = dataStore
@@ -172,6 +185,7 @@ final class ArticleCoordinator: NSObject, Coordinator, ArticleTabCoordinating {
         self.previousPageViewObjectID = previousPageViewObjectID
         self.tabConfig = tabConfig
         self.needsFocusOnSearch = needsFocusOnSearch
+        self.revisionID = revisionID
         super.init()
     }
     
@@ -191,6 +205,7 @@ final class ArticleCoordinator: NSObject, Coordinator, ArticleTabCoordinating {
             return false
         }
         articleVC.isRestoringState = isRestoringState
+        articleVC.initialLoadRevisionID = revisionID
         prepareToShowTabsOverview(articleViewController: articleVC, dataStore)
         
         Task {

--- a/Wikipedia/Code/ArticleViewController+Editing.swift
+++ b/Wikipedia/Code/ArticleViewController+Editing.swift
@@ -92,8 +92,9 @@ extension ArticleViewController {
 
         var queryItems = [
             URLQueryItem(name: "useformat", value: "mobile"),
-            URLQueryItem(name: "veaction", value: "edit"),
-            URLQueryItem(name: "returntoapp", value: "1")
+            URLQueryItem(name: "veaction", value: "edit")
+            // TODO: Restore URLQueryItem(name: "returntoapp", value: "1") once the web's tap-to-return
+            // banner replaces the automatic redirect it currently triggers
         ]
 
         if let sectionID {

--- a/Wikipedia/Code/ArticleViewController+Editing.swift
+++ b/Wikipedia/Code/ArticleViewController+Editing.swift
@@ -91,6 +91,7 @@ extension ArticleViewController {
         var components = URLComponents(url: articleURL, resolvingAgainstBaseURL: false)
 
         var queryItems = [
+            URLQueryItem(name: "useformat", value: "mobile"),
             URLQueryItem(name: "veaction", value: "edit"),
             URLQueryItem(name: "returntoapp", value: "1")
         ]

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -47,6 +47,10 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
     /// Also prioritize pulling data from cache (without revision/etag validation) so the user sees the article as quickly as possible
     var isRestoringState: Bool = false
 
+    /// When set before the initial load, article content is fetched at this specific revision
+    /// (e.g. displaying a freshly published edit when returning from the web Visual Editor)
+    var initialLoadRevisionID: UInt64?
+
     /// Called when initial load starts
     @objc public var loadCompletion: (() -> Void)?
 
@@ -670,7 +674,7 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
 
         setupPageContentServiceJavaScriptInterface {
             let cachePolicy: WMFCachePolicy? = self.isRestoringState ? .foundation(.returnCacheDataElseLoad) : nil
-            self.loadPage(cachePolicy: cachePolicy, revisionID: nil)
+            self.loadPage(cachePolicy: cachePolicy, revisionID: self.initialLoadRevisionID)
         }
     }
 

--- a/Wikipedia/Code/LinkCoordinator.swift
+++ b/Wikipedia/Code/LinkCoordinator.swift
@@ -15,8 +15,18 @@ final class LinkCoordinator: Coordinator {
     private let articleSource: ArticleSource
     private let previousPageViewObjectID: NSManagedObjectID?
     let tabConfig: ArticleTabConfig
-    
-    init(navigationController: UINavigationController, url: URL, dataStore: MWKDataStore?, theme: Theme, articleSource: ArticleSource, previousPageViewObjectID: NSManagedObjectID? = nil, tabConfig: ArticleTabConfig? = nil) {
+    private let revisionID: UInt64?
+
+    init(
+        navigationController: UINavigationController,
+        url: URL,
+        dataStore: MWKDataStore?,
+        theme: Theme,
+        articleSource: ArticleSource,
+        previousPageViewObjectID: NSManagedObjectID? = nil,
+        tabConfig: ArticleTabConfig? = nil,
+        revisionID: UInt64? = nil
+    ) {
         self.navigationController = navigationController
         self.url = url
         self.dataStore = dataStore ?? MWKDataStore.shared()
@@ -24,6 +34,7 @@ final class LinkCoordinator: Coordinator {
         self.articleSource = articleSource
         self.previousPageViewObjectID = previousPageViewObjectID
         self.tabConfig = tabConfig ?? .appendArticleAndAssignCurrentTab
+        self.revisionID = revisionID
     }
 
     @MainActor
@@ -41,7 +52,8 @@ final class LinkCoordinator: Coordinator {
                 theme: theme,
                 source: articleSource,
                 previousPageViewObjectID: previousPageViewObjectID,
-                tabConfig: self.tabConfig)
+                tabConfig: self.tabConfig,
+                revisionID: revisionID)
 
             return articleCoordinator.start()
         case .unknown:

--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.m
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.m
@@ -59,18 +59,41 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
     return activity;
 }
 
++ (nullable NSNumber *)wmf_numberFromQueryValue:(nullable NSString *)value {
+    if (value.length == 0) {
+        return nil;
+    }
+    NSScanner *scanner = [NSScanner scannerWithString:value];
+    double result;
+    if ([scanner scanDouble:&result] && scanner.isAtEnd) {
+        return @(result);
+    }
+    return nil;
+}
+
 + (instancetype)wmf_placesActivityWithURL:(NSURL *)activityURL {
     NSURLComponents *components = [NSURLComponents componentsWithURL:activityURL resolvingAgainstBaseURL:NO];
     NSURL *articleURL = nil;
+    NSNumber *latitude = nil;
+    NSNumber *longitude = nil;
     for (NSURLQueryItem *item in components.queryItems) {
         if ([item.name isEqualToString:@"WMFArticleURL"]) {
             NSString *articleURLString = item.value;
             articleURL = [NSURL URLWithString:articleURLString];
-            break;
+        } else if ([item.name isEqualToString:@"lat"]) {
+            latitude = [self wmf_numberFromQueryValue:item.value];
+        } else if ([item.name isEqualToString:@"lon"]) {
+            longitude = [self wmf_numberFromQueryValue:item.value];
         }
     }
     NSUserActivity *activity = [self wmf_pageActivityWithName:@"Places"];
     activity.webpageURL = articleURL;
+    if (latitude != nil && longitude != nil) {
+        NSMutableDictionary *userInfo = [activity.userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
+        userInfo[@"WMFPlacesLatitude"] = latitude;
+        userInfo[@"WMFPlacesLongitude"] = longitude;
+        activity.userInfo = userInfo;
+    }
     return activity;
 }
 

--- a/Wikipedia/Code/PlacesViewController.swift
+++ b/Wikipedia/Code/PlacesViewController.swift
@@ -2088,6 +2088,14 @@ class PlacesViewController: ArticleLocationCollectionViewController, UISearchBar
         recenterOnUserLocation(self)
     }
 
+    @objc public func showLocation(_ coordinate: CLLocationCoordinate2D) {
+        guard view != nil else { // force view instantiation
+            return
+        }
+        let region = [coordinate].wmf_boundingRegion(with: 10000)
+        currentSearch = PlaceSearch(filter: currentSearchFilter, type: .location, origin: .user, sortStyle: .links, string: nil, region: region, localizedDescription: nil, searchResult: nil)
+    }
+
     @objc public func showArticleURL(_ articleURL: URL) {
         guard let article = dataStore.fetchArticle(with: articleURL), let title = articleURL.wmf_title,
               view != nil else { // force view instantiation

--- a/Wikipedia/Code/VisualEditorReturnJourney.swift
+++ b/Wikipedia/Code/VisualEditorReturnJourney.swift
@@ -20,6 +20,7 @@ struct VisualEditorReturnJourney {
     private static let visualEditorActionQueryItemName = "veaction"
     private static let returnToAppQueryItemName = "returntoapp"
     private static let sectionQueryItemName = "section"
+    private static let useFormatQueryItemName = "useformat"
 
     init?(url: URL) {
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
@@ -58,7 +59,8 @@ struct VisualEditorReturnJourney {
             Self.revisionQueryItemName,
             Self.visualEditorActionQueryItemName,
             Self.returnToAppQueryItemName,
-            Self.sectionQueryItemName
+            Self.sectionQueryItemName,
+            Self.useFormatQueryItemName
         ]
 
         let remainingQueryItems = queryItems.filter { !visualEditorQueryItemNames.contains($0.name) }

--- a/Wikipedia/Code/VisualEditorReturnJourney.swift
+++ b/Wikipedia/Code/VisualEditorReturnJourney.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Parses the URL the web Visual Editor uses to hand the user back to the app after publishing or abandoning an edit, e.g.
+/// `wikipedia://en.wikipedia.org/wiki/Cat?saved=true&revision=12345`.
+/// Also recognizes a return mid-edit through Safari's native app banner, where the
+/// incoming URL is the editing URL itself (`?veaction=edit&returntoapp=1`).
+struct VisualEditorReturnJourney {
+
+    /// Whether the edit was published (`saved=true`) or abandoned (`saved=false`).
+    let saved: Bool
+
+    /// The newly published revision, when the web included one. Always nil for abandoned edits.
+    let revisionID: UInt64?
+
+    /// The article URL with the return journey query items stripped.
+    let articleURL: URL
+
+    private static let savedQueryItemName = "saved"
+    private static let revisionQueryItemName = "revision"
+    private static let visualEditorActionQueryItemName = "veaction"
+    private static let returnToAppQueryItemName = "returntoapp"
+    private static let sectionQueryItemName = "section"
+
+    init?(url: URL) {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else {
+            return nil
+        }
+
+        let savedValue = queryItems.first(where: { $0.name == Self.savedQueryItemName })?.value
+        let revisionValue = queryItems.first(where: { $0.name == Self.revisionQueryItemName })?.value
+        let revisionID = revisionValue.flatMap { UInt64($0) }
+
+        let isEditingContext = queryItems.contains { $0.name == Self.visualEditorActionQueryItemName || $0.name == Self.returnToAppQueryItemName }
+
+        let saved: Bool
+        switch savedValue?.lowercased() {
+        case "true", "1":
+            saved = true
+        case "false", "0":
+            saved = false
+        default:
+            if revisionID != nil {
+                // Treat a revision with a missing or malformed saved value as a publish,
+                // since the web only knows the new revision after saving.
+                saved = true
+            } else if isEditingContext {
+                // The editing URL itself came back (e.g. Safari's native app banner tapped
+                // mid-edit), so nothing was published.
+                saved = false
+            } else {
+                return nil
+            }
+        }
+
+        let visualEditorQueryItemNames: Set<String> = [
+            Self.savedQueryItemName,
+            Self.revisionQueryItemName,
+            Self.visualEditorActionQueryItemName,
+            Self.returnToAppQueryItemName,
+            Self.sectionQueryItemName
+        ]
+
+        let remainingQueryItems = queryItems.filter { !visualEditorQueryItemNames.contains($0.name) }
+        components.queryItems = remainingQueryItems.isEmpty ? nil : remainingQueryItems
+
+        guard let articleURL = components.url else { return nil }
+
+        self.saved = saved
+        self.revisionID = saved ? revisionID : nil
+        self.articleURL = articleURL
+    }
+}

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -59,7 +59,44 @@ extension WMFAppViewController {
             articleSource = .external_link
         }
 
+        if let returnJourney = VisualEditorReturnJourney(url: linkURL) {
+            return processVisualEditorReturnJourney(returnJourney, navigationController: navigationController, articleSource: articleSource)
+        }
+
+        // Any other article deep link (e.g. Safari's native app banner): if the linked article
+        // is already on screen, bring the app to the foreground instead of pushing a duplicate
+        if LinkCoordinator.destination(for: linkURL) == .article,
+           let articleViewController = visibleArticleViewController(),
+           let visibleArticleKey = articleViewController.articleURL.wmf_databaseKey,
+           let incomingArticleKey = linkURL.wmf_databaseKey,
+           visibleArticleKey == incomingArticleKey {
+            if let fragment = linkURL.fragment?.removingPercentEncoding, !fragment.isEmpty {
+                articleViewController.scroll(to: fragment, animated: true)
+            }
+            return true
+        }
+
         let linkCoordinator = LinkCoordinator(navigationController: navigationController, url: linkURL, dataStore: dataStore, theme: theme, articleSource: articleSource, tabConfig: .appendArticleAndAssignNewTabAndSetToCurrent)
+        return linkCoordinator.start()
+    }
+
+    /// Handles the redirect back into the app after a web Visual Editor session (T434236).
+    /// If the same article is already on screen, refreshes it in place instead of pushing a duplicate.
+    private func processVisualEditorReturnJourney(_ returnJourney: VisualEditorReturnJourney, navigationController: UINavigationController, articleSource: ArticleSource) -> Bool {
+
+        if let articleViewController = visibleArticleViewController(),
+           let visibleArticleKey = articleViewController.articleURL.wmf_databaseKey,
+           let incomingArticleKey = returnJourney.articleURL.wmf_databaseKey,
+           visibleArticleKey == incomingArticleKey {
+            if returnJourney.saved {
+                articleViewController.waitForNewContentAndRefresh(returnJourney.revisionID)
+            }
+            // saved == false: the edit was abandoned, leave the article as-is
+            return true
+        }
+
+        // The user is continuing their journey, so append to the current tab rather than opening a new one
+        let linkCoordinator = LinkCoordinator(navigationController: navigationController, url: returnJourney.articleURL, dataStore: dataStore, theme: theme, articleSource: articleSource, tabConfig: .appendArticleAndAssignCurrentTab, revisionID: returnJourney.revisionID)
         return linkCoordinator.start()
     }
 

--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -1318,7 +1318,10 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
             dismissPresentedViewControllers()
             selectedIndex = WMFAppTabType.places.rawValue
             currentTabNavigationController?.popToRootViewController(animated: animated)
-            if let articleURL = activity.wmf_linkURL() {
+            if let coordinate = activity.wmf_placesCoordinate {
+                placesViewController.updateViewModeToMap()
+                placesViewController.showLocation(coordinate)
+            } else if let articleURL = activity.wmf_linkURL() {
                 placesViewController.updateViewModeToMap()
                 placesViewController.showArticleURL(articleURL)
             }
@@ -1442,7 +1445,7 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
         return abs(resignActiveDate.timeIntervalSinceNow) >= wmfTimeBeforeShowingExploreScreenOnLaunch
     }
 
-    func visibleArticleViewController() -> ArticleViewController? {
+    private func visibleArticleViewController() -> ArticleViewController? {
         guard let topVC = currentTabNavigationController?.topViewController else { return nil }
         return topVC as? ArticleViewController
     }

--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -1442,7 +1442,7 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
         return abs(resignActiveDate.timeIntervalSinceNow) >= wmfTimeBeforeShowingExploreScreenOnLaunch
     }
 
-    private func visibleArticleViewController() -> ArticleViewController? {
+    func visibleArticleViewController() -> ArticleViewController? {
         guard let topVC = currentTabNavigationController?.topViewController else { return nil }
         return topVC as? ArticleViewController
     }

--- a/WikipediaUnitTests/Code/VisualEditorReturnJourneyTests.swift
+++ b/WikipediaUnitTests/Code/VisualEditorReturnJourneyTests.swift
@@ -59,7 +59,7 @@ final class VisualEditorReturnJourneyTests: XCTestCase {
     }
 
     func testMidEditReturnThroughNativeAppBanner() throws {
-        let journey = try XCTUnwrap(returnJourney(for: "https://en.wikipedia.org/wiki/Cat?veaction=edit&returntoapp=1&section=2"))
+        let journey = try XCTUnwrap(returnJourney(for: "https://en.wikipedia.org/wiki/Cat?useformat=mobile&veaction=edit&returntoapp=1&section=2"))
         XCTAssertFalse(journey.saved)
         XCTAssertNil(journey.revisionID)
         XCTAssertEqual(journey.articleURL.absoluteString, "https://en.wikipedia.org/wiki/Cat")

--- a/WikipediaUnitTests/Code/VisualEditorReturnJourneyTests.swift
+++ b/WikipediaUnitTests/Code/VisualEditorReturnJourneyTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import Wikipedia
+
+final class VisualEditorReturnJourneyTests: XCTestCase {
+
+    private func returnJourney(for urlString: String) throws -> VisualEditorReturnJourney? {
+        let url = try XCTUnwrap(URL(string: urlString))
+        return VisualEditorReturnJourney(url: url)
+    }
+
+    func testPublishedEditWithRevision() throws {
+        let journey = try XCTUnwrap(returnJourney(for: "https://en.wikipedia.org/wiki/Cat?saved=true&revision=12345"))
+        XCTAssertTrue(journey.saved)
+        XCTAssertEqual(journey.revisionID, 12345)
+        XCTAssertEqual(journey.articleURL.absoluteString, "https://en.wikipedia.org/wiki/Cat")
+    }
+
+    func testPublishedEditWithoutRevision() throws {
+        let journey = try XCTUnwrap(returnJourney(for: "https://en.wikipedia.org/wiki/Cat?saved=true"))
+        XCTAssertTrue(journey.saved)
+        XCTAssertNil(journey.revisionID)
+        XCTAssertEqual(journey.articleURL.absoluteString, "https://en.wikipedia.org/wiki/Cat")
+    }
+
+    func testAbandonedEdit() throws {
+        let journey = try XCTUnwrap(returnJourney(for: "https://en.wikipedia.org/wiki/Cat?saved=false"))
+        XCTAssertFalse(journey.saved)
+        XCTAssertNil(journey.revisionID)
+    }
+
+    func testAbandonedEditIgnoresRevision() throws {
+        let journey = try XCTUnwrap(returnJourney(for: "https://en.wikipedia.org/wiki/Cat?saved=false&revision=12345"))
+        XCTAssertFalse(journey.saved)
+        XCTAssertNil(journey.revisionID)
+    }
+
+    func testRevisionWithoutSavedIsTreatedAsPublished() throws {
+        let journey = try XCTUnwrap(returnJourney(for: "https://en.wikipedia.org/wiki/Cat?revision=12345"))
+        XCTAssertTrue(journey.saved)
+        XCTAssertEqual(journey.revisionID, 12345)
+    }
+
+    func testMalformedRevisionFallsBackToNil() throws {
+        let journey = try XCTUnwrap(returnJourney(for: "https://en.wikipedia.org/wiki/Cat?saved=true&revision=abc"))
+        XCTAssertTrue(journey.saved)
+        XCTAssertNil(journey.revisionID)
+    }
+
+    func testMalformedSavedWithoutRevisionIsNotAReturnJourney() throws {
+        XCTAssertNil(try returnJourney(for: "https://en.wikipedia.org/wiki/Cat?saved=maybe"))
+    }
+
+    func testURLWithoutQueryIsNotAReturnJourney() throws {
+        XCTAssertNil(try returnJourney(for: "https://en.wikipedia.org/wiki/Cat"))
+    }
+
+    func testUnrelatedQueryIsNotAReturnJourney() throws {
+        XCTAssertNil(try returnJourney(for: "https://en.wikipedia.org/wiki/Cat?campaign=test"))
+    }
+
+    func testMidEditReturnThroughNativeAppBanner() throws {
+        let journey = try XCTUnwrap(returnJourney(for: "https://en.wikipedia.org/wiki/Cat?veaction=edit&returntoapp=1&section=2"))
+        XCTAssertFalse(journey.saved)
+        XCTAssertNil(journey.revisionID)
+        XCTAssertEqual(journey.articleURL.absoluteString, "https://en.wikipedia.org/wiki/Cat")
+    }
+
+    func testPublishedEditKeepingEditingQueryItems() throws {
+        let journey = try XCTUnwrap(returnJourney(for: "https://en.wikipedia.org/wiki/Cat?veaction=edit&returntoapp=1&saved=true&revision=12345"))
+        XCTAssertTrue(journey.saved)
+        XCTAssertEqual(journey.revisionID, 12345)
+        XCTAssertEqual(journey.articleURL.absoluteString, "https://en.wikipedia.org/wiki/Cat")
+    }
+
+    func testPreservesOtherQueryItems() throws {
+        let journey = try XCTUnwrap(returnJourney(for: "https://en.wikipedia.org/wiki/Cat?saved=true&revision=12345&campaign=test"))
+        XCTAssertEqual(journey.articleURL.absoluteString, "https://en.wikipedia.org/wiki/Cat?campaign=test")
+    }
+
+    func testPreservesPercentEncodedTitle() throws {
+        let journey = try XCTUnwrap(returnJourney(for: "https://pt.wikipedia.org/wiki/S%C3%A3o_Paulo?saved=true&revision=9"))
+        XCTAssertTrue(journey.saved)
+        XCTAssertEqual(journey.revisionID, 9)
+        XCTAssertEqual(journey.articleURL.absoluteString, "https://pt.wikipedia.org/wiki/S%C3%A3o_Paulo")
+    }
+}


### PR DESCRIPTION
# Places Deep Link — Changes for Test Assignment

## Summary

The app already had a custom URL scheme (`wikipedia://`) used for internal deep linking
(e.g. `wikipedia://places?WMFArticleURL=...` to jump to an article's location on the
map). This was extended so the `places` route also accepts a raw coordinate:

```
wikipedia://places?lat=<latitude>&lon=<longitude>
```

Opening this URL — from any app, via `UIApplication.shared.open(_:)` — switches the
Wikipedia app to the Places tab and centers/zooms the map on the given coordinate,
without waiting for or falling back to the device's own location.

The existing `WMFArticleURL` form of the same route continues to work unchanged.

## How it works (end to end)

1. The calling app opens `wikipedia://places?lat=52.3676&lon=4.9041`.
3. `NSUserActivity+WMFExtensions.m` parses the URL into an `NSUserActivity`. The
   `places` host handler now reads `lat`/`lon` query items (in addition to the existing
   `WMFArticleURL`) and, if both are valid numbers, stores them in the activity's
   `userInfo`.
4. `WMFAppViewController.processUserActivity(_:)` recognizes the `.places` activity
   type, switches `selectedIndex` to the Places tab, and — if a coordinate is present —
   calls a new `PlacesViewController.showLocation(_:)` method with it (falling back to
   the pre-existing `showArticleURL(_:)` behavior if only an article URL was supplied).
5. `showLocation(_:)` sets the Places screen's `currentSearch` to a location-type search
   centered on that coordinate. Setting `currentSearch` is the same mechanism the app
   already used for `showArticleURL(_:)`, and it has a side effect that matters here:
   the app's location-manager code only re-centers the map on the device's current
   location when `currentSearch` is still `nil`. Because it's already set to the
   caller's coordinate by this point, the map is not overridden once the device's GPS
   fix arrives.

## Files changed

- **`Wikipedia/Code/NSUserActivity+WMFExtensions.m`**
  `wmf_placesActivityWithURL:` now also parses `lat` and `lon` query items (validated
  as numbers via `NSScanner`) and stores them in the activity's `userInfo` under
  `WMFPlacesLatitude` / `WMFPlacesLongitude`. Invalid or missing values are simply
  ignored rather than defaulting to `0,0`.

- **`WMF Framework/NSUserActivity+Extensions.swift`**
  Added a `wmf_placesCoordinate: CLLocationCoordinate2D?` computed property that reads
  the two `userInfo` keys back out as a `CLLocationCoordinate2D`.

- **`Wikipedia/Code/PlacesViewController.swift`**
  Added `showLocation(_ coordinate: CLLocationCoordinate2D)`, modeled directly on the
  existing `showArticleURL(_:)` method, but built from a bare coordinate instead of a
  fetched article.

- **`Wikipedia/Code/WMFAppViewController.swift`**
  The `.places` case in `processUserActivity(_:)` now checks for a coordinate first
  (`activity.wmf_placesCoordinate`) and uses it if present, falling back to the
  original article-URL handling otherwise.

No other files required changes — the existing `SceneDelegate` routing, the
cold-launch/deferred-activity queuing, and the `.places` activity-type gating all
already worked generically enough to carry the new data through unmodified.