### PR TITLE
Fix use of display and canonical titles in interests

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/App Onboarding/WMFAppOnboardingFeedPreferenceView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/App Onboarding/WMFAppOnboardingFeedPreferenceView.swift
@@ -163,7 +163,7 @@ private struct WMFAppOnboardingPreviewCardView: View {
                 if viewModel.uiImage == nil, let pill = viewModel.topicPill {
                     topicPillView(pill)
                 }
-                WMFHtmlText(html: viewModel.title, styles: semiboldHeadlineStyle)
+                WMFHtmlText(html: viewModel.displayTitle, styles: semiboldHeadlineStyle)
                     .foregroundStyle(Color(uiColor: theme.text))
                     .lineLimit(2)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/WMFComponents/Sources/WMFComponents/Components/App Onboarding/WMFAppOnboardingFeedPreferenceViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/App Onboarding/WMFAppOnboardingFeedPreferenceViewModel.swift
@@ -138,7 +138,7 @@ public final class WMFAppOnboardingFeedPreferenceViewModel: ObservableObject {
 
         if let featured = response.feedResponse.todaysFeaturedArticle {
             cards.append(WMFAppOnboardingPreviewCardViewModel(
-                title: featured.normalizedTitle ?? featured.title ?? "",
+                displayTitle: featured.displayTitle ?? featured.normalizedTitle ?? featured.title ?? "",
                 description: featured.description,
                 imageURLString: featured.thumbnail?.source,
                 topicPill: nil
@@ -147,7 +147,7 @@ public final class WMFAppOnboardingFeedPreferenceViewModel: ObservableObject {
 
         if let pictureOfDay = response.feedResponse.image {
             cards.append(WMFAppOnboardingPreviewCardViewModel(
-                title: pictureOfTheDayTitle,
+                displayTitle: pictureOfTheDayTitle,
                 description: pictureOfDay.description?.text,
                 imageURLString: pictureOfDay.thumbnail?.source ?? pictureOfDay.image?.source,
                 topicPill: nil
@@ -159,7 +159,7 @@ public final class WMFAppOnboardingFeedPreferenceViewModel: ObservableObject {
             // otherwise the first link that actually has a thumbnail.
             let featured = news.featuredArticle(picturedText: picturedText)
             cards.append(WMFAppOnboardingPreviewCardViewModel(
-                title: inTheNewsTitle,
+                displayTitle: inTheNewsTitle,
                 description: news.story.map(Self.strippingHTMLTags),
                 imageURLString: featured?.thumbnail?.source,
                 topicPill: nil
@@ -203,8 +203,9 @@ public final class WMFAppOnboardingFeedPreferenceViewModel: ObservableObject {
 final class WMFAppOnboardingPreviewCardViewModel: ObservableObject, Identifiable {
 
     let id = UUID()
-    let title: String
     let topicPill: String?
+
+    @Published var displayTitle: String
     @Published var description: String?
     @Published var uiImage: UIImage?
 
@@ -214,8 +215,8 @@ final class WMFAppOnboardingPreviewCardViewModel: ObservableObject, Identifiable
     private var imageTask: Task<Void, Never>?
 
     /// Community cards arrive with all content up front.
-    init(title: String, description: String?, imageURLString: String?, topicPill: String?) {
-        self.title = title
+    init(displayTitle: String, description: String?, imageURLString: String?, topicPill: String?) {
+        self.displayTitle = displayTitle
         self.description = description
         self.imageURL = imageURLString.flatMap { URL(string: $0) }
         self.topicPill = topicPill
@@ -224,19 +225,20 @@ final class WMFAppOnboardingPreviewCardViewModel: ObservableObject, Identifiable
 
     /// Personalized cards carry only a title and hydrate description/image from the article summary.
     init(article: WMFForYouArticle, topicPill: String?) {
-        self.title = article.title.underscoresToSpaces
+        self.displayTitle = article.title.underscoresToSpaces
         self.description = nil
         self.imageURL = nil
         self.topicPill = topicPill
         self.summaryFetchInfo = (article.title, article.project)
     }
 
-    /// Fetches the description and thumbnail URL from the article summary. Awaited before
-    /// the personalized row is revealed, so its cards appear with their text in place.
+    /// Fetches the display title, description, and thumbnail URL from the article summary.
+    /// Awaited before the personalized row is revealed, so its cards appear with their text in place.
     func loadSummaryIfNeeded() async {
         guard !didLoadSummary, let info = summaryFetchInfo else { return }
         didLoadSummary = true
         guard let summary = try? await WMFArticleSummaryDataController.shared.fetchArticleSummary(project: info.project, title: info.title.spacesToUnderscores) else { return }
+        displayTitle = summary.displayTitle
         description = summary.description
         imageURL = summary.thumbnailURL
     }

--- a/WMFComponents/Sources/WMFComponents/Components/Settings/Home/For You/Whats Driving/Your Interests/WMFHomeFeedInterestsSettingsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Settings/Home/For You/Whats Driving/Your Interests/WMFHomeFeedInterestsSettingsView.swift
@@ -255,7 +255,7 @@ private struct WMFInterestSearchResultRow: View {
             .clipShape(RoundedRectangle(cornerRadius: 6))
 
             VStack(alignment: .leading, spacing: 2) {
-                WMFHtmlText(html: card.title, styles: HtmlUtils.Styles(font: WMFFont.for(.subheadline, sized: dynamicTypeSize), boldFont: WMFFont.for(.boldSubheadline, sized: dynamicTypeSize), italicsFont: WMFFont.for(.italicSubheadline, sized: dynamicTypeSize), boldItalicsFont: WMFFont.for(.italicSubheadline, sized: dynamicTypeSize), color: theme.text, linkColor: theme.link, lineSpacing: 1))
+                WMFHtmlText(html: card.displayTitle, styles: HtmlUtils.Styles(font: WMFFont.for(.subheadline, sized: dynamicTypeSize), boldFont: WMFFont.for(.boldSubheadline, sized: dynamicTypeSize), italicsFont: WMFFont.for(.italicSubheadline, sized: dynamicTypeSize), boldItalicsFont: WMFFont.for(.italicSubheadline, sized: dynamicTypeSize), color: theme.text, linkColor: theme.link, lineSpacing: 1))
                 if let description = card.description {
                     Text(description)
                         .font(Font(WMFFont.for(.caption1, sized: dynamicTypeSize)))
@@ -287,7 +287,7 @@ private struct WMFInterestSearchResultRow: View {
     }
 
     private var accessibilityLabel: String {
-        [card.title.wmf_strippingHTMLForAccessibility, card.description]
+        [card.displayTitle.removingHTML, card.description]
             .compactMap { $0 }
             .filter { !$0.isEmpty }
             .joined(separator: ", ")
@@ -353,9 +353,3 @@ private struct LanguageChipView: View {
     }
 }
 
-extension String {
-    /// Strips simple HTML tags so display titles (which may contain markup) read cleanly in VoiceOver.
-    var wmf_strippingHTMLForAccessibility: String {
-        replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
-    }
-}

--- a/WMFComponents/Sources/WMFComponents/Components/Settings/Home/For You/Whats Driving/Your Interests/WMFHomeFeedInterestsSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Settings/Home/For You/Whats Driving/Your Interests/WMFHomeFeedInterestsSettingsViewModel.swift
@@ -254,7 +254,7 @@ public final class WMFHomeFeedInterestsSettingsViewModel: ObservableObject {
                 let results = try await searchDataController.search(term: term, project: .wikipedia(language))
                 guard !Task.isCancelled else { return }
                 self.searchRows = results.map { result in
-                    let alreadySelected = self.gridViewModels.contains { $0.id == result.title && $0.isSelected }
+                    let alreadySelected = self.gridViewModels.contains { $0.id == result.title.normalizedForCoreData && $0.isSelected }
                     let card = WMFInterestArticleCardViewModel(searchResult: result, project: .wikipedia(language), isSelected: alreadySelected)
                     return SearchRow(id: result.pageID, result: result, card: card)
                 }
@@ -277,9 +277,10 @@ public final class WMFHomeFeedInterestsSettingsViewModel: ObservableObject {
 
         var cards: [WMFInterestArticleCardViewModel] = []
         var seenIDs = Set<String>()
-        for interest in interests where !seenIDs.contains(interest.title) {
-            seenIDs.insert(interest.title)
-            cards.append(WMFInterestArticleCardViewModel(pageInterest: interest, project: interest.project ?? project))
+        for interest in interests {
+            let card = WMFInterestArticleCardViewModel(pageInterest: interest, project: interest.project ?? project)
+            guard seenIDs.insert(card.id).inserted else { continue }
+            cards.append(card)
         }
 
         gridViewModels = cards
@@ -293,7 +294,7 @@ public final class WMFHomeFeedInterestsSettingsViewModel: ObservableObject {
         let savedIDs = Set(savedVMs.map { $0.id })
         let remainingSlots = max(0, Self.maxGridArticles - savedVMs.count)
         let randomVMs = articles
-            .filter { !savedIDs.contains($0.title) }
+            .filter { !savedIDs.contains($0.title.normalizedForCoreData) }
             .prefix(remainingSlots)
             .map { WMFInterestArticleCardViewModel(article: $0, project: project) }
         gridViewModels = savedVMs + randomVMs

--- a/WMFComponents/Sources/WMFComponents/Components/Settings/Home/For You/Whats Driving/Your Interests/WMFInterestArticleCardViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Settings/Home/For You/Whats Driving/Your Interests/WMFInterestArticleCardViewModel.swift
@@ -8,50 +8,53 @@ final class WMFInterestArticleCardViewModel: ObservableObject, Identifiable {
     let id: String
     let title: String
     let project: WMFProject
+    @Published var displayTitle: String
     @Published var description: String?
     @Published var uiImage: UIImage?
     @Published var isSelected: Bool
 
     var thumbnailURL: URL?
-    private let summaryFetchInfo: (title: String, project: WMFProject)?
+    private let needsSummary: Bool
     private var imageTask: Task<Void, Never>?
     private var summaryTask: Task<Void, Never>?
 
     init(article: WMFRandomArticle, project: WMFProject, isSelected: Bool = false) {
-        self.id = article.title
-        self.title = article.displayTitle ?? article.title.underscoresToSpaces
+        self.id = article.title.normalizedForCoreData
+        self.title = article.title
+        self.displayTitle = article.displayTitle ?? article.title.underscoresToSpaces
         self.project = project
         self.description = article.description
         self.thumbnailURL = article.thumbnail?.url
-        self.summaryFetchInfo = nil
+        self.needsSummary = false
         self.isSelected = isSelected
     }
 
-    // Used when creating a card from a WMFPageInterest — loads summary on demand
     init(pageInterest: WMFPageInterest, project: WMFProject) {
-        self.id = pageInterest.title
-        self.title = pageInterest.title.underscoresToSpaces
+        self.id = pageInterest.title.normalizedForCoreData
+        self.title = pageInterest.title
+        self.displayTitle = pageInterest.title.underscoresToSpaces
         self.project = project
         self.description = nil
         self.thumbnailURL = nil
-        self.summaryFetchInfo = (pageInterest.title, project)
+        self.needsSummary = true
         self.isSelected = true
     }
 
     // Used when creating a card from an article search result
     init(searchResult: WMFArticleSearchResult, project: WMFProject, isSelected: Bool = false) {
-        self.id = searchResult.title
-        self.title = searchResult.displayTitle ?? searchResult.title.underscoresToSpaces
+        self.id = searchResult.title.normalizedForCoreData
+        self.title = searchResult.title
+        self.displayTitle = searchResult.displayTitle ?? searchResult.title.underscoresToSpaces
         self.project = project
         self.description = searchResult.description
         self.thumbnailURL = searchResult.thumbnailURL
-        self.summaryFetchInfo = nil
+        self.needsSummary = false
         self.isSelected = isSelected
     }
 
     func loadIfNeeded() {
-        if let info = summaryFetchInfo {
-            loadSummaryAndImage(title: info.title, project: info.project)
+        if needsSummary {
+            loadSummaryAndImage()
         } else {
             loadImageIfNeeded()
         }
@@ -68,12 +71,15 @@ final class WMFInterestArticleCardViewModel: ObservableObject, Identifiable {
         }
     }
 
-    private func loadSummaryAndImage(title: String, project: WMFProject) {
+    private func loadSummaryAndImage() {
         guard summaryTask == nil else { return }
+        let title = title
+        let project = project
         summaryTask = Task { [weak self] in
             guard let self else { return }
             guard let summary = try? await WMFArticleSummaryDataController.shared.fetchArticleSummary(project: project, title: title.spacesToUnderscores),
                   !Task.isCancelled else { return }
+            self.displayTitle = summary.displayTitle
             self.description = summary.description
             self.thumbnailURL = summary.thumbnailURL
             if let url = summary.thumbnailURL {

--- a/WMFComponents/Sources/WMFComponents/Components/Settings/Home/For You/Whats Driving/Your Interests/WMFInterestArticleGridView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Settings/Home/For You/Whats Driving/Your Interests/WMFInterestArticleGridView.swift
@@ -39,7 +39,7 @@ struct WMFInterestArticleGridView: View {
 
     private func estimatedHeight(for vm: WMFInterestArticleCardViewModel) -> CGFloat {
         let imageHeight: CGFloat = vm.thumbnailURL != nil ? 100 : 0
-        let titleLines = max(1, Int(ceil(Double(vm.title.count) / 18.0)))
+        let titleLines = max(1, Int(ceil(Double(vm.displayTitle.removingHTML.count) / 18.0)))
         let titleHeight = CGFloat(titleLines) * 20
         let descriptionHeight: CGFloat
         if let desc = vm.description {
@@ -103,7 +103,7 @@ private struct WMFInterestArticleCardView: View {
             // text rather than below its descender space.
             HStack(alignment: .lastTextBaseline, spacing: 4) {
                 VStack(alignment: .leading, spacing: 4) {
-                    WMFHtmlText(html: viewModel.title, styles: HtmlUtils.Styles(font: WMFFont.for(.semiboldHeadline, sized: dynamicTypeSize), boldFont: WMFFont.for(.boldHeadline, sized: dynamicTypeSize), italicsFont: WMFFont.for(.semiboldHeadline, sized: dynamicTypeSize), boldItalicsFont: WMFFont.for(.boldHeadline, sized: dynamicTypeSize), color: theme.text, linkColor: theme.link, lineSpacing: 1))
+                    WMFHtmlText(html: viewModel.displayTitle, styles: HtmlUtils.Styles(font: WMFFont.for(.semiboldHeadline, sized: dynamicTypeSize), boldFont: WMFFont.for(.boldHeadline, sized: dynamicTypeSize), italicsFont: WMFFont.for(.semiboldHeadline, sized: dynamicTypeSize), boldItalicsFont: WMFFont.for(.boldHeadline, sized: dynamicTypeSize), color: theme.text, linkColor: theme.link, lineSpacing: 1))
                     if let description = viewModel.description {
                         Text(description)
                             .font(Font(WMFFont.for(.callout, sized: dynamicTypeSize)))
@@ -145,7 +145,7 @@ private struct WMFInterestArticleCardView: View {
     }
 
     private var accessibilityLabel: String {
-        [viewModel.title.wmf_strippingHTMLForAccessibility, viewModel.description]
+        [viewModel.displayTitle.removingHTML, viewModel.description]
             .compactMap { $0 }
             .filter { !$0.isEmpty }
             .joined(separator: ", ")

--- a/WMFComponents/Tests/WMFComponentsTests/WMFAppOnboardingFeedPreferenceViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFAppOnboardingFeedPreferenceViewModelTests.swift
@@ -129,7 +129,7 @@ struct WMFAppOnboardingFeedPreferenceViewModelTests {
 
         let cards = WMFAppOnboardingFeedPreferenceViewModel.buildPersonalizedCards(from: response)
         #expect(cards.count == 3)
-        #expect(cards[0].title == "Music article")
+        #expect(cards[0].displayTitle == "Music article")
         #expect(cards[0].topicPill == WMFArticleTopic.music.displayName)
         #expect(cards.allSatisfy { $0.topicPill != nil })
     }
@@ -163,7 +163,7 @@ struct WMFAppOnboardingFeedPreferenceViewModelTests {
         let cards = WMFAppOnboardingFeedPreferenceViewModel.buildPersonalizedCards(from: response)
         #expect(cards.count == 2)
         #expect(cards[0].topicPill == WMFArticleTopic.music.displayName)
-        #expect(cards[1].title == "Related article")
+        #expect(cards[1].displayTitle == "Related article")
         #expect(cards[1].topicPill == nil)
     }
 
@@ -174,6 +174,27 @@ struct WMFAppOnboardingFeedPreferenceViewModelTests {
     }
 
     // MARK: - Community cards
+
+    @Test
+    func featuredArticleCardKeepsItsMarkedUpDisplayTitle() throws {
+        // The wiki italicizes film and book titles, and the card renders HTML, so the markup has
+        // to survive rather than being flattened to the normalized title.
+        let json = """
+        {
+            "tfa": {
+                "title": "The_Macomber_Affair",
+                "normalizedtitle": "The Macomber Affair",
+                "displaytitle": "<i>The Macomber Affair</i>"
+            }
+        }
+        """
+        let feedResponse = try JSONDecoder().decode(WMFFeedAPIResponse.self, from: Data(json.utf8))
+        let response = WMFCommunityResponse(date: Date(), feedResponse: feedResponse, onThisDay: nil)
+
+        let cards = makeViewModel().buildCommunityCards(from: response)
+
+        #expect(cards.first?.displayTitle == "<i>The Macomber Affair</i>")
+    }
 
     @Test
     func communityCardsBuildFromFeedResponse() throws {
@@ -205,7 +226,7 @@ struct WMFAppOnboardingFeedPreferenceViewModelTests {
         let cards = viewModel.buildCommunityCards(from: response)
 
         #expect(cards.count == 3)
-        #expect(cards[0].title == "Featured Article")
+        #expect(cards[0].displayTitle == "Featured Article")
         #expect(cards[0].description == "A featured thing")
         #expect(cards[1].description == "A pretty picture")
         // News story HTML is stripped

--- a/WMFComponents/Tests/WMFComponentsTests/WMFHomeFeedInterestsSettingsViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFHomeFeedInterestsSettingsViewModelTests.swift
@@ -353,7 +353,7 @@ struct WMFHomeFeedInterestsSettingsViewModelTests {
             try await Task.sleep(for: .milliseconds(50))
         }
 
-        let titles = Set(viewModel.gridViewModels.map { $0.title })
+        let titles = Set(viewModel.gridViewModels.map { $0.displayTitle })
         #expect(titles.contains("English Article"))
         #expect(titles.contains("Artigo"))
     }
@@ -380,7 +380,7 @@ struct WMFHomeFeedInterestsSettingsViewModelTests {
             try await Task.sleep(for: .milliseconds(50))
         }
 
-        let restored = viewModel.gridViewModels.first { $0.title == "Saved One" }
+        let restored = viewModel.gridViewModels.first { $0.displayTitle == "Saved One" }
         #expect(restored?.isSelected == true)
         #expect(viewModel.selectedArticleCount >= 1)
     }

--- a/WMFComponents/Tests/WMFComponentsTests/WMFInterestArticleCardViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFInterestArticleCardViewModelTests.swift
@@ -19,20 +19,51 @@ struct WMFInterestArticleCardViewModelTests {
         return WMFRandomArticle(pageid: pageid, title: title, displayTitle: displayTitle, variantTitles: nil, description: description, extract: nil, thumbnail: thumbnail)
     }
 
+    private var project: WMFProject {
+        .wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil))
+    }
+
     // MARK: - Title
 
     @Test
-    func prefersDisplayTitleOverTitle() {
+    func displayTitlePrefersTheMarkedUpTitle() {
         let article = makeArticle(title: "Raw title", displayTitle: "<i>Display title</i>")
-        let viewModel = WMFInterestArticleCardViewModel(article: article, project: .wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)))
-        #expect(viewModel.title == "<i>Display title</i>")
+        let viewModel = WMFInterestArticleCardViewModel(article: article, project: project)
+        #expect(viewModel.displayTitle == "<i>Display title</i>")
     }
 
     @Test
-    func fallsBackToTitleWhenDisplayTitleIsNil() {
-        let article = makeArticle(title: "Raw title", displayTitle: nil)
-        let viewModel = WMFInterestArticleCardViewModel(article: article, project: .wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)))
-        #expect(viewModel.title == "Raw title")
+    func displayTitleFallsBackToTheCanonicalTitleWhenAbsent() {
+        let article = makeArticle(title: "Raw_title", displayTitle: nil)
+        let viewModel = WMFInterestArticleCardViewModel(article: article, project: project)
+        #expect(viewModel.displayTitle == "Raw title")
+    }
+
+    /// The display title is markup for some articles (`<i>The Macomber Affair</i>` for a film), and
+    /// `title` is what gets persisted as an interest and looked up for a summary — so it has to stay
+    /// the canonical title, or the interest fetches nothing and its card shows no image.
+    @Test
+    func titleStaysCanonicalWhenTheDisplayTitleCarriesMarkup() {
+        let article = makeArticle(title: "The_Macomber_Affair", displayTitle: "<i>The Macomber Affair</i>")
+        let viewModel = WMFInterestArticleCardViewModel(article: article, project: project)
+        #expect(viewModel.title == "The_Macomber_Affair")
+    }
+
+    @Test
+    func searchResultTitleStaysCanonicalWhenTheDisplayTitleCarriesMarkup() {
+        let result = WMFArticleSearchResult(pageID: 1, namespace: 0, title: "The Macomber Affair", displayTitle: "<i>The Macomber Affair</i>", description: nil, index: 1, thumbnail: nil)
+        let viewModel = WMFInterestArticleCardViewModel(searchResult: result, project: project)
+        #expect(viewModel.title == "The Macomber Affair")
+        #expect(viewModel.displayTitle == "<i>The Macomber Affair</i>")
+    }
+
+    /// A saved interest and a fresh random article describe the same page with differently spaced
+    /// titles, so the ids have to agree or the grid shows the article twice.
+    @Test
+    func idMatchesAcrossSources() {
+        let fromArticle = WMFInterestArticleCardViewModel(article: makeArticle(title: "Marie Curie"), project: project)
+        let fromInterest = WMFInterestArticleCardViewModel(pageInterest: WMFPageInterest(title: "Marie_Curie", timestamp: Date()), project: project)
+        #expect(fromArticle.id == fromInterest.id)
     }
 
     // MARK: - Description
@@ -40,14 +71,14 @@ struct WMFInterestArticleCardViewModelTests {
     @Test
     func descriptionIsNilWhenAbsent() {
         let article = makeArticle(description: nil)
-        let viewModel = WMFInterestArticleCardViewModel(article: article, project: .wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)))
+        let viewModel = WMFInterestArticleCardViewModel(article: article, project: project)
         #expect(viewModel.description == nil)
     }
 
     @Test
     func descriptionIsPopulatedWhenPresent() {
         let article = makeArticle(description: "A short description")
-        let viewModel = WMFInterestArticleCardViewModel(article: article, project: .wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)))
+        let viewModel = WMFInterestArticleCardViewModel(article: article, project: project)
         #expect(viewModel.description == "A short description")
     }
 
@@ -56,14 +87,14 @@ struct WMFInterestArticleCardViewModelTests {
     @Test
     func imageIsNilBeforeLoad() {
         let article = makeArticle(thumbnailSource: "https://example.com/image.jpg")
-        let viewModel = WMFInterestArticleCardViewModel(article: article, project: .wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)))
+        let viewModel = WMFInterestArticleCardViewModel(article: article, project: project)
         #expect(viewModel.uiImage == nil)
     }
 
     @Test
     func loadIfNeededDoesNothingWhenNoThumbnail() {
         let article = makeArticle(thumbnailSource: nil)
-        let viewModel = WMFInterestArticleCardViewModel(article: article, project: .wikipedia(WMFLanguage(languageCode: "en", languageVariantCode: nil)))
+        let viewModel = WMFInterestArticleCardViewModel(article: article, project: project)
         viewModel.loadIfNeeded()
         #expect(viewModel.uiImage == nil)
     }

--- a/WMFComponents/Tests/WMFComponentsTests/WMFInterestsPersistenceRoundTripTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFInterestsPersistenceRoundTripTests.swift
@@ -82,6 +82,30 @@ final class WMFInterestsPersistenceRoundTripTests {
         }
     }
 
+    /// The wiki italicizes some article titles, so the search result's display title arrives as
+    /// markup. Persisting that instead of the canonical title left the interest unresolvable —
+    /// its summary and related-pages lookups 404, so its card showed no image or description.
+    @Test
+    func searchResultWithAMarkedUpDisplayTitlePersistsTheCanonicalTitle() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let store = try #require(WMFDataEnvironment.current.coreDataStore)
+            let pageInterest = try WMFPageInterestDataController(coreDataStore: store)
+            let home = WMFHomeDataController(userDefaultsStore: WMFMockKeyValueStore())
+
+            let vm = WMFHomeFeedInterestsSettingsViewModel(dataController: home, pageInterestDataController: pageInterest, project: project)
+            let result = WMFArticleSearchResult(pageID: 18586452, namespace: 0, title: "The Macomber Affair", displayTitle: "<i>The Macomber Affair</i>", description: "1947 film by Zoltan Korda", index: 1, thumbnail: nil)
+            #expect(vm.addSearchResult(result))
+
+            try await waitFor {
+                let interests = (try? self.syncFetch(pageInterest)) ?? []
+                return !interests.isEmpty
+            }
+
+            let interests = try self.syncFetch(pageInterest)
+            #expect(interests.map { $0.title } == ["The_Macomber_Affair"])
+        }
+    }
+
     private nonisolated func syncFetch(_ controller: WMFPageInterestDataController) throws -> [WMFPageInterest] {
         let semaphore = DispatchSemaphore(value: 0)
         var result: [WMFPageInterest] = []


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T435528

### Notes
* Use of display title to retrieve thumbnails and article summaries resulted in failures

### Test Steps
1. Fresh install and force new onboarding - make sure no old interests remain.
2. Add interests with italicized titles (The Machinist, The Macomber Affair are examples)
3. Make sure the images and summaries load in the feed interest step
4. Make sure they also load when editing your interests in settings after onboarding is done

### Checklist
- [x] Checked against Swift 6 strict concurrency

