### PR TITLE
T435346: Add Force Fundraising Campaign Banner developer settings [boiler plate work]

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
@@ -35,6 +35,14 @@ struct WMFDeveloperSettingsView: View {
                 }
             }
 
+            Section {
+                Toggle("Force Fundraising Campaign Banner", isOn: $viewModel.forceFundraisingCampaignBanner)
+            } header: {
+                Text("Fundraising")
+            } footer: {
+                Text("Force ignores country and language settings. Only works if there is an active campaign.")
+            }
+
             ForEach(viewModel.formViewModel.sections) { section in
                 if let selectSection = section as? WMFFormSectionSelectViewModel {
                     WMFFormSectionSelectView(viewModel: selectSection)

--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
@@ -37,10 +37,15 @@ struct WMFDeveloperSettingsView: View {
 
             Section {
                 Toggle("Force Fundraising Campaign Banner", isOn: $viewModel.forceFundraisingCampaignBanner)
+                Button {
+                    viewModel.clearFundraisingCampaignPersistence()
+                } label: {
+                    Text("Clear banner prompt state and donation history")
+                }
             } header: {
                 Text("Fundraising")
             } footer: {
-                Text("Force ignores country and language settings. Only works if there is an active campaign.")
+                Text("Force ignores country and language settings. Only works if there is an active campaign. Clear resets \"maybe later\" / \"already donated\" and the local donation history so the banner can show again without the force toggle.")
             }
 
             ForEach(viewModel.formViewModel.sections) { section in

--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -47,6 +47,12 @@ import WMFData
         }
     }
 
+    @Published public var forceFundraisingCampaignBanner: Bool = WMFDeveloperSettingsDataController.shared.forceFundraisingCampaignBanner {
+        didSet {
+            WMFDeveloperSettingsDataController.shared.forceFundraisingCampaignBanner = forceFundraisingCampaignBanner
+        }
+    }
+
 
     @objc public init(localizedStrings: WMFDeveloperSettingsLocalizedStrings) {
         self.localizedStrings = localizedStrings

--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -120,6 +120,13 @@ import WMFData
             .store(in: &subscribers)
     }
 
+    public func clearFundraisingCampaignPersistence() {
+        WMFDeveloperSettingsDataController.shared.clearFundraisingCampaignPersistence()
+        Task { @MainActor in
+            WMFToastPresenter.shared.show(WMFToastConfig(title: .init("Fundraising state cleared. The campaign banner can show again.")))
+        }
+    }
+
     public func clearGamesPersistence() {
         Task {
             try? await WMFDeveloperSettingsDataController.shared.clearGamesPersistence()

--- a/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
@@ -113,6 +113,14 @@ public protocol WMFDeveloperSettingsDataControlling: AnyObject {
         set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.developerSettingsYiRV3LoginExperimentB.rawValue, value: newValue) }
     }
 
+    /// Debugging convenience: when true, the fundraising campaign banner ignores country,
+    /// date window, prompt state (maybe later / hidden), opt-out, and donation history gates,
+    /// so it presents on every article view as long as any campaign config exists remotely.
+    public var forceFundraisingCampaignBanner: Bool {
+        get { (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.developerSettingsForceFundraisingCampaignBanner.rawValue)) ?? false }
+        set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.developerSettingsForceFundraisingCampaignBanner.rawValue, value: newValue) }
+    }
+
     public var forceHCaptchaChallenge: Bool {
         get { (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.forceHCaptchaChallenge.rawValue)) ?? false }
         set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.forceHCaptchaChallenge.rawValue, value: newValue) }

--- a/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
@@ -142,6 +142,14 @@ public protocol WMFDeveloperSettingsDataControlling: AnyObject {
         gamesDataController.resetAnnouncementSeen()
     }
 
