### PR TITLE
Enhance Phabricator workflow to handle PR edits and track new task links

### DIFF
--- a/.github/workflows/post_phab.yml
+++ b/.github/workflows/post_phab.yml
@@ -18,9 +18,12 @@ jobs:
         BODY_CHANGES: ${{ toJSON(github.event.changes.body) }}
         PHAB_API_TOKEN: ${{ secrets.PHAB_BOT_API_KEY }}
       run: |
-        # Task IDs referenced at the start of a line, either as a "Bug: T123" trailer
-        # or as a phabricator.wikimedia.org URL (optionally behind the "**Phabricator:**"
-        # label from the PR template).
+        # Task IDs referenced at the start of a line, in either shape:
+        #   - a "Bug:" or "Phabricator:" label, optionally markdown-bolded, followed by
+        #     a bare T123 or a phabricator.wikimedia.org URL
+        #   - a bare phabricator.wikimedia.org URL with no label
+        # A bare "T123" with neither a label nor a URL deliberately does NOT match --
+        # that would be too loose to be safe in prose.
         #
         # The match is case-insensitive, so IDs are upper-cased before `sort -u` and
         # before the added-task diff below -- otherwise "T123" and "t123" count as two
@@ -34,7 +37,7 @@ jobs:
         task_ids() {
           printf '%s' "$1" \
             | tr -d '\r' \
-            | grep -oEi "(^Bug:[[:space:]]*T[0-9]+)|(^([*]*phabricator[*]*:[*]*[[:space:]]*)?https://phabricator\.wikimedia\.org/T[0-9]+)" \
+            | grep -oEi "(^[*]*(bug|phabricator)[*]*:[*]*[[:space:]]*(https://phabricator\.wikimedia\.org/)?T[0-9]+)|(^https://phabricator\.wikimedia\.org/T[0-9]+)" \
             | grep -oEi "T[0-9]+" \
             | tr '[:lower:]' '[:upper:]' \
             | sort -u || true

--- a/.github/workflows/post_phab.yml
+++ b/.github/workflows/post_phab.yml
@@ -22,6 +22,11 @@ jobs:
         # or as a phabricator.wikimedia.org URL (optionally behind the "**Phabricator:**"
         # label from the PR template).
         #
+        # The match is case-insensitive, so IDs are upper-cased before `sort -u` and
+        # before the added-task diff below -- otherwise "T123" and "t123" count as two
+        # distinct tasks, double-posting on one body and re-notifying when an edit only
+        # changes the casing. Upper case is also the canonical form to send Phabricator.
+        #
         # `|| true`: a body with no task reference is normal, not an error. It is
         # harmless under the default `bash -e {0}` shell, but required if this step
         # ever gains an explicit `shell: bash`, which adds `-o pipefail` and would
@@ -31,6 +36,7 @@ jobs:
             | tr -d '\r' \
             | grep -oEi "(^Bug:[[:space:]]*T[0-9]+)|(^([*]*phabricator[*]*:[*]*[[:space:]]*)?https://phabricator\.wikimedia\.org/T[0-9]+)" \
             | grep -oEi "T[0-9]+" \
+            | tr '[:lower:]' '[:upper:]' \
             | sort -u || true
         }
 

--- a/.github/workflows/post_phab.yml
+++ b/.github/workflows/post_phab.yml
@@ -21,12 +21,17 @@ jobs:
         # Task IDs referenced at the start of a line, either as a "Bug: T123" trailer
         # or as a phabricator.wikimedia.org URL (optionally behind the "**Phabricator:**"
         # label from the PR template).
+        #
+        # `|| true`: a body with no task reference is normal, not an error. It is
+        # harmless under the default `bash -e {0}` shell, but required if this step
+        # ever gains an explicit `shell: bash`, which adds `-o pipefail` and would
+        # otherwise fail the step on grep's no-match exit 1.
         task_ids() {
           printf '%s' "$1" \
             | tr -d '\r' \
             | grep -oEi "(^Bug:[[:space:]]*T[0-9]+)|(^([*]*phabricator[*]*:[*]*[[:space:]]*)?https://phabricator\.wikimedia\.org/T[0-9]+)" \
             | grep -oEi "T[0-9]+" \
-            | sort -u
+            | sort -u || true
         }
 
         case "$ACTION" in

--- a/.github/workflows/post_phab.yml
+++ b/.github/workflows/post_phab.yml
@@ -2,24 +2,69 @@ name: Post to Phabricator
 
 on:
   pull_request:
