### PR TITLE
Swift 6 migration — Phase 4: WMFData strict-concurrency burn-down complete + CI gate

### DIFF
--- a/.github/workflows/strict_concurrency_check.yml
+++ b/.github/workflows/strict_concurrency_check.yml
@@ -7,10 +7,12 @@ name: Strict Concurrency Check
 # warnings becomes a hard ERROR once the package flips to Swift 6 language mode, so
 # this is the burn-down metric for the migration (see the Swift 6.2 migration plan).
 #
-# Schemes still burning down their backlog are report-only (WMFData started at ~127).
+# Schemes still burning down their backlog are report-only.
 # As each scheme reaches zero, move it into GATED_SCHEMES below to make it a hard gate:
 # the job then fails if ANY concurrency warning appears in that scheme's own sources.
-# WMFComponents reached zero via default MainActor isolation and is gated.
+# WMFComponents reached zero via default MainActor isolation. WMFData reached zero
+# via Sendable services/models and lock-isolated singleton state (started at ~127).
+# Both are gated. Next up: WMF Framework and the app targets.
 
 on:
   pull_request:
@@ -26,7 +28,7 @@ env:
   # job FAILS if any concurrency warning appears in the scheme's own sources.
   # (Concurrency-scoped on purpose: blanket warnings-as-errors would also trip on
   # unrelated warnings like deprecations.) Space-separated.
-  GATED_SCHEMES: "WMFComponents"
+  GATED_SCHEMES: "WMFData WMFComponents"
 
 concurrency:
   group: "strict-concurrency-${{ github.ref }}"

--- a/WMF Framework/MediaWikiFetcher.swift
+++ b/WMF Framework/MediaWikiFetcher.swift
@@ -15,7 +15,11 @@ private extension WMFMediaWikiServiceRequest.TokenType {
     }
 }
 
