### PR TITLE
Added deeplink support for places (Using Lat, Lon and Place name).

### DIFF
--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.m
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.m
@@ -62,15 +62,33 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
 + (instancetype)wmf_placesActivityWithURL:(NSURL *)activityURL {
     NSURLComponents *components = [NSURLComponents componentsWithURL:activityURL resolvingAgainstBaseURL:NO];
     NSURL *articleURL = nil;
+    NSString *latitudeString = nil;
+    NSString *longitudeString = nil;
+    NSString *placeName = nil;
     for (NSURLQueryItem *item in components.queryItems) {
         if ([item.name isEqualToString:@"WMFArticleURL"]) {
             NSString *articleURLString = item.value;
             articleURL = [NSURL URLWithString:articleURLString];
-            break;
+        } else if ([item.name isEqualToString:@"lat"]) {
+            latitudeString = item.value;
+        } else if ([item.name isEqualToString:@"lon"]) {
+            longitudeString = item.value;
+        } else if ([item.name isEqualToString:@"name"]) {
+            placeName = item.value;
         }
     }
     NSUserActivity *activity = [self wmf_pageActivityWithName:@"Places"];
     activity.webpageURL = articleURL;
+    // Supports opening the Places tab centered on an arbitrary coordinate (rather than an existing article or the user's current location), e.g. from an external app: wikipedia://places?lat=51.5074&lon=-0.1278&name=London
+    if (latitudeString != nil && longitudeString != nil) {
+        NSMutableDictionary *userInfo = [activity.userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
+        userInfo[@"WMFPlacesLatitude"] = latitudeString;
+        userInfo[@"WMFPlacesLongitude"] = longitudeString;
+        if (placeName != nil) {
+            userInfo[@"WMFPlacesName"] = placeName;
+        }
+        activity.userInfo = userInfo;
+    }
     return activity;
 }
 

--- a/Wikipedia/Code/PlacesViewController.swift
+++ b/Wikipedia/Code/PlacesViewController.swift
@@ -2087,6 +2087,18 @@ class PlacesViewController: ArticleLocationCollectionViewController, UISearchBar
         currentSearch = nil // will cause the default search to perform after re-centering
         recenterOnUserLocation(self)
     }
+    
+    // Centers the map on an arbitrary coordinate (rather than an existing article or the user's current location) and performs the default "top articles nearby" search there. Used to open Places at a location supplied by an external caller, e.g. via wikipedia://places?lat=..&lon=..
+    @objc public func showCoordinate(latitude: Double, longitude: Double, name: String?) {
+        guard view != nil else { // force view instantiation
+            return
+        }
+        let coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        let region = [coordinate].wmf_boundingRegion(with: 10000)
+        mapRegion = region
+        let localizedDescription = (name?.isEmpty == false ? name : nil) ?? WMFLocalizedString("places-search-top-articles", value: "All top articles", comment: "A search suggestion for top articles")
+        currentSearch = PlaceSearch(filter: currentSearchFilter, type: .location, origin: .system, sortStyle: .links, string: nil, region: region, localizedDescription: localizedDescription, searchResult: nil)
+    }
 
     @objc public func showArticleURL(_ articleURL: URL) {
         guard let article = dataStore.fetchArticle(with: articleURL), let title = articleURL.wmf_title,

--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -1324,7 +1324,14 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
             dismissPresentedViewControllers()
             selectedIndex = WMFAppTabType.places.rawValue
             currentTabNavigationController?.popToRootViewController(animated: animated)
-            if let articleURL = activity.wmf_linkURL() {
+            if let latitudeString = activity.userInfo?["WMFPlacesLatitude"] as? String,
+               let longitudeString = activity.userInfo?["WMFPlacesLongitude"] as? String,
+               let latitude = Double(latitudeString),
+               let longitude = Double(longitudeString) {
+                let name = activity.userInfo?["WMFPlacesName"] as? String
+                placesViewController.updateViewModeToMap()
+                placesViewController.showCoordinate(latitude: latitude, longitude: longitude, name: name)
+            } else if let articleURL = activity.wmf_linkURL() {
                 placesViewController.updateViewModeToMap()
                 placesViewController.showArticleURL(articleURL)
             }

--- a/WikipediaUnitTests/Code/NSUserActivity+WMFExtensionsTest.m
+++ b/WikipediaUnitTests/Code/NSUserActivity+WMFExtensionsTest.m
@@ -45,4 +45,29 @@
                           @"https://en.wikipedia.org/w/index.php?search=dog&title=Special:Search&fulltext=1");
 }
 
