### PR TITLE
T435346: Donation Reminder groundwork: refactor, feature flag, data layer and shared components (2/3)

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
@@ -36,6 +36,7 @@ struct WMFDeveloperSettingsView: View {
             }
 
             Section {
+                Toggle("Enable Donation Reminder", isOn: $viewModel.enableDonationReminder)
                 Toggle("Force Fundraising Campaign Banner", isOn: $viewModel.forceFundraisingCampaignBanner)
                 Button {
                     viewModel.clearFundraisingCampaignPersistence()

--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -53,6 +53,12 @@ import WMFData
         }
     }
 
+    @Published public var enableDonationReminder: Bool = WMFDeveloperSettingsDataController.shared.enableDonationReminder {
+        didSet {
+            WMFDeveloperSettingsDataController.shared.enableDonationReminder = enableDonationReminder
+        }
+    }
+
 
     @objc public init(localizedStrings: WMFDeveloperSettingsLocalizedStrings) {
         self.localizedStrings = localizedStrings

--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -22,6 +22,7 @@ import WMFData
     }
 }
 
+@MainActor
 @objc public class WMFDeveloperSettingsViewModel: NSObject, ObservableObject {
 
     let localizedStrings: WMFDeveloperSettingsLocalizedStrings

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Buttons/WMFPriceButton.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Buttons/WMFPriceButton.swift
@@ -7,11 +7,13 @@ struct WMFPriceButton: View {
         let currencyCode: String
         let canDeselect: Bool
         let accessibilityHint: String
-        
-        internal init(currencyCode: String, canDeselect: Bool = true, accessibilityHint: String) {
+        let cornerRadius: CGFloat
+
+        internal init(currencyCode: String, canDeselect: Bool = true, accessibilityHint: String, cornerRadius: CGFloat = 8) {
             self.currencyCode = currencyCode
             self.canDeselect = canDeselect
             self.accessibilityHint = accessibilityHint
+            self.cornerRadius = cornerRadius
         }
     }
     
@@ -40,12 +42,12 @@ struct WMFPriceButton: View {
                 .padding([.top, .bottom], 13)
                 .foregroundColor(isSelected ? Color(WMFColor.white) : Color(appEnvironment.theme.text))
                 .background(
-                    RoundedRectangle(cornerRadius: 8)
+                    RoundedRectangle(cornerRadius: configuration.cornerRadius)
                         .stroke(isSelected ? Color(appEnvironment.theme.link) : Color(appEnvironment.theme.baseBackground), lineWidth: 1)
                 )
         }
         .background(isSelected ? Color(appEnvironment.theme.link) : Color(appEnvironment.theme.midBackground))
-        .cornerRadius(8)
+        .cornerRadius(configuration.cornerRadius)
         .accessibilityHint(configuration.accessibilityHint)
         .accessibilityAddTraits( isSelected ? [.isSelected] : [])
     }

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Buttons/WMFSelectablePillButton.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Buttons/WMFSelectablePillButton.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// A capsule-shaped button for single-choice option groups: filled with the link color when
+/// selected, outlined on the neutral background otherwise.
+public struct WMFSelectablePillButton: View {
+
+    @ObservedObject var appEnvironment = WMFAppEnvironment.current
+
+    let label: String
+    let isSelected: Bool
+    let tapAction: () -> Void
+
+    public init(label: String, isSelected: Bool, tapAction: @escaping () -> Void) {
+        self.label = label
+        self.isSelected = isSelected
+        self.tapAction = tapAction
+    }
+
+    public var body: some View {
+        Button {
+            tapAction()
+        } label: {
+            Text(label)
+                .font(Font(WMFFont.for(.mediumSubheadline)))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 13)
+                .foregroundColor(isSelected ? Color(WMFColor.white) : Color(appEnvironment.theme.text))
+                .background(
+                    Capsule()
+                        .stroke(isSelected ? Color(appEnvironment.theme.link) : Color(appEnvironment.theme.baseBackground), lineWidth: 1)
+                )
+        }
+        .background(Capsule().fill(isSelected ? Color(appEnvironment.theme.link) : Color(appEnvironment.theme.midBackground)))
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+}

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/WMFBetaBadge.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/WMFBetaBadge.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import WMFNativeLocalizations
+
+public struct WMFBetaBadge: View {
+
+    @ObservedObject var appEnvironment = WMFAppEnvironment.current
+
+    private let betaLabel = WMFLocalizedString("beta-badge-label", value: "Beta", comment: "Label indicating a feature is in beta.")
+
+    public init() {}
+
+    public var body: some View {
+        HStack(spacing: 4) {
+            if let betaImage = WMFSFSymbolIcon.for(symbol: .flask, font: WMFFont.caption1) {
+                Image(uiImage: betaImage)
+            }
+            Text(betaLabel)
+                .font(Font(WMFFont.for(.caption1)))
+        }
+        .foregroundColor(Color(appEnvironment.theme.secondaryText))
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Capsule().stroke(Color(appEnvironment.theme.baseBackground), lineWidth: 1))
+    }
+}

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/WMFPriceTextField.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/WMFPriceTextField.swift
@@ -8,6 +8,7 @@ struct WMFPriceTextField: View {
         let doneTitle: String
         let textfieldAccessibilityHint: String
         let doneAccessibilityHint: String
+        var cornerRadius: CGFloat = 8
     }
     
     let configuration: Configuration
