### PR TITLE
T435382: Fix crash when tapping a paragraph moved marker in revision diff

### DIFF
--- a/Wikipedia/Code/DiffListViewController.swift
+++ b/Wikipedia/Code/DiffListViewController.swift
@@ -7,6 +7,12 @@ class DiffListViewController: ThemeableViewController {
     
     fileprivate static let headerReuseIdentifier = "DiffHeaderView"
     fileprivate static let headerExtendedReuseIdentifier = "DiffHeaderExtendedView"
+
+    enum Section: Int, CaseIterable {
+        case header
+        case extendedHeader
+        case items
+    }
     
     enum ListUpdateType {
         case itemExpandUpdate(indexPath: IndexPath) // tapped context cell to expand
@@ -244,40 +250,38 @@ private extension DiffListViewController {
 extension DiffListViewController: UICollectionViewDataSource {
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 3
+        return Section.allCases.count
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        
-        if section == 0 || section == 1 {
-            return 0
-        } else {
+        if section == Section.items.rawValue {
             return dataSource.count
         }
-        
+        return 0
     }
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
 
-        if indexPath.section == 0 {
+        switch Section(rawValue: indexPath.section) {
+        case .header:
             guard let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: Self.headerReuseIdentifier, for: indexPath) as? DiffHeaderView else {
                 return UICollectionReusableView()
             }
-            
+
             headerView.configure(with: diffHeaderViewModel, tappedHeaderTitleAction: tappedHeaderTitleAction, theme: theme)
             return headerView
-        } else if indexPath.section == 1 {
+        case .extendedHeader:
             guard let headerExtendedView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: Self.headerExtendedReuseIdentifier, for: indexPath) as? DiffHeaderExtendedView else {
                 return UICollectionReusableView()
             }
-            
+
             headerExtendedView.update(diffHeaderViewModel, theme: theme)
             headerExtendedView.tappedHeaderUsernameAction = tappedHeaderUsernameAction
             return headerExtendedView
-        } else {
+        default:
             return UICollectionReusableView()
         }
-        
+
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -312,30 +316,27 @@ extension DiffListViewController: UICollectionViewDataSource {
 extension DiffListViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        
-        guard section == 0 || section == 1 else {
-            return .zero
-        }
-        
-        if section == 0 {
+
+        switch Section(rawValue: section) {
+        case .header:
             let headerView = DiffHeaderContentView()
             headerView.configure(with: diffHeaderViewModel, tappedHeaderTitleAction: tappedHeaderTitleAction, theme: theme)
             let size =  headerView.systemLayoutSizeFitting(CGSize(width: collectionView.frame.width, height: UIView.layoutFittingExpandedSize.height),
                                                       withHorizontalFittingPriority: .required, // Width is fixed
                                                       verticalFittingPriority: .fittingSizeLevel) // Height can be as large as needed
             return size
-        } else if section == 1 {
+        case .extendedHeader:
             let headerExtendedView = DiffHeaderExtendedView()
             headerExtendedView.update(diffHeaderViewModel, theme: theme)
             headerExtendedView.tappedHeaderUsernameAction = tappedHeaderUsernameAction
-            
+
             let size =  headerExtendedView.systemLayoutSizeFitting(CGSize(width: collectionView.frame.width, height: UIView.layoutFittingExpandedSize.height),
                                                       withHorizontalFittingPriority: .required, // Width is fixed
                                                       verticalFittingPriority: .fittingSizeLevel) // Height can be as large as needed
             return size
+        default:
+            return .zero
         }
-        
-        return .zero
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
@@ -405,7 +406,7 @@ extension DiffListViewController: DiffListChangeCellDelegate {
         if let indexOfOtherMoveCell = indexOfOtherMoveCell,
             let changeItemToScrollTo = changeItemToScrollTo {
 
-            let indexPathOfOtherMoveCell = IndexPath(item: indexOfOtherMoveCell, section: 0)
+            let indexPathOfOtherMoveCell = IndexPath(item: indexOfOtherMoveCell, section: Section.items.rawValue)
             let visibleIndexPaths = collectionView.indexPathsForVisibleItems
             
             if visibleIndexPaths.contains(indexPathOfOtherMoveCell) { // cell already configured, skip straight to detecting offset needed to get top of *item* on screen.
@@ -416,7 +417,7 @@ extension DiffListViewController: DiffListChangeCellDelegate {
                 // avoids weird bouncing when scrolling up if we choose the index path below
                 let indexAfterIndexOfOtherMoveCell = indexOfOtherMoveCell + 1
                 let indexToScrollTo = moveDirection == .down ? indexOfOtherMoveCell : ((dataSource.count) > indexAfterIndexOfOtherMoveCell) ? indexAfterIndexOfOtherMoveCell : indexOfOtherMoveCell
-                let indexPathToScrollTo = IndexPath(item: indexToScrollTo, section: 0)
+                let indexPathToScrollTo = IndexPath(item: indexToScrollTo, section: Section.items.rawValue)
                 
                 // first scroll to cell, scrollViewDidEndAnimation will then scroll to item
                 scrollDidFinishInfo = (indexPathOfOtherMoveCell, changeItemToScrollTo)


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T435382

### Notes
* Since the July 2024 diff redesign, list items live in section 2 of the diff collection view — sections 0 and 1 contain no items and exist only to host the two header supplementary views (a flow layout allows one header per section). `didTapItem` predates that change and still built its scroll target with `section: 0`, so tapping a "paragraph moved" marker always raised `NSInternalInconsistencyException` in `scrollToItem` and crashed the app.
* This introduces a `Section` enum and uses it everywhere the section layout is assumed. Besides fixing the crash, it restores the visible-cell shortcut and the fine-grained `scrollToChangeItem` offset, which also depended on the correct section.

### Test Steps
1. Open a diff containing a moved paragraph, e.g. `https://en.wikipedia.org/wiki/Special:MobileDiff/1369045204...1370193452` (via `xcrun simctl openurl booted`, or through article history / watchlist)
2. Tap a "Paragraph moved down/up" marker
3. Before: crash. After: the list scrolls to the other half of the move and centers it

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
N/A — crash fix, no visual changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)