### PR TITLE
T434696: Onboarding Interest/Article Cards

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/App Onboarding/WMFAppOnboardingFeedPreferenceView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/App Onboarding/WMFAppOnboardingFeedPreferenceView.swift
@@ -163,9 +163,8 @@ private struct WMFAppOnboardingPreviewCardView: View {
                 if viewModel.uiImage == nil, let pill = viewModel.topicPill {
                     topicPillView(pill)
                 }
-                WMFHtmlText(html: viewModel.displayTitle, styles: semiboldHeadlineStyle)
+                WMFHtmlText(html: viewModel.displayTitle, styles: semiboldHeadlineStyle, lineLimit: 2)
                     .foregroundStyle(Color(uiColor: theme.text))
-                    .lineLimit(2)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 if let description = viewModel.description {
                     Text(description)

--- a/WMFComponents/Sources/WMFComponents/Components/Settings/Home/For You/Whats Driving/Your Interests/WMFInterestArticleGridView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Settings/Home/For You/Whats Driving/Your Interests/WMFInterestArticleGridView.swift
@@ -83,6 +83,10 @@ private struct WMFInterestArticleCardView: View {
 
     @ObservedObject var viewModel: WMFInterestArticleCardViewModel
     let theme: WMFTheme
+    
+    private var subheadlineStyles: HtmlUtils.Styles {
+        return HtmlUtils.Styles(font: WMFFont.for(.boldSubheadline), boldFont: WMFFont.for(.boldSubheadline), italicsFont: WMFFont.for(.boldItalicSubheadline), boldItalicsFont: WMFFont.for(.boldItalicSubheadline), color: theme.text, linkColor: theme.link, lineSpacing: 1)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -103,7 +107,7 @@ private struct WMFInterestArticleCardView: View {
             // text rather than below its descender space.
             HStack(alignment: .lastTextBaseline, spacing: 4) {
                 VStack(alignment: .leading, spacing: 4) {
-                    WMFHtmlText(html: viewModel.displayTitle, styles: HtmlUtils.Styles(font: WMFFont.for(.semiboldHeadline, sized: dynamicTypeSize), boldFont: WMFFont.for(.boldHeadline, sized: dynamicTypeSize), italicsFont: WMFFont.for(.semiboldHeadline, sized: dynamicTypeSize), boldItalicsFont: WMFFont.for(.boldHeadline, sized: dynamicTypeSize), color: theme.text, linkColor: theme.link, lineSpacing: 1))
+                    WMFHtmlText(html: viewModel.displayTitle, styles: subheadlineStyles)
                     if let description = viewModel.description {
                         Text(description)
                             .font(Font(WMFFont.for(.callout, sized: dynamicTypeSize)))

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/WMFHtmlText.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/WMFHtmlText.swift
@@ -1,23 +1,32 @@
 import SwiftUI
 
 struct WMFHtmlText: View {
-    
+
     @ObservedObject var appEnvironment = WMFAppEnvironment.current
     let html: String
     let styles: HtmlUtils.Styles
-    
+    var lineLimit: Int? = nil
+
     private var theme: WMFTheme {
         return appEnvironment.theme
     }
-    
+
     private var attributedString: AttributedString {
         return (try? HtmlUtils.attributedStringFromHtml(html, styles: styles)) ?? AttributedString(html)
     }
-    
+
     var body: some View {
-        Text(attributedString)
-            .lineLimit(nil)
-            .lineSpacing(styles.lineSpacing)
-            .fixedSize(horizontal: false, vertical: true)
+        if let lineLimit {
+            // Clamped: truncates within height-constrained containers (fixed-size cards)
+            Text(attributedString)
+                .lineSpacing(styles.lineSpacing)
+                .lineLimit(lineLimit)
+        } else {
+            // Unclamped: takes full ideal height (masonry grid cards, prose)
+            Text(attributedString)
+                .lineSpacing(styles.lineSpacing)
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
 }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T434696

### Notes
* 

### Test Steps
1. Go through onboarding of Group B (fresh install until assigned new onboarding) 
2. Select titles that are italicized (I search "the" and select a bunch) 
3. Ensure you see them properly once selected
4. When you go to the next screen, make sure you see italics, and make sure it doesn't clip through the card

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e 26 liquid glass - 2026-08-24 at 16 17 27" src="https://github.com/user-attachments/assets/c9f30769-64ae-4b40-9d41-9a1d7471a342" />
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e 26 liquid glass - 2026-08-24 at 16 17 22" src="https://github.com/user-attachments/assets/fbc963c2-8a7d-44e8-96df-16058f7fa1a9" />
