### PR TITLE
Fix For You instrumentation

### DIFF
--- a/WMFData/Sources/WMFData/Data Controllers/Home/WMFHomeDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Home/WMFHomeDataController.swift
@@ -29,8 +29,8 @@ import WMFTestKitchen
 
     @objc public static let shared = WMFHomeDataController()
 
-    // Assigned once in init from a local WMFExperimentsDataController; immutable after.
-    nonisolated private let homeTabAssignment: HomeTabExperimentAssignment
+    // Written once by assignExperiment() on the main thread at launch, before any concurrent reads.
+    nonisolated(unsafe) private var homeTabAssignment: HomeTabExperimentAssignment = .control
 
     public init(
         feedDataController: any WMFFeedDataControlling = WMFFeedDataController.shared,
@@ -38,9 +38,7 @@ import WMFTestKitchen
         userDefaultsStore: WMFKeyValueStore? = WMFDataEnvironment.current.userDefaultsStore,
         relatedPagesDataController: WMFRelatedPagesDataController = WMFRelatedPagesDataController.shared,
         savedArticlesDataController: WMFSavedArticlesDataController = WMFSavedArticlesDataController.shared,
-        onThisDayDataController: WMFOnThisDayDataController = WMFOnThisDayDataController.shared,
-        experimentStore: WMFKeyValueStore? = WMFDataEnvironment.current.sharedCacheStore,
-        testKitchenClient: TestKitchenClient? = WMFDataEnvironment.current.testKitchenClient
+        onThisDayDataController: WMFOnThisDayDataController = WMFOnThisDayDataController.shared
     ) {
         self.feedDataController = feedDataController
         self.basicService = basicService
@@ -48,21 +46,6 @@ import WMFTestKitchen
         self.relatedPagesDataController = relatedPagesDataController
         self.savedArticlesDataController = savedArticlesDataController
         self.onThisDayDataController = onThisDayDataController
-
-        if let experimentStore {
-            let controller = WMFExperimentsDataController(store: experimentStore)
-            let bucket = try? controller.determineBucketForExperiment(.homeTab, withPercentage: 50)
-            homeTabAssignment = bucket == .homeTabGroupB ? .groupB : .control
-        } else {
-            homeTabAssignment = .control
-        }
-
-        let assigned = homeTabAssignment == .groupB ? "treatment" : "control"
-        testKitchenClient?.getInstrument(name: "apps-home-feed")
-            .submitInteraction(
-                action: "experiment_exposure",
-                experimentData: ExperimentData(enrolled: "ios-home-feed", assigned: assigned)
-            )
         
         NotificationCenter.default.addObserver(
             forName: WMFNSNotification.pageViewHistoryDidChange,
@@ -76,6 +59,21 @@ import WMFTestKitchen
         }
     }
     
+    public nonisolated func assignExperiment() {
+        guard let store = WMFDataEnvironment.current.sharedCacheStore else { return }
+        let controller = WMFExperimentsDataController(store: store)
+        let bucket = try? controller.determineBucketForExperiment(.homeTab, withPercentage: 50)
+        homeTabAssignment = bucket == .homeTabGroupB ? .groupB : .control
+    }
+
+    public nonisolated func logExperimentExposure() {
+        WMFDataEnvironment.current.testKitchenClient?.getInstrument(name: "apps-home-feed")
+            .submitInteraction(
+                action: "experiment_exposure",
+                experimentData: experimentData
+            )
+    }
+
     private func invalidateForYouCache(project: WMFProject?) {
         guard let store = WMFDataEnvironment.current.sharedCacheStore else { return }
         let target = project ?? selectedLanguage().map { WMFProject.wikipedia($0) }

--- a/WMFData/Sources/WMFData/Data Controllers/Home/WMFHomeDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Home/WMFHomeDataController.swift
@@ -66,6 +66,10 @@ import WMFTestKitchen
         homeTabAssignment = bucket == .homeTabGroupB ? .groupB : .control
     }
 