-public final class MediaWikiFetcher: Fetcher, WMFService {
+// @unchecked Sendable: WMFService now requires Sendable (its instances are shared
+// across concurrency domains). MediaWikiFetcher's Fetcher state (session, tokens)
+// is legacy-managed and already used from multiple queues; a real audit happens
+// when WMF Framework starts its own strict-concurrency burn-down.
+public final class MediaWikiFetcher: Fetcher, WMFService, @unchecked Sendable {
 
     public enum MediaWikiFetcherError: LocalizedError {
         case invalidRequest

--- a/WMFComponents/Sources/WMFComponents/Components/Donate Form/WMFDonateViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Donate Form/WMFDonateViewModel.swift
@@ -533,25 +533,29 @@ extension WMFDonateViewModel: PKPaymentAuthorizationControllerDelegate {
         let dataController = WMFDonateDataController.shared
         dataController.submitPayment(amount: finalAmount, countryCode: countryCode, currencyCode: currencyCode, languageCode: languageCode, paymentToken: paymentToken, paymentNetwork: paymentNetwork, donorNameComponents: donorNameComponents, recurring: recurring, donorEmail: donorEmail, donorAddressComponents: donorAddressComponents, emailOptIn: emailOptIn, transactionFee: transactionFeeOptInViewModel.isSelected, metricsID: metricsID, appVersion: appVersion, appInstallID: appInstallID) { result in
 
-            switch result {
-            case .success:
-                self.saveDonationToLocalHistory(with: dataController, recurring: recurring, currencyCode: self.currencyCode)
-            case .failure(let error):
-                // Only log errors, don't show to user since we are assuming success.
-                if let dataControllerError = error as? WMFDonateDataControllerError {
-                    switch dataControllerError {
-                    case .paymentsWikiResponseError:
+            // The data controller calls back off-main; hop to the main actor before
+            // touching view model state.
+            Task { @MainActor in
+                switch result {
+                case .success:
+                    self.saveDonationToLocalHistory(with: dataController, recurring: recurring, currencyCode: self.currencyCode)
+                case .failure(let error):
+                    // Only log errors, don't show to user since we are assuming success.
+                    if let dataControllerError = error as? WMFDonateDataControllerError {
+                        switch dataControllerError {
+                        case .paymentsWikiResponseError:
+                            self.loggingDelegate?.handleDonateLoggingAction(.nativeFormDidTriggerError(error: error))
+                        }
+                    } else {
                         self.loggingDelegate?.handleDonateLoggingAction(.nativeFormDidTriggerError(error: error))
                     }
-                } else {
-                    self.loggingDelegate?.handleDonateLoggingAction(.nativeFormDidTriggerError(error: error))
                 }
-            }
 
-            // Always end the background task
-            if self.submitPaymentBackgroundTask != .invalid {
-                application.endBackgroundTask(self.submitPaymentBackgroundTask)
-                self.submitPaymentBackgroundTask = .invalid
+                // Always end the background task
+                if self.submitPaymentBackgroundTask != .invalid {
+                    application.endBackgroundTask(self.submitPaymentBackgroundTask)
+                    self.submitPaymentBackgroundTask = .invalid
+                }
             }
         }
 

--- a/WMFComponents/Sources/WMFComponents/Components/Suggested Edits/Image Recommendations/WMFImageRecommendationsBottomSheetViewController.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Suggested Edits/Image Recommendations/WMFImageRecommendationsBottomSheetViewController.swift
@@ -129,13 +129,16 @@ extension WMFImageRecommendationsBottomSheetViewController: WMFImageRecommendati
                 
                 // Send feedback API call
                 self.viewModel.sendFeedback(editRevId: nil, accepted: false, reasons: options, caption: nil, completion: { [weak self] result in
-                    switch result {
-                    case .success:
-                        break
-                    case .failure(let error):
-                        self?.delegate?.imageRecommendationsDidTriggerError(error)
+                    // The data controller calls back off-main; hop to the main actor
+                    // before touching the delegate.
+                    Task { @MainActor [weak self] in
+                        switch result {
+                        case .success:
+                            break
+                        case .failure(let error):
+                            self?.delegate?.imageRecommendationsDidTriggerError(error)
+                        }
                     }
-                    
                 })
                 // Dismisses Survey View
                 self.dismiss(animated: true, completion: { [weak self] in

--- a/WMFComponents/Sources/WMFComponents/Components/Suggested Edits/Image Recommendations/WMFImageRecommendationsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Suggested Edits/Image Recommendations/WMFImageRecommendationsViewModel.swift
@@ -209,23 +209,25 @@ public final class WMFImageRecommendationsViewModel: ObservableObject {
         }
     }
     
-    func fetchImageRecommendationsIfNeeded(completion: @escaping () -> Void) {
-        
+    func fetchImageRecommendationsIfNeeded(completion: @escaping @MainActor @Sendable () -> Void) {
+
         guard imageRecommendations.isEmpty else {
             completion()
             return
         }
-        
+
         loading = true
         growthTasksDataController.getImageRecommendationsCombined { [weak self] result in
-            guard let self else {
-                completion()
-                return
-            }
-            
-            switch result {
-            case .success(let pages):
-                DispatchQueue.main.async {
+            // The data controller calls back off-main; hop to the main actor before
+            // touching view model state.
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    completion()
+                    return
+                }
+
+                switch result {
+                case .success(let pages):
                     self.loadingError = nil
                     let imageDataArray = self.getFirstImageData(for: pages)
 
@@ -235,25 +237,21 @@ public final class WMFImageRecommendationsViewModel: ObservableObject {
                             self.imageRecommendations.append(combinedImageRecommendation)
                         }
                     }
-                    
+
                     guard let firstRecommendation = self.imageRecommendations.first else {
-                        DispatchQueue.main.async {
-                            self.loading = false
-                            completion()
-                        }
+                        self.loading = false
+                        completion()
                         return
                     }
-                    
+
                     self.populateImageAndArticleSummary(for: firstRecommendation) { [weak self] error in
                         self?.currentRecommendation = firstRecommendation
                         self?.loading = false
                         self?.loadingError = error
                         completion()
                     }
-                }
-                
-            case .failure(let error):
-                DispatchQueue.main.async {
+
+                case .failure(let error):
                     self.loading = false
                     self.loadingError = error
                     completion()
@@ -262,7 +260,7 @@ public final class WMFImageRecommendationsViewModel: ObservableObject {
         }
     }
     
-    public func next(completion: @escaping () -> Void) {
+    public func next(completion: @escaping @MainActor @Sendable () -> Void) {
         guard !imageRecommendations.isEmpty else {
             self.currentRecommendation = nil
             completion()
@@ -297,7 +295,7 @@ public final class WMFImageRecommendationsViewModel: ObservableObject {
         }
     }
     
-    public func sendFeedback(editRevId: UInt64?, accepted: Bool, reasons: [String] = [], caption: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+    public func sendFeedback(editRevId: UInt64?, accepted: Bool, reasons: [String] = [], caption: String?, completion: @escaping @Sendable (Result<Void, Error>) -> Void) {
         
         guard !needsSuppressPosting else {
             completion(.success(()))
@@ -313,7 +311,7 @@ public final class WMFImageRecommendationsViewModel: ObservableObject {
     }
 
 
-    private func populateImageAndArticleSummary(for imageRecommendation: ImageRecommendation, completion: @escaping (Error?) -> Void) {
+    private func populateImageAndArticleSummary(for imageRecommendation: ImageRecommendation, completion: @escaping @MainActor @Sendable (Error?) -> Void) {
         let group = DispatchGroup()
         var populateError: Error? = nil
 
@@ -336,7 +334,10 @@ public final class WMFImageRecommendationsViewModel: ObservableObject {
         startTime = Date()
 
         group.notify(queue: .main) {
-            completion(populateError)
+            let error = populateError
+            Task { @MainActor in
+                completion(error)
+            }
         }
     }
 

--- a/WMFComponents/Sources/WMFComponents/Components/Watchlist/WMFWatchlistViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Watchlist/WMFWatchlistViewModel.swift
@@ -156,21 +156,25 @@ public final class WMFWatchlistViewModel: ObservableObject {
         menuButtonItemsWithoutThank = menuButtonItems.dropLast()
     }
 
-	 public func fetchWatchlist(_ completion: (() -> Void)? = nil) {
+	 public func fetchWatchlist(_ completion: (@MainActor @Sendable () -> Void)? = nil) {
         dataController.fetchWatchlist { result in
-			switch result {
-			case .success(let watchlist):
-				self.items = watchlist.items.map { item in
-                    let viewModel = ItemViewModel(title: item.title, commentHTML: item.commentHtml, commentWikitext: item.commentWikitext, timestamp: item.timestamp, username: item.username, isAnonymous: item.isAnon, isTemp: item.isTemp, isBot: item.isBot, revisionID: item.revisionID, oldRevisionID: item.oldRevisionID, byteChange: Int(item.byteLength) - Int(item.oldByteLength), project: item.project, htmlStripped: self.localizedStrings.htmlStripped)
-					return viewModel
-				}
-				self.sections = self.sortWatchlistItems()
-                self.activeFilterCount = watchlist.activeFilterCount
-			case .failure:
-				break
-			}
-			self.hasPerformedInitialFetch = true
-            completion?()
+            // The data controller calls back off-main; hop to the main actor before
+            // touching view model state.
+            Task { @MainActor in
+                switch result {
+                case .success(let watchlist):
+                    self.items = watchlist.items.map { item in
+                        let viewModel = ItemViewModel(title: item.title, commentHTML: item.commentHtml, commentWikitext: item.commentWikitext, timestamp: item.timestamp, username: item.username, isAnonymous: item.isAnon, isTemp: item.isTemp, isBot: item.isBot, revisionID: item.revisionID, oldRevisionID: item.oldRevisionID, byteChange: Int(item.byteLength) - Int(item.oldByteLength), project: item.project, htmlStripped: self.localizedStrings.htmlStripped)
+                        return viewModel
+                    }
+                    self.sections = self.sortWatchlistItems()
+                    self.activeFilterCount = watchlist.activeFilterCount
+                case .failure:
+                    break
+                }
+                self.hasPerformedInitialFetch = true
+                completion?()
+            }
 		}
 	}
 

--- a/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
@@ -10,20 +10,31 @@ public protocol WMFDeveloperSettingsDataControlling: AnyObject {
     var enableYiRLoginExperimentB: Bool { get }
 }
 
-@objc public final class WMFDeveloperSettingsDataController: NSObject, WMFDeveloperSettingsDataControlling {
+// @unchecked Sendable: must stay an NSObject subclass for Obj-C callers, so it
+// cannot be an actor. All mutable state lives in WMFLockIsolated boxes below;
+// everything else is immutable or delegates to the (Sendable) environment stores.
+@objc public final class WMFDeveloperSettingsDataController: NSObject, WMFDeveloperSettingsDataControlling, @unchecked Sendable {
 
     @objc public static let shared = WMFDeveloperSettingsDataController()
 
     private let service: WMFService?
-    private var sharedCacheStore: WMFKeyValueStore?
-    private var featureConfig: WMFFeatureConfigResponse?
+    private let _sharedCacheStore: WMFLockIsolated<WMFKeyValueStore?>
+    private var sharedCacheStore: WMFKeyValueStore? {
+        get { _sharedCacheStore.value }
+        set { _sharedCacheStore.value = newValue }
+    }
+    private let _featureConfig = WMFLockIsolated<WMFFeatureConfigResponse?>(nil)
+    private var featureConfig: WMFFeatureConfigResponse? {
+        get { _featureConfig.value }
+        set { _featureConfig.value = newValue }
+    }
     private let cacheDirectoryName = WMFSharedCacheDirectoryNames.developerSettings.rawValue
     
     private let cacheFeatureConfigFileName = "AppsFeatureConfig"
 
     public init(service: WMFService? = WMFDataEnvironment.current.basicService, sharedCacheStore: WMFKeyValueStore? = WMFDataEnvironment.current.sharedCacheStore) {
         self.service = service
-        self.sharedCacheStore = sharedCacheStore
+        self._sharedCacheStore = WMFLockIsolated(sharedCacheStore)
         super.init()
         NotificationCenter.default.addObserver(forName: WMFNSNotification.coreDataStoreSetup, object: nil, queue: nil) { [weak self] _ in
             guard let self else { return }
@@ -180,7 +191,7 @@ public protocol WMFDeveloperSettingsDataControlling: AnyObject {
         return featureConfig
     }
 
-    @objc public func fetchFeatureConfig(completion: @escaping (Error?) -> Void) {
+    @objc public func fetchFeatureConfig(completion: @escaping @Sendable (Error?) -> Void) {
         guard let service else {
             completion(WMFDataControllerError.basicServiceUnavailable)
             return

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonateDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonateDataController.swift
@@ -1,15 +1,33 @@
 import Foundation
 import Contacts
 
-@objc final public class WMFDonateDataController: NSObject {
-    
+// @unchecked Sendable: must stay an NSObject subclass for Obj-C callers, so it
+// cannot be an actor. All mutable state lives in WMFLockIsolated boxes below.
+@objc final public class WMFDonateDataController: NSObject, @unchecked Sendable {
+
     // MARK: - Properties
-    
-    var service: WMFService?
-    var sharedCacheStore: WMFKeyValueStore?
-    
-    private var donateConfig: WMFDonateConfig?
-    private var paymentMethods: WMFPaymentMethods?
+
+    private let _service: WMFLockIsolated<WMFService?>
+    var service: WMFService? {
+        get { _service.value }
+        set { _service.value = newValue }
+    }
+    private let _sharedCacheStore: WMFLockIsolated<WMFKeyValueStore?>
+    var sharedCacheStore: WMFKeyValueStore? {
+        get { _sharedCacheStore.value }
+        set { _sharedCacheStore.value = newValue }
+    }
+
+    private let _donateConfig = WMFLockIsolated<WMFDonateConfig?>(nil)
+    private var donateConfig: WMFDonateConfig? {
+        get { _donateConfig.value }
+        set { _donateConfig.value = newValue }
+    }
+    private let _paymentMethods = WMFLockIsolated<WMFPaymentMethods?>(nil)
+    private var paymentMethods: WMFPaymentMethods? {
+        get { _paymentMethods.value }
+        set { _paymentMethods.value = newValue }
+    }
     
     private let cacheDirectoryName = WMFSharedCacheDirectoryNames.donorExperience.rawValue
     private let cacheDonateConfigContainerFileName = "AppsDonationConfig"
@@ -32,9 +50,9 @@ import Contacts
     public static let shared = WMFDonateDataController()
     
     public init(service: WMFService? = WMFDataEnvironment.current.basicService, sharedCacheStore: WMFKeyValueStore? = WMFDataEnvironment.current.sharedCacheStore) {
-       self.service = service
-        self.sharedCacheStore = sharedCacheStore
-   }
+        self._service = WMFLockIsolated(service)
+        self._sharedCacheStore = WMFLockIsolated(sharedCacheStore)
+    }
     
     // MARK: - Public
     
@@ -67,7 +85,7 @@ import Contacts
         return (self.donateConfig, self.paymentMethods)
     }
     
-    @objc public func fetchConfigsForCountryCode(_ countryCode: String, completion: @escaping (Error?) -> Void) {
+    @objc public func fetchConfigsForCountryCode(_ countryCode: String, completion: @escaping @Sendable (Error?) -> Void) {
         fetchConfigs(for: countryCode) { result in
             switch result {
             case .success:
@@ -78,7 +96,7 @@ import Contacts
         }
     }
     
-    public func fetchConfigs(for countryCode: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    public func fetchConfigs(for countryCode: String, completion: @escaping @Sendable (Result<Void, Error>) -> Void) {
         
         guard let service else {
             completion(.failure(WMFDataControllerError.basicServiceUnavailable))
@@ -103,43 +121,44 @@ import Contacts
             "action": "raw"
         ]
         
-        var errors: [Error] = []
-        
-        var donateConfig: WMFDonateConfig?
-        var paymentMethods: WMFPaymentMethods?
-        
+        // Aggregated behind a lock: both service callbacks land on URLSession's queue
+        // concurrently with each other.
+        let fetchState = WMFLockIsolated<(donateConfig: WMFDonateConfig?, paymentMethods: WMFPaymentMethods?, errors: [Error])>((nil, nil, []))
+
         group.enter()
         let paymentMethodsRequest = WMFBasicServiceRequest(url: paymentMethodsURL, method: .GET, parameters: paymentMethodParameters, acceptType: .json)
         service.performDecodableGET(request: paymentMethodsRequest) { (result: Result<WMFPaymentMethods, Error>) in
             defer {
                 group.leave()
             }
-            
+
             switch result {
             case .success(let response):
-                paymentMethods = response
+                fetchState.withLock { $0.paymentMethods = response }
             case .failure(let error):
-                errors.append(error)
+                fetchState.withLock { $0.errors.append(error) }
             }
         }
-        
+
         group.enter()
         let donateConfigRequest = WMFBasicServiceRequest(url: donateConfigURL, method: .GET, parameters: donateConfigParameters, acceptType: .json)
         service.performDecodableGET(request: donateConfigRequest) { (result: Result<WMFDonateConfigResponse, Error>) in
-            
+
             defer {
                 group.leave()
             }
-            
+
             switch result {
             case .success(let response):
-                donateConfig = response.config
+                fetchState.withLock { $0.donateConfig = response.config }
             case .failure(let error):
-                errors.append(error)
+                fetchState.withLock { $0.errors.append(error) }
             }
         }
-        
+
         group.notify(queue: .main) {
+
+            let (donateConfig, paymentMethods, errors) = fetchState.value
 
             if let firstError = errors.first {
                 self.donateConfig = nil
@@ -148,8 +167,8 @@ import Contacts
                 return
             }
             
-            guard var donateConfig,
-                var paymentMethods else {
+            guard var donateConfig = donateConfig,
+                  var paymentMethods = paymentMethods else {
                 self.donateConfig = nil
                 self.paymentMethods = nil
                 completion(.failure(WMFServiceError.unexpectedResponse))
@@ -169,7 +188,7 @@ import Contacts
         }
     }
     
-    public func submitPayment(amount: Decimal, countryCode: String, currencyCode: String, languageCode: String, paymentToken: String, paymentNetwork: String?, donorNameComponents: PersonNameComponents, recurring: Bool, donorEmail: String, donorAddressComponents: CNPostalAddress, emailOptIn: Bool?, transactionFee: Bool, metricsID: String?, appVersion: String?, appInstallID: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+    public func submitPayment(amount: Decimal, countryCode: String, currencyCode: String, languageCode: String, paymentToken: String, paymentNetwork: String?, donorNameComponents: PersonNameComponents, recurring: Bool, donorEmail: String, donorAddressComponents: CNPostalAddress, emailOptIn: Bool?, transactionFee: Bool, metricsID: String?, appVersion: String?, appInstallID: String?, completion: @escaping @Sendable (Result<Void, Error>) -> Void) {
 
         guard !WMFDeveloperSettingsDataController.shared.bypassDonation else {
             completion(.success(()))

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFFundraisingCampaignDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFFundraisingCampaignDataController.swift
@@ -1,31 +1,38 @@
 import Foundation
 
-@objc final public class WMFFundraisingCampaignDataController: NSObject {
-    
-    private actor SafeDictionary<Key: Hashable, Value> {
-        private var dictionary: [Key: Value]
-        init(dict: [Key: Value] = [Key: Value]()) {
-            self.dictionary = dict
-        }
-        
-        func getValue(forKey key: Key) -> Value? {
-            dictionary[key]
-        }
-        
-        func update(value: Value, forKey key: Key) {
-            dictionary[key] = value
-        }
-    }
+// @unchecked Sendable: must stay an NSObject subclass for Obj-C callers, so it
+// cannot be an actor. All mutable state lives in WMFLockIsolated boxes below.
+@objc final public class WMFFundraisingCampaignDataController: NSObject, @unchecked Sendable {
     
     // MARK: - Properties
-    
-    var service: WMFService?
-    var sharedCacheStore: WMFKeyValueStore?
-    var mediaWikiService: WMFService?
-    
-    private var activeCountryConfigs: [WMFFundraisingCampaignConfig] = []
-    private var promptState: WMFFundraisingCampaignPromptState?
-    private var preferencesBannerOptIns: SafeDictionary<WMFProject, Bool> = SafeDictionary<WMFProject, Bool>()
+
+    private let _service: WMFLockIsolated<WMFService?>
+    var service: WMFService? {
+        get { _service.value }
+        set { _service.value = newValue }
+    }
+    private let _sharedCacheStore: WMFLockIsolated<WMFKeyValueStore?>
+    var sharedCacheStore: WMFKeyValueStore? {
+        get { _sharedCacheStore.value }
+        set { _sharedCacheStore.value = newValue }
+    }
+    private let _mediaWikiService: WMFLockIsolated<WMFService?>
+    var mediaWikiService: WMFService? {
+        get { _mediaWikiService.value }
+        set { _mediaWikiService.value = newValue }
+    }
+
+    private let _activeCountryConfigs = WMFLockIsolated<[WMFFundraisingCampaignConfig]>([])
+    private var activeCountryConfigs: [WMFFundraisingCampaignConfig] {
+        get { _activeCountryConfigs.value }
+        set { _activeCountryConfigs.value = newValue }
+    }
+    private let _promptState = WMFLockIsolated<WMFFundraisingCampaignPromptState?>(nil)
+    private var promptState: WMFFundraisingCampaignPromptState? {
+        get { _promptState.value }
+        set { _promptState.value = newValue }
+    }
+    private let preferencesBannerOptIns = WMFLockIsolated<[WMFProject: Bool]>([:])
     
     private let cacheDirectoryName = WMFSharedCacheDirectoryNames.donorExperience.rawValue
     private let cacheConfigFileName = "AppsCampaignConfig"
@@ -34,9 +41,9 @@ import Foundation
     // MARK: - Lifecycle
     
     private init(service: WMFService? = WMFDataEnvironment.current.basicService, sharedCacheStore: WMFKeyValueStore? = WMFDataEnvironment.current.sharedCacheStore, mediaWikiService: WMFService? = WMFDataEnvironment.current.mediaWikiService) {
-        self.service = service
-        self.sharedCacheStore = sharedCacheStore
-        self.mediaWikiService = mediaWikiService
+        self._service = WMFLockIsolated(service)
+        self._sharedCacheStore = WMFLockIsolated(sharedCacheStore)
+        self._mediaWikiService = WMFLockIsolated(mediaWikiService)
     }
     
     @objc(sharedInstance)
@@ -45,7 +52,7 @@ import Foundation
     // MARK: - Public
     
     public func isOptedIn(project: WMFProject) async -> Bool {
-        return await preferencesBannerOptIns.getValue(forKey: project) ?? true
+        return preferencesBannerOptIns.value[project] ?? true
     }
     
     /// Set asset as "maybe later" in persistence, so that it can be loaded later only once the maybe later date has passed
@@ -129,7 +136,7 @@ import Foundation
     ///   - countryCode: Country code of the user. Can use Locale.current.regionCode
     ///   - currentDate: Current date, sent in as a parameter for stable unit testing.
     ///   - completion: Completion handler indicating if the fetch was successful or not.
-    public func fetchConfig(countryCode: String, currentDate: Date, completion: @escaping (Result<Void, Error>) -> Void) {
+    public func fetchConfig(countryCode: String, currentDate: Date, completion: @escaping @Sendable (Result<Void, Error>) -> Void) {
         guard let service else {
             completion(.failure(WMFDataControllerError.basicServiceUnavailable))
             return
@@ -165,7 +172,7 @@ import Foundation
         }
     }
     
-    public func fetchMediaWikiBannerOptIn(project: WMFProject, completion: ((Result<Void, Error>) -> Void)? = nil) {
+    public func fetchMediaWikiBannerOptIn(project: WMFProject, completion: (@Sendable (Result<Void, Error>) -> Void)? = nil) {
         guard let mediaWikiService else {
             completion?(.failure(WMFDataControllerError.mediaWikiServiceUnavailable))
             return
@@ -185,7 +192,7 @@ import Foundation
         
         let request = WMFMediaWikiServiceRequest(url:url, method: .GET, backend: .mediaWiki, parameters: parameters)
         
-        let completion: (Result<[String: Any]?, Error>) -> Void = { result in
+        let completion: @Sendable (Result<[String: Any]?, Error>) -> Void = { result in
             switch result {
             case .success(let dict):
                 
@@ -195,18 +202,8 @@ import Foundation
                     
                     if options.keys.contains("centralnotice-display-campaign-type-fundraising") {
                         
-                        if let responseOptInFlag = (options["centralnotice-display-campaign-type-fundraising"] as? Bool) {
-                            
-                            Task {
-                                await self.preferencesBannerOptIns.update(value:responseOptInFlag, forKey:project)
-                                
-                            }
-                        } else {
-                            Task {
-                                await self.preferencesBannerOptIns.update(value:false, forKey:project)
-                                
-                            }
-                        }
+                        let responseOptInFlag = (options["centralnotice-display-campaign-type-fundraising"] as? Bool) ?? false
+                        self.preferencesBannerOptIns.withLock { $0[project] = responseOptInFlag }
                     }
                     
                 }
@@ -228,7 +225,7 @@ import Foundation
         sharedCacheStore = WMFDataEnvironment.current.sharedCacheStore
         activeCountryConfigs = []
         promptState = nil
-        preferencesBannerOptIns = SafeDictionary<WMFProject, Bool>()
+        preferencesBannerOptIns.value = [:]
     }
     
     // MARK: - Private

--- a/WMFData/Sources/WMFData/Data Controllers/Growth Tasks/WMFGrowthTasksDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Growth Tasks/WMFGrowthTasksDataController.swift
@@ -1,8 +1,15 @@
 import Foundation
 
-@objc public final class WMFGrowthTasksDataController: NSObject {
+// @unchecked Sendable: must stay an NSObject subclass for Obj-C callers, so it
+// cannot be an actor. Mutable state is a WMFLockIsolated box plus the lock-guarded
+// static cache below.
+@objc public final class WMFGrowthTasksDataController: NSObject, @unchecked Sendable {
 
-    private var service = WMFDataEnvironment.current.mediaWikiService
+    private let _service = WMFLockIsolated(WMFDataEnvironment.current.mediaWikiService)
+    private var service: WMFService? {
+        get { _service.value }
+        set { _service.value = newValue }
+    }
     let project: WMFProject
     
     // In-memory cache shared across instances. Guarded by `cacheLock` so the
@@ -33,7 +40,7 @@ import Foundation
         Self.currentImageRecommendations[project] = []
     }
 
-    public func getImageRecommendationsCombined(completion: @escaping (Result<[WMFImageRecommendation.Page], Error>) -> Void) {
+    public func getImageRecommendationsCombined(completion: @escaping @Sendable (Result<[WMFImageRecommendation.Page], Error>) -> Void) {
         guard let service else {
             completion(.failure(WMFDataControllerError.mediaWikiServiceUnavailable))
             return
@@ -171,7 +178,7 @@ public extension WMFGrowthTasksDataController {
         self.init(project: WMFProject.wikipedia(language))
     }
     
-    @objc func hasImageRecommendations(completion: @escaping (Bool) -> Void) {
+    @objc func hasImageRecommendations(completion: @escaping @Sendable (Bool) -> Void) {
         getImageRecommendationsCombined { result in
             switch result {
             case .success(let pages):

--- a/WMFData/Sources/WMFData/Data Controllers/Image Recommendations/WMFImageRecommendationsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Image Recommendations/WMFImageRecommendationsDataController.swift
@@ -53,7 +53,7 @@ public class WMFImageRecommendationsDataController {
     
     // MARK: - PUT Send Feedback
     
-    public func sendFeedback(project: WMFProject, pageTitle: String, editRevId: UInt64?, fileName: String, accepted: Bool, reasons: [String] = [], caption: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+    public func sendFeedback(project: WMFProject, pageTitle: String, editRevId: UInt64?, fileName: String, accepted: Bool, reasons: [String] = [], caption: String?, completion: @escaping @Sendable (Result<Void, Error>) -> Void) {
 
         guard let service else {
             completion(.failure(WMFDataControllerError.mediaWikiServiceUnavailable))
@@ -80,7 +80,7 @@ public class WMFImageRecommendationsDataController {
 
         let request = WMFMediaWikiServiceRequest(url: url, method: .PUT, backend: .mediaWikiREST, tokenType: .csrf, parameters: parameters as [String : Any])
         
-        let completion: (Result<[String: Any]?, Error>) -> Void = { result in
+        let completion: @Sendable (Result<[String: Any]?, Error>) -> Void = { result in
             switch result {
             case .success:
                 completion(.success(()))

--- a/WMFData/Sources/WMFData/Data Controllers/Shared/UserContributionsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/UserContributionsDataController.swift
@@ -77,7 +77,7 @@ public actor UserContributionsDataController {
         }
     }
     
-    public func fetchUserContributionsCount(username: String, project: WMFProject?, startDate: String, endDate: String, completion: @escaping (Result<(Int, Bool), Error>) -> Void) {
+    public func fetchUserContributionsCount(username: String, project: WMFProject?, startDate: String, endDate: String, completion: @escaping @Sendable (Result<(Int, Bool), Error>) -> Void) {
         guard let service = service else {
             completion(.failure(WMFDataControllerError.mediaWikiServiceUnavailable))
             return

--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFArticleDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFArticleDataController.swift
@@ -99,7 +99,7 @@ public final class WMFArticleDataController {
     ///   - project: Project the article belongs to (EN Wiki, etc)
     ///   - request: Request struct to fetch certain pieces of data. So far can support watchlist status and user rollback rights.
     ///   - completion: Completion block called when API has completed
-    public func fetchArticleInfo(title: String, project: WMFProject, request: ArticleInfoRequest, completion: @escaping (Result<WMFArticleInfoResponse, Error>) -> Void) {
+    public func fetchArticleInfo(title: String, project: WMFProject, request: ArticleInfoRequest, completion: @escaping @Sendable (Result<WMFArticleInfoResponse, Error>) -> Void) {
          
         guard let mediaWikiService else {
              completion(.failure(WMFDataControllerError.mediaWikiServiceUnavailable))

--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFGlobalEditCountDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFGlobalEditCountDataController.swift
@@ -24,7 +24,7 @@ final class WMFGlobalEditCountDataController {
         }
     }
     
-    func fetchEditCount(startDate: Date, endDate: Date, completion: @escaping (Result<Int, Error>) -> Void) {
+    func fetchEditCount(startDate: Date, endDate: Date, completion: @escaping @Sendable (Result<Int, Error>) -> Void) {
         guard let service = service else {
             completion(.failure(WMFDataControllerError.basicServiceUnavailable))
             return

--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFImageDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFImageDataController.swift
@@ -38,7 +38,7 @@ public actor WMFImageDataController {
         return data
     }
 
-    public func fetchImageInfo(title: String, thumbnailWidth: UInt, project: WMFProject, completion: @escaping (Result<WMFImageInfo, Error>) -> Void) {
+    public func fetchImageInfo(title: String, thumbnailWidth: UInt, project: WMFProject, completion: @escaping @Sendable (Result<WMFImageInfo, Error>) -> Void) {
         guard let mediaWikiService else {
             completion(.failure(WMFDataControllerError.mediaWikiServiceUnavailable))
             return

--- a/WMFData/Sources/WMFData/Data Controllers/Shared/WMFUserImpactDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Shared/WMFUserImpactDataController.swift
@@ -23,7 +23,7 @@ public actor WMFUserImpactDataController {
         }
     }
     
-    func fetch(userID: Int, project: WMFProject, language: String, completion: @escaping (Result<WMFUserImpactData, Error>) -> Void) {
+    func fetch(userID: Int, project: WMFProject, language: String, completion: @escaping @Sendable (Result<WMFUserImpactData, Error>) -> Void) {
         guard let service = service else {
             completion(.failure(WMFDataControllerError.basicServiceUnavailable))
             return
@@ -46,7 +46,7 @@ public actor WMFUserImpactDataController {
 
         let request = WMFMediaWikiServiceRequest(url: url, method: .GET, backend: .mediaWikiREST, tokenType: .none, parameters: nil)
 
-        let completionHandler: (Result<[String: Any]?, Error>) -> Void = { result in
+        let completionHandler: @Sendable (Result<[String: Any]?, Error>) -> Void = { result in
             switch result {
             case .success(let data):
                 guard let jsonData = data else {

--- a/WMFData/Sources/WMFData/Data Controllers/Temp Accounts/WMFTempAccountDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Temp Accounts/WMFTempAccountDataController.swift
@@ -1,16 +1,30 @@
 import Foundation
 
-@objc public class WMFTempAccountDataController: NSObject {
+// @unchecked Sendable: must stay an NSObject subclass for Obj-C callers, so it
+// cannot be an actor. All mutable state lives in WMFLockIsolated boxes below.
+@objc public final class WMFTempAccountDataController: NSObject, @unchecked Sendable {
     @objc public static let shared = WMFTempAccountDataController()
-    
-    private var mediaWikiService = WMFDataEnvironment.current.mediaWikiService
 
-    private var _primaryWikiHasTempAccountsEnabled: Bool?
+    private let _mediaWikiService = WMFLockIsolated(WMFDataEnvironment.current.mediaWikiService)
+    private var mediaWikiService: WMFService? {
+        get { _mediaWikiService.value }
+        set { _mediaWikiService.value = newValue }
+    }
+
+    private let _primaryWikiHasTempAccountsEnabledBox = WMFLockIsolated<Bool?>(nil)
+    private var _primaryWikiHasTempAccountsEnabled: Bool? {
+        get { _primaryWikiHasTempAccountsEnabledBox.value }
+        set { _primaryWikiHasTempAccountsEnabledBox.value = newValue }
+    }
     @objc public var primaryWikiHasTempAccountsEnabled: Bool {
         return _primaryWikiHasTempAccountsEnabled ?? false
     }
 
-    public var wikisWithTempAccountsEnabled: [String] = []
+    private let _wikisWithTempAccountsEnabled = WMFLockIsolated<[String]>([])
+    public var wikisWithTempAccountsEnabled: [String] {
+        get { _wikisWithTempAccountsEnabled.value }
+        set { _wikisWithTempAccountsEnabled.value = newValue }
+    }
 
     @objc public func checkWikiTempAccountAvailability(language: String, isCheckingPrimaryWiki: Bool) {
         Task {
@@ -61,7 +75,7 @@ import Foundation
         }
     }
 
-    private func fetchWikiTempStatus(project: WMFProject, completion: ((Result<Bool, Error>) -> Void)? = nil) {
+    private func fetchWikiTempStatus(project: WMFProject, completion: (@Sendable (Result<Bool, Error>) -> Void)? = nil) {
         guard let mediaWikiService else {
             completion?(.failure(WMFDataControllerError.mediaWikiServiceUnavailable))
             return

--- a/WMFData/Sources/WMFData/Data Controllers/Watchlist/WMFWatchlistDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Watchlist/WMFWatchlistDataController.swift
@@ -1,9 +1,16 @@
 import Foundation
 import UIKit
 
-public class WMFWatchlistDataController {
-    
-    var service = WMFDataEnvironment.current.mediaWikiService
+// @unchecked Sendable: exposes a broad synchronous API to legacy call sites, so it
+// cannot become an actor yet. The only mutable state is the service reference,
+// held in a WMFLockIsolated box.
+public final class WMFWatchlistDataController: @unchecked Sendable {
+
+    private let _service = WMFLockIsolated(WMFDataEnvironment.current.mediaWikiService)
+    var service: WMFService? {
+        get { _service.value }
+        set { _service.value = newValue }
+    }
     private let sharedCacheStore = WMFDataEnvironment.current.sharedCacheStore
     private let userDefaultsStore = WMFDataEnvironment.current.userDefaultsStore
 
@@ -93,7 +100,7 @@ public class WMFWatchlistDataController {
     
     // MARK: GET Watchlist Items
 
-    public func fetchWatchlist(completion: @escaping (Result<WMFWatchlist, Error>) -> Void) {
+    public func fetchWatchlist(completion: @escaping @Sendable (Result<WMFWatchlist, Error>) -> Void) {
         
         guard let service else {
             completion(.failure(WMFDataControllerError.mediaWikiServiceUnavailable))
@@ -124,10 +131,13 @@ public class WMFWatchlistDataController {
         apply(filterSettings: filterSettings, to: &parameters)
         
         let group = DispatchGroup()
-        var items: [WMFWatchlist.Item] = []
-        var errors: [WMFProject: [WMFDataControllerError]] = [:]
-        projects.forEach { project in
-            errors[project] = []
+        // Aggregated behind a lock: the per-project service callbacks land on
+        // URLSession's queue concurrently with each other.
+        let fetchState = WMFLockIsolated<(items: [WMFWatchlist.Item], errors: [WMFProject: [WMFDataControllerError]])>(([], [:]))
+        fetchState.withLock { state in
+            projects.forEach { project in
+                state.errors[project] = []
+            }
         }
         
         for project in projects {
@@ -152,46 +162,49 @@ public class WMFWatchlistDataController {
                 
                 switch result {
                 case .success(let apiResponse):
-                    
+
                     if let apiResponseErrors = apiResponse.errors,
                        !apiResponseErrors.isEmpty {
-                        
+
                         let mediaWikiResponseErrors = apiResponseErrors.map { WMFDataControllerError.mediaWikiResponseError($0) }
-                        errors[project, default: []].append(contentsOf: mediaWikiResponseErrors)
+                        fetchState.withLock { $0.errors[project, default: []].append(contentsOf: mediaWikiResponseErrors) }
                         return
                     }
-                    
+
                     guard let query = apiResponse.query else {
-                        errors[project, default: []].append(WMFDataControllerError.unexpectedResponse)
+                        fetchState.withLock { $0.errors[project, default: []].append(WMFDataControllerError.unexpectedResponse) }
                         return
                     }
-                    
-                    items.append(contentsOf: self.watchlistItems(from: query, project: project))
-                    
+
+                    let newItems = self.watchlistItems(from: query, project: project)
+                    fetchState.withLock { $0.items.append(contentsOf: newItems) }
+
                     try? sharedCacheStore?.save(key: WMFSharedCacheDirectoryNames.watchlists.rawValue, project.id, value: apiResponse)
-                    
+
                 case .failure(let error):
                     var usedCache = false
-                    
+
                     if (error as NSError).isInternetConnectionError {
-                        
+
                         let cachedResult: WatchlistAPIResponse? = try? sharedCacheStore?.load(key: WMFSharedCacheDirectoryNames.watchlists.rawValue, project.id)
-                        
+
                         if let query = cachedResult?.query {
-                            items.append(contentsOf: self.watchlistItems(from: query, project: project))
+                            let cachedItems = self.watchlistItems(from: query, project: project)
+                            fetchState.withLock { $0.items.append(contentsOf: cachedItems) }
                             usedCache = true
                         }
                     }
-                    
+
                     if !usedCache {
-                        errors[project, default: []].append(WMFDataControllerError.serviceError(error))
+                        fetchState.withLock { $0.errors[project, default: []].append(WMFDataControllerError.serviceError(error)) }
                     }
                 }
             }
         }
         
         group.notify(queue: .main) {
-        
+
+            let (items, errors) = fetchState.value
             let successProjects = errors.filter { $0.value.isEmpty }
             let failureProjects = errors.filter { !$0.value.isEmpty }
             
@@ -311,7 +324,7 @@ public class WMFWatchlistDataController {
     
     // MARK: POST Watch Item
      
-     public func watch(title: String, project: WMFProject, expiry: WMFWatchlistExpiryType, completion: @escaping (Result<Void, Error>) -> Void) {
+     public func watch(title: String, project: WMFProject, expiry: WMFWatchlistExpiryType, completion: @escaping @Sendable (Result<Void, Error>) -> Void) {
 
          guard let service else {
              completion(.failure(WMFDataControllerError.mediaWikiServiceUnavailable))
@@ -352,7 +365,7 @@ public class WMFWatchlistDataController {
 
      // MARK: POST Unwatch Item
      
-     public func unwatch(title: String, project: WMFProject, completion: @escaping (Result<Void, Error>) -> Void) {
+     public func unwatch(title: String, project: WMFProject, completion: @escaping @Sendable (Result<Void, Error>) -> Void) {
 
          guard let service else {
              completion(.failure(WMFDataControllerError.mediaWikiServiceUnavailable))
@@ -393,7 +406,7 @@ public class WMFWatchlistDataController {
     
     // MARK: POST Rollback Page
     
-    public func rollback(title: String, project: WMFProject, username: String, completion: @escaping (Result<WMFUndoOrRollbackResult, Error>) -> Void) {
+    public func rollback(title: String, project: WMFProject, username: String, completion: @escaping @Sendable (Result<WMFUndoOrRollbackResult, Error>) -> Void) {
         
         guard let service else {
             completion(.failure(WMFDataControllerError.mediaWikiServiceUnavailable))
@@ -436,7 +449,7 @@ public class WMFWatchlistDataController {
     
     // MARK: POST Undo Revision
     
-    public func undo(title: String, revisionID: UInt, summary: String, username: String, project: WMFProject, completion: @escaping (Result<WMFUndoOrRollbackResult, Error>) -> Void) {
+    public func undo(title: String, revisionID: UInt, summary: String, username: String, project: WMFProject, completion: @escaping @Sendable (Result<WMFUndoOrRollbackResult, Error>) -> Void) {
 
         guard let service else {
             completion(.failure(WMFDataControllerError.mediaWikiServiceUnavailable))
@@ -491,7 +504,7 @@ public class WMFWatchlistDataController {
         }
     }
     
-    private func fetchUndoRevisionSummaryPrefixText(revisionID: UInt, username: String, project: WMFProject, completion: @escaping (Result<String, Error>) -> Void) {
+    private func fetchUndoRevisionSummaryPrefixText(revisionID: UInt, username: String, project: WMFProject, completion: @escaping @Sendable (Result<String, Error>) -> Void) {
         
         guard let service else {
             completion(.failure(WMFDataControllerError.mediaWikiServiceUnavailable))

--- a/WMFData/Sources/WMFData/Models/Developer Settings/WMFFeatureConfigResponse.swift
+++ b/WMFData/Sources/WMFData/Models/Developer Settings/WMFFeatureConfigResponse.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-public struct WMFFeatureConfigResponse: Codable {
+public struct WMFFeatureConfigResponse: Codable, Sendable {
     
-    public struct Common: Codable {
+    public struct Common: Codable, Sendable {
         public let yir: [YearInReview]
         
-        public struct YearInReview: Codable {
+        public struct YearInReview: Codable, Sendable {
             
-            public struct TopReadPercentage: Codable {
+            public struct TopReadPercentage: Codable, Sendable {
                 public let identifier: String
                 public let min: Int
                 public let max: Int?
@@ -103,10 +103,10 @@ public struct WMFFeatureConfigResponse: Codable {
         }
     }
     
-    public struct IOS: Codable {
+    public struct IOS: Codable, Sendable {
         public let hCaptcha: HCaptcha?
         
-        public struct HCaptcha: Codable {
+        public struct HCaptcha: Codable, Sendable {
             public let baseURL: String
             public let jsSrc: String
             public let endpoint: String

--- a/WMFData/Sources/WMFData/Models/Donor Experience/WMFDonateConfig.swift
+++ b/WMFData/Sources/WMFData/Models/Donor Experience/WMFDonateConfig.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct WMFDonateConfig: Codable {
+public struct WMFDonateConfig: Codable, Sendable {
     let version: Int
     public let currencyMinimumDonation: [String: Decimal]
     public let currencyMaximumDonation: [String: Decimal]

--- a/WMFData/Sources/WMFData/Models/Donor Experience/WMFDonateConfigResponse.swift
+++ b/WMFData/Sources/WMFData/Models/Donor Experience/WMFDonateConfigResponse.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct WMFDonateConfigResponse: Codable {
+public struct WMFDonateConfigResponse: Codable, Sendable {
     
     static let currentVersion = 1
     var config: WMFDonateConfig

--- a/WMFData/Sources/WMFData/Models/Donor Experience/WMFPaymentMethods.swift
+++ b/WMFData/Sources/WMFData/Models/Donor Experience/WMFPaymentMethods.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PassKit
 
-public struct WMFPaymentMethods: Codable {
+public struct WMFPaymentMethods: Codable, Sendable {
     
     struct Response: Codable {
         

--- a/WMFData/Sources/WMFData/Models/Donor Experience/WMFPaymentSubmissionResponse.swift
+++ b/WMFData/Sources/WMFData/Models/Donor Experience/WMFPaymentSubmissionResponse.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-final public class WMFPaymentSubmissionResponse: Codable {
-    public class Response: Codable {
+final public class WMFPaymentSubmissionResponse: Codable, Sendable {
+    public final class Response: Codable, Sendable {
         let status: String
         let errorMessage: String?
         let orderID: String?

--- a/WMFData/Sources/WMFData/Models/Image Recommendations/WMFImageRecommendation.swift
+++ b/WMFData/Sources/WMFData/Models/Image Recommendations/WMFImageRecommendation.swift
@@ -1,28 +1,28 @@
 import Foundation
 
-public struct WMFImageRecommendation {
+public struct WMFImageRecommendation: Sendable {
     
     let page: Page
 
-    public struct Page {
+    public struct Page: Sendable {
         public let pageid: Int
         public let title: String
         public let growthimagesuggestiondata: [GrowthImageSuggestionData]?
         public let revisions: [Revision]
     }
 
-    public struct Revision {
+    public struct Revision: Sendable {
         public let revID: Int
         public let wikitext: String
     }
 
-    public struct GrowthImageSuggestionData {
+    public struct GrowthImageSuggestionData: Sendable {
         let titleNamespace: Int
         public let titleText: String
         public let images: [ImageSuggestion]
     }
 
-    public struct ImageSuggestion: Codable {
+    public struct ImageSuggestion: Codable, Sendable {
         public let image: String
         public let displayFilename: String
         public let source: String
@@ -30,7 +30,7 @@ public struct WMFImageRecommendation {
         public let metadata: ImageMetadata
     }
 
-    public struct ImageMetadata: Codable {
+    public struct ImageMetadata: Codable, Sendable {
         public let descriptionUrl: String
         public let thumbUrl: String
         public let fullUrl: String

--- a/WMFData/Sources/WMFData/Models/Watchlist/WMFWatchlist.swift
+++ b/WMFData/Sources/WMFData/Models/Watchlist/WMFWatchlist.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public struct WMFWatchlist {
+public struct WMFWatchlist: Sendable {
     
-    public struct Item {
+    public struct Item: Sendable {
         public let title: String
         public let revisionID: UInt
         public let oldRevisionID: UInt

--- a/WMFData/Sources/WMFData/Service/Protocol/WMFService.swift
+++ b/WMFData/Sources/WMFData/Service/Protocol/WMFService.swift
@@ -1,9 +1,13 @@
 import Foundation
 
-public protocol WMFService {
-    func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<Data, Error>) -> Void)
-    func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<[String: Any]?, Error>) -> Void)
-    func performDecodableGET<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void)
-    func performDecodablePOST<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void)
+// Sendable: service instances are shared across concurrency domains by design —
+// data controllers hold them and invoke them from arbitrary tasks and queues.
+public protocol WMFService: Sendable {
+    // Completions are @Sendable: implementations invoke them from URLSession's
+    // delegate queue, so they cross a concurrency boundary by construction.
+    func perform<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Result<Data, Error>) -> Void)
+    func perform<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Result<[String: Any]?, Error>) -> Void)
+    func performDecodableGET<R: WMFServiceRequest, T: Decodable & Sendable>(request: R, completion: @escaping @Sendable (Result<T, Error>) -> Void)
+    func performDecodablePOST<R: WMFServiceRequest, T: Decodable & Sendable>(request: R, completion: @escaping @Sendable (Result<T, Error>) -> Void)
     func clearCachedData()
 }

--- a/WMFData/Sources/WMFData/Service/Protocol/WMFURLSession.swift
+++ b/WMFData/Sources/WMFData/Service/Protocol/WMFURLSession.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-public protocol WMFURLSession {
+// Sendable: session abstractions back WMFService implementations, which are
+// themselves Sendable. URLSession already satisfies this.
+public protocol WMFURLSession: Sendable {
     func wmfDataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> WMFURLSessionDataTask
     func clearCachedData()
 }

--- a/WMFData/Sources/WMFData/Service/WMFBasicService.swift
+++ b/WMFData/Sources/WMFData/Service/WMFBasicService.swift
@@ -9,9 +9,9 @@ public final class WMFBasicService: WMFService {
         self.urlSession = urlSession
     }
     
-    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<Data, Error>) -> Void) {
+    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Result<Data, Error>) -> Void) {
         
-        let completion: ((Data?, URLResponse?, Error?) -> Void) = { data, response, error in
+        let completion: (@Sendable (Data?, URLResponse?, Error?) -> Void) = { data, response, error in
             if let error {
                 completion(.failure(error))
                 return
@@ -36,9 +36,9 @@ public final class WMFBasicService: WMFService {
         }
     }
     
-    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<[String: Any]?, Error>) -> Void) {
+    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Result<[String: Any]?, Error>) -> Void) {
         
-        let completion: ((Result<Data, any Error>) -> Void) = { result in
+        let completion: (@Sendable (Result<Data, any Error>) -> Void) = { result in
             switch result {
             case .success(let data):
                 
@@ -56,7 +56,7 @@ public final class WMFBasicService: WMFService {
         perform(request: request, completion: completion)
     }
     
-    private func performPOST<R: WMFServiceRequest>(request: R, completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
+    private func performPOST<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) {
         
         guard let basicRequest = request as? WMFBasicServiceRequest,
               let url = request.url,
@@ -145,7 +145,7 @@ public final class WMFBasicService: WMFService {
         task.resume()
     }
     
-    private func performGET<R: WMFServiceRequest>(request: R, completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
+    private func performGET<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) {
          
         guard let basicRequest = request as? WMFBasicServiceRequest,
               let url = request.url,
@@ -219,7 +219,7 @@ public final class WMFBasicService: WMFService {
         task.resume()
     }
     
-    public func performDecodableGET<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void) {
+    public func performDecodableGET<R: WMFServiceRequest, T: Decodable & Sendable>(request: R, completion: @escaping @Sendable (Result<T, Error>) -> Void) {
         
         performGET(request: request) { data, response, error in
             
@@ -243,7 +243,7 @@ public final class WMFBasicService: WMFService {
         }
     }
     
-    public func performDecodablePOST<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void) {
+    public func performDecodablePOST<R: WMFServiceRequest, T: Decodable & Sendable>(request: R, completion: @escaping @Sendable (Result<T, Error>) -> Void) {
         
         performPOST(request: request) { data, response, error in
             

--- a/WMFData/Sources/WMFData/Utility/WMFLockIsolated.swift
+++ b/WMFData/Sources/WMFData/Utility/WMFLockIsolated.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// A minimal lock-guarded box for mutable state on classes that must stay
+/// `NSObject`-based (Obj-C visible singletons) and therefore cannot become actors.
+/// Holding all mutable stored properties in `WMFLockIsolated` boxes is what makes
+/// those classes' `@unchecked Sendable` conformances sound — every read/write is
+/// serialized behind the lock. Keep accesses coarse: read once into a local,
+/// compute, then write back, rather than many fine-grained hops.
+final class WMFLockIsolated<Value>: @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var _value: Value
+
+    init(_ value: Value) {
+        self._value = value
+    }
+
+    var value: Value {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _value
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _value = newValue
+        }
+    }
+
+    /// Perform a read-modify-write (or any compound access) atomically.
+    @discardableResult
+    func withLock<T>(_ body: (inout Value) throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body(&_value)
+    }
+}

--- a/WMFData/Sources/WMFDataMocks/WMFMockBasicService.swift
+++ b/WMFData/Sources/WMFDataMocks/WMFMockBasicService.swift
@@ -118,7 +118,7 @@ fileprivate extension WMFData.WMFServiceRequest {
 
 }
 
-public class WMFMockBasicService: WMFService {
+public final class WMFMockBasicService: WMFService {
     
     private let overrideJSONResourceName: String?
     
@@ -126,7 +126,7 @@ public class WMFMockBasicService: WMFService {
         self.overrideJSONResourceName = jsonResourceName
     }
     
-    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<Data, any Error>) -> Void) {
+    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Result<Data, any Error>) -> Void) {
         guard let jsonData = jsonData(for: request) else {
             completion(.failure(WMFMockError.unableToPullData))
             return
@@ -135,7 +135,7 @@ public class WMFMockBasicService: WMFService {
         completion(.success(jsonData))
     }
     
-    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<[String: Any]?, Error>) -> Void) {
+    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Result<[String: Any]?, Error>) -> Void) {
         
         guard let jsonData = jsonData(for: request) else {
             completion(.failure(WMFMockError.unableToPullData))
@@ -150,7 +150,7 @@ public class WMFMockBasicService: WMFService {
         completion(.success(jsonDict))
     }
     
-    public func performDecodableGET<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void) {
+    public func performDecodableGET<R: WMFServiceRequest, T: Decodable & Sendable>(request: R, completion: @escaping @Sendable (Result<T, Error>) -> Void) {
         
         guard let jsonData = jsonData(for: request) else {
             completion(.failure(WMFMockError.unableToPullData))
@@ -167,7 +167,7 @@ public class WMFMockBasicService: WMFService {
         completion(.success(response))
     }
     
-    public func performDecodablePOST<R, T>(request: R, completion: @escaping (Result<T, Error>) -> Void) where R : WMFData.WMFServiceRequest, T : Decodable {
+    public func performDecodablePOST<R, T>(request: R, completion: @escaping @Sendable (Result<T, Error>) -> Void) where R : WMFData.WMFServiceRequest, T : Decodable {
         
         guard let jsonData = jsonData(for: request) else {
             completion(.failure(WMFMockError.unableToPullData))

--- a/WMFData/Sources/WMFDataMocks/WMFMockGrowthTasksService.swift
+++ b/WMFData/Sources/WMFDataMocks/WMFMockGrowthTasksService.swift
@@ -46,7 +46,7 @@ fileprivate extension WMFData.WMFServiceRequest {
     }
 }
 
-public final class WMFMockGrowthTasksService: WMFService {
+public final class WMFMockGrowthTasksService: WMFService, @unchecked Sendable {
 
     public init() {}
 
@@ -80,7 +80,7 @@ public final class WMFMockGrowthTasksService: WMFService {
 
     }
     
-    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<Data, any Error>) -> Void) {
+    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Result<Data, any Error>) -> Void) {
         guard let jsonData = jsonData(for: request) else {
             completion(.failure(WMFMockError.unableToPullData))
             return
@@ -89,7 +89,7 @@ public final class WMFMockGrowthTasksService: WMFService {
         completion(.success(jsonData))
     }
 
-    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<[String : Any]?, Error>) -> Void) {
+    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Result<[String : Any]?, Error>) -> Void) {
 
         guard let jsonData = jsonData(for: request) else {
             completion(.failure(WMFMockError.unableToPullData))
@@ -105,7 +105,7 @@ public final class WMFMockGrowthTasksService: WMFService {
 
     }
     
-    public func performDecodableGET<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void) {
+    public func performDecodableGET<R: WMFServiceRequest, T: Decodable & Sendable>(request: R, completion: @escaping @Sendable (Result<T, Error>) -> Void) {
         guard let jsonData = jsonData(for: request) else {
             completion(.failure(WMFMockError.unableToPullData))
             return
@@ -122,7 +122,7 @@ public final class WMFMockGrowthTasksService: WMFService {
 
     }
     
-    public func performDecodablePOST<R, T>(request: R, completion: @escaping (Result<T, Error>) -> Void) {
+    public func performDecodablePOST<R, T>(request: R, completion: @escaping @Sendable (Result<T, Error>) -> Void) {
 
     }
     

--- a/WMFData/Sources/WMFDataMocks/WMFMockServiceNoInternetConnection.swift
+++ b/WMFData/Sources/WMFDataMocks/WMFMockServiceNoInternetConnection.swift
@@ -3,28 +3,28 @@ import WMFData
 
 #if DEBUG
 
-public class WMFMockServiceNoInternetConnection: WMFService {
+public final class WMFMockServiceNoInternetConnection: WMFService {
 
     public init() {
         
     }
     
-    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<Data, any Error>) -> Void) {
+    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Result<Data, any Error>) -> Void) {
         let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
         completion(.failure(error))
     }
     
-    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<[String: Any]?, Error>) -> Void) {
+    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Result<[String: Any]?, Error>) -> Void) {
         let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
         completion(.failure(error))
     }
     
-    public func performDecodableGET<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void) {
+    public func performDecodableGET<R: WMFServiceRequest, T: Decodable & Sendable>(request: R, completion: @escaping @Sendable (Result<T, Error>) -> Void) {
         let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
         completion(.failure(error))
     }
     
-    public func performDecodablePOST<R, T>(request: R, completion: @escaping (Result<T, Error>) -> Void) where R : WMFData.WMFServiceRequest, T : Decodable {
+    public func performDecodablePOST<R, T>(request: R, completion: @escaping @Sendable (Result<T, Error>) -> Void) where R : WMFData.WMFServiceRequest, T : Decodable {
         let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
         completion(.failure(error))
     }

--- a/WMFData/Sources/WMFDataMocks/WMFMockURLSession.swift
+++ b/WMFData/Sources/WMFDataMocks/WMFMockURLSession.swift
@@ -12,7 +12,8 @@ struct WMFMockData: Codable {
     let twoString: String
 }
 
-final class WMFMockSuccessURLSession: WMFURLSession {
+// @unchecked Sendable: test-only; the recorded url var is written and read serially by tests.
+final class WMFMockSuccessURLSession: WMFURLSession, @unchecked Sendable {
     
     var url: URL?
     
@@ -33,7 +34,7 @@ final class WMFMockSuccessURLSession: WMFURLSession {
     }
 }
 
-final class WMFMockServerErrorSession: WMFURLSession {
+final class WMFMockServerErrorSession: WMFURLSession, @unchecked Sendable {
     func wmfDataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> WMFData.WMFURLSessionDataTask {
 
         let response = HTTPURLResponse(url: URL(string: "http://wikipedia.org")!, statusCode: 500, httpVersion: nil, headerFields: nil)
@@ -47,7 +48,7 @@ final class WMFMockServerErrorSession: WMFURLSession {
     }
 }
 
-final class WMFMockNoInternetConnectionSession: WMFURLSession {
+final class WMFMockNoInternetConnectionSession: WMFURLSession, @unchecked Sendable {
     func wmfDataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> WMFData.WMFURLSessionDataTask {
 
         let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
@@ -60,7 +61,7 @@ final class WMFMockNoInternetConnectionSession: WMFURLSession {
     }
 }
 
-final class WMFMockMissingDataSession: WMFURLSession {
+final class WMFMockMissingDataSession: WMFURLSession, @unchecked Sendable {
     func wmfDataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> WMFData.WMFURLSessionDataTask {
 
         let response = HTTPURLResponse(url: URL(string: "http://wikipedia.org")!, statusCode: 200, httpVersion: nil, headerFields: nil)

--- a/WMFData/Sources/WMFDataMocks/WMFMockWatchlistMediaWikiService.swift
+++ b/WMFData/Sources/WMFDataMocks/WMFMockWatchlistMediaWikiService.swift
@@ -117,7 +117,8 @@ fileprivate extension WMFData.WMFServiceRequest {
     }
 }
 
-public class WMFMockWatchlistMediaWikiService: WMFService {
+// @unchecked Sendable: test-only; the demo-app toggle is set before requests begin.
+public final class WMFMockWatchlistMediaWikiService: WMFService, @unchecked Sendable {
 
     public var randomizeGetWatchStatusResponse: Bool = false // used in WMFComponents Demo app
     
@@ -125,7 +126,7 @@ public class WMFMockWatchlistMediaWikiService: WMFService {
         
     }
     
-    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<Data, any Error>) -> Void) {
+    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Result<Data, any Error>) -> Void) {
         guard let jsonData = jsonData(for: request) else {
             completion(.failure(WMFMockError.unableToPullData))
             return
@@ -134,7 +135,7 @@ public class WMFMockWatchlistMediaWikiService: WMFService {
         completion(.success(jsonData))
     }
     
-    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping (Result<[String: Any]?, Error>) -> Void) {
+    public func perform<R: WMFServiceRequest>(request: R, completion: @escaping @Sendable (Result<[String: Any]?, Error>) -> Void) {
         
         guard let jsonData = jsonData(for: request) else {
             completion(.failure(WMFMockError.unableToPullData))
@@ -149,7 +150,7 @@ public class WMFMockWatchlistMediaWikiService: WMFService {
         completion(.success(jsonDict))
     }
     
-    public func performDecodableGET<R: WMFServiceRequest, T: Decodable>(request: R, completion: @escaping (Result<T, Error>) -> Void) {
+    public func performDecodableGET<R: WMFServiceRequest, T: Decodable & Sendable>(request: R, completion: @escaping @Sendable (Result<T, Error>) -> Void) {
         
         guard let jsonData = jsonData(for: request) else {
             completion(.failure(WMFMockError.unableToPullData))
@@ -166,7 +167,7 @@ public class WMFMockWatchlistMediaWikiService: WMFService {
         completion(.success(response))
     }
     
-    public func performDecodablePOST<R, T>(request: R, completion: @escaping (Result<T, Error>) -> Void) where R : WMFData.WMFServiceRequest, T : Decodable {
+    public func performDecodablePOST<R, T>(request: R, completion: @escaping @Sendable (Result<T, Error>) -> Void) where R : WMFData.WMFServiceRequest, T : Decodable {
         
     }
     


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T389255

## Swift 6 migration — Phase 4: WMFData has zero strict-concurrency warnings

This PR is part of the Swift 6 migration. The migration changes the leaf
packages first. This PR completes the WMFData burn-down. The count of warnings was approximately 127 at the start. The count is now zero. The CI gate now monitors WMFData and WMFComponents. The gate stops each PR that adds a concurrency warning to these two packages.

### WMFData
- `WMFService` and `WMFURLSession` are now `Sendable` protocols. Their
  completions are `@Sendable`. This is necessary for two reasons. Data
  controllers hold service instances and use them from many tasks and queues.
  URLSession calls the completions from its delegate queue. The decodable
  service methods now specify `T: Decodable & Sendable`. The response models
  are now `Sendable`.
- `WMFLockIsolated` is a new utility. It is a box that holds mutable state
  behind a lock. Some classes must stay subclasses of `NSObject` because
  Objective-C code uses them. These classes cannot become actors. These
  controllers now keep all mutable state in `WMFLockIsolated` boxes: developer
  settings, donate, fundraising campaign, temp accounts, growth tasks, and
  watchlist. Each `@unchecked Sendable` conformance has a comment that gives
  the reason. The lock makes the conformance safe.
- This PR repairs two data races. The donate-config fetch and the watchlist
  fetch each use a `DispatchGroup` to do two or more requests at the same time.
  Before this PR, the callbacks wrote to shared local variables at the same
  time. Now the callbacks write to one lock-protected box.

### WMFComponents (related changes)
- The data controller callbacks are now `@Sendable`. They do not run on the
  main actor. The watchlist, donate, and image recommendations view models now
  move to the main actor in these callbacks. Then they change the view model
  state. The completion callbacks of these view models now have the type
  `@MainActor @Sendable`. The image recommendations fetch does not use
  `DispatchQueue.main.async` now. It uses `Task { @MainActor in }`.
- The WMFComponents warning count stays at zero.

### App code
- `MediaWikiFetcher` is now `@unchecked Sendable`. A comment gives the reason.
  The full examination of this class will occur in the WMF Framework phase.

### CI
- The Strict Concurrency Check workflow now includes WMFData in
  `GATED_SCHEMES`. The job fails if a PR adds a concurrency warning to WMFData
  or WMFComponents sources.

### Verification
- A clean build shows zero warnings for WMFData and zero warnings for
  WMFComponents. The count procedure is the same as the CI procedure. The
  environment was Xcode 26.6 and an iPhone 17 simulator with iOS 26.5.
- All 202 WMFData unit tests passed. All 258 WMFComponents unit tests passed.
  The Wikipedia app scheme compiled correctly.
- The script `scripts/lint-wmfdata-test-fixtures.sh` gave a pass result.

### Notes for reviewers
- The language modes did not change. The packages stay in mode `.v5`. In this
  mode, violations are warnings. The `.v6` change for WMFComponents stays on
  hold because of swiftlang/swift#87316.
- The next phase adds WMF Framework to the workflow matrix in report-only mode.
  Then its burn-down starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)