@@ -26,9 +27,9 @@ struct WMFPriceTextField: View {
             .foregroundColor(Color(appEnvironment.theme.text))
             .padding(5)
             .background(
-                RoundedRectangle(cornerRadius: 8)
+                RoundedRectangle(cornerRadius: configuration.cornerRadius)
                     .strokeBorder(Color(appEnvironment.theme.baseBackground), lineWidth: 1)
-                    .background(RoundedRectangle(cornerRadius: 8).fill(Color(appEnvironment.theme.midBackground)))
+                    .background(RoundedRectangle(cornerRadius: configuration.cornerRadius).fill(Color(appEnvironment.theme.midBackground)))
                 )
             .lineLimit(1)
             .multilineTextAlignment(.center)

--- a/WMFComponents/Sources/WMFComponents/Style/WMFIcon.swift
+++ b/WMFComponents/Sources/WMFComponents/Style/WMFIcon.swift
@@ -136,6 +136,9 @@ public enum WMFSFSymbolIcon {
     case textPage
     case leave
     case gear
+    case booksVerticalFill
+    case creditCard
+    case flask
     case gearShape
     case calendar
     case calendarExclamation
@@ -363,6 +366,12 @@ public enum WMFSFSymbolIcon {
             image = UIImage(systemName: "rectangle.portrait.and.arrow.right", withConfiguration: configuration)
         case .gear:
             image = UIImage(systemName: "gear", withConfiguration: configuration)
+        case .booksVerticalFill:
+            image = UIImage(systemName: "books.vertical.fill", withConfiguration: configuration)
+        case .creditCard:
+            image = UIImage(systemName: "creditcard", withConfiguration: configuration)
+        case .flask:
+            image = UIImage(systemName: "flask", withConfiguration: configuration)
         case .gearShape:
             image = UIImage(systemName: "gearshape", withConfiguration: configuration)
         case .heartFilled:

--- a/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
@@ -150,6 +150,12 @@ public protocol WMFDeveloperSettingsDataControlling: AnyObject {
         WMFDonateDataController.shared.deleteLocalDonationHistory()
     }
 
+    /// Feature flag for the Donation Reminder experiment
+    public var enableDonationReminder: Bool {
+        get { (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.developerSettingsEnableDonationReminder.rawValue)) ?? false }
+        set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.developerSettingsEnableDonationReminder.rawValue, value: newValue) }
+    }
+
     public var enableVisualEditingJourney: Bool {
         get { (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.developerSettingsEnableVisualEditingJourney.rawValue)) ?? false }
         set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.developerSettingsEnableVisualEditingJourney.rawValue, value: newValue) }

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
@@ -22,7 +22,7 @@ public struct WMFDonationReminder: Codable, Equatable, Sendable {
     }
 }
 
