### PR TITLE
Add appInstallId query parameter to outbound visual editor URL

### DIFF
--- a/Wikipedia/Code/ArticleViewController+Editing.swift
+++ b/Wikipedia/Code/ArticleViewController+Editing.swift
@@ -103,6 +103,10 @@ extension ArticleViewController {
         if let sectionID {
             queryItems.append(URLQueryItem(name: "section", value: String(sectionID)))
         }
+        if let appInstallId: String = try? WMFDataEnvironment.current.crossProcessUserDefaultsStore?.load(key: WMFUserDefaultsKey.appInstallID.rawValue), !appInstallId.isEmpty {
+            queryItems.append(URLQueryItem(name: "appinstallid", value: appInstallId))
+        }
+        
         components?.queryItems = queryItems
         navigate(to: components?.url, useSafari: true)
     }

--- a/Wikipedia/Code/VisualEditorReturnJourney.swift
+++ b/Wikipedia/Code/VisualEditorReturnJourney.swift
@@ -21,6 +21,7 @@ struct VisualEditorReturnJourney {
     private static let returnToAppQueryItemName = "returntoapp"
     private static let sectionQueryItemName = "section"
     private static let useFormatQueryItemName = "useformat"
+    private static let appInstallIDQueryItemName = "appinstallid"
 
     init?(url: URL) {
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
@@ -60,7 +61,8 @@ struct VisualEditorReturnJourney {
             Self.visualEditorActionQueryItemName,
             Self.returnToAppQueryItemName,
             Self.sectionQueryItemName,
-            Self.useFormatQueryItemName
+            Self.useFormatQueryItemName,
+            Self.appInstallIDQueryItemName
         ]
 
         let remainingQueryItems = queryItems.filter { !visualEditorQueryItemNames.contains($0.name) }

--- a/Wikipedia/Code/VisualEditorReturnJourney.swift
+++ b/Wikipedia/Code/VisualEditorReturnJourney.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Parses the URL the web Visual Editor uses to hand the user back to the app after publishing or abandoning an edit, e.g.
-/// `wikipedia://en.wikipedia.org/wiki/Cat?saved=true&revision=12345`.
+/// `wikipedia://en.wikipedia.org/wiki/Cat?saved=true&revision=12345&appinstallid=6789`.
 /// Also recognizes a return mid-edit through Safari's native app banner, where the
 /// incoming URL is the editing URL itself (`?veaction=edit&returntoapp=1`).
 struct VisualEditorReturnJourney {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T435362

### Notes
* This PR appends the app's unique install id (appInstallid) as a key-value pair to the query string for visual editor.

### Test Steps
1. 

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
