### PR TITLE
Improve HTTP error handling in Session network requests

### DIFF
--- a/Wikipedia/Code/Session.swift
+++ b/Wikipedia/Code/Session.swift
@@ -461,8 +461,12 @@ public class Session: NSObject {
                 completionHandler(nil, response, error)
                 return
             }
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            guard let httpResponse = response as? HTTPURLResponse else {
                 completionHandler(nil, response, nil)
+                return
+            }
+            guard HTTPStatusCode.isSuccessful(httpResponse.statusCode) else {
+                completionHandler(nil, response, RequestError.http(httpResponse.statusCode))
                 return
             }
             do {
@@ -488,8 +492,12 @@ public class Session: NSObject {
                 completionHandler(nil, response, error)
                 return
             }
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            guard let httpResponse = response as? HTTPURLResponse else {
                 completionHandler(nil, response, nil)
+                return
+            }
+            guard HTTPStatusCode.isSuccessful(httpResponse.statusCode) else {
+                completionHandler(nil, response, RequestError.http(httpResponse.statusCode))
                 return
             }
             do {


### PR DESCRIPTION
### Notes
* Split HTTP response validation into two separate guard statements for better error reporting
* When an HTTP response has a non-200 status code, now returns a `RequestError.http(statusCode)` instead of `nil`
* Applied consistently to two request handling methods in the Session class

### Test Steps
1. Verify that network requests with non-200 HTTP status codes now properly report the error via the completion handler
2. Confirm that requests with valid 200 responses continue to work as expected
3. Test that invalid response types (non-HTTPURLResponse) still return nil error as before

### Checklist
- [ ] Checked against Swift 6 strict concurrency

https://claude.ai/code/session_01XoXAuCUJsJEttNPdMqzGMQ