+    /// Resets everything that can suppress the fundraising campaign banner: the "maybe later" /
+    /// permanently hidden prompt state and the local donation history (which hides the banner
+    /// for 250 days after a donation).
+    public func clearFundraisingCampaignPersistence() {
+        WMFFundraisingCampaignDataController.shared.clearPromptState()
+        WMFDonateDataController.shared.deleteLocalDonationHistory()
+    }
+
     public var enableVisualEditingJourney: Bool {
         get { (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.developerSettingsEnableVisualEditingJourney.rawValue)) ?? false }
         set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.developerSettingsEnableVisualEditingJourney.rawValue, value: newValue) }

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFFundraisingCampaignDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFFundraisingCampaignDataController.swift
@@ -31,6 +31,10 @@ import Foundation
     private let cacheConfigFileName = "AppsCampaignConfig"
     private let cachePromptStateFileName = "WMFFundraisingCampaignPromptState"
 
+    private var isForcingBannerForDevelopment: Bool {
+        WMFDeveloperSettingsDataController.shared.forceFundraisingCampaignBanner
+    }
+
     // MARK: - Lifecycle
     
     private init(service: WMFService? = WMFDataEnvironment.current.basicService, sharedCacheStore: WMFKeyValueStore? = WMFDataEnvironment.current.sharedCacheStore, mediaWikiService: WMFService? = WMFDataEnvironment.current.mediaWikiService) {
@@ -97,7 +101,11 @@ import Foundation
     ///   - currentDate: Current date, sent in as a parameter for stable unit testing.
     /// - Returns: WMFAsset containing information to display in campaign modal.
     public func loadActiveCampaignAsset(countryCode: String, wmfProject: WMFProject, currentDate: Date) -> WMFFundraisingCampaignConfig.WMFAsset? {
-        
+
+        guard !isForcingBannerForDevelopment else {
+            return forcedCampaignAssetForDevelopment(countryCode: countryCode, wmfProject: wmfProject, currentDate: currentDate)
+        }
+
         guard activeCountryConfigs.isEmpty else {
             
             // re-filter activeCountryConfigs in case campaigns have ended
@@ -220,6 +228,30 @@ import Foundation
         mediaWikiService.perform(request: request, completion: completion)
     }
     
+    // MARK: - Development
+
+    /// Only reachable via the "Force Fundraising Campaign Banner" developer setting. Reads the raw
+    /// cached config (saved unfiltered by fetchConfig) and returns the first asset, ignoring country,
+    /// date window, and prompt state, falling back to any language if the wiki has no asset.
+    private func forcedCampaignAssetForDevelopment(countryCode: String, wmfProject: WMFProject, currentDate: Date) -> WMFFundraisingCampaignConfig.WMFAsset? {
+
+        guard let cachedResult: WMFFundraisingCampaignConfigResponse = try? sharedCacheStore?.load(key: cacheDirectoryName, cacheConfigFileName) else {
+            return nil
+        }
+
+        let configs = activeCountryConfigs(from: cachedResult, countryCode: countryCode, currentDate: currentDate, ignoringCountryAndDateFilters: true)
+
+        if let languageCode = wmfProject.languageCode {
+            for config in configs {
+                if let asset = config.assets[languageCode] {
+                    return asset
+                }
+            }
+        }
+
+        return configs.first?.assets.values.first
+    }
+
     // MARK: - Testing
 
     @_spi(Testing) public func reset() {
@@ -238,7 +270,7 @@ import Foundation
         guard let asset = activeLanguageSpecificAsset(languageCode: languageCode, languageVariantCode: languageVariantCode) else {
             return nil
         }
-        
+
         let validateAsset: ((WMFFundraisingCampaignConfig.WMFAsset, WMFFundraisingCampaignPromptState) -> WMFFundraisingCampaignConfig.WMFAsset?) = { asset, promptState in
             guard promptState.campaignID == asset.id else {
                 return asset
@@ -284,7 +316,7 @@ import Foundation
                 return languageVariantCodeAsset
             }
         }
-        
+
         return nil
     }
     
@@ -301,30 +333,30 @@ import Foundation
             guard (firstAsset.startDate...firstAsset.endDate).contains(currentDate) else {
                 return
             }
-            
+
             configs.append(config)
         }
         
         return configs
     }
     