+    public nonisolated var experimentData: ExperimentData {
+        ExperimentData(enrolled: "ios-home-feed", assigned: homeTabAssignment == .groupB ? "treatment" : "control")
+    }
+
     public nonisolated func logExperimentExposure() {
         WMFDataEnvironment.current.testKitchenClient?.getInstrument(name: "apps-home-feed")
             .submitInteraction(

--- a/WMFData/Tests/WMFDataTests/WMFHomeDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFHomeDataControllerTests.swift
@@ -516,8 +516,6 @@ final class WMFHomeDataControllerTests: XCTestCase {
         let controller = WMFHomeDataController(
             feedDataController: WMFMockFeedDataController(response: stubResponse)
         )
-        WMFDataEnvironment.current.sharedCacheStore = nil
-        controller.assignExperiment()
         XCTAssertEqual(controller.persistedHomeTabAssignment(), .control)
     }
 
@@ -525,8 +523,6 @@ final class WMFHomeDataControllerTests: XCTestCase {
         let controller = WMFHomeDataController(
             feedDataController: WMFMockFeedDataController(response: stubResponse)
         )
-        WMFDataEnvironment.current.sharedCacheStore = nil
-        controller.assignExperiment()
         XCTAssertFalse(controller.isHomeTabGroupB)
     }
 

--- a/WMFData/Tests/WMFDataTests/WMFHomeDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFHomeDataControllerTests.swift
@@ -514,43 +514,43 @@ final class WMFHomeDataControllerTests: XCTestCase {
 
     func testPersistredHomeTabAssignmentReturnsControlWhenNoExperimentStore() {
         let controller = WMFHomeDataController(
-            feedDataController: WMFMockFeedDataController(response: stubResponse),
-            experimentStore: nil
+            feedDataController: WMFMockFeedDataController(response: stubResponse)
         )
+        WMFDataEnvironment.current.sharedCacheStore = nil
+        controller.assignExperiment()
         XCTAssertEqual(controller.persistedHomeTabAssignment(), .control)
     }
 
     func testIsHomeTabGroupBIsFalseWhenControlAssigned() {
         let controller = WMFHomeDataController(
-            feedDataController: WMFMockFeedDataController(response: stubResponse),
-            experimentStore: nil
+            feedDataController: WMFMockFeedDataController(response: stubResponse)
         )
+        WMFDataEnvironment.current.sharedCacheStore = nil
+        controller.assignExperiment()
         XCTAssertFalse(controller.isHomeTabGroupB)
     }
 
     func testPersistredHomeTabAssignmentIsStableAcrossMultipleCalls() {
-        let store = WMFMockKeyValueStore()
         let controller = WMFHomeDataController(
-            feedDataController: WMFMockFeedDataController(response: stubResponse),
-            experimentStore: store
+            feedDataController: WMFMockFeedDataController(response: stubResponse)
         )
+        controller.assignExperiment()
         let first = controller.persistedHomeTabAssignment()
         let second = controller.persistedHomeTabAssignment()
         XCTAssertEqual(first, second)
     }
 
     func testPersistredHomeTabAssignmentIsStableAcrossNewControllerInstancesWithSameStore() {
-        // Two controllers sharing the same store must land in the same bucket,
+        // Two controllers sharing the same store (set in setUp) must land in the same bucket,
         // because determineBucketForExperiment persists the result.
-        let store = WMFMockKeyValueStore()
         let first = WMFHomeDataController(
-            feedDataController: WMFMockFeedDataController(response: stubResponse),
-            experimentStore: store
+            feedDataController: WMFMockFeedDataController(response: stubResponse)
         )
+        first.assignExperiment()
         let second = WMFHomeDataController(
-            feedDataController: WMFMockFeedDataController(response: stubResponse),
-            experimentStore: store
+            feedDataController: WMFMockFeedDataController(response: stubResponse)
         )
+        second.assignExperiment()
         XCTAssertEqual(first.persistedHomeTabAssignment(), second.persistedHomeTabAssignment())
     }
 

--- a/Wikipedia/Code/AppOnboardingCoordinator.swift
+++ b/Wikipedia/Code/AppOnboardingCoordinator.swift
@@ -45,26 +45,26 @@ final class AppOnboardingCoordinator: NSObject {
             project: project,
             searchLanguages: preferredWMFLanguages(),
             logDidTapTopic: { [weak self] in
-                self?.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "topic_select")
+                self?.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "topic_select", experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapArticle: { [weak self] in
-                self?.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "article_select")
+                self?.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "article_select", experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapDeselectAll: { [weak self] in
-                self?.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "deselect_all")
+                self?.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "deselect_all", experimentData: WMFHomeDataController.shared.experimentData)
             }
         )
         let feedPreferenceViewModel = WMFAppOnboardingFeedPreferenceViewModel(
             project: project,
             logImpression: { [weak self] noInterests in
                 let actionSubtype: String? = noInterests ? "no_interests" : nil
-                self?.homeFeedInstrument?.submitInteraction(action: "impression", actionSource: "feed_order_customize", actionSubtype: actionSubtype)
+                self?.homeFeedInstrument?.submitInteraction(action: "impression", actionSource: "feed_order_customize", actionSubtype: actionSubtype, experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapCommunity: { [weak self] in
-                self?.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_order_customize", elementId: "community_first")
+                self?.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_order_customize", elementId: "community_first", experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapPersonalized: { [weak self] in
-                self?.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_order_customize", elementId: "for_you_first")
+                self?.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_order_customize", elementId: "for_you_first", experimentData: WMFHomeDataController.shared.experimentData)
             }
         )
         
@@ -76,15 +76,15 @@ final class AppOnboardingCoordinator: NSObject {
                 self?.presentWebView(urlString: CommonStrings.aboutWikipediaURLString)
             },
             didTapPrivacyPolicy: { [weak self] in
-                self?.onboardingInstrument?.submitInteraction(action: "click", actionSource: "onboarding_privacy", elementId: "privacy_policy")
+                self?.onboardingInstrument?.submitInteraction(action: "click", actionSource: "onboarding_privacy", elementId: "privacy_policy", experimentData: WMFHomeDataController.shared.experimentData)
                 self?.presentWebView(urlString: CommonStrings.privacyPolicyURLString)
             },
             didTapTermsOfUse: { [weak self] in
-                self?.onboardingInstrument?.submitInteraction(action: "click", actionSource: "onboarding_privacy", elementId: "terms_of_use")
+                self?.onboardingInstrument?.submitInteraction(action: "click", actionSource: "onboarding_privacy", elementId: "terms_of_use", experimentData: WMFHomeDataController.shared.experimentData)
                 self?.presentWebView(urlString: CommonStrings.termsOfUseURLString)
             },
             didTapAddLanguages: { [weak self] in
-                self?.onboardingInstrument?.submitInteraction(action: "click", actionSource: "onboarding_language", elementId: "add_language_button")
+                self?.onboardingInstrument?.submitInteraction(action: "click", actionSource: "onboarding_language", elementId: "add_language_button", experimentData: WMFHomeDataController.shared.experimentData)
                 self?.presentPreferredLanguages()
             },
             onCompletion: { [weak self] in
@@ -96,21 +96,21 @@ final class AppOnboardingCoordinator: NSObject {
                 switch step {
                 case .personalizationIntro:
                     self.homeFeedInstrument = TestKitchenAdapter.shared.client.getInstrument(name: "apps-home-feed")
-                    self.homeFeedInstrument?.submitInteraction(action: "impression", actionSource: "feed_entry")
+                    self.homeFeedInstrument?.submitInteraction(action: "impression", actionSource: "feed_entry", experimentData: WMFHomeDataController.shared.experimentData)
                 case .interests:
-                    self.homeFeedInstrument?.submitInteraction(action: "impression", actionSource: "feed_customize")
+                    self.homeFeedInstrument?.submitInteraction(action: "impression", actionSource: "feed_customize", experimentData: WMFHomeDataController.shared.experimentData)
                 case .feedPreference:
                     // handling it in child view model so that we can capture "no interests" subtype. The "no interests" data is not available from this hook, the child view model has to load the data first.
                     break
                 case .loading:
-                    self.homeFeedInstrument?.submitInteraction(action: "impression", actionSource: "feed_loading")
+                    self.homeFeedInstrument?.submitInteraction(action: "impression", actionSource: "feed_loading", experimentData: WMFHomeDataController.shared.experimentData)
                 case .intro:
                     self.onboardingInstrument = TestKitchenAdapter.shared.client.getInstrument(name: "apps-onboarding")
-                    self.onboardingInstrument?.submitInteraction(action: "impression", actionSource: "onboarding_welcome")
+                    self.onboardingInstrument?.submitInteraction(action: "impression", actionSource: "onboarding_welcome", experimentData: WMFHomeDataController.shared.experimentData)
                 case .dataPrivacy:
-                    self.onboardingInstrument?.submitInteraction(action: "impression", actionSource: "onboarding_privacy")
+                    self.onboardingInstrument?.submitInteraction(action: "impression", actionSource: "onboarding_privacy", experimentData: WMFHomeDataController.shared.experimentData)
                 case .languages:
-                    self.onboardingInstrument?.submitInteraction(action: "impression", actionSource: "onboarding_language")
+                    self.onboardingInstrument?.submitInteraction(action: "impression", actionSource: "onboarding_language", experimentData: WMFHomeDataController.shared.experimentData)
                 }
             },
             logSkip: { [weak self] step in
@@ -118,12 +118,12 @@ final class AppOnboardingCoordinator: NSObject {
                 guard let self else { return }
                 switch step {
                 case .personalizationIntro:
-                    self.homeFeedInstrument?.startFunnel(name: "feed_customize").submitInteraction(action: "click", actionSource: "feed_entry", elementId: "skip_button")
+                    self.homeFeedInstrument?.startFunnel(name: "feed_customize").submitInteraction(action: "click", actionSource: "feed_entry", elementId: "skip_button", experimentData: WMFHomeDataController.shared.experimentData)
                 case .interests:
-                    self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "skip_button")
+                    self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "skip_button", experimentData: WMFHomeDataController.shared.experimentData)
                 case .feedPreference:
                     let actionSubtype: String? = !feedPreferenceViewModel.isPersonalizedAvailable ? "no_interests" : nil
-                    self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_order_customize", actionSubtype: actionSubtype, elementId: "skip_button")
+                    self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_order_customize", actionSubtype: actionSubtype, elementId: "skip_button", experimentData: WMFHomeDataController.shared.experimentData)
                 case .loading:
                     assertionFailure("Loading view does not have a skip button")
                 case .intro:
@@ -141,21 +141,21 @@ final class AppOnboardingCoordinator: NSObject {
                 guard let self else { return }
                 switch step {
                 case .personalizationIntro:
-                    self.homeFeedInstrument?.startFunnel(name: "feed_customize").submitInteraction(action: "click", actionSource: "feed_entry", elementId: "next_button")
+                    self.homeFeedInstrument?.startFunnel(name: "feed_customize").submitInteraction(action: "click", actionSource: "feed_entry", elementId: "next_button", experimentData: WMFHomeDataController.shared.experimentData)
                 case .interests:
-                    self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "next_button")
+                    self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "next_button", experimentData: WMFHomeDataController.shared.experimentData)
                 case .feedPreference:
                     let actionSubtype: String? = !feedPreferenceViewModel.isPersonalizedAvailable ? "no_interests" : nil
-                    self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_order_customize", actionSubtype: actionSubtype, elementId: "next_button")
+                    self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: "feed_order_customize", actionSubtype: actionSubtype, elementId: "next_button", experimentData: WMFHomeDataController.shared.experimentData)
                 case .loading:
                     assertionFailure("Loading view does not have a skip button")
                 case .intro:
                     self.onboardingInstrument = TestKitchenAdapter.shared.client.getInstrument(name: "apps-onboarding")
-                    self.onboardingInstrument?.submitInteraction(action: "click", actionSource: "onboarding_welcome", elementId: "next_button")
+                    self.onboardingInstrument?.submitInteraction(action: "click", actionSource: "onboarding_welcome", elementId: "next_button", experimentData: WMFHomeDataController.shared.experimentData)
                 case .dataPrivacy:
-                    self.onboardingInstrument?.submitInteraction(action: "click", actionSource: "onboarding_privacy", elementId: "next_button")
+                    self.onboardingInstrument?.submitInteraction(action: "click", actionSource: "onboarding_privacy", elementId: "next_button", experimentData: WMFHomeDataController.shared.experimentData)
                 case .languages:
-                    self.onboardingInstrument?.submitInteraction(action: "click", actionSource: "onboarding_language", elementId: "next_button")
+                    self.onboardingInstrument?.submitInteraction(action: "click", actionSource: "onboarding_language", elementId: "next_button", experimentData: WMFHomeDataController.shared.experimentData)
                 }
             }
         )
@@ -181,26 +181,26 @@ final class AppOnboardingCoordinator: NSObject {
             project: project,
             searchLanguages: preferredWMFLanguages(),
             logDidTapTopic: {
-                instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "topic_select")
+                instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "topic_select", experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapArticle: {
-                instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "article_select")
+                instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "article_select", experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapDeselectAll: {
-                instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "deselect_all")
+                instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "deselect_all", experimentData: WMFHomeDataController.shared.experimentData)
             }
         )
         let feedPreferenceViewModel = WMFAppOnboardingFeedPreferenceViewModel(
             project: project,
             logImpression: { noInterests in
                 let actionSubtype: String? = noInterests ? "no_interests" : nil
-                instrument.submitInteraction(action: "impression", actionSource: "feed_order_customize", actionSubtype: actionSubtype)
+                instrument.submitInteraction(action: "impression", actionSource: "feed_order_customize", actionSubtype: actionSubtype, experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapCommunity: {
-                instrument.submitInteraction(action: "click", actionSource: "feed_order_customize", elementId: "community_first")
+                instrument.submitInteraction(action: "click", actionSource: "feed_order_customize", elementId: "community_first", experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapPersonalized: {
-                instrument.submitInteraction(action: "click", actionSource: "feed_order_customize", elementId: "for_you_first")
+                instrument.submitInteraction(action: "click", actionSource: "feed_order_customize", elementId: "for_you_first", experimentData: WMFHomeDataController.shared.experimentData)
             }
         )
 
@@ -228,12 +228,12 @@ final class AppOnboardingCoordinator: NSObject {
                 case .personalizationIntro:
                     assertionFailure("Condensed flow should not see personalization intro.")
                 case .interests:
-                    instrument.submitInteraction(action: "impression", actionSource: "feed_customize")
+                    instrument.submitInteraction(action: "impression", actionSource: "feed_customize", experimentData: WMFHomeDataController.shared.experimentData)
                 case .feedPreference:
                     // handling it in child view model so that we can capture "no interests" subtype.  The "no interests" data is not available from this hook, the child view model has to load the data first.
                     break
                 case .loading:
-                    instrument.submitInteraction(action: "impression", actionSource: "feed_loading")
+                    instrument.submitInteraction(action: "impression", actionSource: "feed_loading", experimentData: WMFHomeDataController.shared.experimentData)
                     break
                 case .intro, .languages, .dataPrivacy:
                     assertionFailure("Condensed flow should not see intro, languages, or data privacy.")
@@ -244,10 +244,10 @@ final class AppOnboardingCoordinator: NSObject {
                 case .personalizationIntro:
                     assertionFailure("Condensed flow should not see personalization intro.")
                 case .interests:
-                    instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "skip_button")
+                    instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "skip_button", experimentData: WMFHomeDataController.shared.experimentData)
                 case .feedPreference:
                     let actionSubtype: String? = !feedPreferenceViewModel.isPersonalizedAvailable ? "no_interests" : nil
-                    instrument.submitInteraction(action: "click", actionSource: "feed_order_customize", actionSubtype: actionSubtype, elementId: "skip_button")
+                    instrument.submitInteraction(action: "click", actionSource: "feed_order_customize", actionSubtype: actionSubtype, elementId: "skip_button", experimentData: WMFHomeDataController.shared.experimentData)
                 case .loading:
                     assertionFailure("Loading view does not have a skip button")
                 case .intro, .languages, .dataPrivacy:
@@ -260,10 +260,10 @@ final class AppOnboardingCoordinator: NSObject {
                  case .personalizationIntro:
                      assertionFailure("Condensed flow should not see personalization intro.")
                  case .interests:
-                     instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "next_button")
+                     instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "next_button", experimentData: WMFHomeDataController.shared.experimentData)
                  case .feedPreference:
                      let actionSubtype: String? = !feedPreferenceViewModel.isPersonalizedAvailable ? "no_interests" : nil
-                     instrument.submitInteraction(action: "click", actionSource: "feed_order_customize", actionSubtype: actionSubtype, elementId: "next_button")
+                     instrument.submitInteraction(action: "click", actionSource: "feed_order_customize", actionSubtype: actionSubtype, elementId: "next_button", experimentData: WMFHomeDataController.shared.experimentData)
                  case .loading:
                      assertionFailure("Loading view does not have a next button")
                  case .intro, .languages, .dataPrivacy:

--- a/Wikipedia/Code/HomeCoordinator.swift
+++ b/Wikipedia/Code/HomeCoordinator.swift
@@ -70,36 +70,36 @@ final class HomeCoordinator: NSObject, Coordinator {
 
         viewModel.logCardDidTapShare = { [weak self, weak viewModel] module in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, elementId: "article_share", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, actionSubtype: "feed_overflow", elementId: "article_share", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
         }
 
         viewModel.logCardDidSave = { [weak self, weak viewModel] card in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: card.module.loggingId, elementId: "article_save", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: card.module.loggingId, actionSubtype: "feed_overflow", elementId: "article_save", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
             let articleURL = card.project.siteURL?.wmf_URL(withTitle: card.title)
             ReadingListsFunnel.shared.logSave(category: .article, label: nil, articleURL: articleURL)
         }
 
         viewModel.logCardDidUnsave = { [weak self, weak viewModel] card in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: card.module.loggingId, elementId: "article_unsave", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: card.module.loggingId, actionSubtype: "feed_overflow", elementId: "article_unsave", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
             let articleURL = card.project.siteURL?.wmf_URL(withTitle: card.title)
             ReadingListsFunnel.shared.logUnsave(category: .article, label: nil, articleURL: articleURL)
         }
 
         viewModel.logCardDidTapHideCard = { [weak self, weak viewModel] module in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, elementId: "card_hide", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, actionSubtype: "feed_overflow", elementId: "card_hide", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
         }
 
         viewModel.logCardDidTapHideModule = { [weak self, weak viewModel] module in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, elementId: "module_hide", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, actionSubtype: "feed_overflow", elementId: "module_hide", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
         }
 
         viewModel.logDidTapCustomizeInterests = { [weak self, weak viewModel] module, elementId in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, elementId: elementId, mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, actionSubtype: "feed_overflow", elementId: elementId, mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
         }
 
         viewModel.logEmptyViewImpression = { [weak self, weak viewModel] in

--- a/Wikipedia/Code/HomeCoordinator.swift
+++ b/Wikipedia/Code/HomeCoordinator.swift
@@ -60,58 +60,58 @@ final class HomeCoordinator: NSObject, Coordinator {
                 actionContext = ["lang_code": languageCode]
             }
             // Note: purposefully not leaning on homeFeedInstrument property here, as the deck doesn't specify that.
-            TestKitchenAdapter.shared.client.getInstrument(name: "apps-home-feed").submitInteraction(action: "click", actionSource: "language_menu", elementId: "language_change", actionContext: actionContext, mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            TestKitchenAdapter.shared.client.getInstrument(name: "apps-home-feed").submitInteraction(action: "click", actionSource: "language_menu", elementId: "language_change", actionContext: actionContext, mediawikiDatabase: self.mediawikiDatabase(for: viewModel), experimentData: WMFHomeDataController.shared.experimentData)
         }
         
         viewModel.logCardImpression = { [weak self, weak viewModel] module, cardIndex in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "impression", actionSource: module, actionContext: ["index": cardIndex], mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "impression", actionSource: module, actionContext: ["index": cardIndex], mediawikiDatabase: self.mediawikiDatabase(for: viewModel), experimentData: WMFHomeDataController.shared.experimentData)
         }
 
         viewModel.logCardDidTapShare = { [weak self, weak viewModel] module in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, actionSubtype: "feed_overflow", elementId: "article_share", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, actionSubtype: "feed_overflow", elementId: "article_share", mediawikiDatabase: self.mediawikiDatabase(for: viewModel), experimentData: WMFHomeDataController.shared.experimentData)
         }
 
         viewModel.logCardDidSave = { [weak self, weak viewModel] card in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: card.module.loggingId, actionSubtype: "feed_overflow", elementId: "article_save", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: card.module.loggingId, actionSubtype: "feed_overflow", elementId: "article_save", mediawikiDatabase: self.mediawikiDatabase(for: viewModel), experimentData: WMFHomeDataController.shared.experimentData)
             let articleURL = card.project.siteURL?.wmf_URL(withTitle: card.title)
             ReadingListsFunnel.shared.logSave(category: .article, label: nil, articleURL: articleURL)
         }
 
         viewModel.logCardDidUnsave = { [weak self, weak viewModel] card in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: card.module.loggingId, actionSubtype: "feed_overflow", elementId: "article_unsave", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: card.module.loggingId, actionSubtype: "feed_overflow", elementId: "article_unsave", mediawikiDatabase: self.mediawikiDatabase(for: viewModel), experimentData: WMFHomeDataController.shared.experimentData)
             let articleURL = card.project.siteURL?.wmf_URL(withTitle: card.title)
             ReadingListsFunnel.shared.logUnsave(category: .article, label: nil, articleURL: articleURL)
         }
 
         viewModel.logCardDidTapHideCard = { [weak self, weak viewModel] module in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, actionSubtype: "feed_overflow", elementId: "card_hide", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, actionSubtype: "feed_overflow", elementId: "card_hide", mediawikiDatabase: self.mediawikiDatabase(for: viewModel), experimentData: WMFHomeDataController.shared.experimentData)
         }
 
         viewModel.logCardDidTapHideModule = { [weak self, weak viewModel] module in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, actionSubtype: "feed_overflow", elementId: "module_hide", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, actionSubtype: "feed_overflow", elementId: "module_hide", mediawikiDatabase: self.mediawikiDatabase(for: viewModel), experimentData: WMFHomeDataController.shared.experimentData)
         }
 
         viewModel.logDidTapCustomizeInterests = { [weak self, weak viewModel] module, elementId in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, actionSubtype: "feed_overflow", elementId: elementId, mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, actionSubtype: "feed_overflow", elementId: elementId, mediawikiDatabase: self.mediawikiDatabase(for: viewModel), experimentData: WMFHomeDataController.shared.experimentData)
         }
 
         viewModel.logEmptyViewImpression = { [weak self, weak viewModel] in
             guard let self, let viewModel else { return }
-            self.homeFeedInstrument?.submitInteraction(action: "impression", actionSource: "EmptyForYouCard", mediawikiDatabase: self.mediawikiDatabase(for: viewModel))
+            self.homeFeedInstrument?.submitInteraction(action: "impression", actionSource: "EmptyForYouCard", mediawikiDatabase: self.mediawikiDatabase(for: viewModel), experimentData: WMFHomeDataController.shared.experimentData)
         }
 
         viewModel.logCardDidTapArticle = { [weak self, weak viewModel] module, articleTitle in
             guard let self, let viewModel else { return }
             let project = self.currentProject(forViewModel: viewModel)
             let pageData = TestKitchenAdapter.getPageData(title: articleTitle, project: project)
-            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, elementId: "article_open", mediawikiDatabase: self.mediawikiDatabase(for: viewModel), pageData: pageData)
+            self.homeFeedInstrument?.submitInteraction(action: "click", actionSource: module, elementId: "article_open", mediawikiDatabase: self.mediawikiDatabase(for: viewModel), pageData: pageData, experimentData: WMFHomeDataController.shared.experimentData)
         }
 
         let vc = HomeViewController(dataStore: dataStore, theme: theme, viewModel: viewModel, homeCoordinator: self)