-public final class WMFDonationReminderDataController: Sendable {
+public final class WMFDonationReminderDataController {
 
     public static let shared = WMFDonationReminderDataController()
 

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+public struct WMFDonationReminder: Codable, Equatable, Sendable {
+
+    public enum Trigger: Codable, Equatable, Sendable {
+        case articlesRead(count: Int)
+        case timeElapsed(days: Int)
+    }
+
+    public let trigger: Trigger
+    public let amount: Decimal
+    public let currencyCode: String
+    public let createdDate: Date
+    public var isEnabled: Bool
+
+    public init(trigger: Trigger, amount: Decimal, currencyCode: String, createdDate: Date, isEnabled: Bool) {
+        self.trigger = trigger
+        self.amount = amount
+        self.currencyCode = currencyCode
+        self.createdDate = createdDate
+        self.isEnabled = isEnabled
+    }
+}
+
+public final class WMFDonationReminderDataController: Sendable {
+
+    public static let shared = WMFDonationReminderDataController()
+
+    private var userDefaultsStore: WMFKeyValueStore? { WMFDataEnvironment.current.userDefaultsStore }
+
+    private init() {}
+
+    public func saveReminder(_ reminder: WMFDonationReminder) {
+        try? userDefaultsStore?.save(key: WMFUserDefaultsKey.donationReminder.rawValue, value: reminder)
+    }
+
+    public func loadReminder() -> WMFDonationReminder? {
+        return try? userDefaultsStore?.load(key: WMFUserDefaultsKey.donationReminder.rawValue)
+    }
+
+    public func clearReminder() {
+        try? userDefaultsStore?.remove(key: WMFUserDefaultsKey.donationReminder.rawValue)
+    }
+}

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -44,6 +44,7 @@ public enum WMFUserDefaultsKey: String {
     case isSubscribedToEchoNotifications = "is-subscribed-to-echo-notifications"
     case forceHCaptchaChallenge = "force-hcaptcha-challenge"
     case developerSettingsForceFundraisingCampaignBanner = "dev-settings-force-fundraising-campaign-banner"
+    case developerSettingsEnableDonationReminder = "dev-settings-enable-donation-reminder"
 
     case allowGestureZoomArticleWebview = "allow-gesture-zoom-article-webview"
     // Reading Challenge 2026 (feature removed, see WMFReadingChallengeCompletionDataController)

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -45,6 +45,7 @@ public enum WMFUserDefaultsKey: String {
     case forceHCaptchaChallenge = "force-hcaptcha-challenge"
     case developerSettingsForceFundraisingCampaignBanner = "dev-settings-force-fundraising-campaign-banner"
     case developerSettingsEnableDonationReminder = "dev-settings-enable-donation-reminder"
+    case donationReminder = "donation-reminder"
 
     case allowGestureZoomArticleWebview = "allow-gesture-zoom-article-webview"
     // Reading Challenge 2026 (feature removed, see WMFReadingChallengeCompletionDataController)

--- a/WMFData/Tests/WMFDataTests/WMFDonationReminderDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFDonationReminderDataControllerTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+import WMFDataTestSupport
+@testable import WMFData
+@testable import WMFDataMocks
+
+@Suite(.serialized)
+final class WMFDonationReminderDataControllerTests {
+
+    private let fixture = WMFDataTestFixture()
+    private let controller = WMFDonationReminderDataController.shared
+
+    @Test
+    func saveAndLoadArticleBasedReminder() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let createdDate = Date(timeIntervalSince1970: 1_755_600_000)
+            let reminder = WMFDonationReminder(trigger: .articlesRead(count: 5), amount: 2, currencyCode: "EUR", createdDate: createdDate, isEnabled: true)
+
+            controller.saveReminder(reminder)
+
+            let loadedReminder = try #require(controller.loadReminder())
+            #expect(loadedReminder == reminder)
+            #expect(loadedReminder.trigger == .articlesRead(count: 5))
+            #expect(loadedReminder.amount == 2)
+            #expect(loadedReminder.currencyCode == "EUR")
+            #expect(loadedReminder.isEnabled == true)
+        }
+    }
+
+    @Test
+    func saveAndLoadTimeBasedReminder() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let createdDate = Date(timeIntervalSince1970: 1_755_600_000)
+            let reminder = WMFDonationReminder(trigger: .timeElapsed(days: 14), amount: 10.50, currencyCode: "EUR", createdDate: createdDate, isEnabled: true)
+
+            controller.saveReminder(reminder)
+
+            let loadedReminder = try #require(controller.loadReminder())
+            #expect(loadedReminder.trigger == .timeElapsed(days: 14))
+            #expect(loadedReminder.amount == Decimal(string: "10.50"))
+        }
+    }
+
+    @Test
+    func saveOverwritesPreviousReminder() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let createdDate = Date(timeIntervalSince1970: 1_755_600_000)
+            controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 5), amount: 2, currencyCode: "EUR", createdDate: createdDate, isEnabled: true))
+            controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 20), amount: 5, currencyCode: "EUR", createdDate: createdDate, isEnabled: false))
+
+            let loadedReminder = try #require(controller.loadReminder())
+            #expect(loadedReminder.trigger == .articlesRead(count: 20))
+            #expect(loadedReminder.amount == 5)
+            #expect(loadedReminder.isEnabled == false)
+        }
+    }
+
+    @Test
+    func loadWithoutSavedReminderReturnsNil() async {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            #expect(controller.loadReminder() == nil)
+        }
+    }
+
+    @Test
+    func clearRemovesSavedReminder() async {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let createdDate = Date(timeIntervalSince1970: 1_755_600_000)
+            controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 10), amount: 1, currencyCode: "EUR", createdDate: createdDate, isEnabled: true))
+
+            controller.clearReminder()
+
+            #expect(controller.loadReminder() == nil)
+        }
+    }
+
+    private func configureEnvironment() async {
+        WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
+    }
+}

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -1758,6 +1758,7 @@
 		B0BCF0AC2023AC7700986F72 /* ScrollableEducationPanelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BCF0AA2023AC7700986F72 /* ScrollableEducationPanelViewController.swift */; };
 		B0BCF0AD2023AC7700986F72 /* ScrollableEducationPanelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BCF0AA2023AC7700986F72 /* ScrollableEducationPanelViewController.swift */; };
 		B0C06B9F218240CA00E481CC /* Collection+AsyncMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C06B9E218240CA00E481CC /* Collection+AsyncMapTests.swift */; };