-    private func activeCountryConfigs(from response: WMFFundraisingCampaignConfigResponse, countryCode: String, currentDate: Date) -> [WMFFundraisingCampaignConfig] {
-        
+    private func activeCountryConfigs(from response: WMFFundraisingCampaignConfigResponse, countryCode: String, currentDate: Date, ignoringCountryAndDateFilters: Bool = false) -> [WMFFundraisingCampaignConfig] {
+
         var configs: [WMFFundraisingCampaignConfig] = []
-        
+
         response.configs.forEach({ config in
-            
-            guard config.countryCodes.contains(countryCode) else {
+
+            guard config.countryCodes.contains(countryCode) || ignoringCountryAndDateFilters else {
                 return
             }
-            
+
             let dateFormatter = DateFormatter.mediaWikiAPIDateFormatter
             guard let startDate = dateFormatter.date(from: config.startTimeString),
                   let endDate = dateFormatter.date(from: config.endTimeString) else {
                 return
             }
-            
-            guard (startDate...endDate).contains(currentDate) else {
+
+            guard (startDate...endDate).contains(currentDate) || ignoringCountryAndDateFilters else {
                 return
             }
             

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFFundraisingCampaignDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFFundraisingCampaignDataController.swift
@@ -230,6 +230,14 @@ import Foundation
     
     // MARK: - Development
 
+    /// Clears the persisted "maybe later" / permanently hidden prompt state so the campaign banner
+    /// can present again. Orchestrated by WMFDeveloperSettingsDataController for the developer
+    /// settings screen; lives here because the prompt state cache is private to this controller.
+    public func clearPromptState() {
+        promptState = nil
+        try? sharedCacheStore?.remove(key: cacheDirectoryName, cachePromptStateFileName)
+    }
+
     /// Only reachable via the "Force Fundraising Campaign Banner" developer setting. Reads the raw
     /// cached config (saved unfiltered by fetchConfig) and returns the first asset, ignoring country,
     /// date window, and prompt state, falling back to any language if the wiki has no asset.

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -43,6 +43,7 @@ public enum WMFUserDefaultsKey: String {
     case openAppOnSearchTab = "open-app-on-search-tab"
     case isSubscribedToEchoNotifications = "is-subscribed-to-echo-notifications"
     case forceHCaptchaChallenge = "force-hcaptcha-challenge"
+    case developerSettingsForceFundraisingCampaignBanner = "dev-settings-force-fundraising-campaign-banner"
 
     case allowGestureZoomArticleWebview = "allow-gesture-zoom-article-webview"
     // Reading Challenge 2026 (feature removed, see WMFReadingChallengeCompletionDataController)

--- a/WMFData/Tests/WMFDataTests/WMFFundraisingCampaignDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFFundraisingCampaignDataControllerTests.swift
@@ -190,10 +190,76 @@ final class WMFFundraisingCampaignDataControllerTests {
         }
     }
 
+    // MARK: - Force Fundraising Campaign Banner developer setting
+
+    @Test
+    func forceBannerDeveloperSettingIgnoresCountryAndDateFilters() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.forceFundraisingCampaignBanner = true
+            let invalidCountry = "US"
+            let invalidDate = try invalidDate()
+
+            try await controller.fetchConfig(countryCode: invalidCountry, currentDate: invalidDate)
+
+            let asset = try #require(controller.loadActiveCampaignAsset(countryCode: invalidCountry, wmfProject: enProject, currentDate: invalidDate))
+            #expect(asset.id == "NL_2023_11")
+        }
+    }
+
+    @Test
+    func forceBannerDeveloperSettingFallsBackToAnyLanguageAsset() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.forceFundraisingCampaignBanner = true
+            let germanProject = WMFProject.wikipedia(WMFLanguage(languageCode: "de", languageVariantCode: nil))
+            let validDate = try validFirstDayDate()
+
+            try await controller.fetchConfig(countryCode: "NL", currentDate: validDate)
+
+            #expect(controller.loadActiveCampaignAsset(countryCode: "NL", wmfProject: germanProject, currentDate: validDate) != nil)
+        }
+    }
+
+    @Test
+    func forceBannerDeveloperSettingIgnoresPromptState() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.forceFundraisingCampaignBanner = true
+            let validDate = try validFirstDayDate()
+
+            try await controller.fetchConfig(countryCode: "NL", currentDate: validDate)
+            let asset = try #require(controller.loadActiveCampaignAsset(countryCode: "NL", wmfProject: nlProject, currentDate: validDate))
+
+            controller.markAssetAsPermanentlyHidden(asset: asset)
+
+            #expect(controller.loadActiveCampaignAsset(countryCode: "NL", wmfProject: nlProject, currentDate: validDate) != nil)
+        }
+    }
+
+    // MARK: - Clear fundraising campaign persistence developer action
+
+    @Test
+    func clearFundraisingCampaignPersistenceClearsPromptStateAndDonationHistory() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let validDate = try validFirstDayDate()
+            try await controller.fetchConfig(countryCode: "NL", currentDate: validDate)
+            let asset = try #require(controller.loadActiveCampaignAsset(countryCode: "NL", wmfProject: nlProject, currentDate: validDate))
+            controller.markAssetAsPermanentlyHidden(asset: asset)
+            #expect(controller.loadActiveCampaignAsset(countryCode: "NL", wmfProject: nlProject, currentDate: validDate) == nil)
+
+            _ = WMFDonateDataController.shared.saveLocalDonationHistory(type: .oneTime, amount: 5, currencyCode: "EUR", isNative: true)
+            #expect(WMFDonateDataController.shared.loadLocalDonationHistory(startDate: nil, endDate: nil)?.isEmpty == false)
+
+            WMFDeveloperSettingsDataController.shared.clearFundraisingCampaignPersistence()
+
+            #expect(controller.loadActiveCampaignAsset(countryCode: "NL", wmfProject: nlProject, currentDate: validDate) != nil)
+            #expect(WMFDonateDataController.shared.loadLocalDonationHistory(startDate: nil, endDate: nil) == nil)
+        }
+    }
+
     private func configureEnvironment() async {
         WMFDataEnvironment.current.basicService = WMFFundraisingCampaignRequestMockService()
         WMFDataEnvironment.current.serviceEnvironment = .staging
         WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
+        WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
     }
 
     private func validFirstDayDate() throws -> Date {

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -17,6 +17,7 @@ extension ArticleViewController {
         }
 
         let fundraisingDataController = WMFFundraisingCampaignDataController.shared
+        let isForcingBannerForDevelopment = WMFDeveloperSettingsDataController.shared.forceFundraisingCampaignBanner
 
         Task {
             let isOptedIn = await fundraisingDataController.isOptedIn(project: wmfProject)
@@ -33,13 +34,7 @@ extension ArticleViewController {
                 }
             }
 
-            guard isOptedIn else {
-                willDisplayCampaignModal = false
-                onNothingShown?()
-                return
-            }
-
-            guard !userDonatedWithinLast250Days() else {
+            guard (isOptedIn && !userDonatedWithinLast250Days()) || isForcingBannerForDevelopment else {
                 willDisplayCampaignModal = false
                 onNothingShown?()
                 return

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -34,7 +34,9 @@ extension ArticleViewController {
                 }
             }
 
-            guard (isOptedIn && !userDonatedWithinLast250Days()) || isForcingBannerForDevelopment else {
+            let isFirstAppSession = UserDefaults.standard.wmf_appResignActiveDate() == nil
+
+            guard (isOptedIn && !userDonatedWithinLast250Days() && !isFirstAppSession) || isForcingBannerForDevelopment else {
                 willDisplayCampaignModal = false
                 onNothingShown?()
                 return

--- a/Wikipedia/Code/MWKDataStore.m
+++ b/Wikipedia/Code/MWKDataStore.m
@@ -916,6 +916,9 @@ NSString *const WMFCacheContextCrossProcessNotificiationChannelNamePrefix = @"or
                                  [taskGroup leave];
                              });
                          }];