--- a/Wikipedia/Code/HomeFeedSettingsCoordinator.swift
+++ b/Wikipedia/Code/HomeFeedSettingsCoordinator.swift
@@ -91,16 +91,16 @@ final class HomeFeedSettingsCoordinator: Coordinator {
             project: project,
             searchLanguages: searchLanguages,
             logImpressionIfNeeded: {
-                resolvedInstrument.submitInteraction(action: "impression", actionSource: "feed_customize")
+                resolvedInstrument.submitInteraction(action: "impression", actionSource: "feed_customize", experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapTopic: {
-                resolvedInstrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "topic_select")
+                resolvedInstrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "topic_select", experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapArticle: {
-                resolvedInstrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "article_select")
+                resolvedInstrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "article_select", experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapDeselectAll: {
-                resolvedInstrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "deselect_all")
+                resolvedInstrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "deselect_all", experimentData: WMFHomeDataController.shared.experimentData)
             }
         )
         return WMFHomeFeedInterestsSettingsViewController(viewModel: viewModel, closeButtonHandler: closeButtonHandler)
@@ -139,7 +139,7 @@ final class HomeFeedSettingsCoordinator: Coordinator {
 
     private func showForYouModulesSettings() {
         let instrument = TestKitchenAdapter.shared.client.getInstrument(name: "apps-home-feed")
-        instrument.submitInteraction(action: "click", actionSource: "settings", elementId: "feed_modules_for_you")
+        instrument.submitInteraction(action: "click", actionSource: "settings", elementId: "feed_modules_for_you", experimentData: WMFHomeDataController.shared.experimentData)
         
         let viewModel = WMFHomeFeedForYouSettingsViewModel(
             logToggleModule: { module, isOn in
@@ -150,7 +150,7 @@ final class HomeFeedSettingsCoordinator: Coordinator {
                 case .becauseYouRead: elementId = "BECAUSE_READ"
                 case .continueReading: elementId = "CONTINUE"
                 }
-                instrument.submitInteraction(action: action, actionSource: "settings", actionSubtype: "feed_for_you", elementId: elementId)
+                instrument.submitInteraction(action: action, actionSource: "settings", actionSubtype: "feed_for_you", elementId: elementId, experimentData: WMFHomeDataController.shared.experimentData)
             }
         )
         let forYouSettingsVC = WMFHomeFeedForYouSettingsViewController(viewModel: viewModel)
@@ -158,13 +158,13 @@ final class HomeFeedSettingsCoordinator: Coordinator {
     }
 
     private func showWhatsDrivingSettings() {
-        TestKitchenAdapter.shared.client.getInstrument(name: "apps-home-feed").submitInteraction(action: "click", actionSource: "settings", elementId: "feed_data_info")
+        TestKitchenAdapter.shared.client.getInstrument(name: "apps-home-feed").submitInteraction(action: "click", actionSource: "settings", elementId: "feed_data_info", experimentData: WMFHomeDataController.shared.experimentData)
         activeNavigationController.pushViewController(makeWhatsDrivingViewController(), animated: true)
     }
 
     private func showInterestsSettings() {
         
-        TestKitchenAdapter.shared.client.getInstrument(name: "apps-home-feed").submitInteraction(action: "click", actionSource: "settings", elementId: "customize_feed")
+        TestKitchenAdapter.shared.client.getInstrument(name: "apps-home-feed").submitInteraction(action: "click", actionSource: "settings", elementId: "customize_feed", experimentData: WMFHomeDataController.shared.experimentData)
         
         let language = homeDataController.selectedLanguage() ?? WMFDataEnvironment.current.primaryAppLanguage ?? WMFLanguage(languageCode: "en", languageVariantCode: nil)
         let project = WMFProject.wikipedia(language)
@@ -176,16 +176,16 @@ final class HomeFeedSettingsCoordinator: Coordinator {
             project: project,
             searchLanguages: searchLanguages,
             logImpressionIfNeeded: {
-                instrument.submitInteraction(action: "impression", actionSource: "feed_customize")
+                instrument.submitInteraction(action: "impression", actionSource: "feed_customize", experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapTopic: {
-                instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "topic_select")
+                instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "topic_select", experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapArticle: {
-                instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "article_select")
+                instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "article_select", experimentData: WMFHomeDataController.shared.experimentData)
             },
             logDidTapDeselectAll: {
-                instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "deselect_all")
+                instrument.submitInteraction(action: "click", actionSource: "feed_customize", elementId: "deselect_all", experimentData: WMFHomeDataController.shared.experimentData)
             }
         
         )
@@ -195,7 +195,7 @@ final class HomeFeedSettingsCoordinator: Coordinator {
 
     private func switchToSearchTab() {
         // `AppDelegate` is compiled out of test builds (replaced by `MockAppDelegate`), so any reference to it must be guarded in test builds
-        TestKitchenAdapter.shared.client.getInstrument(name: "apps-home-feed").submitInteraction(action: "click", actionSource: "settings", elementId: "reading_history")
+        TestKitchenAdapter.shared.client.getInstrument(name: "apps-home-feed").submitInteraction(action: "click", actionSource: "settings", elementId: "reading_history", experimentData: WMFHomeDataController.shared.experimentData)
 #if !TEST
         guard let appViewController = (UIApplication.shared.delegate as? AppDelegate)?.appViewController else {
             return
@@ -205,7 +205,7 @@ final class HomeFeedSettingsCoordinator: Coordinator {
     }
 
     private func showLanguages() {
-        TestKitchenAdapter.shared.client.getInstrument(name: "apps-home-feed").submitInteraction(action: "click", actionSource: "settings", elementId: "languages")
+        TestKitchenAdapter.shared.client.getInstrument(name: "apps-home-feed").submitInteraction(action: "click", actionSource: "settings", elementId: "languages", experimentData: WMFHomeDataController.shared.experimentData)
         let languagesVC = WMFPreferredLanguagesViewController.preferredLanguagesViewController()
         languagesVC.showExploreFeedCustomizationSettings = true
         languagesVC.apply(currentTheme)

--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -954,8 +954,9 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
     private func resumeApp(_ completion: (() -> Void)?) {
         // Assign and apply the home tab experiment before onboarding decisions are made,
         // so that presentOnboardingIfNeeded and loadMainUI both see the correct flag.
-        _ = WMFHomeDataController.shared.persistedHomeTabAssignment()
-        
+        WMFHomeDataController.shared.assignExperiment()
+        WMFHomeDataController.shared.logExperimentExposure()
+
         presentOnboardingIfNeeded { didShowOnboarding in
             self.loadMainUI()
             let done: () -> Void = {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T427689

### Notes
See https://wikimedia.slack.com/archives/C0BB50D9TGD/p1787787953017929

### Test Steps
1. Regression. Confirm 50% A/B test still appears to be assigning correctly. Confirm these 4 cases can be hit:

**Fresh install:**
        - 50% of the time you see new app onboarding, you see experiment_exposure event logged with treatment experiment data.
        - 50% of the time you see legacy app onboarding, you see experiment_exposure event logged with control experiment data.

**Fresh install App Store build, then run this branch (i.e. upgrade path):**
        - 50% of the time you see new app one-time onboarding, you see experiment_exposure event logged with treatment experiment data.
        - 50% of the time you see old explore feed, you see experiment_exposure event logged with control + experiment data.

2. While in treatment / for you, tap overflow menu buttons in article cards, confirm you see "feed_overflow" in events.
3. Tap around, confirm all events you see that go to either apps-home-feed instrument or apps-onboarding also have additional experiment data added.

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
