### PR TITLE
Fix blank space in home when keyboard was active

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Home/WMFHomeView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Home/WMFHomeView.swift
@@ -46,6 +46,7 @@ public struct WMFHomeView: View {
     public var body: some View {
         mainContent
             .animation(.easeInOut(duration: 0.2), value: viewModel.isRefreshingForYou)
+            .ignoresSafeArea(.keyboard)
             .task { viewModel.loadCurrentTabFeedIfNeeded() }
             .onChange(of: viewModel.selectedTab) {
                 viewModel.loadCurrentTabFeedIfNeeded()


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T435878

### Notes
* One-line fix 

### Test Steps

1. Open the app on the Home tab (Community or For You feed).
2. Open a screen that shows the keyboard and keep the keyboard up.
3. Donate form: Profile → Donate, tap the custom amount field.
4. With the keyboard still visible, return to the Home tab (dismiss the donate modal / switch tabs).

### Checklist
- [x] Checked against Swift 6 strict concurrency
