### PR TITLE
Improve event intake requests

### DIFF
--- a/WMF Framework/Event Platform/EventPlatformClient.swift
+++ b/WMF Framework/Event Platform/EventPlatformClient.swift
@@ -944,33 +944,55 @@ import WMFTestKitchen
             
             let data = try encoder.encode(eventPayload)
 
-            guard let streamConfigs = streamConfigurations else {
-                appendEventToInputBuffer(data: data, stream: stream)
-                return
-            }
-            guard let config = streamConfigs[stream] else {
-                DDLogError("EPC: Event submitted to '\(stream)' but only the following streams are configured: \(streamConfigs.keys.map(\.rawValue).joined(separator: ", "))")
-                return
-            }
-            guard samplingController.inSample(stream: stream, config: config) else {
-                DDLogWarn("EPC: Stream '\(stream.rawValue)' is not in sample")
-                return
-            }
-
-            #if DEBUG
-            // Convert to loose dictionary so we can sort keys and print that way.
-            if let dict = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                let printablePayload = PrintableEventPayload(payload: dict)
-                DDLogDebug("\n\n📊EPC: Scheduling event to be sent to \(config.destination_event_service):")
-                DDLogDebug("\(printablePayload)")
-            }
-            #endif
-
-            storageManager.push(data: data, stream: stream)
+            _submitPreEncoded(data: data, stream: stream)
         } catch let error {
             DDLogError("EPC: \(error.localizedDescription)")
         }
 
+    }
+
+    /**
+     * Submit an already-encoded event payload according to the given stream's configuration.
+     *
+     * This is the single point where every event — including pre-encoded ones from
+     * TestKitchen — is buffered (while stream configs are unavailable), checked against
+     * the stream's sampling configuration, and persisted for sending.
+     */
+    func submitPreEncoded(data: Data, stream: Stream) {
+        encodeQueue.async {
+            self._submitPreEncoded(data: data, stream: stream)
+        }
+    }
+
+    /// Private, synchronous version of `submitPreEncoded`.
+    private func _submitPreEncoded(data: Data, stream: Stream) {
+        guard let storageManager = self.storageManager else {
+            return
+        }
+
+        guard let streamConfigs = streamConfigurations else {
+            appendEventToInputBuffer(data: data, stream: stream)
+            return
+        }
+        guard let config = streamConfigs[stream] else {
+            DDLogError("EPC: Event submitted to '\(stream)' but only the following streams are configured: \(streamConfigs.keys.map(\.rawValue).joined(separator: ", "))")
+            return
+        }
+        guard samplingController.inSample(stream: stream, config: config) else {
+            DDLogWarn("EPC: Stream '\(stream.rawValue)' is not in sample")
+            return
+        }
+
+        #if DEBUG
+        // Convert to loose dictionary so we can sort keys and print that way.
+        if let dict = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
+            let printablePayload = PrintableEventPayload(payload: dict)
+            DDLogDebug("\n\n📊EPC: Scheduling event to be sent to \(config.destination_event_service):")
+            DDLogDebug("\(printablePayload)")
+        }
+        #endif
+
+        storageManager.push(data: data, stream: stream)
     }
 }
 

--- a/WMF Framework/Event Platform/EventPlatformClient.swift
+++ b/WMF Framework/Event Platform/EventPlatformClient.swift
@@ -653,6 +653,7 @@ import WMFTestKitchen
 
         DDLogDebug("EPC: Processing all scheduled requests")
         let batches = Self.makeBatches(events: events, configs: streamConfigurations, chunkSize: Self.batchChunkSize)
+        WMFEventLoggingDiagnosticsDataController.shared.recordFlush(posts: batches.count, events: events.count)
         sendBatches(batches, startingAt: 0, hasty: hasty, storageManager: storageManager, completion: completion)
     }
 
@@ -675,6 +676,8 @@ import WMFTestKitchen
             case .purge:
                 if case .failure = result {
                     DDLogError("EPC: The analytics service reported partial failure (207) for a batch of \(batch.events.count) events. Invalid events were dropped by the server.")
+                    /// Upper bound: a 207 body identifies the rejected subset, but we don't parse it.
+                    WMFEventLoggingDiagnosticsDataController.shared.recordDrop(reason: .serverRejected, count: batch.events.count)
                 }
                 for event in batch.events {
                     storageManager.markPurgeable(event: event)
@@ -720,6 +723,7 @@ import WMFTestKitchen
                     default:
                         /// Give up on events rejected by the server
                         DDLogError("EPC: The analytics service failed to process an event. A response code of 400 could indicate that the event didn't conform to provided schema. Check the error for more information.: \(error)")
+                        WMFEventLoggingDiagnosticsDataController.shared.recordDrop(reason: .serverRejected)
                         storageManager.markPurgeable(event: event)
                     }
                 }
@@ -976,10 +980,12 @@ import WMFTestKitchen
         }
         guard let config = streamConfigs[stream] else {
             DDLogError("EPC: Event submitted to '\(stream)' but only the following streams are configured: \(streamConfigs.keys.map(\.rawValue).joined(separator: ", "))")
+            WMFEventLoggingDiagnosticsDataController.shared.recordDrop(reason: .unconfiguredStream)
             return
         }
         guard samplingController.inSample(stream: stream, config: config) else {
             DDLogWarn("EPC: Stream '\(stream.rawValue)' is not in sample")
+            WMFEventLoggingDiagnosticsDataController.shared.recordDrop(reason: .notInSample)
             return
         }
 
@@ -1024,6 +1030,7 @@ private extension EventPlatformClient {
              */
             if self.inputBuffer.count == self.inbutBufferLimit {
                 _ = self.inputBuffer.remove(at: 0)
+                WMFEventLoggingDiagnosticsDataController.shared.recordDrop(reason: .inputBufferOverflow)
             }
             self.inputBuffer.append((data, stream))
         }

--- a/WMF Framework/Event Platform/EventPlatformClient.swift
+++ b/WMF Framework/Event Platform/EventPlatformClient.swift
@@ -540,10 +540,107 @@ import WMFTestKitchen
         return uri
     }
 
+    /// PostEventError describes the possible failure cases when POSTing an event
+    enum PostEventError: Error {
+        case networkingLibraryError(_ error: Error)
+        case missingResponse
+        case unexpectedResponse(_ httpCode: Int)
+        /// The server is throttling (429) or failing (5xx); the request may succeed later.
+        case retryableServerError(statusCode: Int, retryAfter: TimeInterval?)
+    }
+
+    /// What to do with a batch's events after the server (or the networking library) answers.
+    enum BatchDisposition: Equatable {
+        /// Mark every event in the batch purgeable — delivered, or dropped by the server.
+        case purge
+        /// Leave the events stored to retry on a later flush.
+        case retain
+        /// Leave the events stored and suppress all flushing for the given interval.
+        case retainAndBackoff(TimeInterval)
+        /// The array as a whole was rejected — re-send the events individually, once.
+        case retryIndividually
+    }
+
+    /// Backoff applied when a retryable server error carries no usable Retry-After header.
+    static let defaultBackoffInterval: TimeInterval = 300
+
+    /// Upper bound on any server-requested backoff, so a hostile or buggy header
+    /// cannot stall analytics delivery indefinitely.
+    static let maximumBackoffInterval: TimeInterval = 3600
+
+    static func disposition(for result: Result<Void, PostEventError>) -> BatchDisposition {
+        switch result {
+        case .success:
+            return .purge
+        case .failure(let error):
+            switch error {
+            case .networkingLibraryError:
+                return .retain
+            case .retryableServerError(_, let retryAfter):
+                return .retainAndBackoff(min(retryAfter ?? defaultBackoffInterval, maximumBackoffInterval))
+            case .unexpectedResponse(let statusCode) where statusCode == 207:
+                /// Partial success: the server ingested the valid events and rejected the
+                /// rest. Rejected (schema-invalid) events would never become valid, so the
+                /// whole batch is done — matching the legacy per-event behavior of
+                /// dropping server-rejected events.
+                return .purge
+            case .unexpectedResponse, .missingResponse:
+                return .retryIndividually
+            }
+        }
+    }
+
+    /**
+     * Parses an HTTP `Retry-After` header value, which is either a non-negative
+     * delta in seconds or an HTTP-date.
+     */
+    static func retryAfterInterval(fromHeaderValue value: String?, now: Date = Date()) -> TimeInterval? {
+        guard let value = value?.trimmingCharacters(in: .whitespaces), !value.isEmpty else {
+            return nil
+        }
+        if let seconds = TimeInterval(value) {
+            return seconds >= 0 ? seconds : nil
+        }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE',' dd MMM yyyy HH':'mm':'ss 'GMT'"
+        if let date = formatter.date(from: value) {
+            return max(0, date.timeIntervalSince(now))
+        }
+        return nil
+    }
+
+    /**
+     * The earliest date another intake request may be sent, set when the server asks us
+     * to back off (429, or a 5xx). In-memory only: the worker retries every 30 seconds,
+     * so a backoff lost to a relaunch costs at most one extra request.
+     */
+    private var nextPermittedSendDate: Date? {
+        get {
+            queue.sync {
+                return _nextPermittedSendDate
+            }
+        }
+        set {
+            queue.async {
+                self._nextPermittedSendDate = newValue
+            }
+        }
+    }
+    private var _nextPermittedSendDate: Date? = nil
+
     /// Shared send path for `flushStoredEvents` and `postAllScheduled`: pops all pending
     /// events and sends one POST per destination-sized batch instead of one per event.
