### PR TITLE
Glassify headers in For You

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Home/WMFHomeView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Home/WMFHomeView.swift
@@ -59,6 +59,7 @@ public struct WMFHomeView: View {
                 forYouTabContent
                     .ignoresSafeArea()
                     .environment(\.forYouHeaderBottom, headerBottom)
+                    .environment(\.colorScheme, .dark)
                 headerBar(isForYou: true)
                     .padding(.top, headerBarTopInset)
                     .background {
@@ -73,11 +74,9 @@ public struct WMFHomeView: View {
                     .padding(.top, refreshIndicatorTopInset)
             }
             .ignoresSafeArea()
-            .environment(\.colorScheme, .dark)
             .onPreferenceChange(WMFForYouHeaderBottomKey.self) { headerBottom = $0 }
         } else {
             communitySection
-
                 .environment(\.colorScheme, theme.preferredColorScheme)
         }
     }
@@ -101,73 +100,80 @@ public struct WMFHomeView: View {
             .background(Color(uiColor: theme.paperBackground))
         }
     }
-
+    
     private func headerBar(isForYou: Bool) -> some View {
         HStack(spacing: 8) {
-            Picker("", selection: $viewModel.selectedTab) {
-                Text(viewModel.communityTabTitle).tag(WMFHomeViewModel.Tab.community)
-                Text(viewModel.forYouTabTitle).tag(WMFHomeViewModel.Tab.forYou)
+            if #available(iOS 26.0, *) {
+                Picker("", selection: $viewModel.selectedTab) {
+                    Text(viewModel.communityTabTitle).tag(WMFHomeViewModel.Tab.community)
+                    Text(viewModel.forYouTabTitle).tag(WMFHomeViewModel.Tab.forYou)
+                }
+                .glassEffect()
+                .padding(.vertical, 2)
+                .pickerStyle(.segmented)
+                .fixedSize()
+            } else {
+                // Fallback on earlier versions
             }
-            .padding(.vertical, 2)
-            .pickerStyle(.segmented)
-            .fixedSize()
 
             Spacer()
 
             if viewModel.shouldShowLanguagePicker {
-                Menu {
-                    ForEach(viewModel.languages) { language in
-                        Button {
-                            if language.languageCode != viewModel.selectedLanguage?.languageCode {
-                                viewModel.logDidTapLanguagePicker?(language.languageCode)
-                            }
-                            viewModel.didSelectLanguage?(language)
-                        } label: {
-                            if language.languageCode == viewModel.selectedLanguage?.languageCode {
-                                Label {
-                                    Text(language.localizedName)
-                                } icon: {
-                                    Image(uiImage: WMFSFSymbolIcon.for(symbol: .checkmark) ?? UIImage())
+                if #available(iOS 26.0, *) {
+                    Menu {
+                        ForEach(viewModel.languages) { language in
+                            Button {
+                                if language.languageCode != viewModel.selectedLanguage?.languageCode {
+                                    viewModel.logDidTapLanguagePicker?(language.languageCode)
                                 }
-                                .minimumScaleFactor(0.25)
-                            } else {
-                                Text(language.localizedName)
+                                viewModel.didSelectLanguage?(language)
+                            } label: {
+                                if language.languageCode == viewModel.selectedLanguage?.languageCode {
+                                    Label {
+                                        Text(language.localizedName)
+                                    } icon: {
+                                        Image(uiImage: WMFSFSymbolIcon.for(symbol: .checkmark) ?? UIImage())
+                                    }
                                     .minimumScaleFactor(0.25)
+                                } else {
+                                    Text(language.localizedName)
+                                        .minimumScaleFactor(0.25)
+                                }
+                            }
+                            .tint(.primary)
+                        }
+                        Divider()
+                        Button {
+                            viewModel.didTapEditLanguages?()
+                        } label: {
+                            Label {
+                                Text(viewModel.editLanguagesTitle)
+                            } icon: {
+                                Image(uiImage: WMFSFSymbolIcon.for(symbol: .globe) ?? UIImage())
                             }
                         }
-                    }
-                    Divider()
-                    Button {
-                        viewModel.didTapEditLanguages?()
+                        .tint(.primary)
                     } label: {
-                        Label {
-                            Text(viewModel.editLanguagesTitle)
-                        } icon: {
-                            Image(uiImage: WMFSFSymbolIcon.for(symbol: .globe) ?? UIImage())
+                        HStack {
+                            Text(viewModel.languageButtonTitle)
+                                .font(Font(WMFFont.for(.semiboldSubheadline)))
+                                .dynamicTypeSize(.xSmall ... .large)
+                                .minimumScaleFactor(0.25)
+                                // .foregroundStyle(isForYou ? Color(uiColor: WMFColor.white) : Color(uiColor: theme.text))
+                                .lineLimit(1)
+                            Image(uiImage: WMFSFSymbolIcon.for(symbol: .chevronUpChevronDown, font: .boldCaption1, compatibleWith: .wmfCappedForSFSymbols) ?? UIImage())
+                                // .foregroundStyle(isForYou ? Color(uiColor: WMFColor.white) : Color(uiColor: theme.text))
                         }
+                        .tint(.primary)
                     }
-                } label: {
-                    HStack {
-                        Text(viewModel.languageButtonTitle)
-                            .font(Font(WMFFont.for(.semiboldSubheadline)))
-                            .dynamicTypeSize(.xSmall ... .large)
-                            .minimumScaleFactor(0.25)
-                            .foregroundStyle(isForYou ? Color(uiColor: WMFColor.white) : Color(uiColor: theme.text))
-                            .lineLimit(1)
-                        Image(uiImage: WMFSFSymbolIcon.for(symbol: .chevronUpChevronDown, font: .boldCaption1, compatibleWith: .wmfCappedForSFSymbols) ?? UIImage())
-                            .foregroundStyle(isForYou ? Color(uiColor: WMFColor.white) : Color(uiColor: theme.text))
-                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .tint(.primary)
+                    .glassEffect()
+                    .accessibilityIdentifier(AccessibilityIdentifiers.Home.languagePickerButton)
+                } else {
+                    // Fallback on earlier versions
                 }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
-                .background {
-                    if #available(iOS 26.0, *) {
-                        Capsule().fill(.clear).glassEffect(in: Capsule())
-                    } else {
-                        Capsule().fill(.ultraThinMaterial)
-                    }
-                }
-                .accessibilityIdentifier(AccessibilityIdentifiers.Home.languagePickerButton)
             }
         }
         .padding(.horizontal, 16)

--- a/WMFComponents/Sources/WMFComponents/Components/Home/WMFHomeView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Home/WMFHomeView.swift
@@ -61,6 +61,7 @@ public struct WMFHomeView: View {
                     .environment(\.forYouHeaderBottom, headerBottom)
                     .environment(\.colorScheme, .dark)
                 headerBar(isForYou: true)
+                    .modifier(WMFLegacyDarkHeaderModifier())
                     .padding(.top, headerBarTopInset)
                     .background {
                         GeometryReader { proxy in
@@ -247,6 +248,16 @@ public struct WMFHomeView: View {
                 .font(Font(WMFFont.for(.headline)))
                 .foregroundStyle(Color(uiColor: theme.secondaryText))
             Spacer()
+        }
+    }
+}
+
+private struct WMFLegacyDarkHeaderModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+        } else {
+            content.environment(\.colorScheme, .dark)
         }
     }
 }

--- a/WMFComponents/Sources/WMFComponents/Components/Home/WMFHomeView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Home/WMFHomeView.swift
@@ -103,81 +103,78 @@ public struct WMFHomeView: View {
     
     private func headerBar(isForYou: Bool) -> some View {
         HStack(spacing: 8) {
-            if #available(iOS 26.0, *) {
-                Picker("", selection: $viewModel.selectedTab) {
-                    Text(viewModel.communityTabTitle).tag(WMFHomeViewModel.Tab.community)
-                    Text(viewModel.forYouTabTitle).tag(WMFHomeViewModel.Tab.forYou)
-                }
-                .glassEffect()
-                .padding(.vertical, 2)
-                .pickerStyle(.segmented)
-                .fixedSize()
-            } else {
-                // Fallback on earlier versions
+            Picker("", selection: $viewModel.selectedTab) {
+                Text(viewModel.communityTabTitle).tag(WMFHomeViewModel.Tab.community)
+                Text(viewModel.forYouTabTitle).tag(WMFHomeViewModel.Tab.forYou)
             }
-
+            .padding(.vertical, 2)
+            .pickerStyle(.segmented)
+            .fixedSize()
+            .modifier(WMFGlassEffectModifier())
+            
             Spacer()
-
+            
             if viewModel.shouldShowLanguagePicker {
-                if #available(iOS 26.0, *) {
-                    Menu {
-                        ForEach(viewModel.languages) { language in
-                            Button {
-                                if language.languageCode != viewModel.selectedLanguage?.languageCode {
-                                    viewModel.logDidTapLanguagePicker?(language.languageCode)
-                                }
-                                viewModel.didSelectLanguage?(language)
-                            } label: {
-                                if language.languageCode == viewModel.selectedLanguage?.languageCode {
-                                    Label {
-                                        Text(language.localizedName)
-                                    } icon: {
-                                        Image(uiImage: WMFSFSymbolIcon.for(symbol: .checkmark) ?? UIImage())
-                                    }
-                                    .minimumScaleFactor(0.25)
-                                } else {
-                                    Text(language.localizedName)
-                                        .minimumScaleFactor(0.25)
-                                }
-                            }
-                            .tint(.primary)
-                        }
-                        Divider()
+                Menu {
+                    ForEach(viewModel.languages) { language in
                         Button {
-                            viewModel.didTapEditLanguages?()
-                        } label: {
-                            Label {
-                                Text(viewModel.editLanguagesTitle)
-                            } icon: {
-                                Image(uiImage: WMFSFSymbolIcon.for(symbol: .globe) ?? UIImage())
+                            if language.languageCode != viewModel.selectedLanguage?.languageCode {
+                                viewModel.logDidTapLanguagePicker?(language.languageCode)
                             }
-                        }
-                        .tint(.primary)
-                    } label: {
-                        HStack {
-                            Text(viewModel.languageButtonTitle)
-                                .font(Font(WMFFont.for(.semiboldSubheadline)))
-                                .dynamicTypeSize(.xSmall ... .large)
+                            viewModel.didSelectLanguage?(language)
+                        } label: {
+                            if language.languageCode == viewModel.selectedLanguage?.languageCode {
+                                Label {
+                                    Text(language.localizedName)
+                                } icon: {
+                                    Image(uiImage: WMFSFSymbolIcon.for(symbol: .checkmark) ?? UIImage())
+                                }
                                 .minimumScaleFactor(0.25)
-                                // .foregroundStyle(isForYou ? Color(uiColor: WMFColor.white) : Color(uiColor: theme.text))
-                                .lineLimit(1)
-                            Image(uiImage: WMFSFSymbolIcon.for(symbol: .chevronUpChevronDown, font: .boldCaption1, compatibleWith: .wmfCappedForSFSymbols) ?? UIImage())
-                                // .foregroundStyle(isForYou ? Color(uiColor: WMFColor.white) : Color(uiColor: theme.text))
+                            } else {
+                                Text(language.localizedName)
+                                    .minimumScaleFactor(0.25)
+                            }
                         }
                         .tint(.primary)
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
+                    Divider()
+                    Button {
+                        viewModel.didTapEditLanguages?()
+                    } label: {
+                        Label {
+                            Text(viewModel.editLanguagesTitle)
+                        } icon: {
+                            Image(uiImage: WMFSFSymbolIcon.for(symbol: .globe) ?? UIImage())
+                        }
+                    }
                     .tint(.primary)
-                    .glassEffect()
-                    .accessibilityIdentifier(AccessibilityIdentifiers.Home.languagePickerButton)
-                } else {
-                    // Fallback on earlier versions
+                } label: {
+                    HStack {
+                        Text(viewModel.languageButtonTitle)
+                            .font(Font(WMFFont.for(.semiboldSubheadline)))
+                            .dynamicTypeSize(.xSmall ... .large)
+                            .minimumScaleFactor(0.25)
+                            .foregroundStyle(languageButtonForeground(isForYou: isForYou))
+                            .lineLimit(1)
+                        Image(uiImage: WMFSFSymbolIcon.for(symbol: .chevronUpChevronDown, font: .boldCaption1, compatibleWith: .wmfCappedForSFSymbols) ?? UIImage())
+                            .foregroundStyle(languageButtonForeground(isForYou: isForYou))
+                    }
                 }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .modifier(WMFLanguageButtonContainerModifier())
+                .accessibilityIdentifier(AccessibilityIdentifiers.Home.languagePickerButton)
             }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 16)
+    }
+
+    private func languageButtonForeground(isForYou: Bool) -> Color {
+        if #available(iOS 26.0, *) {
+            return .primary
+        }
+        return isForYou ? Color(uiColor: WMFColor.white) : Color(uiColor: theme.text)
     }
 
     // MARK: - For You Tab
@@ -250,6 +247,29 @@ public struct WMFHomeView: View {
                 .font(Font(WMFFont.for(.headline)))
                 .foregroundStyle(Color(uiColor: theme.secondaryText))
             Spacer()
+        }
+    }
+}
+
+private struct WMFGlassEffectModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.glassEffect()
+        } else {
+            content
+        }
+    }
+}
+
+private struct WMFLanguageButtonContainerModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .tint(.primary)
+                .glassEffect()
+        } else {
+            content
+                .background(Capsule().fill(.ultraThinMaterial))
         }
     }
 }


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
Just something I noticed over the weekend - the Community / For You Picker is not properly glassy (it just looks semi-transparent), and the content of the language picker doesn't react / flip when the background changes. This fixes those issues.

iOS 17/18 should remain unchanged.

### Test Steps
1. Page through For You, confirm picker and language buttons are readable.

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
Before: 
<img width="568" height="1084" alt="Screenshot 2026-08-24 at 8 41 52 AM" src="https://github.com/user-attachments/assets/b85c0148-8495-407a-b2e8-f76633ef734c" />

After:
<img width="568" height="1084" alt="Screenshot 2026-08-24 at 8 42 52 AM" src="https://github.com/user-attachments/assets/cf8d438b-3767-44ea-950b-cb4f51fa795e" />