+		E81A4C0626082000005CD006 /* FundraisingAnnouncementDismissActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81A4C0526082000005CD005 /* FundraisingAnnouncementDismissActionTests.swift */; };
 		B0C6BE401E4068C60033BD6E /* WMFLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C6BE3F1E4068C60033BD6E /* WMFLoginViewController.swift */; };
 		B0C6BE421E413B3F0033BD6E /* WMFAccountCreationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C6BE411E413B3F0033BD6E /* WMFAccountCreationViewController.swift */; };
 		B0C6BE481E428C940033BD6E /* WMFAccountCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C6BE471E428C940033BD6E /* WMFAccountCreator.swift */; };
@@ -3834,6 +3835,7 @@
 		B0B4CF0B1CC0501B0051DF7A /* WMFArticleLanguagesSectionHeader.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = WMFArticleLanguagesSectionHeader.xib; sourceTree = "<group>"; };
 		B0BCF0AA2023AC7700986F72 /* ScrollableEducationPanelViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScrollableEducationPanelViewController.swift; sourceTree = "<group>"; };
 		B0C06B9E218240CA00E481CC /* Collection+AsyncMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+AsyncMapTests.swift"; sourceTree = "<group>"; };
+		E81A4C0526082000005CD005 /* FundraisingAnnouncementDismissActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FundraisingAnnouncementDismissActionTests.swift; sourceTree = "<group>"; };
 		B0C6BE3F1E4068C60033BD6E /* WMFLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WMFLoginViewController.swift; path = Wikipedia/Code/WMFLoginViewController.swift; sourceTree = SOURCE_ROOT; };
 		B0C6BE411E413B3F0033BD6E /* WMFAccountCreationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WMFAccountCreationViewController.swift; path = Wikipedia/Code/WMFAccountCreationViewController.swift; sourceTree = SOURCE_ROOT; };
 		B0C6BE471E428C940033BD6E /* WMFAccountCreator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WMFAccountCreator.swift; sourceTree = "<group>"; };
@@ -7330,6 +7332,7 @@
 				830ECAD51FBDE77F0080B1EF /* ReadingListsTests.swift */,
 				FA71B2C400000002000000AA /* SavedArticlesFetcherTests.swift */,
 				B0C06B9E218240CA00E481CC /* Collection+AsyncMapTests.swift */,