+    /// Batches go out sequentially so a server backoff stops the rest of the flush.
     private func postStoredEvents(hasty: Bool, completion: (() -> Void)?) {
         guard let storageManager = self.storageManager else {
+            completion?()
+            return
+        }
+
+        if let nextPermittedSendDate = self.nextPermittedSendDate, Date() < nextPermittedSendDate {
+            DDLogDebug("EPC: Suppressing flush until \(nextPermittedSendDate) as requested by the server")
             completion?()
             return
         }
@@ -556,50 +653,59 @@ import WMFTestKitchen
 
         DDLogDebug("EPC: Processing all scheduled requests")
         let batches = Self.makeBatches(events: events, configs: streamConfigurations, chunkSize: Self.batchChunkSize)
-        let group = DispatchGroup()
-        for batch in batches {
-            group.enter()
+        sendBatches(batches, startingAt: 0, hasty: hasty, storageManager: storageManager, completion: completion)
+    }
 
-            let uri = Self.intakeURI(for: batch.destination, hasty: hasty)
-            httpPost(url: uri, body: Self.encodeBatchBody(batch.events.map(\.data))) { result in
-                switch result {
-                case .success:
-                    for event in batch.events {
-                        storageManager.markPurgeable(event: event)
-                    }
-                case .failure(let error):
-                    switch error {
-                    case .networkingLibraryError:
-                        /// Leave unmarked to retry on networking library failure
-                        break
-                    case .unexpectedResponse(let statusCode) where statusCode == 207:
-                        /// Partial success: the server ingested the valid events and rejected
-                        /// the rest. Rejected (schema-invalid) events would never become valid,
-                        /// so the whole batch is done — matching the legacy per-event behavior
-                        /// of dropping server-rejected events.
-                        DDLogError("EPC: The analytics service reported partial failure (207) for a batch of \(batch.events.count) events. Invalid events were dropped by the server.")
-                        for event in batch.events {
-                            storageManager.markPurgeable(event: event)
-                        }
-                    default:
-                        /// The array as a whole was rejected — possibly poisoned by a single
-                        /// malformed blob. Retry the events individually, once, so one bad
-                        /// event only loses itself.
-                        DDLogError("EPC: A batch of \(batch.events.count) events was rejected (\(error)). Retrying events individually.")
-                        self.postIndividually(batch.events, uri: uri, group: group, storageManager: storageManager)
-                    }
-                }
-                group.leave()
+    private func sendBatches(_ batches: [EventBatch], startingAt index: Int, hasty: Bool, storageManager: StorageManager, completion: (() -> Void)?) {
+        guard index < batches.count else {
+            queue.async {
+                completion?()
             }
+            return
         }
-        group.notify(queue: queue) {
-            completion?()
+
+        let batch = batches[index]
+        let uri = Self.intakeURI(for: batch.destination, hasty: hasty)
+        let continueWithNextBatch = {
+            self.sendBatches(batches, startingAt: index + 1, hasty: hasty, storageManager: storageManager, completion: completion)
+        }
+
+        httpPost(url: uri, body: Self.encodeBatchBody(batch.events.map(\.data))) { result in
+            switch Self.disposition(for: result) {
+            case .purge:
+                if case .failure = result {
+                    DDLogError("EPC: The analytics service reported partial failure (207) for a batch of \(batch.events.count) events. Invalid events were dropped by the server.")
+                }
+                for event in batch.events {
+                    storageManager.markPurgeable(event: event)
+                }
+                continueWithNextBatch()
+            case .retain:
+                /// Leave unmarked to retry on networking library failure
+                continueWithNextBatch()
+            case .retainAndBackoff(let interval):
+                /// The server is throttling or failing; keep the events stored and stop
+                /// flushing (including the remaining batches) until the window passes.
+                DDLogWarn("EPC: The analytics service asked us to back off (\(result)). Suppressing event sends for \(Int(interval))s.")
+                self.nextPermittedSendDate = Date().addingTimeInterval(interval)
+                self.queue.async {
+                    completion?()
+                }
+            case .retryIndividually:
+                /// The array as a whole was rejected — possibly poisoned by a single
+                /// malformed blob. Retry the events individually, once, so one bad
+                /// event only loses itself.
+                DDLogError("EPC: A batch of \(batch.events.count) events was rejected (\(result)). Retrying events individually.")
+                self.postIndividually(batch.events, uri: uri, storageManager: storageManager, completion: continueWithNextBatch)
+            }
         }
     }
 
     /// One-pass fallback used when a whole batch is rejected: the legacy per-event send,
-    /// purging on any server response and retaining only on networking errors.
-    private func postIndividually(_ events: [PersistedEvent], uri: URL, group: DispatchGroup, storageManager: StorageManager) {
+    /// purging on definitive server responses and retaining on networking errors and
+    /// retryable server errors.
+    private func postIndividually(_ events: [PersistedEvent], uri: URL, storageManager: StorageManager, completion: @escaping () -> Void) {
+        let group = DispatchGroup()
         for event in events {
             group.enter()
             httpPost(url: uri, body: event.data) { result in
@@ -608,8 +714,8 @@ import WMFTestKitchen
                     storageManager.markPurgeable(event: event)
                 case .failure(let error):
                     switch error {
-                    case .networkingLibraryError:
-                        /// Leave unmarked to retry on networking library failure
+                    case .networkingLibraryError, .retryableServerError:
+                        /// Leave unmarked to retry on a later flush
                         break
                     default:
                         /// Give up on events rejected by the server
@@ -619,6 +725,9 @@ import WMFTestKitchen
                 }
                 group.leave()
             }
+        }
+        group.notify(queue: DispatchQueue.global(qos: .utility)) {
+            completion()
         }
     }
 
@@ -916,13 +1025,7 @@ private extension EventPlatformClient {
 // MARK: NetworkIntegration
 
 private extension EventPlatformClient {
-    /// PostEventError describes the possible failure cases when POSTing an event
-    enum PostEventError: Error {
-        case networkingLibraryError(_ error: Error)
-        case missingResponse
-        case unexpectedResponse(_ httpCode: Int)
-    }
-    
+
     /**
      * HTTP POST
      * - Parameter body: Body of the POST request
@@ -945,7 +1048,13 @@ private extension EventPlatformClient {
                 return
             }
             guard httpResponse.statusCode == 201 || httpResponse.statusCode == 202 else {
-                fail(PostEventError.unexpectedResponse(httpResponse.statusCode))
+                let statusCode = httpResponse.statusCode
+                if statusCode == 429 || (500...599).contains(statusCode) {
+                    let retryAfter = EventPlatformClient.retryAfterInterval(fromHeaderValue: httpResponse.value(forHTTPHeaderField: "Retry-After"))
+                    fail(PostEventError.retryableServerError(statusCode: statusCode, retryAfter: retryAfter))
+                } else {
+                    fail(PostEventError.unexpectedResponse(statusCode))
+                }
                 return
             }
             completion(.success(()))

--- a/WMF Framework/Event Platform/EventPlatformClient.swift
+++ b/WMF Framework/Event Platform/EventPlatformClient.swift
@@ -401,6 +401,107 @@ import WMFTestKitchen
      * completion handler so the process stays alive until the network round-trip finishes.
      */
     public func flushStoredEvents(completion: (() -> Void)? = nil) {
+        postStoredEvents(hasty: false, completion: completion)
+    }
+
+    /**
+     * Flush the queue of outgoing requests in a first-in-first-out,
+     * fire-and-forget fashion
+     */
+    func postAllScheduled(_ completion: (() -> Void)? = nil) {
+        #if DEBUG
+        postStoredEvents(hasty: false, completion: completion)
+        #else
+        postStoredEvents(hasty: true, completion: completion)
+        #endif
+    }
+
+    /// The destination intake service for an event, resolved from its stream's configuration.
+    enum EventDestination {
+        case analytics
+        case logging
+    }
+
+    /// One outgoing intake request: up to `batchChunkSize` events bound for the same destination.
+    struct EventBatch {
+        let destination: EventDestination
+        let events: [PersistedEvent]
+    }
+
+    /// Maximum number of events sent in a single intake POST. Payloads run 0.5–2 KB per
+    /// event, so 50 keeps request bodies well under EventGate's limits.
+    static let batchChunkSize = 50
+
+    /**
+     * Groups events by destination intake service and splits each group into chunks of at
+     * most `chunkSize`, preserving the events' relative order within each destination.
+     * With no stream configurations, every event resolves to the analytics intake.
+     */
+    static func makeBatches(events: [PersistedEvent], configs: [Stream: StreamConfiguration]?, chunkSize: Int) -> [EventBatch] {
+        guard !events.isEmpty else {
+            return []
+        }
+        let size = max(1, chunkSize)
+
+        var grouped: [EventDestination: [PersistedEvent]] = [:]
+        var destinationsInOrder: [EventDestination] = []
+        for event in events {
+            let destination: EventDestination = configs?[event.stream]?.destination_event_service == "eventgate-logging-external" ? .logging : .analytics
+            if grouped[destination] == nil {
+                destinationsInOrder.append(destination)
+            }
+            grouped[destination, default: []].append(event)
+        }
+
+        var batches: [EventBatch] = []
+        for destination in destinationsInOrder {
+            guard let destinationEvents = grouped[destination] else {
+                continue
+            }
+            var start = 0
+            while start < destinationEvents.count {
+                let end = min(start + size, destinationEvents.count)
+                batches.append(EventBatch(destination: destination, events: Array(destinationEvents[start..<end])))
+                start = end
+            }
+        }
+        return batches
+    }
+
+    /**
+     * Joins already-encoded event objects into a JSON array body without re-decoding them.
+     * Every stored blob is a complete JSON object produced by JSONEncoder, and JSON is
+     * whitespace-tolerant, so pretty-printed DEBUG blobs concatenate correctly too.
+     */
+    static func encodeBatchBody(_ datas: [Data]) -> Data {
+        var body = Data("[".utf8)
+        for (index, data) in datas.enumerated() {
+            if index > 0 {
+                body.append(UInt8(ascii: ","))
+            }
+            body.append(data)
+        }
+        body.append(UInt8(ascii: "]"))
+        return body
+    }
+
+    private static func intakeURI(for destination: EventDestination, hasty: Bool) -> URL {
+        var uri: URL
+        switch destination {
+        case .analytics:
+            uri = analyticsEventIntakeURI
+        case .logging:
+            uri = loggingEventIntakeURI
+        }
+        if hasty {
+            uri.append(queryItems: [URLQueryItem(name: "hasty", value: "true")])
+        }
+        return uri
+    }
+
+    /// Shared send path for `flushStoredEvents` and `postAllScheduled`: pops all pending
+    /// events and sends one POST per destination-sized batch instead of one per event.
+    private func postStoredEvents(hasty: Bool, completion: (() -> Void)?) {
         guard let storageManager = self.storageManager else {
             completion?()
             return
@@ -412,82 +513,39 @@ import WMFTestKitchen
             return
         }
 
-        let group = DispatchGroup()
-
-        for event in events {
-            group.enter()
-            
-            var uri = EventPlatformClient.analyticsEventIntakeURI
-            if streamConfigurations?[event.stream]?.destination_event_service == "eventgate-logging-external" {
-                uri = EventPlatformClient.loggingEventIntakeURI
-            }
-            
-            httpPost(url: uri, body: event.data) { [weak storageManager] result in
-                defer { group.leave() }
-                switch result {
-                case .success:
-                    storageManager?.markPurgeable(event: event)
-                case .failure(let error):
-                    switch error {
-                    case .networkingLibraryError:
-                        break // leave in store to retry
-                    default:
-                        storageManager?.markPurgeable(event: event)
-                    }
-                }
-            }
-        }
-
-        group.notify(queue: queue) {
-            completion?()
-        }
-    }
-
-    /**
-     * Flush the queue of outgoing requests in a first-in-first-out,
-     * fire-and-forget fashion
-     */
-    func postAllScheduled(_ completion: (() -> Void)? = nil) {
-        guard let storageManager = self.storageManager else {
-            completion?()
-            return
-        }
-
-        let events = storageManager.popAll()
-        if events.count == 0 {
-            completion?()
-            return
-        }
-
         DDLogDebug("EPC: Processing all scheduled requests")
+        let batches = Self.makeBatches(events: events, configs: streamConfigurations, chunkSize: Self.batchChunkSize)
         let group = DispatchGroup()
-        for event in events {
+        for batch in batches {
             group.enter()
 
-            var uri = EventPlatformClient.analyticsEventIntakeURI
-            if streamConfigurations?[event.stream]?.destination_event_service == "eventgate-logging-external" {
-                uri = EventPlatformClient.loggingEventIntakeURI
-            }
-            
-            #if !DEBUG
-            uri.append(queryItems: [URLQueryItem(name: "hasty", value: "true")])
-            #endif
-
-            httpPost(url: uri, body: event.data) { result in
+            let uri = Self.intakeURI(for: batch.destination, hasty: hasty)
+            httpPost(url: uri, body: Self.encodeBatchBody(batch.events.map(\.data))) { result in
                 switch result {
                 case .success:
-                    storageManager.markPurgeable(event: event)
-                    break
+                    for event in batch.events {
+                        storageManager.markPurgeable(event: event)
+                    }
                 case .failure(let error):
                     switch error {
                     case .networkingLibraryError:
                         /// Leave unmarked to retry on networking library failure
                         break
+                    case .unexpectedResponse(let statusCode) where statusCode == 207:
+                        /// Partial success: the server ingested the valid events and rejected
+                        /// the rest. Rejected (schema-invalid) events would never become valid,
+                        /// so the whole batch is done — matching the legacy per-event behavior
+                        /// of dropping server-rejected events.
+                        DDLogError("EPC: The analytics service reported partial failure (207) for a batch of \(batch.events.count) events. Invalid events were dropped by the server.")
+                        for event in batch.events {
+                            storageManager.markPurgeable(event: event)
+                        }
                     default:
-                        /// Give up on events rejected by the server
-                        DDLogError("EPC: The analytics service failed to process an event. A response code of 400 could indicate that the event didn't conform to provided schema. Check the error for more information.: \(error)")
-                        storageManager.markPurgeable(event: event)
-                        break
+                        /// The array as a whole was rejected — possibly poisoned by a single
+                        /// malformed blob. Retry the events individually, once, so one bad
+                        /// event only loses itself.
+                        DDLogError("EPC: A batch of \(batch.events.count) events was rejected (\(error)). Retrying events individually.")
+                        self.postIndividually(batch.events, uri: uri, group: group, storageManager: storageManager)
                     }
                 }
                 group.leave()
@@ -497,7 +555,32 @@ import WMFTestKitchen
             completion?()
         }
     }
-    
+
+    /// One-pass fallback used when a whole batch is rejected: the legacy per-event send,
+    /// purging on any server response and retaining only on networking errors.
+    private func postIndividually(_ events: [PersistedEvent], uri: URL, group: DispatchGroup, storageManager: StorageManager) {
+        for event in events {
+            group.enter()
+            httpPost(url: uri, body: event.data) { result in
+                switch result {
+                case .success:
+                    storageManager.markPurgeable(event: event)
+                case .failure(let error):
+                    switch error {
+                    case .networkingLibraryError:
+                        /// Leave unmarked to retry on networking library failure
+                        break
+                    default:
+                        /// Give up on events rejected by the server
+                        DDLogError("EPC: The analytics service failed to process an event. A response code of 400 could indicate that the event didn't conform to provided schema. Check the error for more information.: \(error)")
+                        storageManager.markPurgeable(event: event)
+                    }
+                }
+                group.leave()
+            }
+        }
+    }
+
     /// Codable struct of additional metadata, embedded in the structure of EventBody and MinimalEventBody.
     struct Meta: Codable {
         let stream: Stream
@@ -796,7 +879,7 @@ private extension EventPlatformClient {
     enum PostEventError: Error {
         case networkingLibraryError(_ error: Error)
         case missingResponse
-        case unexepectedResponse(_ httpCode: Int)
+        case unexpectedResponse(_ httpCode: Int)
     }
     
     /**
@@ -821,7 +904,7 @@ private extension EventPlatformClient {
                 return
             }
             guard httpResponse.statusCode == 201 || httpResponse.statusCode == 202 else {
-                fail(PostEventError.unexepectedResponse(httpResponse.statusCode))
+                fail(PostEventError.unexpectedResponse(httpResponse.statusCode))
                 return
             }
             completion(.success(()))

--- a/WMF Framework/Event Platform/EventPlatformClient.swift
+++ b/WMF Framework/Event Platform/EventPlatformClient.swift
@@ -273,10 +273,25 @@ import WMFTestKitchen
 
     // MARK: - Methods
 
+    /// On-disk copy of the last stream configuration response, shared across processes via
+    /// the app-group container so widget/extension processes never need to fetch it.
+    private struct CachedStreamConfigResponse: Codable {
+        let fetchDate: Date
+        let data: Data
+    }
+
+    /// How long a cached stream configuration response stays fresh enough to skip the
+    /// per-launch network refresh. Config changes deploy on a roughly daily cadence.
+    private static let streamConfigCacheMaxAge: TimeInterval = 60 * 60 * 24
+
+    private static var streamConfigCache: SharedContainerCache {
+        SharedContainerCache(fileName: SharedContainerCacheCommonNames.streamConfigCache)
+    }
+
     public override init() {
         self.storageManager = StorageManager.shared
         self.samplingController = SamplingController()
-        
+
         super.init()
 
         self.samplingController.delegate = self
@@ -286,7 +301,27 @@ import WMFTestKitchen
             return
         }
 
-        self.fetchStreamConfiguration(retries: 10, retryDelay: 30)
+        let cachedResponse: CachedStreamConfigResponse? = Self.streamConfigCache.loadCache()
+        if let cachedResponse {
+            DDLogDebug("EPC: Loading stream configs from shared cache (fetched \(cachedResponse.fetchDate))")
+            self.loadStreamConfiguration(cachedResponse.data)
+        }
+
+        guard !Bundle.main.isAppExtension else {
+            /// Extensions rely on the cache the main app maintains. A widget process is
+            /// short-lived and about to be suspended — a retrying fetch of the
+            /// rate-limited streamconfigs MediaWiki API there is wasted traffic.
+            return
+        }
+
+        if let cachedResponse {
+            let cacheAge = Date().timeIntervalSince(cachedResponse.fetchDate)
+            if cacheAge >= 0 && cacheAge < Self.streamConfigCacheMaxAge {
+                return
+            }
+        }
+
+        self.fetchStreamConfiguration(retries: 2, retryDelay: 30)
     }
 
 
@@ -313,7 +348,7 @@ import WMFTestKitchen
                 return
             }
 
-            self.loadStreamConfiguration(data)
+            self.loadStreamConfiguration(data, persistToSharedCache: true)
         })
     }
 
@@ -335,7 +370,7 @@ import WMFTestKitchen
      * }
      * ```
      */
-    private func loadStreamConfiguration(_ data: Data) {
+    private func loadStreamConfiguration(_ data: Data, persistToSharedCache: Bool = false) {
         #if DEBUG
         if String.init(data: data, encoding: String.Encoding.utf8) != nil {
             DDLogDebug("EPC: Downloaded stream configs (line break here to read raw configs)")
@@ -350,6 +385,12 @@ import WMFTestKitchen
         }
         do {
             let json = try JSONDecoder().decode(StreamConfigurationsJSON.self, from: data)
+
+            /// Persist only network responses that decoded successfully, so a bad payload
+            /// can never poison the cross-process cache. Cache replays never re-persist.
+            if persistToSharedCache {
+                Self.streamConfigCache.saveCache(CachedStreamConfigResponse(fetchDate: Date(), data: data))
+            }
 
             // Make them available to any newly logged events before flushing
             // buffer (this is set using serial queue but asynchronously)

--- a/WMF Framework/SharedContainerCache.swift
+++ b/WMF Framework/SharedContainerCache.swift
@@ -5,6 +5,7 @@ import Foundation
     @objc public static let talkPageCache = "Talk Page Cache"
     public static let widgetCache = "Widget Cache"
     @objc public static let didYouKnowCache = "Did You Know Cache"
+    public static let streamConfigCache = "Stream Config Cache"
 }
 
 public final class SharedContainerCache: SharedContainerCacheHousekeepingProtocol {

--- a/WMF Framework/TestKitchenAdapter.swift
+++ b/WMF Framework/TestKitchenAdapter.swift
@@ -120,23 +120,18 @@ import CocoaLumberjackSwift
     // MARK: - EventSender
 
     public func sendEvents(_ events: [Event]) {
-        guard let storageManager = EventPlatformClient.shared.storageManager else {
-            DDLogError("TestKitchenAdapter: StorageManager unavailable")
-            return
-        }
-        
         let encoder = JSONEncoder()
         for event in events {
-            
+
 #if DEBUG
             encoder.outputFormatting = .prettyPrinted
 #endif
-            
+
             guard let data = try? encoder.encode(event) else {
                 DDLogError("TestKitchenAdapter: Failed to encode event")
                 continue
             }
-            
+
 #if DEBUG
             // Convert to loose dictionary so we can sort keys and print that way.
             if let dict = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
@@ -145,8 +140,11 @@ import CocoaLumberjackSwift
                 print("\(printablePayload)")
             }
 #endif
-            
-            storageManager.push(data: data, stream: .productMetricsAppBase)
+
+            /// Submitting through the client (rather than pushing straight to storage)
+            /// applies the stream's sampling configuration to TestKitchen events and
+            /// buffers them while stream configs are still loading on a first launch.
+            EventPlatformClient.shared.submitPreEncoded(data: data, stream: .productMetricsAppBase)
         }
     }
 }

--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
@@ -35,6 +35,16 @@ struct WMFDeveloperSettingsView: View {
                 }
             }
 
+            Section(header: Text("Event Logging")) {
+                Text(viewModel.eventLoggingDiagnosticsText)
+                    .font(.footnote.monospaced())
+                Button {
+                    viewModel.resetEventLoggingDiagnostics()
+                } label: {
+                    Text("Reset counters")
+                }
+            }
+
             ForEach(viewModel.formViewModel.sections) { section in
                 if let selectSection = section as? WMFFormSectionSelectViewModel {
                     WMFFormSectionSelectView(viewModel: selectSection)
@@ -44,5 +54,8 @@ struct WMFDeveloperSettingsView: View {
         }
         .listStyle(InsetGroupedListStyle())
         .listBackgroundColor(Color(theme.baseBackground))
+        .onAppear {
+            viewModel.refreshEventLoggingDiagnostics()
+        }
     }
 }

--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -114,6 +114,32 @@ import WMFData
             .store(in: &subscribers)
     }
 
+    @Published public var eventLoggingDiagnosticsText: String = ""
+
+    public func refreshEventLoggingDiagnostics() {
+        let diagnostics = WMFEventLoggingDiagnosticsDataController.shared.snapshot()
+
+        var lines: [String] = [
+            "Flushes: \(diagnostics.flushCount)",
+            "POST requests: \(diagnostics.postCount)",
+            "Events sent: \(diagnostics.eventsSentCount)",
+            "Events in last flush: \(diagnostics.eventsInLastFlush)"
+        ]
+        if let lastFlushDate = diagnostics.lastFlushDate {
+            lines.append("Last flush: \(lastFlushDate.formatted(date: .omitted, time: .standard))")
+        }
+        if !diagnostics.dropCounts.isEmpty {
+            let drops = diagnostics.dropCounts.sorted { $0.key < $1.key }.map { "\($0.key): \($0.value)" }
+            lines.append("Drops — " + drops.joined(separator: ", "))
+        }
+        eventLoggingDiagnosticsText = lines.joined(separator: "\n")
+    }
+
+    public func resetEventLoggingDiagnostics() {
+        WMFEventLoggingDiagnosticsDataController.shared.reset()
+        refreshEventLoggingDiagnostics()
+    }
+
     public func clearGamesPersistence() {
         Task {
             try? await WMFDeveloperSettingsDataController.shared.clearGamesPersistence()

--- a/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFEventLoggingDiagnosticsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFEventLoggingDiagnosticsDataController.swift
@@ -1,0 +1,80 @@
+import Foundation
+import os
+
+/// Counters describing the event-logging pipeline's request and drop behavior,
+/// surfaced in developer settings so intake traffic is measurable.
+public struct WMFEventLoggingDiagnostics: Codable, Sendable {
+    public var flushCount: Int = 0
+    public var postCount: Int = 0
+    public var eventsSentCount: Int = 0
+    public var eventsInLastFlush: Int = 0
+    public var dropCounts: [String: Int] = [:]
+    public var lastFlushDate: Date?
+
+    public init() {
+    }
+}
+
+public enum WMFEventDropReason: String, Sendable {
+    case serverRejected = "server-rejected"
+    case errorThrottled = "error-throttled"
+    case notInSample = "not-in-sample"
+    case unconfiguredStream = "unconfigured-stream"
+    case inputBufferOverflow = "input-buffer-overflow"
+}
+
+/// Records and reads the event-logging diagnostics counters. Increments arrive from
+/// GCD callbacks and background threads in the event pipeline, so the read-modify-write
+/// is guarded by a lock rather than an actor — every call site is synchronous, and a
+/// counter must never make the pipeline hop or wait. Failures to persist are swallowed:
+/// diagnostics must never affect event sending.
+public final class WMFEventLoggingDiagnosticsDataController: Sendable {
+
+    public static let shared = WMFEventLoggingDiagnosticsDataController()
+
+    private let lock = OSAllocatedUnfairLock()
+
+    private var userDefaultsStore: WMFKeyValueStore? {
+        WMFDataEnvironment.current.userDefaultsStore
+    }
+
+    public func recordFlush(posts: Int, events: Int) {
+        mutate { diagnostics in
+            diagnostics.flushCount += 1
+            diagnostics.postCount += posts
+            diagnostics.eventsSentCount += events
+            diagnostics.eventsInLastFlush = events
+            diagnostics.lastFlushDate = Date()
+        }
+    }
+
+    public func recordDrop(reason: WMFEventDropReason, count: Int = 1) {
+        mutate { diagnostics in
+            diagnostics.dropCounts[reason.rawValue, default: 0] += count
+        }
+    }
+
+    public func snapshot() -> WMFEventLoggingDiagnostics {
+        return lock.withLock {
+            return load()
+        }
+    }
+
+    public func reset() {
+        lock.withLock {
+            try? userDefaultsStore?.remove(key: WMFUserDefaultsKey.eventLoggingDiagnostics.rawValue)
+        }
+    }
+
+    private func load() -> WMFEventLoggingDiagnostics {
+        return (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.eventLoggingDiagnostics.rawValue)) ?? WMFEventLoggingDiagnostics()
+    }
+
+    private func mutate(_ block: (inout WMFEventLoggingDiagnostics) -> Void) {
+        lock.withLock {
+            var diagnostics = load()
+            block(&diagnostics)
+            try? userDefaultsStore?.save(key: WMFUserDefaultsKey.eventLoggingDiagnostics.rawValue, value: diagnostics)
+        }
+    }
+}

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -59,6 +59,7 @@ public enum WMFUserDefaultsKey: String {
     // Logging
     case appInstallID = "wmf-app-install-id"
     case sessionID = "wmf-session-id"
+    case eventLoggingDiagnostics = "event-logging-diagnostics"
 
     // Home feed: Community modules
     case homeFeedCommunityFeaturedArticleIsOn = "home-feed-community-featured-article-is-on"

--- a/WMFData/Tests/WMFDataTests/WMFEventLoggingDiagnosticsDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFEventLoggingDiagnosticsDataControllerTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+import WMFDataTestSupport
+@testable import WMFData
+@testable import WMFDataMocks
+
+@Suite(.serialized)
+final class WMFEventLoggingDiagnosticsDataControllerTests {
+
+    private let fixture = WMFDataTestFixture()
+
+    @Test
+    func recordFlushAccumulates() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let controller = WMFEventLoggingDiagnosticsDataController.shared
+            controller.reset()
+
+            controller.recordFlush(posts: 2, events: 40)
+            controller.recordFlush(posts: 1, events: 9)
+
+            let diagnostics = controller.snapshot()
+            #expect(diagnostics.flushCount == 2)
+            #expect(diagnostics.postCount == 3)
+            #expect(diagnostics.eventsSentCount == 49)
+            #expect(diagnostics.eventsInLastFlush == 9)
+            #expect(diagnostics.lastFlushDate != nil)
+        }
+    }
+
+    @Test
+    func recordDropCountsByReason() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let controller = WMFEventLoggingDiagnosticsDataController.shared
+            controller.reset()
+
+            controller.recordDrop(reason: .notInSample)
+            controller.recordDrop(reason: .notInSample)
+            controller.recordDrop(reason: .errorThrottled, count: 3)
+
+            let diagnostics = controller.snapshot()
+            #expect(diagnostics.dropCounts[WMFEventDropReason.notInSample.rawValue] == 2)
+            #expect(diagnostics.dropCounts[WMFEventDropReason.errorThrottled.rawValue] == 3)
+            #expect(diagnostics.dropCounts[WMFEventDropReason.serverRejected.rawValue] == nil)
+        }
+    }
+
+    @Test
+    func resetClearsEverything() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let controller = WMFEventLoggingDiagnosticsDataController.shared
+            controller.recordFlush(posts: 1, events: 5)
+            controller.recordDrop(reason: .serverRejected)
+
+            controller.reset()
+
+            let diagnostics = controller.snapshot()
+            #expect(diagnostics.flushCount == 0)
+            #expect(diagnostics.postCount == 0)
+            #expect(diagnostics.eventsSentCount == 0)
+            #expect(diagnostics.dropCounts.isEmpty)
+            #expect(diagnostics.lastFlushDate == nil)
+        }
+    }
+
+    @Test
+    func concurrentIncrementsAreNotLost() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let controller = WMFEventLoggingDiagnosticsDataController.shared
+            controller.reset()
+
+            await withTaskGroup(of: Void.self) { group in
+                for _ in 0..<50 {
+                    group.addTask {
+                        controller.recordDrop(reason: .notInSample)
+                    }
+                }
+            }
+
+            let diagnostics = controller.snapshot()
+            #expect(diagnostics.dropCounts[WMFEventDropReason.notInSample.rawValue] == 50)
+        }
+    }
+
+    @Test
+    func aMissingStoreNeverThrows() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureMissingStoreEnvironment) {
+            let controller = WMFEventLoggingDiagnosticsDataController.shared
+            controller.recordFlush(posts: 1, events: 1)
+            controller.recordDrop(reason: .serverRejected)
+            controller.reset()
+
+            let diagnostics = controller.snapshot()
+            #expect(diagnostics.flushCount == 0)
+        }
+    }
+
+    private func configureEnvironment() async {
+        WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
+    }
+
+    private func configureMissingStoreEnvironment() async {
+        WMFDataEnvironment.current.userDefaultsStore = nil
+    }
+}

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -695,6 +695,7 @@
 		679E6FA72C44537B00B6E9F1 /* WMFBarButtonItemPopoverMessageViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679E6FA52C44537B00B6E9F1 /* WMFBarButtonItemPopoverMessageViewController+Extensions.swift */; };
 		679E6FA82C44537B00B6E9F1 /* WMFBarButtonItemPopoverMessageViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679E6FA52C44537B00B6E9F1 /* WMFBarButtonItemPopoverMessageViewController+Extensions.swift */; };
 		679F0AAD24574AD400EF4A6A /* ArticleViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679F0AAC24574AD400EF4A6A /* ArticleViewControllerTests.swift */; };