-    types: [opened, closed]
+    types: [opened, edited, closed]
 
 jobs:
   post_to_phab:
     runs-on: ubuntu-latest
     steps:
-    - name: Post to Phabricator when pull request is opened or closed
-      if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'closed') }}
+    - name: Post to Phabricator when pull request is opened, linked, or closed
       env:
+        ACTION: ${{ github.event.action }}
+        ACTOR: ${{ github.actor }}
+        PR_URL: ${{ github.event.pull_request._links.html.href }}
         PR_BODY: ${{ github.event.pull_request.body }}
+        PR_BODY_BEFORE: ${{ github.event.changes.body.from }}
+        BODY_CHANGES: ${{ toJSON(github.event.changes.body) }}
+        PHAB_API_TOKEN: ${{ secrets.PHAB_BOT_API_KEY }}
       run: |
-        message="${{ github.actor }} ${{ github.event.action }} ${{ github.event.pull_request._links.html.href }}"
-        echo -e "${PR_BODY}" | grep -oEi "(^Bug:\s*T[0-9]+)|(^([*]*phabricator[*]*:[*]*\s*)?https:\/\/phabricator\.wikimedia\.org\/T[0-9]+)" | grep -oEi "T[0-9]+" | while IFS= read -r line; do
-          echo "Processing: $line"
+        # Task IDs referenced at the start of a line, either as a "Bug: T123" trailer
+        # or as a phabricator.wikimedia.org URL (optionally behind the "**Phabricator:**"
+        # label from the PR template).
+        task_ids() {
+          printf '%s' "$1" \
+            | tr -d '\r' \
+            | grep -oEi "(^Bug:[[:space:]]*T[0-9]+)|(^([*]*phabricator[*]*:[*]*[[:space:]]*)?https://phabricator\.wikimedia\.org/T[0-9]+)" \
+            | grep -oEi "T[0-9]+" \
+            | sort -u
+        }
+
+        case "$ACTION" in
+          opened|closed)
+            verb="$ACTION"
+            ids=$(task_ids "$PR_BODY")
+            ;;
+          edited)
+            # `edited` also fires for title and base-branch changes; only a body edit
+            # carries a changes.body object. Post only for tasks the edit added, so
+            # unrelated body edits don't re-notify an already-linked task.
+            if [ "$BODY_CHANGES" = "null" ]; then
+              echo "Body unchanged, nothing to do."
+              exit 0
+            fi
+            verb="linked"
+            before=$(task_ids "$PR_BODY_BEFORE")
+            after=$(task_ids "$PR_BODY")
+            if [ -n "$before" ]; then
+              ids=$(printf '%s\n' "$after" | grep -Fxv -f <(printf '%s\n' "$before") || true)
+            else
+              ids="$after"
+            fi
+            ;;
+          *)
+            exit 0
+            ;;
+        esac
+
+        message="$ACTOR $verb $PR_URL"
+
+        printf '%s\n' "$ids" | while IFS= read -r task; do
+          [ -n "$task" ] || continue
+          echo "Processing: $task"
           curl --header "User-Agent: GitHubPRBot/1.0 (https://phabricator.wikimedia.org/p/GitHubPRBot)" \
               https://phabricator.wikimedia.org/api/maniphest.edit \
-              -d api.token=${{ secrets.PHAB_BOT_API_KEY }} \
+              -d api.token="${PHAB_API_TOKEN}" \
               -d transactions[0][type]=comment \
               -d transactions[0][value]="${message}" \
-              -d objectIdentifier=${line}
+              -d objectIdentifier="${task}"
         done


### PR DESCRIPTION
**Phabricator:** 

### Notes
* Extended the GitHub Actions workflow to trigger on PR edits in addition to opens and closes
* Added logic to detect when a PR body edit introduces new Phabricator task links
* Only posts notifications for newly-linked tasks on edit events, avoiding duplicate notifications for already-linked tasks
* Improved task ID extraction with a reusable `task_ids()` function that handles both "Bug: T###" trailers and Phabricator URL formats
* Enhanced environment variable handling and improved shell script robustness (proper quoting, null checks, set operations)

### Test Steps
1. Open a PR without any task references
2. Edit the PR body to add a task reference (e.g., "Bug: T12345")
3. Verify that a comment is posted to the task linking the PR
4. Edit the PR body again without changing task references
5. Verify that no new comment is posted
6. Edit the PR body to add an additional task reference
7. Verify that only the newly-added task receives a notification

### Checklist
- [ ] Checked against Swift 6 strict concurrency

https://claude.ai/code/session_01XyimsJL4PymoNhpfWeQ5DG