### PR TITLE
Improve For You readability on iOS 17 & 18

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Home/WMFHomeView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Home/WMFHomeView.swift
@@ -267,7 +267,7 @@ private struct WMFGlassEffectModifier: ViewModifier {
         if #available(iOS 26.0, *) {
             content.glassEffect()
         } else {
-            content
+            content.background(RoundedRectangle(cornerRadius: 9).fill(.ultraThinMaterial))
         }
     }
 }

--- a/Wikipedia/Code/HomeViewController.swift
+++ b/Wikipedia/Code/HomeViewController.swift
@@ -217,7 +217,21 @@ final class HomeViewController: UIViewController, WMFNavigationBarConfiguring, T
 
     private func updateNavigationBarAppearance(for tab: WMFHomeViewModel.Tab) {
         guard let navController = navigationController as? WMFComponentNavigationController else { return }
-        navController.setTransparentAppearance(tab == .forYou)
+        if tab == .forYou, #unavailable(iOS 26.0) {
+            navController.setTransparentAppearance(false)
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = Theme.black.colors.chromeBackground
+            appearance.shadowColor = .clear
+            navController.navigationBar.standardAppearance = appearance
+            navController.navigationBar.scrollEdgeAppearance = appearance
+            navController.navigationBar.compactAppearance = appearance
+            if #available(iOS 18.0, *) {
+                navController.navigationBar.compactScrollEdgeAppearance = appearance
+            }
+        } else {
+            navController.setTransparentAppearance(tab == .forYou)
+        }
     }
 
     private func updateTabBarAppearance(for tab: WMFHomeViewModel.Tab) {


### PR DESCRIPTION
**Phabricator:** N/A

### Notes
Fixes readability issues in iOS 17 and 18. If needed we could investigate more into keeping the transparent nav bar, but this was the quickest fix I could make in the moment.

### Test Steps
1. Confirm For You headers on iOS 17 / 18 are readable. iOS 26 should be unchanged.

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
Before:
<img width="559" height="1062" alt="Screenshot 2026-08-24 at 9 23 24 AM" src="https://github.com/user-attachments/assets/5bab68e1-519c-4eb4-9544-e42d5c2238b9" />

After:
<img width="559" height="1062" alt="Screenshot 2026-08-24 at 9 24 25 AM" src="https://github.com/user-attachments/assets/fd4f4b37-2982-4172-b472-45af890c8d83" />