+		A7E1B47C2E4C000000000002 /* EventPlatformBatchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E1B47C2E4C000000000001 /* EventPlatformBatchingTests.swift */; };
 		679F0AAF24574AD400EF4A6A /* MockSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679F0AAE24574AD400EF4A6A /* MockSchemeHandler.swift */; };
 		67A0699E2D417C4A00290D70 /* UIViewController+ProfileButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A0699D2D417C4000290D70 /* UIViewController+ProfileButton.swift */; };
 		67A0699F2D417C4A00290D70 /* UIViewController+ProfileButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A0699D2D417C4000290D70 /* UIViewController+ProfileButton.swift */; };
@@ -3297,6 +3298,7 @@
 		679DEF002F621D8E00B21570 /* TestKitchenLogAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestKitchenLogAdapter.swift; sourceTree = "<group>"; };
 		679E6FA52C44537B00B6E9F1 /* WMFBarButtonItemPopoverMessageViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WMFBarButtonItemPopoverMessageViewController+Extensions.swift"; sourceTree = "<group>"; };
 		679F0AAC24574AD400EF4A6A /* ArticleViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleViewControllerTests.swift; sourceTree = "<group>"; };
+		A7E1B47C2E4C000000000001 /* EventPlatformBatchingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPlatformBatchingTests.swift; sourceTree = "<group>"; };
 		679F0AAE24574AD400EF4A6A /* MockSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSchemeHandler.swift; sourceTree = "<group>"; };
 		67A0699D2D417C4000290D70 /* UIViewController+ProfileButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+ProfileButton.swift"; sourceTree = "<group>"; };
 		67A417DF2FBFD9E100C0DE01 /* ArticleImageGalleryUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleImageGalleryUITests.swift; sourceTree = "<group>"; };
@@ -5887,6 +5889,7 @@
 			children = (
 				D17F65B649B1404086AB3BE8 /* ArticlePeekPreviewViewControllerTests.swift */,
 				679F0AAC24574AD400EF4A6A /* ArticleViewControllerTests.swift */,