+				E81A4C0526082000005CD005 /* FundraisingAnnouncementDismissActionTests.swift */,
 				D8396D1A22CF7052005625D8 /* WMFArticleTests.swift */,
 				8386BDE623857F87007EE89D /* URLParsingAndRoutingTests.swift */,
 				A452F9FA24081A7200D8ED09 /* LocationManagerTests.swift */,
@@ -9407,6 +9410,7 @@
 				A452F9F824081A5500D8ED09 /* MockCLLocationManager.swift in Sources */,
 				67DAEDEC27E8FB63005CF9B6 /* NotificationsCenterDetailViewModelUserTalkMessageTests.swift in Sources */,
 				B0C06B9F218240CA00E481CC /* Collection+AsyncMapTests.swift in Sources */,
+				E81A4C0626082000005CD006 /* FundraisingAnnouncementDismissActionTests.swift in Sources */,
 				BC62AE621C58FC810064C589 /* NSProcessInfo+WMFTestEnvironment.m in Sources */,
 				D8BDA8C11E71C0760031F4BF /* WMFBlocksKitTests.m in Sources */,
 				B0E8092F1C0D1A0B0065EBC0 /* NSURL+WMFExtrasTests.m in Sources */,

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -74,7 +74,7 @@ extension ArticleViewController {
 
         let shouldShowMaybeLater = dataController.showShowMaybeLaterOption(asset: asset, currentDate: Date())
 
-        wmf_showFundraisingAnnouncement(theme: theme, asset: asset, primaryButtonTapHandler: { [weak self] button, viewController in
+        wmf_showFundraisingAnnouncement(theme: theme, asset: asset, showMaybeLater: shouldShowMaybeLater, donateButtonTapHandler: { [weak self] button, viewController in
 
             guard let self else {
                 return
@@ -105,33 +105,26 @@ extension ArticleViewController {
 
             dataController.markAssetAsPermanentlyHidden(asset: asset)
 
-        }, secondaryButtonTapHandler: { _, _ in
+        }, maybeLaterButtonTapHandler: { _, _ in
             DonateFunnel.shared.logFundraisingCampaignModalDidTapMaybeLater(project: project, metricsID: asset.metricsID)
-
-            if shouldShowMaybeLater {
-                dataController.markAssetAsMaybeLater(asset: asset, currentDate: Date())
-                self.donateDidSetMaybeLater(metricsID: asset.metricsID)
-            } else {
-                DonateFunnel.shared.logFundraisingCampaignModalDidTapAlreadyDonated(project: project, metricsID: asset.metricsID)
-                self.donateAlreadyDonated()
-                dataController.markAssetAsPermanentlyHidden(asset: asset)
-            }
-
-        }, optionalButtonTapHandler: { _, _ in
+            dataController.markAssetAsMaybeLater(asset: asset, currentDate: Date())
+            self.donateDidSetMaybeLater(metricsID: asset.metricsID)
+        }, alreadyDonatedButtonTapHandler: { _, _ in
             DonateFunnel.shared.logFundraisingCampaignModalDidTapAlreadyDonated(project: project, metricsID: asset.metricsID)
             self.donateAlreadyDonated()
             dataController.markAssetAsPermanentlyHidden(asset: asset)
-
         }, footerLinkAction: { url in
             DonateFunnel.shared.logFundraisingCampaignModalDidTapDonorPolicy(project: project, metricsID: asset.metricsID)
             self.navigate(to: url, useSafari: true)
-        }, traceableDismissHandler: { action in
-
-            if action == .tappedClose {
+        }, dismissHandler: { action in
+            switch action {
+            case .close:
                 DonateFunnel.shared.logFundraisingCampaignModalDidTapClose(project: project, metricsID: asset.metricsID)
                 dataController.markAssetAsPermanentlyHidden(asset: asset)
+            case .donate, .maybeLater, .alreadyDonated, .other:
+                break
             }
-        }, showMaybeLater: shouldShowMaybeLater)
+        })
     }
 
     func donateDidSetMaybeLater(metricsID: String) {

--- a/Wikipedia/Code/FundraisingAnnouncementPanel.swift
+++ b/Wikipedia/Code/FundraisingAnnouncementPanel.swift
@@ -71,21 +71,65 @@ final class FundraisingAnnouncementPanelViewController: ScrollableEducationPanel
 
 }
 
+enum FundraisingAnnouncementDismissAction {
+    case donate
+    case maybeLater
+    case alreadyDonated
+    case close
+    case other
+
+    init(lastAction: ScrollableEducationPanelViewController.LastAction, showMaybeLater: Bool) {
+        switch lastAction {
+        case .tappedPrimary:
+            self = .donate
+        case .tappedSecondary:
+            self = showMaybeLater ? .maybeLater : .alreadyDonated
+        case .tappedOptional:
+            self = .alreadyDonated
+        case .tappedClose:
+            self = .close
+        case .tappedBackground, .none:
+            self = .other
+        }
+    }
+}
+
 extension UIViewController {
 
-    func wmf_showFundraisingAnnouncement(theme: Theme, asset: WMFFundraisingCampaignConfig.WMFAsset, primaryButtonTapHandler: ScrollableEducationPanelButtonTapHandler?, secondaryButtonTapHandler: ScrollableEducationPanelButtonTapHandler?, optionalButtonTapHandler: ScrollableEducationPanelButtonTapHandler?, footerLinkAction: ((URL) -> Void)?, traceableDismissHandler: ScrollableEducationPanelTraceableDismissHandler?, showMaybeLater: Bool) {
+    func wmf_showFundraisingAnnouncement(
+        theme: Theme,
+        asset: WMFFundraisingCampaignConfig.WMFAsset,
+        showMaybeLater: Bool,
+        donateButtonTapHandler: ScrollableEducationPanelButtonTapHandler?,
+        maybeLaterButtonTapHandler: ScrollableEducationPanelButtonTapHandler?,
+        alreadyDonatedButtonTapHandler: ScrollableEducationPanelButtonTapHandler?,
+        footerLinkAction: ((URL) -> Void)?,
+        dismissHandler: ((FundraisingAnnouncementDismissAction) -> Void)?
+    ) {
 
-        let alert = FundraisingAnnouncementPanelViewController(announcement: asset, theme: theme, showOptionalButton: showMaybeLater, primaryButtonTapHandler: { button, viewController in
-            primaryButtonTapHandler?(button, viewController)
-        }, secondaryButtonTapHandler: { button, viewController in
-            secondaryButtonTapHandler?(button, viewController)
-            self.dismiss(animated: true)
-        }, optionalButtonTapHandler: { button, viewController in
-            optionalButtonTapHandler?(button, viewController)
-            self.dismiss(animated: true)
-        }, traceableDismissHandler: { lastAction in
-            traceableDismissHandler?(lastAction)
-        }, footerLinkAction: footerLinkAction)
+        let alert = FundraisingAnnouncementPanelViewController(
+            announcement: asset,
+            theme: theme,
+            showOptionalButton: showMaybeLater,
+            primaryButtonTapHandler: { button, viewController in
+                donateButtonTapHandler?(button, viewController)
+            },
+            secondaryButtonTapHandler: { button, viewController in
+                if showMaybeLater {
+                    maybeLaterButtonTapHandler?(button, viewController)
+                } else {
+                    alreadyDonatedButtonTapHandler?(button, viewController)
+                }
+                self.dismiss(animated: true)
+            },
+            optionalButtonTapHandler: { button, viewController in
+                alreadyDonatedButtonTapHandler?(button, viewController)
+                self.dismiss(animated: true)
+            },
+            traceableDismissHandler: { lastAction in
+                dismissHandler?(FundraisingAnnouncementDismissAction(lastAction: lastAction, showMaybeLater: showMaybeLater))
+            },
+            footerLinkAction: footerLinkAction)
 
         present(alert, animated: true)
     }

--- a/WikipediaUnitTests/Code/FundraisingAnnouncementDismissActionTests.swift
+++ b/WikipediaUnitTests/Code/FundraisingAnnouncementDismissActionTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import Wikipedia
+
+struct FundraisingAnnouncementDismissActionTests {
+
+    @Test
+    func secondaryButtonMapsToMaybeLaterWhenMaybeLaterIsShown() {
+        #expect(FundraisingAnnouncementDismissAction(lastAction: .tappedSecondary, showMaybeLater: true) == .maybeLater)
+    }
+
+    @Test
+    func secondaryButtonMapsToAlreadyDonatedOnCampaignLastDay() {
+        #expect(FundraisingAnnouncementDismissAction(lastAction: .tappedSecondary, showMaybeLater: false) == .alreadyDonated)
+    }
+
+    @Test(arguments: [true, false])
+    func remainingActionsMapIndependentlyOfMaybeLater(showMaybeLater: Bool) {
+        #expect(FundraisingAnnouncementDismissAction(lastAction: .tappedPrimary, showMaybeLater: showMaybeLater) == .donate)
+        #expect(FundraisingAnnouncementDismissAction(lastAction: .tappedOptional, showMaybeLater: showMaybeLater) == .alreadyDonated)
+        #expect(FundraisingAnnouncementDismissAction(lastAction: .tappedClose, showMaybeLater: showMaybeLater) == .close)
+        #expect(FundraisingAnnouncementDismissAction(lastAction: .tappedBackground, showMaybeLater: showMaybeLater) == .other)
+        #expect(FundraisingAnnouncementDismissAction(lastAction: ScrollableEducationPanelViewController.LastAction.none, showMaybeLater: showMaybeLater) == .other)
+    }
+}


### PR DESCRIPTION
**Phabricator:**  https://phabricator.wikimedia.org/T435346

### Notes
>[!IMPORTANT]
> Groundwork for the Donation Reminder experiment's Maybe Later setup screen (stacked on #6084; the screen itself comes in a follow-up PR). Best reviewed commit by commit:

* **Semantic banner handler refactor** 4d286647ba492bc883ccba67e0479821dfc44db0 — the fundraising panel reuses its secondary button slot for "I already donated" on the campaign's last day, which forced callers to re-derive button meaning. The wrapper now exposes donate/maybeLater/alreadyDonated handlers and a semantic dismiss action, with unit tests for the mapping. Also fixes a pre-existing double-log on the last day (secondary tap logged both maybe-later and already-donated). 
* **`enableDonationReminder` developer feature flag** 510be1d7b1e2aa2eb481115b5bf63203660d30de — gates all Donation Reminder work so this stack can merge to main without shipping a partial experience. Off by default; no effect in this PR.
* **`WMFDonationReminderDataController` + `WMFDonationReminder` model** 6c3b835086d2be8c46a1df614f00de7770360f3a — persists the user's reminder (article- or time-based trigger, amount, currency, created date, enabled state), with unit tests.
* **`WMFPriceButton` / `WMFPriceTextField`** gain an optional `cornerRadius` (default `8`) so the new screen can render them as capsules. **The Donate Form is visually unchanged** 86a9300c73a88eb568fb349e26202fd1c63bb530 — it doesn't pass the parameter.
* **New SF Symbol cases** in `WMFSFSymbolIcon` 86a9300c73a88eb568fb349e26202fd1c63bb530: `booksVerticalFill`, `creditCard`, `flask` (per the iOS designs).
* **New shared components** 6e257d5885e1d1f860c414a9b6a3f485f39c0775: `WMFBetaBadge` (outlined "Beta" capsule with flask icon) and `WMFSelectablePillButton` (capsule for single-choice option groups; also intended for the experiment's upcoming feedback screen).
* Only new translatable string: `beta-badge-label` ("Beta").

### Test Steps
1. Build and run.
2. Open the donate form (fundraising banner → Donate now, or Settings → Support Wikipedia) and confirm the preset amount buttons and custom amount field look unchanged (8pt corners, same colors/fonts).
3. With a campaign banner visible (Developer Settings → "Force Fundraising Campaign Banner"), tap each button and confirm existing behavior is unchanged: Donate now opens the donate flow, Maybe later schedules tomorrow's banner + toast, I already donated / close hide the banner.
4. The feature flag and new components have no user-facing effect yet — routing and the setup screen land in the follow-up PR.

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
_No visual changes in this PR — the new components are consumed by the follow-up PR (screenshots there)._