+- (void)testPlacesURLWithCoordinateReturnsLatitudeLongitudeAndName {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?lat=51.5074&lon=-0.1278&name=London"];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertEqualObjects(activity.userInfo[@"WMFPlacesLatitude"], @"51.5074");
+    XCTAssertEqualObjects(activity.userInfo[@"WMFPlacesLongitude"], @"-0.1278");
+    XCTAssertEqualObjects(activity.userInfo[@"WMFPlacesName"], @"London");
+}
+
+- (void)testPlacesURLWithoutCoordinateHasNoLatitudeOrLongitude {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places"];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertNil(activity.userInfo[@"WMFPlacesLatitude"]);
+    XCTAssertNil(activity.userInfo[@"WMFPlacesLongitude"]);
+}
+
+- (void)testPlacesURLWithPartialCoordinateHasNoLatitudeOrLongitude {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?lat=51.5074"];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertNil(activity.userInfo[@"WMFPlacesLatitude"]);
+    XCTAssertNil(activity.userInfo[@"WMFPlacesLongitude"]);
+}
+
 @end


### PR DESCRIPTION
**Phabricator:** https://github.com/wikimedia/wikipedia-ios/pull/6123
- Deeplink now directly opens the places tab for incoming latitude, longitude and optional place name. 
   example: wikipedia://places?lat={latitude}&lon={longitude}&name={optional display name}. 

### Notes
* Extends the existing `wikipedia://places` deep link - previously only usable with an already-known `WMFArticleURL` - to also accept a raw coordinate: `wikipedia://places?lat={latitude}&lon={longitude}&name={optional display name}`.
* No new URL scheme or `Info.plist` change was needed - `wikipedia/wikipedia-official` are already registered.
* `NSUserActivity+WMFExtensions.m`: `wmf_placesActivityWithURL`: now also parses `lat/lon/name` query items (alongside the existing `WMFArticleURL` one) and stores them in the activity's `userInfo` under `WMFPlacesLatitude / WMFPlacesLongitude / WMFPlacesName`. Only sets them when both latitude and longitude are present and parse cleanly - a partial or missing coordinate falls back to the pre-existing behaviour untouched.
* `WMFAppViewController.swift`: `processUserActivity(_:animated:completion:)`'s `.places` case checks for a coordinate in `userInfo` first; if present, routes to the new `PlacesViewController.showCoordinate(latitude:longitude:name:)`. Falls back to the original `showArticleURL(_:) `path when there's no coordinate, so existing article-centric deep links are unaffected.
* `PlacesViewController.swift`: new `showCoordinate(latitude:longitude:name:)` builds a 10km-radius `MKCoordinateRegion` around the given coordinate and sets it as `currentSearch`, mirroring the existing `zoomAndPanMapView(toLocation:)` pattern used for the user's real location - so it triggers the same "top articles nearby" default search, just centered elsewhere. Does not touch or request location permission.
* Motivation: lets an external companion app (in our case, a separate Places-browsing app) open this app directly on the Places tab centered on a location it supplies, instead of the device's current location.

### Test Steps
1. Build and run the `Wikipedia-Staging` scheme on Simulator.
2. From a Reminder app (Saved): open URL `"wikipedia://places?lat=51.5074&lon=-0.1278&name=London"`.
3. Confirm the app launches (or foregrounds) directly on the Places tab, map centered on London.
4. Repeat with a different coordinate and confirm it re-centers there, not the previous location, just to prove it's not hardcoded.
5. Test cold launch (app not running) and warm launch (already foregrounded) - both should route correctly.
6. Sanity-check the pre-existing article-based deep link still works unaffected: wikipedia://places?WMFArticleURL=<url>.
7. Run WikipediaUnitTests - 
New coverage in `NSUserActivity+WMFExtensionsTest.m` (`testPlacesURLWithCoordinateReturnsLatitudeLongitudeAndName`, `testPlacesURLWithoutCoordinateHasNoLatitudeOrLongitude`, `testPlacesURLWithPartialCoordinateHasNoLatitudeOrLongitude`) plus the full existing suite - all 400 tests pass.

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
https://drive.google.com/file/d/1DivbQyIwJ1sSR8UjcgyW9G_0VaTR0T7m/view?usp=sharing