+				A7E1B47C2E4C000000000001 /* EventPlatformBatchingTests.swift */,
 				AD82B5752FC0D83F00F310B2 /* ArticlePreviewingDelegateMock.swift */,
 				679F0AAE24574AD400EF4A6A /* MockSchemeHandler.swift */,
 			);
@@ -9400,6 +9403,7 @@
 				B0D530EB1CE151C10078BAED /* CodeFileLocationTests.m in Sources */,
 				E446C3D95A844026889BE43A /* ArticlePeekPreviewViewControllerTests.swift in Sources */,
 				679F0AAD24574AD400EF4A6A /* ArticleViewControllerTests.swift in Sources */,
+				A7E1B47C2E4C000000000002 /* EventPlatformBatchingTests.swift in Sources */,
 				679F0AAF24574AD400EF4A6A /* MockSchemeHandler.swift in Sources */,
 				D864D68C1DA3EA3800B86934 /* NumberFormatterExtrasTests.swift in Sources */,
 				D8A3C8F22FBB000100E6073C /* UserDefaultsThemeTests.swift in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -696,6 +696,7 @@
 		679E6FA82C44537B00B6E9F1 /* WMFBarButtonItemPopoverMessageViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679E6FA52C44537B00B6E9F1 /* WMFBarButtonItemPopoverMessageViewController+Extensions.swift */; };
 		679F0AAD24574AD400EF4A6A /* ArticleViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679F0AAC24574AD400EF4A6A /* ArticleViewControllerTests.swift */; };
 		A7E1B47C2E4C000000000002 /* EventPlatformBatchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E1B47C2E4C000000000001 /* EventPlatformBatchingTests.swift */; };