+    // Fire and forget. This fetch must not delay the combined completion.
+    [[WMFFundraisingCampaignDataController sharedInstance] fetchConfigWithCountryCode:[[NSLocale currentLocale] countryCode] currentDate:[NSDate now]];
+
     // Remote Feature config
     [taskGroup enter];
     [[WMFDeveloperSettingsDataController shared] fetchFeatureConfigWithCompletion:^(NSError *_Nullable error) {

--- a/Wikipedia/Code/WMFAnnouncementsContentSource.m
+++ b/Wikipedia/Code/WMFAnnouncementsContentSource.m
@@ -2,14 +2,12 @@
 #import "WMFAnnouncementsFetcher.h"
 #import "WMFAnnouncement.h"
 #import <WMF/WMF-Swift.h>
-@import WMFData;
 
 @interface WMFAnnouncementsContentSource ()
 
 @property (readwrite, nonatomic, strong) NSURL *siteURL;
 @property (readwrite, nonatomic, strong) WMFAnnouncementsFetcher *fetcher;
 @property (readwrite, nonatomic, strong) MWKDataStore *userDataStore;
-@property (readwrite, nonatomic, strong) WMFFundraisingCampaignDataController *fundraisingCampaignDataController;
 @property (readonly, nonatomic, assign) BOOL isLoggedIn;
 
 @end
@@ -23,7 +21,6 @@
         self.siteURL = siteURL;
         self.userDataStore = userDataStore;
         self.fetcher = [[WMFAnnouncementsFetcher alloc] initWithSession:userDataStore.session configuration:userDataStore.configuration];
-        self.fundraisingCampaignDataController = [WMFFundraisingCampaignDataController sharedInstance];
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(userWasLoggedIn:)
                                                      name:[WMFAuthenticationManager didLogInNotification]
@@ -66,10 +63,6 @@
         return;
     }
     
-    NSString *countryCode = [[NSLocale currentLocale] countryCode];
-
-    [self.fundraisingCampaignDataController fetchConfigWithCountryCode:countryCode currentDate:[NSDate now]];
-
     [self.fetcher fetchAnnouncementsForURL:self.siteURL
         force:force
         failure:^(NSError *_Nonnull error) {


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T435346


### Notes
>[!IMPORTANT]
> this dev settings only works when we have an active campaign. which we do, right now.

* Boilerplate/tooling for the Donation Reminder work: testing the banner flows currently requires setting the simulator region, deleting the app, and reopening articles until the campaign config is cached.
* Adds a "Fundraising" section to Developer Settings with two things:
  * **Force Fundraising Campaign Banner**: presents the banner on any article view, ignoring country, date window, prompt state ("maybe later" / "already donated"), opt-out, and donation history gates. The production path is untouched — the flag branches once at the top of `loadActiveCampaignAsset` into a development-only method. Still requires an active campaign in the remote config (real asset, not mocked).
  * **Clear banner prompt state and donation history**: resets "maybe later" / "already donated" and the local donation history (250-day gate), so the real flow can be re-tested without reinstalling the app. Follows the `clearGamesPersistence()` pattern.

### Test Steps
1. Build and run, enable Developer Settings, toggle "Force Fundraising Campaign Banner".
2. Open any article (any language, any region) — the banner presents. Tap "I already donated"; open another article — banner presents again.
3. Toggle force off, tap "Clear banner prompt state and donation history" — with a matching campaign (region/language), the banner presents once more under production rules.

### Checklist
- [x] Checked against Swift 6 strict concurrency


### Screenshots/Videos

https://github.com/user-attachments/assets/63b5a97c-0aaf-44c3-9d09-06f370e0adcb
