### PR TITLE
T436271: Add app install ID to client error events

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
@@ -17,6 +17,21 @@ struct WMFDeveloperSettingsView: View {
                 Toggle("Enable Developer Mode", isOn: $viewModel.enableDeveloperMode)
             }
 
+            Section(header: Text("App install ID"), footer: Text("Tap to copy. Use it to find this install's errors in Logstash.")) {
+                Button {
+                    viewModel.copyAppInstallID()
+                } label: {
+                    HStack {
+                        Text(viewModel.appInstallID ?? "Unavailable")
+                            .font(Font(WMFFont.for(.callout)))
+                        Spacer()
+                        if let copyIcon = WMFSFSymbolIcon.for(symbol: .docOnDoc) {
+                            Image(uiImage: copyIcon)
+                        }
+                    }
+                }
+            }
+
             Section(header: Text("Games")) {
                 Toggle("Show Games Version 2", isOn: $viewModel.showGamesV2)
                 Button {

--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -119,12 +119,11 @@ import WMFData
         try? WMFDataEnvironment.current.crossProcessUserDefaultsStore?.load(key: WMFUserDefaultsKey.appInstallID.rawValue)
     }
 
+    @MainActor
     public func copyAppInstallID() {
         guard let appInstallID else { return }
         UIPasteboard.general.string = appInstallID
-        Task { @MainActor in
-            WMFToastPresenter.shared.show(WMFToastConfig(title: .init("App install ID copied")))
-        }
+        WMFToastPresenter.shared.show(WMFToastConfig(title: .init("App install ID copied")))
     }
 
     public func clearGamesPersistence() {

--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Combine
 import WMFData
 
@@ -112,6 +113,18 @@ import WMFData
         enableHomePhase2.$isSelected
             .sink { isSelected in WMFDeveloperSettingsDataController.shared.enableHomePhase2 = isSelected }
             .store(in: &subscribers)
+    }
+
+    public var appInstallID: String? {
+        try? WMFDataEnvironment.current.crossProcessUserDefaultsStore?.load(key: WMFUserDefaultsKey.appInstallID.rawValue)
+    }
+
+    public func copyAppInstallID() {
+        guard let appInstallID else { return }
+        UIPasteboard.general.string = appInstallID
+        Task { @MainActor in
+            WMFToastPresenter.shared.show(WMFToastConfig(title: .init("App install ID copied")))
+        }
     }
 
     public func clearGamesPersistence() {

--- a/WMFComponents/Sources/WMFComponents/Style/WMFIcon.swift
+++ b/WMFComponents/Sources/WMFComponents/Style/WMFIcon.swift
@@ -178,6 +178,7 @@ public enum WMFSFSymbolIcon {
     case sparkles
     case xmarkCircle
     case docText
+    case docOnDoc
     case chevronUpChevronDown
     case globe
     case newspaper
@@ -453,6 +454,8 @@ public enum WMFSFSymbolIcon {
             image = UIImage(systemName: "xmark.circle", withConfiguration: configuration)
         case .docText:
             image = UIImage(systemName: "doc.text", withConfiguration: configuration)
+        case .docOnDoc:
+            image = UIImage(systemName: "doc.on.doc", withConfiguration: configuration)
         case .chevronUpChevronDown:
             image = UIImage(systemName: "chevron.up.chevron.down", withConfiguration: configuration)
         case .globe:

--- a/Wikipedia/Code/ClientErrorFunnel.swift
+++ b/Wikipedia/Code/ClientErrorFunnel.swift
@@ -8,11 +8,24 @@ import WMFData
 
     @objc public static let shared = ClientErrorFunnel()
 
+    // The schema rejects unknown top-level fields (additionalProperties: false),
+    // so the app install ID travels inside error_context, the schema's
+    // designated field for arbitrary extra data.
+    private static var appInstallIDContext: [String: String]? {
+        let appInstallID: String? = try? WMFDataEnvironment.current.crossProcessUserDefaultsStore?.load(key: WMFUserDefaultsKey.appInstallID.rawValue)
+
+        guard let appInstallID else {
+            return nil
+        }
+
+        return ["app_install_id": appInstallID]
+    }
+
     private struct Event: EventInterface {
         static let schema: EventPlatformClient.Schema = .clientError
         let message: String?
         let errorClass: String?
-        let errorContext: String?
+        let errorContext: [String: String]?
         let stackTrace: String?
         let url: String?
         let http: Http?
@@ -41,7 +54,7 @@ import WMFData
         let event: ClientErrorFunnel.Event = ClientErrorFunnel.Event(
             message: message,
             errorClass: nil,
-            errorContext: nil,
+            errorContext: Self.appInstallIDContext,
             stackTrace: nil,
             url: nil,
             http: nil
@@ -63,7 +76,7 @@ import WMFData
         let event = Event(
             message: "HTTP \(info.statusCode)",
             errorClass: info.source,
-            errorContext: nil,
+            errorContext: Self.appInstallIDContext,
             stackTrace: nil,
             url: info.url,
             http: http

--- a/Wikipedia/Code/HelpViewController.swift
+++ b/Wikipedia/Code/HelpViewController.swift
@@ -128,7 +128,12 @@ class HelpViewController: SinglePageWebViewController {
     @objc func sendEmail() {
         let address = HelpViewController.emailAddress
         let subject = HelpViewController.emailSubject
-        let body = "\n\n\n\nVersion: \(WikipediaAppUtils.versionedUserAgent())"
+        var body = "\n\n\n\nVersion: \(WikipediaAppUtils.versionedUserAgent())"
+
+        let appInstallID: String? = try? WMFDataEnvironment.current.crossProcessUserDefaultsStore?.load(key: WMFUserDefaultsKey.appInstallID.rawValue)
+        if let appInstallID {
+            body += "\nApp install ID: \(appInstallID)"
+        }
         let mailto = "mailto:\(address)?subject=\(subject)&body=\(body)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
 
         guard let encodedMailto = mailto, let mailtoURL = URL(string: encodedMailto), UIApplication.shared.canOpenURL(mailtoURL) else {

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -858,7 +858,7 @@ extension WMFAppViewController {
         
         let store = WMFDataEnvironment.current.crossProcessUserDefaultsStore
         let appInstallID: String? = try? store?.load(key: WMFUserDefaultsKey.appInstallID.rawValue)
-        let sessionID: String? = try? store?.load(key: WMFUserDefaultsKey.appInstallID.rawValue)
+        let sessionID: String? = try? store?.load(key: WMFUserDefaultsKey.sessionID.rawValue)
         
         if legacyAppInstallID == nil && appInstallID == nil {
             // This is likely a fresh install! Generate a new app install ID

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -830,7 +830,15 @@ extension WMFAppViewController {
         WMFDataEnvironment.current.testKitchenClient = TestKitchenAdapter.shared.client
 
         evaluateAppInstallAndSessionIDs()
-        
+
+        // Warn level on purpose: the default log threshold (WMFLogging.h) is
+        // warning, and this line must reach the log file that ships with the
+        // "Export user data" package so errors in Logstash can be correlated
+        // with an exported log through the same install ID.
+        if let appInstallID: String = try? WMFDataEnvironment.current.crossProcessUserDefaultsStore?.load(key: WMFUserDefaultsKey.appInstallID.rawValue) {
+            DDLogWarn("App install ID: \(appInstallID)")
+        }
+
         #if TEST || UITEST
             TestNetworkFixtureInterceptor.configureBasicServiceIfNeeded()
         #endif


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T436271

### Notes
* **Client error events:** the install ID travels inside `error_context` (`error_context.app_install_id`). It cannot go at the top level: the `/mediawiki/client/error/2.0.0` schema declares `additionalProperties: false`, so switching to the full event body (`needsMinimal: false`) would get every event rejected by EventGate with a 400 — `error_context` is the schema's designated field for arbitrary extra data (string map, max 32 keys).
* Fixed the type of `Event.errorContext` from `String?` to `[String: String]?`: the schema requires an object. Latent until now because we always sent `nil`.
* **Launch log:** the install ID is logged once at launch, after `evaluateAppInstallAndSessionIDs()` generates/migrates it. `DDLogWarn` on purpose: the default log threshold (`WMFLogging.h`) is warning, and the line must reach the `console.log` that ships with the "Export user data" package.
* **Support email:** the install ID is appended to the `mailto:` body in `HelpViewController.sendEmail()`, below the app version. The user sees it in the draft before sending. The Explore feed and Activity tab feedback emails were left out of scope — happy to add them here or in a follow-up if we want them too.
* **Developer settings:** new "App install ID" section at the top of the screen, with tap-to-copy
* **Drive-by fix:** `evaluateAppInstallAndSessionIDs()` loaded the session ID with the app install ID key, so the legacy session ID migration never ran. The fix is retroactively a no-op: for users who already went through the broken path, `UserSession` has long since generated a session ID, and the migration only writes when the destination is empty.
* **Post-deploy step:** the `error_context.app_install_id` field is new to the Logstash index — someone with access needs to refresh the field list on the index pattern (Management → Index Patterns) so autocomplete/aggregations work. Asked in #talk-to-sre.

### Test Steps
1. Launch the app and check the console for the `App install ID: <uuid>` line at startup.
2. Open a nonexistent article (e.g. `wikipedia://en.wikipedia.org/wiki/Some_Nonexistent_Title_123` from Safari in the simulator). With `ddLogLevel` set to `DDLogLevelAll` locally, confirm the scheduled client error event includes `error_context` with `app_install_id` matching the launch log.
3. Verified end to end in production Logstash: event visible with `error_context.app_install_id`, `http.status_code: 404` and `error_class: SessionDelegate` (screenshot below).
4. Settings → About → enable developer mode → Developer settings: the "App install ID" section shows the same UUID; tapping copies it (toast confirms) and pasting elsewhere matches.
5. Settings → Help → email button: the draft body contains `App install ID: <uuid>` below the version line.

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
<img width="590" height="1278" alt="Screenshot 2026-08-27 at 1 59 54 PM" src="https://github.com/user-attachments/assets/96c2be35-b347-4f05-a6fd-cfcbc7f2f41f" />
<img width="764" height="357" alt="Screenshot 2026-08-27 at 1 12 08 PM" src="https://github.com/user-attachments/assets/a14daa95-af9b-4f25-9b51-3c72fb5cb254" />
<img width="884" height="824" alt="Screenshot 2026-08-27 at 1 25 47 PM" src="https://github.com/user-attachments/assets/5f1b1756-a138-45c2-b281-f43a46177a61" />