+		A7E1B47C2E4C000000000004 /* ClientErrorFunnelThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E1B47C2E4C000000000003 /* ClientErrorFunnelThrottleTests.swift */; };
 		679F0AAF24574AD400EF4A6A /* MockSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679F0AAE24574AD400EF4A6A /* MockSchemeHandler.swift */; };
 		67A0699E2D417C4A00290D70 /* UIViewController+ProfileButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A0699D2D417C4000290D70 /* UIViewController+ProfileButton.swift */; };
 		67A0699F2D417C4A00290D70 /* UIViewController+ProfileButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A0699D2D417C4000290D70 /* UIViewController+ProfileButton.swift */; };
@@ -3299,6 +3300,7 @@
 		679E6FA52C44537B00B6E9F1 /* WMFBarButtonItemPopoverMessageViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WMFBarButtonItemPopoverMessageViewController+Extensions.swift"; sourceTree = "<group>"; };
 		679F0AAC24574AD400EF4A6A /* ArticleViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleViewControllerTests.swift; sourceTree = "<group>"; };
 		A7E1B47C2E4C000000000001 /* EventPlatformBatchingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPlatformBatchingTests.swift; sourceTree = "<group>"; };
+		A7E1B47C2E4C000000000003 /* ClientErrorFunnelThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientErrorFunnelThrottleTests.swift; sourceTree = "<group>"; };
 		679F0AAE24574AD400EF4A6A /* MockSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSchemeHandler.swift; sourceTree = "<group>"; };
 		67A0699D2D417C4000290D70 /* UIViewController+ProfileButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+ProfileButton.swift"; sourceTree = "<group>"; };
 		67A417DF2FBFD9E100C0DE01 /* ArticleImageGalleryUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleImageGalleryUITests.swift; sourceTree = "<group>"; };
@@ -5890,6 +5892,7 @@
 				D17F65B649B1404086AB3BE8 /* ArticlePeekPreviewViewControllerTests.swift */,
 				679F0AAC24574AD400EF4A6A /* ArticleViewControllerTests.swift */,
 				A7E1B47C2E4C000000000001 /* EventPlatformBatchingTests.swift */,
+				A7E1B47C2E4C000000000003 /* ClientErrorFunnelThrottleTests.swift */,
 				AD82B5752FC0D83F00F310B2 /* ArticlePreviewingDelegateMock.swift */,
 				679F0AAE24574AD400EF4A6A /* MockSchemeHandler.swift */,
 			);
@@ -9404,6 +9407,7 @@
 				E446C3D95A844026889BE43A /* ArticlePeekPreviewViewControllerTests.swift in Sources */,
 				679F0AAD24574AD400EF4A6A /* ArticleViewControllerTests.swift in Sources */,
 				A7E1B47C2E4C000000000002 /* EventPlatformBatchingTests.swift in Sources */,
+				A7E1B47C2E4C000000000004 /* ClientErrorFunnelThrottleTests.swift in Sources */,
 				679F0AAF24574AD400EF4A6A /* MockSchemeHandler.swift in Sources */,
 				D864D68C1DA3EA3800B86934 /* NumberFormatterExtrasTests.swift in Sources */,
 				D8A3C8F22FBB000100E6073C /* UserDefaultsThemeTests.swift in Sources */,

--- a/Wikipedia/Code/ClientErrorFunnel.swift
+++ b/Wikipedia/Code/ClientErrorFunnel.swift
@@ -102,6 +102,7 @@ struct ClientErrorThrottle {
 
     func logEvent(message: String?) {
         guard throttle.withLock({ $0.shouldLog(errorClass: "message", urlString: nil, statusCode: nil) }) else {
+            WMFEventLoggingDiagnosticsDataController.shared.recordDrop(reason: .errorThrottled)
             return
         }
 
@@ -127,6 +128,7 @@ struct ClientErrorThrottle {
         }
 
         guard throttle.withLock({ $0.shouldLog(errorClass: info.source, urlString: info.url, statusCode: info.statusCode) }) else {
+            WMFEventLoggingDiagnosticsDataController.shared.recordDrop(reason: .errorThrottled)
             return
         }
 

--- a/Wikipedia/Code/ClientErrorFunnel.swift
+++ b/Wikipedia/Code/ClientErrorFunnel.swift
@@ -1,12 +1,75 @@
 import Foundation
 import WMF
 import WMFData
+import os
 
-// Stateless — no stored properties, and EventPlatformClient.submit handles its
-// own synchronization — so it is safe to use from any thread.
+/// Sliding-window throttle for client-error events, so an outage or a rate-limiting
+/// spike can't multiply our own analytics traffic. Pure value type with an injectable
+/// clock; all synchronization happens in the funnel's lock.
+struct ClientErrorThrottle {
+    /// Maximum events per (error class, host, status class) key per window.
+    static let maxEventsPerKeyPerWindow = 5
+    /// 429s get one event per host per window: a rate-limited host must not receive
+    /// an error-event stampede about being rate limited.
+    static let maxRateLimitEventsPerHostPerWindow = 1
+    static let windowDuration: TimeInterval = 600
+
+    struct Key: Hashable {
+        let errorClass: String
+        let host: String
+        let statusCodeClass: Int
+    }
+
+    private struct WindowState {
+        var windowStart: Date
+        var count: Int
+    }
+
+    private var windows: [Key: WindowState] = [:]
+    private var rateLimitWindows: [String: WindowState] = [:]
+
+    /// Returns whether an error event with these attributes may be logged, counting it
+    /// against its window if so.
+    mutating func shouldLog(errorClass: String?, urlString: String?, statusCode: Int?, now: Date = Date()) -> Bool {
+        let host = urlString.flatMap { URL(string: $0)?.host } ?? "unknown"
+        prune(now: now)
+
+        if statusCode == 429 {
+            return Self.admit(&rateLimitWindows, key: host, limit: Self.maxRateLimitEventsPerHostPerWindow, now: now)
+        }
+
+        let key = Key(errorClass: errorClass ?? "unknown", host: host, statusCodeClass: (statusCode ?? 0) / 100)
+        return Self.admit(&windows, key: key, limit: Self.maxEventsPerKeyPerWindow, now: now)
+    }
+
+    private static func admit<K: Hashable>(_ table: inout [K: WindowState], key: K, limit: Int, now: Date) -> Bool {
+        if var state = table[key], now.timeIntervalSince(state.windowStart) < Self.windowDuration {
+            guard state.count < limit else {
+                return false
+            }
+            state.count += 1
+            table[key] = state
+            return true
+        }
+        table[key] = WindowState(windowStart: now, count: 1)
+        return true
+    }
+
+    /// Bounds memory by dropping expired windows whenever a new event arrives.
+    private mutating func prune(now: Date) {
+        windows = windows.filter { now.timeIntervalSince($0.value.windowStart) < Self.windowDuration }
+        rateLimitWindows = rateLimitWindows.filter { now.timeIntervalSince($0.value.windowStart) < Self.windowDuration }
+    }
+}
+
+// @unchecked because NSObject is not Sendable; the only mutable state is the
+// throttle, which is guarded by its lock, and EventPlatformClient.submit handles
+// its own synchronization — so it is safe to use from any thread.
 @objc(WMFClientErrorFunnel) public final class ClientErrorFunnel: NSObject, @unchecked Sendable {
 
     @objc public static let shared = ClientErrorFunnel()
+
+    private let throttle = OSAllocatedUnfairLock(initialState: ClientErrorThrottle())
 
     private struct Event: EventInterface {
         static let schema: EventPlatformClient.Schema = .clientError
@@ -38,6 +101,10 @@ import WMFData
     }
 
     func logEvent(message: String?) {
+        guard throttle.withLock({ $0.shouldLog(errorClass: "message", urlString: nil, statusCode: nil) }) else {
+            return
+        }
+
         let event: ClientErrorFunnel.Event = ClientErrorFunnel.Event(
             message: message,
             errorClass: nil,
@@ -56,6 +123,10 @@ import WMFData
         // currently bypass the hooks that call this method; this guard makes sure
         // the loop can't be closed by accident later.
         if let url = info.url, url.contains("intake-analytics") || url.contains("intake-logging") {
+            return
+        }
+
+        guard throttle.withLock({ $0.shouldLog(errorClass: info.source, urlString: info.url, statusCode: info.statusCode) }) else {
             return
         }
 

--- a/WikipediaUnitTests/Code/ClientErrorFunnelThrottleTests.swift
+++ b/WikipediaUnitTests/Code/ClientErrorFunnelThrottleTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import WMF
+
+final class ClientErrorFunnelThrottleTests: XCTestCase {
+
+    private var now: Date!
+
+    override func setUp() {
+        super.setUp()
+        now = Date(timeIntervalSince1970: 1_756_000_000)
+    }
+
+    func testAllowsUpToCapPerKeyPerWindow() {
+        var throttle = ClientErrorThrottle()
+        for i in 0..<ClientErrorThrottle.maxEventsPerKeyPerWindow {
+            XCTAssertTrue(throttle.shouldLog(errorClass: "Session", urlString: "https://en.wikipedia.org/w/api.php", statusCode: 500, now: now), "event \(i) should be admitted")
+        }
+        XCTAssertFalse(throttle.shouldLog(errorClass: "Session", urlString: "https://en.wikipedia.org/w/api.php", statusCode: 500, now: now))
+    }
+
+    func testKeysAreIndependent() {
+        var throttle = ClientErrorThrottle()
+        for _ in 0..<ClientErrorThrottle.maxEventsPerKeyPerWindow {
+            XCTAssertTrue(throttle.shouldLog(errorClass: "Session", urlString: "https://en.wikipedia.org/w/api.php", statusCode: 500, now: now))
+        }
+        // Different host, error class, or status class each get their own window
+        XCTAssertTrue(throttle.shouldLog(errorClass: "Session", urlString: "https://de.wikipedia.org/w/api.php", statusCode: 500, now: now))
+        XCTAssertTrue(throttle.shouldLog(errorClass: "WMFBasicService", urlString: "https://en.wikipedia.org/w/api.php", statusCode: 500, now: now))
+        XCTAssertTrue(throttle.shouldLog(errorClass: "Session", urlString: "https://en.wikipedia.org/w/api.php", statusCode: 404, now: now))
+    }
+
+    func testWindowExpiryResetsTheCount() {
+        var throttle = ClientErrorThrottle()
+        for _ in 0..<ClientErrorThrottle.maxEventsPerKeyPerWindow {
+            XCTAssertTrue(throttle.shouldLog(errorClass: "Session", urlString: "https://en.wikipedia.org/w/api.php", statusCode: 500, now: now))
+        }
+        XCTAssertFalse(throttle.shouldLog(errorClass: "Session", urlString: "https://en.wikipedia.org/w/api.php", statusCode: 500, now: now))
+
+        let afterWindow = now.addingTimeInterval(ClientErrorThrottle.windowDuration + 1)
+        XCTAssertTrue(throttle.shouldLog(errorClass: "Session", urlString: "https://en.wikipedia.org/w/api.php", statusCode: 500, now: afterWindow))
+    }
+
+    func testRateLimitResponsesCapAtOnePerHostRegardlessOfErrorClass() {
+        var throttle = ClientErrorThrottle()
+        XCTAssertTrue(throttle.shouldLog(errorClass: "Session", urlString: "https://en.wikipedia.org/w/api.php", statusCode: 429, now: now))
+        XCTAssertFalse(throttle.shouldLog(errorClass: "Session", urlString: "https://en.wikipedia.org/w/api.php", statusCode: 429, now: now))
+        XCTAssertFalse(throttle.shouldLog(errorClass: "WMFBasicService", urlString: "https://en.wikipedia.org/w/rest.php", statusCode: 429, now: now))
+
+        // A different host gets its own 429 budget
+        XCTAssertTrue(throttle.shouldLog(errorClass: "Session", urlString: "https://commons.wikimedia.org/w/api.php", statusCode: 429, now: now))
+
+        // Non-429 errors from the same host are unaffected by the 429 budget
+        XCTAssertTrue(throttle.shouldLog(errorClass: "Session", urlString: "https://en.wikipedia.org/w/api.php", statusCode: 500, now: now))
+    }
+
+    func testMissingURLAndStatusStillThrottles() {
+        var throttle = ClientErrorThrottle()
+        for _ in 0..<ClientErrorThrottle.maxEventsPerKeyPerWindow {
+            XCTAssertTrue(throttle.shouldLog(errorClass: nil, urlString: nil, statusCode: nil, now: now))
+        }
+        XCTAssertFalse(throttle.shouldLog(errorClass: nil, urlString: nil, statusCode: nil, now: now))
+    }
+}

--- a/WikipediaUnitTests/Code/EventPlatformBatchingTests.swift
+++ b/WikipediaUnitTests/Code/EventPlatformBatchingTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import WMF
+
+final class EventPlatformBatchingTests: XCTestCase {
+
+    private typealias Stream = EventPlatformClient.Stream
+    private typealias StreamConfiguration = EventPlatformClient.StreamConfiguration
+
+    private func makeEvent(stream: Stream, json: String = "{\"test\":true}", index: Int = 0) -> PersistedEvent {
+        return PersistedEvent(data: Data(json.utf8), stream: stream, managedObjectURI: URL(string: "x-coredata://test/WMFEPEventRecord/p\(index)")!)
+    }
+
+    private func makeConfigs(loggingStreams: [Stream]) -> [Stream: StreamConfiguration] {
+        var configs: [Stream: StreamConfiguration] = [
+            .search: StreamConfiguration(destination_event_service: "eventgate-analytics-external", sampling: nil),
+            .sessions: StreamConfiguration(destination_event_service: "eventgate-analytics-external", sampling: nil)
+        ]
+        for stream in loggingStreams {
+            configs[stream] = StreamConfiguration(destination_event_service: "eventgate-logging-external", sampling: nil)
+        }
+        return configs
+    }
+
+    // MARK: - makeBatches
+
+    func testMakeBatchesWithNoEventsReturnsNoBatches() {
+        let batches = EventPlatformClient.makeBatches(events: [], configs: makeConfigs(loggingStreams: []), chunkSize: 50)
+        XCTAssertTrue(batches.isEmpty)
+    }
+
+    /// Regression test for the widget routing bug: with stream configs unavailable,
+    /// every event must fall back to the analytics intake in a single batch.
+    func testMakeBatchesWithNilConfigsRoutesEverythingToAnalytics() {
+        let events = [makeEvent(stream: .search, index: 0), makeEvent(stream: .clientError, index: 1)]
+        let batches = EventPlatformClient.makeBatches(events: events, configs: nil, chunkSize: 50)
+        XCTAssertEqual(batches.count, 1)
+        XCTAssertEqual(batches.first?.destination, .analytics)
+        XCTAssertEqual(batches.first?.events.count, 2)
+    }
+
+    func testMakeBatchesGroupsByDestination() {
+        let configs = makeConfigs(loggingStreams: [.clientError])
+        let events = [
+            makeEvent(stream: .search, index: 0),
+            makeEvent(stream: .clientError, index: 1),
+            makeEvent(stream: .sessions, index: 2),
+            makeEvent(stream: .clientError, index: 3)
+        ]
+        let batches = EventPlatformClient.makeBatches(events: events, configs: configs, chunkSize: 50)
+        XCTAssertEqual(batches.count, 2)
+
+        let analytics = batches.first { $0.destination == .analytics }
+        let logging = batches.first { $0.destination == .logging }
+        XCTAssertEqual(analytics?.events.count, 2)
+        XCTAssertEqual(logging?.events.count, 2)
+
+        // Relative order within a destination is preserved
+        XCTAssertEqual(analytics?.events.map(\.managedObjectURI.lastPathComponent), ["p0", "p2"])
+        XCTAssertEqual(logging?.events.map(\.managedObjectURI.lastPathComponent), ["p1", "p3"])
+    }
+
+    func testMakeBatchesTreatsUnconfiguredStreamsAsAnalytics() {
+        let configs = makeConfigs(loggingStreams: [])
+        let batches = EventPlatformClient.makeBatches(events: [makeEvent(stream: .watchlist)], configs: configs, chunkSize: 50)
+        XCTAssertEqual(batches.count, 1)
+        XCTAssertEqual(batches.first?.destination, .analytics)
+    }
+
+    func testMakeBatchesChunkBoundaries() {
+        let configs = makeConfigs(loggingStreams: [])
+        for (eventCount, expectedChunks) in [(1, 1), (50, 1), (51, 2), (137, 3)] {
+            let events = (0..<eventCount).map { makeEvent(stream: .search, index: $0) }
+            let batches = EventPlatformClient.makeBatches(events: events, configs: configs, chunkSize: 50)
+            XCTAssertEqual(batches.count, expectedChunks, "\(eventCount) events should produce \(expectedChunks) batches")
+            XCTAssertEqual(batches.reduce(0) { $0 + $1.events.count }, eventCount, "no events may be lost to chunking")
+            for batch in batches {
+                XCTAssertLessThanOrEqual(batch.events.count, 50)
+            }
+        }
+    }
+
+    func testMakeBatchesClampsNonPositiveChunkSize() {
+        let events = (0..<3).map { makeEvent(stream: .search, index: $0) }
+        let batches = EventPlatformClient.makeBatches(events: events, configs: nil, chunkSize: 0)
+        XCTAssertEqual(batches.count, 3)
+    }
+
+    // MARK: - encodeBatchBody
+
+    func testEncodeBatchBodyProducesValidJSONArray() throws {
+        let compact = Data("{\"a\":1}".utf8)
+        let prettyPrinted = Data("{\n  \"b\" : 2\n}".utf8)
+        let body = EventPlatformClient.encodeBatchBody([compact, prettyPrinted, compact])
+
+        let parsed = try JSONSerialization.jsonObject(with: body)
+        let array = try XCTUnwrap(parsed as? [[String: Int]])
+        XCTAssertEqual(array.count, 3)
+        XCTAssertEqual(array[0]["a"], 1)
+        XCTAssertEqual(array[1]["b"], 2)
+        XCTAssertEqual(array[2]["a"], 1)
+    }
+
+    func testEncodeBatchBodySingleEvent() throws {
+        let body = EventPlatformClient.encodeBatchBody([Data("{\"a\":1}".utf8)])
+        let array = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [[String: Int]])
+        XCTAssertEqual(array, [["a": 1]])
+    }
+}

--- a/WikipediaUnitTests/Code/EventPlatformBatchingTests.swift
+++ b/WikipediaUnitTests/Code/EventPlatformBatchingTests.swift
@@ -105,4 +105,52 @@ final class EventPlatformBatchingTests: XCTestCase {
         let array = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [[String: Int]])
         XCTAssertEqual(array, [["a": 1]])
     }
+
+    // MARK: - disposition(for:)
+
+    private enum FakeError: Error {
+        case network
+    }
+
+    func testDispositionTruthTable() {
+        XCTAssertEqual(EventPlatformClient.disposition(for: .success(())), .purge)
+        XCTAssertEqual(EventPlatformClient.disposition(for: .failure(.networkingLibraryError(FakeError.network))), .retain)
+        XCTAssertEqual(EventPlatformClient.disposition(for: .failure(.unexpectedResponse(207))), .purge)
+        XCTAssertEqual(EventPlatformClient.disposition(for: .failure(.unexpectedResponse(400))), .retryIndividually)
+        XCTAssertEqual(EventPlatformClient.disposition(for: .failure(.missingResponse)), .retryIndividually)
+        XCTAssertEqual(EventPlatformClient.disposition(for: .failure(.retryableServerError(statusCode: 429, retryAfter: 60))), .retainAndBackoff(60))
+        XCTAssertEqual(EventPlatformClient.disposition(for: .failure(.retryableServerError(statusCode: 503, retryAfter: nil))), .retainAndBackoff(EventPlatformClient.defaultBackoffInterval))
+    }
+
+    func testDispositionClampsExcessiveRetryAfter() {
+        let disposition = EventPlatformClient.disposition(for: .failure(.retryableServerError(statusCode: 429, retryAfter: 86400)))
+        XCTAssertEqual(disposition, .retainAndBackoff(EventPlatformClient.maximumBackoffInterval))
+    }
+
+    // MARK: - Retry-After parsing
+
+    func testRetryAfterParsesDeltaSeconds() {
+        XCTAssertEqual(EventPlatformClient.retryAfterInterval(fromHeaderValue: "120"), 120)
+        XCTAssertEqual(EventPlatformClient.retryAfterInterval(fromHeaderValue: " 5 "), 5)
+        XCTAssertEqual(EventPlatformClient.retryAfterInterval(fromHeaderValue: "0"), 0)
+    }
+
+    func testRetryAfterParsesHTTPDate() throws {
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-27T12:00:00Z"))
+        let interval = EventPlatformClient.retryAfterInterval(fromHeaderValue: "Wed, 27 Aug 2026 12:01:00 GMT", now: now)
+        XCTAssertEqual(interval, 60)
+    }
+
+    func testRetryAfterHTTPDateInThePastClampsToZero() throws {
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-27T12:00:00Z"))
+        let interval = EventPlatformClient.retryAfterInterval(fromHeaderValue: "Wed, 27 Aug 2026 11:00:00 GMT", now: now)
+        XCTAssertEqual(interval, 0)
+    }
+
+    func testRetryAfterRejectsGarbage() {
+        XCTAssertNil(EventPlatformClient.retryAfterInterval(fromHeaderValue: nil))
+        XCTAssertNil(EventPlatformClient.retryAfterInterval(fromHeaderValue: ""))
+        XCTAssertNil(EventPlatformClient.retryAfterInterval(fromHeaderValue: "soon"))
+        XCTAssertNil(EventPlatformClient.retryAfterInterval(fromHeaderValue: "-30"))
+    }
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T436283

### Notes
**1. The client sends events in batches**
The client collects the stored events at each flush. It groups the events by
destination service. It sends one POST for each group, with a maximum of 50
events for each POST. Before this change, the client sent one POST for each
event. If the server rejects a full batch, the client sends the events one at
a time, one time only. Thus one bad event cannot remove the other events in
the batch.

**2. The client keeps the stream configuration in a cache**
The client writes the stream configuration to the shared app-group container.
At the start, the client reads the cache first. The main app gets a new
configuration from the network a maximum of one time each day, with 2 retries.
Widget processes do not get the configuration from the network. They read the
cache only. This also repairs a defect: widgets sent all events to the
analytics service because the configuration was not available.

**3. The client obeys the Retry-After header**
Before this change, the client discarded events when the server sent a 429 or
5xx response. Now the client keeps the events and stops all sends until the
Retry-After time is complete. The default wait time is 5 minutes. The maximum
wait time is 1 hour. The client sends the batches in sequence. Thus one
throttled response stops the remaining batches in that flush.

**4. TestKitchen events go through sampling**
Before this change, the app sent all TestKitchen events for all users. Now
TestKitchen events go through the same sampling check as the other streams.
NOTE: The server stream configuration now controls the product_metrics.app_base
stream. If the configuration is not available on the server, or the sample
rate is zero, the client discards these events. This is a new behavior. Please
tell the analytics team.

**5. The client limits the client-error events**
Before this change, each HTTP response with a status of 400 or more caused one
error event. A server problem could cause a large quantity of error events.
Now the client permits a maximum of 5 error events for each error type, host,
and status class in each 10-minute window. For 429 responses, the client
permits a maximum of 1 error event for each host in each window.

**6. Developer settings show event-logging counters**
A new "Event Logging" section shows the number of flushes, POST requests,
events sent, and events discarded, with the reason. A button sets the counters
to zero. The counters help us measure the request quantity and find
regressions.

## Risks

- The client discards events that the server rejects. This is the same
  behavior as before this change.
- A cached stream configuration can be a maximum of 1 day old.
- The backoff state is in memory only. After a restart, the app sends a
  maximum of one extra request.
 

### Test Steps
1. Coming soon 

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
