### PR TITLE
Make saved-article rate limiting detectable and act on it

### DIFF
--- a/WMF Framework/ArticleCacheController.swift
+++ b/WMF Framework/ArticleCacheController.swift
@@ -2,14 +2,14 @@ import Foundation
 
 public final class ArticleCacheController: CacheController {
     
-    init(moc: NSManagedObjectContext, imageCacheController: ImageCacheController, session: Session, configuration: Configuration, preferredLanguageDelegate: WMFPreferredLanguageInfoProvider) {
+    init(moc: NSManagedObjectContext, imageCacheController: ImageCacheController, session: Session, configuration: Configuration, preferredLanguageDelegate: WMFPreferredLanguageInfoProvider, throttle: CacheRequestThrottle = CacheRequestThrottle()) {
         let articleFetcher = ArticleFetcher(session: session, configuration: configuration)
         let imageInfoFetcher = MWKImageInfoFetcher(session: session, configuration: configuration)
         imageInfoFetcher.preferredLanguageDelegate = preferredLanguageDelegate
         let cacheFileWriter = CacheFileWriter(fetcher: articleFetcher)
-        
+
         let articleDBWriter = ArticleCacheDBWriter(articleFetcher: articleFetcher, cacheBackgroundContext: moc, imageController: imageCacheController, imageInfoFetcher: imageInfoFetcher)
-        super.init(dbWriter: articleDBWriter, fileWriter: cacheFileWriter)
+        super.init(dbWriter: articleDBWriter, fileWriter: cacheFileWriter, throttle: throttle)
     }
 
     enum ArticleCacheControllerError: Error {
@@ -29,45 +29,58 @@ public final class ArticleCacheController: CacheController {
             case .success(let syncResult):
             
                 let group = DispatchGroup()
-                
+
                 var successfulAddKeys: [CacheController.UniqueKey] = []
                 var failedAddKeys: [(CacheController.UniqueKey, Error)] = []
                 var successfulRemoveKeys: [CacheController.UniqueKey] = []
                 var failedRemoveKeys: [(CacheController.UniqueKey, Error)] = []
+
+                // These four are appended to from concurrent completion callbacks and
+                // read in the notify block, so every access is serialised here.
+                let syncResultsQueue = DispatchQueue(label: "org.wikimedia.cache.article.syncResults")
                 
                 // add new urls in file system
                 for urlRequest in syncResult.addURLRequests {
-                    
+
                     guard let uniqueKey = self.fileWriter.uniqueFileNameForURLRequest(urlRequest), urlRequest.url != nil else {
                         continue
                     }
-                    
+
                     group.enter()
-                    
-                    self.fileWriter.add(groupKey: groupKey, urlRequest: urlRequest) { (fileWriterResult) in
-                        switch fileWriterResult {
-                        case .success(let response, _):
-                            
-                            self.dbWriter.markDownloaded(urlRequest: urlRequest, response: response) { (dbWriterResult) in
-                            
+
+                    // Bounded like the download path. This runs in the foreground every
+                    // time an already-saved article is opened, competing with the
+                    // WebView's own resource loads, so an unbounded burst here is worse
+                    // placed than the same burst while saving.
+                    self.throttle.enqueue(groupKey: groupKey) { done in
+
+                        self.fileWriter.add(groupKey: groupKey, urlRequest: urlRequest) { (fileWriterResult) in
+                            switch fileWriterResult {
+                            case .success(let response, _):
+
+                                self.dbWriter.markDownloaded(urlRequest: urlRequest, response: response) { (dbWriterResult) in
+
+                                    defer {
+                                        done()
+                                        group.leave()
+                                    }
+
+                                    switch dbWriterResult {
+                                    case .success:
+                                        syncResultsQueue.sync { successfulAddKeys.append(uniqueKey) }
+                                    case .failure(let error):
+                                        syncResultsQueue.sync { failedAddKeys.append((uniqueKey, error)) }
+                                    }
+                                }
+                            case .failure(let error):
+
                                 defer {
+                                    done()
                                     group.leave()
                                 }
-                                    
-                                switch dbWriterResult {
-                                case .success:
-                                    successfulAddKeys.append(uniqueKey)
-                                case .failure(let error):
-                                    failedAddKeys.append((uniqueKey, error))
-                                }
+
+                                syncResultsQueue.sync { failedAddKeys.append((uniqueKey, error)) }
                             }
-                        case .failure(let error):
-                            
-                            defer {
-                                group.leave()
-                            }
-                            
-                            failedAddKeys.append((uniqueKey, error))
                         }
                     }
                 }
@@ -94,29 +107,29 @@ public final class ArticleCacheController: CacheController {
                                 
                                 switch dbWriterResult {
                                 case .success:
-                                    successfulRemoveKeys.append(uniqueKey)
+                                    syncResultsQueue.sync { successfulRemoveKeys.append(uniqueKey) }
                                 case .failure(let error):
-                                    failedRemoveKeys.append((uniqueKey, error))
+                                    syncResultsQueue.sync { failedRemoveKeys.append((uniqueKey, error)) }
                                 }
                             }
                         case .failure(let error):
                             defer {
                                 group.leave()
                             }
-                            
-                            failedRemoveKeys.append((uniqueKey, error))
+
+                            syncResultsQueue.sync { failedRemoveKeys.append((uniqueKey, error)) }
                         }
                     }
                 }
                 
                 group.notify(queue: DispatchQueue.global(qos: .userInitiated)) {
-                    if let error = failedAddKeys.first?.1 ?? failedRemoveKeys.first?.1 {
-                        groupCompletion(.failure(error: CacheControllerError.atLeastOneItemFailedInSync(error)))
-                        return
+                    let result: FinalGroupResult = syncResultsQueue.sync { () -> FinalGroupResult in
+                        if let error = failedAddKeys.first?.1 ?? failedRemoveKeys.first?.1 {
+                            return .failure(error: CacheControllerError.atLeastOneItemFailedInSync(error))
+                        }
+                        return .success(uniqueKeys: successfulAddKeys + successfulRemoveKeys)
                     }
-                    
-                    let successKeys = successfulAddKeys + successfulRemoveKeys
-                    groupCompletion(.success(uniqueKeys: successKeys))
+                    groupCompletion(result)
                 }
                 
             case .failure(let error):

--- a/WMF Framework/ArticleCacheResourceDBWriting.swift
+++ b/WMF Framework/ArticleCacheResourceDBWriting.swift
@@ -3,7 +3,23 @@ import Foundation
 struct ImageAndResourceURLs {
     let offlineResourcesURLs: [URL]
     let mediaListURLs: [URL]
-    let imageInfoURLs: [URL]
+    /// Image metadata URLs paired with the title each one is for.
+    ///
+    /// The title is kept alongside the URL because the offline download fetches this
+    /// metadata in batches but has to store the result under each single-title URL —
+    /// see `ImageInfoResponseSplitter`.
+    let imageInfo: [ImageInfoURL]
+}
+
+struct ImageInfoURL {
+    let title: String
+    let url: URL
+}
+
+extension ImageAndResourceURLs {
+    var imageInfoURLs: [URL] {
+        imageInfo.map { $0.url }
+    }
 }
 
 enum ImageAndResourceResult {
@@ -135,7 +151,7 @@ extension ArticleCacheResourceDBWriting {
         
         var mobileHtmlOfflineResourceURLs: [URL] = []
         var mediaListURLs: [URL] = []
-        var imageInfoURLs: [URL] = []
+        var imageInfo: [ImageInfoURL] = []
         
         var mediaListError: Error?
         var mobileHtmlOfflineResourceError: Error?
@@ -172,11 +188,15 @@ extension ArticleCacheResourceDBWriting {
                 
                 let imageTitles = items.map { $0.imageTitle }
                 let dedupedTitles = Set(imageTitles)
-                
+
                 // add imageInfoFetcher's urls for deduped titles (for captions/licensing info in gallery)
+                //
+                // These stay single-title URLs even though the download fetches them in
+                // batches: the permanent cache is keyed by the literal request URL, and
+                // the gallery asks for one title at a time.
                 for title in dedupedTitles {
                     if let imageInfoURL = self.imageInfoFetcher.galleryInfoURL(forImageTitles: [title], fromSiteURL: articleURL) {
-                        imageInfoURLs.append(imageInfoURL)
+                        imageInfo.append(ImageInfoURL(title: title, url: imageInfoURL))
                     }
                 }
                 
@@ -199,7 +219,7 @@ extension ArticleCacheResourceDBWriting {
                 return
             }
             
-            let result = ImageAndResourceURLs(offlineResourcesURLs: mobileHtmlOfflineResourceURLs, mediaListURLs: mediaListURLs, imageInfoURLs: imageInfoURLs)
+            let result = ImageAndResourceURLs(offlineResourcesURLs: mobileHtmlOfflineResourceURLs, mediaListURLs: mediaListURLs, imageInfo: imageInfo)
             completion(.success(result))
         }
     }

--- a/WMF Framework/CacheController.swift
+++ b/WMF Framework/CacheController.swift
@@ -140,6 +140,11 @@ public class CacheController {
     let dbWriter: CacheDBWriting
     let fileWriter: CacheFileWriter
     let gatekeeper = CacheGatekeeper()
+
+    /// Serialises the per-group result arrays in `finishDBAdd`, which are appended to
+    /// from URLSession and global-queue callbacks running concurrently. Follows the
+    /// same labelled-serial-queue convention as `CacheGatekeeper`.
+    private let resultsQueue = DispatchQueue(label: "org.wikimedia.cache.controller.results")
     
     init(dbWriter: CacheDBWriting, fileWriter: CacheFileWriter) {
         self.dbWriter = dbWriter
@@ -196,8 +201,20 @@ public class CacheController {
 
             var successfulKeys: [CacheController.UniqueKey] = []
             var failedKeys: [(CacheController.UniqueKey, Error)] = []
+            let resultsQueue = self.resultsQueue
 
             let group = DispatchGroup()
+
+            // Hold the group open for the duration of the loop itself. Without this
+            // the group can reach zero as soon as the first request completes — before
+            // the loop has issued the rest — and the group completion fires early with
+            // a partial result, marking the article downloaded before its resources
+            // are fetched. This also makes the empty and all-skipped cases work: the
+            // balancing leave below lets the notify fire with no results, where
+            // previously nothing fired at all and the group key was stranded in the
+            // gatekeeper's currentlyAdding list forever.
+            group.enter()
+
             for urlRequest in urlRequests {
 
                 guard let uniqueKey = fileWriter.uniqueFileNameForURLRequest(urlRequest),
@@ -225,6 +242,9 @@ public class CacheController {
                 fileWriter.add(groupKey: groupKey, urlRequest: urlRequest) { [weak self] (result) in
 
                     guard let self = self else {
+                        // Still balance the group — a deallocated controller must not
+                        // strand the group completion.
+                        group.leave()
                         return
                     }
 
@@ -241,11 +261,11 @@ public class CacheController {
 
                             switch result {
                             case .success:
-                                successfulKeys.append(uniqueKey)
+                                resultsQueue.sync { successfulKeys.append(uniqueKey) }
                                 individualResult = FinalIndividualResult.success(uniqueKey: uniqueKey)
 
                             case .failure(let error):
-                                failedKeys.append((uniqueKey, error))
+                                resultsQueue.sync { failedKeys.append((uniqueKey, error)) }
                                 individualResult = FinalIndividualResult.failure(error: error)
                             }
 
@@ -260,22 +280,26 @@ public class CacheController {
                             group.leave()
                         }
 
-                        failedKeys.append((uniqueKey, error))
+                        resultsQueue.sync { failedKeys.append((uniqueKey, error)) }
                         let individualResult = FinalIndividualResult.failure(error: error)
                         self.gatekeeper.runAndRemoveIndividualCompletions(uniqueKey: uniqueKey, individualResult: individualResult)
                     }
                 }
-
-                group.notify(queue: DispatchQueue.global(qos: .userInitiated)) {
-                    let groupResult: FinalGroupResult
-                    if let error = failedKeys.first?.1 {
-                        groupResult = FinalGroupResult.failure(error: CacheControllerError.atLeastOneItemFailedInFileWriter(error))
-                    } else {
-                        groupResult = FinalGroupResult.success(uniqueKeys: successfulKeys)
-                    }
-                    groupCompleteBlock(groupResult)
-                }
             }
+
+            // Registered once, after the loop, and before the balancing leave so it
+            // cannot fire until every request has been issued and has completed.
+            group.notify(queue: DispatchQueue.global(qos: .userInitiated)) {
+                let groupResult: FinalGroupResult = resultsQueue.sync { () -> FinalGroupResult in
+                    if let error = failedKeys.first?.1 {
+                        return FinalGroupResult.failure(error: CacheControllerError.atLeastOneItemFailedInFileWriter(error))
+                    }
+                    return FinalGroupResult.success(uniqueKeys: successfulKeys)
+                }
+                groupCompleteBlock(groupResult)
+            }
+
+            group.leave()
 
         case .failure(let error):
             let groupResult = FinalGroupResult.failure(error: error)

--- a/WMF Framework/CacheController.swift
+++ b/WMF Framework/CacheController.swift
@@ -145,10 +145,16 @@ public class CacheController {
     /// from URLSession and global-queue callbacks running concurrently. Follows the
     /// same labelled-serial-queue convention as `CacheGatekeeper`.
     private let resultsQueue = DispatchQueue(label: "org.wikimedia.cache.controller.results")
-    
-    init(dbWriter: CacheDBWriting, fileWriter: CacheFileWriter) {
+
+    /// Bounds concurrent downloads per group. Shared with the other cache controller
+    /// so one article's budget covers its resources and its images together — see
+    /// `CacheRequestThrottle`.
+    let throttle: CacheRequestThrottle
+
+    init(dbWriter: CacheDBWriting, fileWriter: CacheFileWriter, throttle: CacheRequestThrottle = CacheRequestThrottle()) {
         self.dbWriter = dbWriter
         self.fileWriter = fileWriter
+        self.throttle = throttle
     }
 
     public func add(url: URL, groupKey: GroupKey, individualCompletion: @escaping IndividualCompletionBlock, groupCompletion: @escaping GroupCompletionBlock) {
@@ -239,50 +245,63 @@ public class CacheController {
                     continue
                 }
 
-                fileWriter.add(groupKey: groupKey, urlRequest: urlRequest) { [weak self] (result) in
+                throttle.enqueue(groupKey: groupKey) { [weak self] done in
 
                     guard let self = self else {
-                        // Still balance the group — a deallocated controller must not
-                        // strand the group completion.
+                        // Release the slot and balance the group — a deallocated
+                        // controller must not strand the group completion, nor leave
+                        // the rest of the group queued behind a slot that never frees.
+                        done()
                         group.leave()
                         return
                     }
 
-                    switch result {
-                    case .success(let response, let data):
+                    self.fileWriter.add(groupKey: groupKey, urlRequest: urlRequest) { [weak self] (result) in
 
-                        self.dbWriter.markDownloaded(urlRequest: urlRequest, response: response) { (result) in
+                        guard let self = self else {
+                            done()
+                            group.leave()
+                            return
+                        }
+
+                        switch result {
+                        case .success(let response, let data):
+
+                            self.dbWriter.markDownloaded(urlRequest: urlRequest, response: response) { (result) in
+
+                                defer {
+                                    done()
+                                    group.leave()
+                                }
+
+                                let individualResult: FinalIndividualResult
+
+                                switch result {
+                                case .success:
+                                    resultsQueue.sync { successfulKeys.append(uniqueKey) }
+                                    individualResult = FinalIndividualResult.success(uniqueKey: uniqueKey)
+
+                                case .failure(let error):
+                                    resultsQueue.sync { failedKeys.append((uniqueKey, error)) }
+                                    individualResult = FinalIndividualResult.failure(error: error)
+                                }
+
+                                self.gatekeeper.runAndRemoveIndividualCompletions(uniqueKey: uniqueKey, individualResult: individualResult)
+                            }
+
+                            self.finishFileSave(data: data, mimeType: response.mimeType, uniqueKey: uniqueKey, url: url)
+
+                        case .failure(let error):
 
                             defer {
+                                done()
                                 group.leave()
                             }
 
-                            let individualResult: FinalIndividualResult
-
-                            switch result {
-                            case .success:
-                                resultsQueue.sync { successfulKeys.append(uniqueKey) }
-                                individualResult = FinalIndividualResult.success(uniqueKey: uniqueKey)
-
-                            case .failure(let error):
-                                resultsQueue.sync { failedKeys.append((uniqueKey, error)) }
-                                individualResult = FinalIndividualResult.failure(error: error)
-                            }
-
+                            resultsQueue.sync { failedKeys.append((uniqueKey, error)) }
+                            let individualResult = FinalIndividualResult.failure(error: error)
                             self.gatekeeper.runAndRemoveIndividualCompletions(uniqueKey: uniqueKey, individualResult: individualResult)
                         }
-
-                        self.finishFileSave(data: data, mimeType: response.mimeType, uniqueKey: uniqueKey, url: url)
-
-                    case .failure(let error):
-
-                        defer {
-                            group.leave()
-                        }
-
-                        resultsQueue.sync { failedKeys.append((uniqueKey, error)) }
-                        let individualResult = FinalIndividualResult.failure(error: error)
-                        self.gatekeeper.runAndRemoveIndividualCompletions(uniqueKey: uniqueKey, individualResult: individualResult)
                     }
                 }
             }

--- a/WMF Framework/CacheFetching.swift
+++ b/WMF Framework/CacheFetching.swift
@@ -1,4 +1,6 @@
 import Foundation
+import CocoaLumberjackSwift
+import WMFData
 
 public struct CacheFetchingResult {
     let data: Data
@@ -38,8 +40,45 @@ public protocol CacheFetching {
     func writeBundledFiles(mimeType: String, bundledFileURL: URL, urlRequest: URLRequest, completion: @escaping (Result<Void, Error>) -> Void)
 }
 
+/// Reports HTTP failures on the permanent-cache download path.
+///
+/// The rest of the networking stack already reports them — `Session.handleResponse`
+/// for the JSON task methods, `SessionDelegate` for the delegate-driven tasks the
+/// SchemeHandler uses — but neither covers this path: `Session.dataTask(with:completionHandler:)`
+/// doesn't call `handleResponse`, and its completion-handler task suppresses the
+/// data-delegate callbacks. Without this, every saved-article resource download is
+/// invisible in instrumentation, rate limits included.
+enum CacheFetchingHTTPErrorLogger {
+
+    /// Distinguishes these events from the "Session" and "SessionDelegate" sources
+    /// already in the stream, so download-driven throttling can be told apart from
+    /// throttling while reading an article.
+    static let source = "CacheFetching"
+
+    static func logIfNeeded(httpResponse: HTTPURLResponse, urlRequest: URLRequest) {
+        // Deliberately narrower than `isHTTPError`: this path sees routine 404s for
+        // resources an article no longer references, and logging those would swamp
+        // the stream. Rate limits and server errors are the ones worth acting on.
+        let statusCode = httpResponse.statusCode
+        guard statusCode == RequestError.rateLimitedStatusCode || (500...599).contains(statusCode) else {
+            return
+        }
+
+        DDLogError("CacheFetching: HTTP \(statusCode) for \(urlRequest.url?.absoluteString ?? "unknown URL")")
+
+        ClientErrorFunnel.shared.logHTTPError(
+            info: WMFHTTPErrorInfo(
+                statusCode: statusCode,
+                method: urlRequest.httpMethod,
+                url: urlRequest.url?.absoluteString,
+                source: source
+            )
+        )
+    }
+}
+
 extension CacheFetching where Self:Fetcher {
-    
+
     @discardableResult public func dataForURLRequest(_ urlRequest: URLRequest, completion: @escaping DataCompletion) -> URLSessionTask? {
         
         let task = session.dataTask(with: urlRequest) { (data, urlResponse, error) in
@@ -53,8 +92,13 @@ extension CacheFetching where Self:Fetcher {
                 return
             }
             
+            // Carry the status code rather than flattening every non-200 into
+            // .unexpectedResponse. SavedArticlesFetcher needs to tell a rate limit
+            // (429) apart from an ordinary failure so it can pause globally instead
+            // of branding the article and escalating its backoff.
             if let httpResponse = unwrappedResponse as? HTTPURLResponse, httpResponse.statusCode != 200 {
-                completion(.failure(RequestError.unexpectedResponse))
+                CacheFetchingHTTPErrorLogger.logIfNeeded(httpResponse: httpResponse, urlRequest: urlRequest)
+                completion(.failure(RequestError.from(code: httpResponse.statusCode, response: httpResponse)))
                 return
             }
             

--- a/WMF Framework/CacheRequestThrottle.swift
+++ b/WMF Framework/CacheRequestThrottle.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Bounds how many permanent-cache download requests are in flight for one group.
+///
+/// A group is an article. Saving a single article fans out into a mobile-html
+/// request, one request per offline resource, one `imageinfo` call per image and one
+/// download per image — previously all issued at once, from two `finishDBAdd` runs
+/// sharing the same group key (`ArticleCacheDBWriter.add` kicks off
+/// `imageController.add(urls:)` alongside its own requests). One throttle instance is
+/// shared by the article and image controllers so a group's budget covers both.
+///
+/// Non-blocking by construction. On the article path `finishDBAdd` runs on the cache
+/// managed object context's private queue, and the completion it would be waiting on
+/// hops back onto that same context via `markDownloaded`, so a blocking wait here
+/// would deadlock. All state is mutated inside `queue.async` and no caller ever waits.
+final class CacheRequestThrottle {
+
+    /// Requests in flight per group. Images share this budget with the metadata calls
+    /// that are the actual rate-limit pressure, so setting it too low slows saving
+    /// without reducing load on the throttled endpoints.
+    static let defaultMaxConcurrentRequestsPerGroup = 6
+
+    let maxConcurrentRequestsPerGroup: Int
+
+    private let queue = DispatchQueue(label: "org.wikimedia.cache.throttle")
+    private var inFlightByGroup: [CacheController.GroupKey: Int] = [:]
+    private var pendingByGroup: [CacheController.GroupKey: [Work]] = [:]
+
+    /// Work handed to the throttle. It is given a `done` block and must call it once
+    /// its request has finished, whether it succeeded or failed.
+    typealias Work = (@escaping () -> Void) -> Void
+
+    init(maxConcurrentRequestsPerGroup: Int = CacheRequestThrottle.defaultMaxConcurrentRequestsPerGroup) {
+        self.maxConcurrentRequestsPerGroup = max(1, maxConcurrentRequestsPerGroup)
+    }
+
+    /// Runs `work` as soon as a slot is free for `groupKey`, or immediately if one is.
+    ///
+    /// The `done` block `work` receives is safe to call from any thread and more than
+    /// once — only the first call releases the slot. Success and failure arrive on
+    /// different queues here, and a doubled release would let the group exceed its
+    /// budget while a dropped one would leak a slot and stall the group for good.
+    func enqueue(groupKey: CacheController.GroupKey, work: @escaping Work) {
+        queue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            guard self.inFlightByGroup[groupKey, default: 0] < self.maxConcurrentRequestsPerGroup else {
+                self.pendingByGroup[groupKey, default: []].append(work)
+                return
+            }
+
+            self.startOnQueue(groupKey: groupKey, work: work)
+        }
+    }
+
+    /// Number of requests currently in flight for a group. Test seam.
+    func inFlightCount(for groupKey: CacheController.GroupKey) -> Int {
+        queue.sync { inFlightByGroup[groupKey] ?? 0 }
+    }
+
+    // MARK: - Private, all called on `queue`
+
+    private func startOnQueue(groupKey: CacheController.GroupKey, work: @escaping Work) {
+        inFlightByGroup[groupKey, default: 0] += 1
+        work(makeDoneBlock(for: groupKey))
+    }
+
+    private func makeDoneBlock(for groupKey: CacheController.GroupKey) -> () -> Void {
+        var released = false
+        return { [weak self] in
+            guard let self = self else {
+                return
+            }
+            // Hopping onto the queue is what makes `released` safe to read and write
+            // from whichever thread the request completed on.
+            self.queue.async {
+                guard !released else {
+                    return
+                }
+                released = true
+                self.releaseSlotOnQueue(groupKey: groupKey)
+            }
+        }
+    }
+
+    private func releaseSlotOnQueue(groupKey: CacheController.GroupKey) {
+        inFlightByGroup[groupKey] = max(0, (inFlightByGroup[groupKey] ?? 0) - 1)
+
+        // A later change will also need to drop this group's pending work on
+        // cancellation; that is what keeping it in a per-group list buys.
+        if var pending = pendingByGroup[groupKey], !pending.isEmpty {
+            let next = pending.removeFirst()
+            pendingByGroup[groupKey] = pending.isEmpty ? nil : pending
+            startOnQueue(groupKey: groupKey, work: next)
+            return
+        }
+
+        pendingByGroup[groupKey] = nil
+        if inFlightByGroup[groupKey] == 0 {
+            inFlightByGroup[groupKey] = nil
+        }
+    }
+}

--- a/WMF Framework/Fetcher.swift
+++ b/WMF Framework/Fetcher.swift
@@ -399,11 +399,24 @@ open class Fetcher: NSObject {
             defer {
                  self.untrack(taskFor: key)
             }
+            let httpResponse = response as? HTTPURLResponse
             guard let result = result else {
-                completionHandler(.failure(error ?? RequestError.unexpectedResponse), response as? HTTPURLResponse)
+                // Session.jsonDecodableTask reports a non-200 as (nil, response, nil) —
+                // a nil error — so without recovering the status code here every
+                // failure looks identical and a rate limit (429) is indistinguishable
+                // from an ordinary one.
+                let resolvedError: Error
+                if let error = error {
+                    resolvedError = error
+                } else if let statusCode = httpResponse?.statusCode, !HTTPStatusCode.isSuccessful(statusCode) {
+                    resolvedError = RequestError.from(code: statusCode, response: httpResponse)
+                } else {
+                    resolvedError = RequestError.unexpectedResponse
+                }
+                completionHandler(.failure(resolvedError), httpResponse)
                 return
             }
-            completionHandler(.success(result), response as? HTTPURLResponse)
+            completionHandler(.success(result), httpResponse)
         }
         
         track(task: task, for: key)

--- a/WMF Framework/ImageCacheController.swift
+++ b/WMF Framework/ImageCacheController.swift
@@ -37,13 +37,13 @@ public final class ImageCacheController: CacheController {
     private let imageFetcher: ImageFetcher
     fileprivate let memoryCache: NSCache<NSString, Image>
     
-    init(moc: NSManagedObjectContext, session: Session, configuration: Configuration) {
+    init(moc: NSManagedObjectContext, session: Session, configuration: Configuration, throttle: CacheRequestThrottle = CacheRequestThrottle()) {
         self.imageFetcher = ImageFetcher(session: session, configuration: configuration)
         memoryCache = NSCache<NSString, Image>()
         memoryCache.totalCostLimit = 10000000 // pixel count
         let fileWriter = CacheFileWriter(fetcher: imageFetcher)
         let dbWriter = ImageCacheDBWriter(imageFetcher: imageFetcher, cacheBackgroundContext: moc)
-        super.init(dbWriter: dbWriter, fileWriter: fileWriter)
+        super.init(dbWriter: dbWriter, fileWriter: fileWriter, throttle: throttle)
     }
     
     struct FetchResult {

--- a/WMF Framework/ImageInfoResponseSplitter.swift
+++ b/WMF Framework/ImageInfoResponseSplitter.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Splits one batched `action=query&prop=imageinfo` response into per-title bodies.
+///
+/// The offline download fetches image metadata in batches to keep it from making one
+/// `api.php` request per image, but the gallery reads it back one title at a time and
+/// the permanent cache is keyed by the literal request URL
+/// (`PermanentlyPersistableURLCache.imageInfoItemKeyForURL`). So each page of a batched
+/// response has to be stored under the single-title URL the gallery will later ask for.
+enum ImageInfoResponseSplitter {
+
+    enum SplitError: Error {
+        /// The response had no `query.pages` to split.
+        case malformedResponse
+    }
+
+    struct SplitResult {
+        /// Body to store, keyed by the requested title it belongs to.
+        let bodiesByRequestedTitle: [String: Data]
+        /// Requested titles the response carried no page for — a deleted or renamed
+        /// file, or a title the API did not recognise.
+        let missingTitles: [String]
+    }
+
+    /// Header fields that describe the batch and would be wrong against a single title.
+    ///
+    /// `Etag` is read back to populate `If-None-Match`
+    /// (`PermanentlyPersistableURLCache.urlRequestFromURL`), so storing the batch's
+    /// validator against a single-title URL would send the server a validator
+    /// belonging to a different resource. `Content-Length` describes the batch body.
+    private static let droppedHeaderFields = ["etag", "content-length"]
+
+    /// The batch response's headers, minus the ones that only make sense for the batch.
+    static func perTitleHeaderFields(from response: HTTPURLResponse?) -> [String: String] {
+        guard let response = response else {
+            return [:]
+        }
+
+        var fields: [String: String] = [:]
+        for (rawKey, rawValue) in response.allHeaderFields {
+            guard let key = rawKey as? String, let value = rawValue as? String else {
+                continue
+            }
+            guard !droppedHeaderFields.contains(key.lowercased()) else {
+                continue
+            }
+            fields[key] = value
+        }
+        return fields
+    }
+
+    /// Rebuilds one single-title response body per requested title.
+    ///
+    /// Each body keeps the `{"query": {"pages": {<pageid>: <page>}}}` shape that
+    /// `MWKImageInfoFetcher.responseObjectForJSON:` reads, so the read path is
+    /// unchanged.
+    static func split(response: [String: Any], requestedTitles: [String]) throws -> SplitResult {
+        guard let query = response["query"] as? [String: Any],
+              let pages = query["pages"] as? [String: Any] else {
+            throw SplitError.malformedResponse
+        }
+
+        // The API normalises titles (underscores to spaces, first-letter case) and
+        // reports what it did in `query.normalized`, so a returned page's title often
+        // is not the string we asked for.
+        var normalisedByRequested: [String: String] = [:]
+        if let normalized = query["normalized"] as? [[String: Any]] {
+            for entry in normalized {
+                guard let from = entry["from"] as? String, let to = entry["to"] as? String else {
+                    continue
+                }
+                normalisedByRequested[canonicalised(from)] = to
+            }
+        }
+
+        var pagesByTitle: [String: (pageID: String, page: Any)] = [:]
+        for (pageID, page) in pages {
+            guard let page = page as? [String: Any], let title = page["title"] as? String else {
+                continue
+            }
+            pagesByTitle[canonicalised(title)] = (pageID, page)
+        }
+
+        var bodies: [String: Data] = [:]
+        var missing: [String] = []
+
+        for requestedTitle in requestedTitles {
+            let canonicalRequested = canonicalised(requestedTitle)
+            let lookup = normalisedByRequested[canonicalRequested].map(canonicalised) ?? canonicalRequested
+
+            guard let match = pagesByTitle[lookup] else {
+                missing.append(requestedTitle)
+                continue
+            }
+
+            let body: [String: Any] = ["query": ["pages": [match.pageID: match.page]]]
+            guard JSONSerialization.isValidJSONObject(body),
+                  let data = try? JSONSerialization.data(withJSONObject: body) else {
+                missing.append(requestedTitle)
+                continue
+            }
+
+            bodies[requestedTitle] = data
+        }
+
+        return SplitResult(bodiesByRequestedTitle: bodies, missingTitles: missing)
+    }
+
+    /// Underscores and spaces are interchangeable in MediaWiki titles, and the
+    /// response echoes whichever form it prefers, so compare on one of them.
+    private static func canonicalised(_ title: String) -> String {
+        title.replacingOccurrences(of: "_", with: " ").precomposedStringWithCanonicalMapping
+    }
+}

--- a/WMF Framework/PermanentCacheController.swift
+++ b/WMF Framework/PermanentCacheController.swift
@@ -12,8 +12,12 @@ public final class PermanentCacheController: NSObject {
     /// - Parameter configuration: the configuration to utilize for configuring requests
     /// - Parameter preferredLanguageDelegate: the preferredLanguageDelegate to utilize for determining the user's preferred languages
     @objc public init(moc: NSManagedObjectContext, session: Session, configuration: Configuration, preferredLanguageDelegate: WMFPreferredLanguageInfoProvider) {
-        imageCache = ImageCacheController(moc: moc, session: session, configuration: configuration)
-        articleCache = ArticleCacheController(moc: moc, imageCacheController: imageCache, session: session, configuration: configuration, preferredLanguageDelegate: preferredLanguageDelegate)
+        // One throttle for both controllers: a single article's download fans out
+        // through the article cache and the image cache at the same time under one
+        // group key, so they have to share a budget for it to mean anything.
+        let throttle = CacheRequestThrottle()
+        imageCache = ImageCacheController(moc: moc, session: session, configuration: configuration, throttle: throttle)
+        articleCache = ArticleCacheController(moc: moc, imageCacheController: imageCache, session: session, configuration: configuration, preferredLanguageDelegate: preferredLanguageDelegate, throttle: throttle)
         urlCache = PermanentlyPersistableURLCache(moc: moc)
         managedObjectContext = moc
         super.init()

--- a/WMF Framework/PermanentlyPersistableURLCache.swift
+++ b/WMF Framework/PermanentlyPersistableURLCache.swift
@@ -699,6 +699,42 @@ public extension HTTPURLResponse {
     static let etagHeaderKey = "Etag"
     static let varyHeaderKey = "Vary"
     static let acceptLanguageHeaderValue = "Accept-Language"
+    static let retryAfterHeaderKey = "Retry-After"
+
+    /// The `Retry-After` header as an interval from now, or nil when the header is
+    /// absent or unparseable. RFC 9110 allows either delta-seconds or an HTTP-date,
+    /// so both are handled. A date already in the past yields 0 rather than a
+    /// negative interval.
+    var retryAfterInterval: TimeInterval? {
+        // value(forHTTPHeaderField:) rather than allHeaderFields: HTTP/2 sends header
+        // names lowercased, so an exact-case subscript would miss "retry-after".
+        guard let value = value(forHTTPHeaderField: HTTPURLResponse.retryAfterHeaderKey)?
+            .trimmingCharacters(in: .whitespaces), !value.isEmpty else {
+            return nil
+        }
+
+        if let seconds = TimeInterval(value) {
+            return max(0, seconds)
+        }
+
+        guard let date = DateFormatter.wmf_httpDateFormatter.date(from: value) else {
+            return nil
+        }
+
+        return max(0, date.timeIntervalSinceNow)
+    }
+}
+
+public extension DateFormatter {
+    /// IMF-fixdate, the preferred HTTP-date format (RFC 9110). Fixed to POSIX and
+    /// GMT so it does not vary with the device's locale or time zone.
+    static let wmf_httpDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        return formatter
+    }()
 }
 
 public extension URLRequest {

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -2631,6 +2631,7 @@
 		F1A700000000000000000012 /* TestHTTPClientProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A700000000000000000011 /* TestHTTPClientProfile.swift */; };
 		F1A700000000000000000013 /* TestNetworkFixtureURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A700000000000000000014 /* TestNetworkFixtureURLSession.swift */; };
 		FA71B2C400000001000000AA /* SavedArticlesFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA71B2C400000002000000AA /* SavedArticlesFetcherTests.swift */; };
+		FA71B2C400000003000000AA /* CacheControllerCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA71B2C400000004000000AA /* CacheControllerCompletionTests.swift */; };
 		FACE0000000000000000FE02 /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE0000000000000000FE01 /* HomeCoordinator.swift */; };
 		FACE0000000000000000FE03 /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE0000000000000000FE01 /* HomeCoordinator.swift */; };
 		FACE0000000000000000FE04 /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE0000000000000000FE01 /* HomeCoordinator.swift */; };
@@ -4344,6 +4345,7 @@
 		F1A700000000000000000011 /* TestHTTPClientProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHTTPClientProfile.swift; sourceTree = "<group>"; };
 		F1A700000000000000000014 /* TestNetworkFixtureURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNetworkFixtureURLSession.swift; sourceTree = "<group>"; };
 		FA71B2C400000002000000AA /* SavedArticlesFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedArticlesFetcherTests.swift; sourceTree = "<group>"; };
+		FA71B2C400000004000000AA /* CacheControllerCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheControllerCompletionTests.swift; sourceTree = "<group>"; };
 		FACE0000000000000000FE01 /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		FACE0000000000000000FE05 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		FACE0000000000000000FE11 /* HomeFeedSettingsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFeedSettingsCoordinator.swift; sourceTree = "<group>"; };
@@ -7329,6 +7331,7 @@
 				B389CFCA1E6784B600483C06 /* WMFDatabaseHousekeeperTests.swift */,
 				830ECAD51FBDE77F0080B1EF /* ReadingListsTests.swift */,
 				FA71B2C400000002000000AA /* SavedArticlesFetcherTests.swift */,
+				FA71B2C400000004000000AA /* CacheControllerCompletionTests.swift */,
 				B0C06B9E218240CA00E481CC /* Collection+AsyncMapTests.swift */,
 				D8396D1A22CF7052005625D8 /* WMFArticleTests.swift */,
 				8386BDE623857F87007EE89D /* URLParsingAndRoutingTests.swift */,
@@ -9469,6 +9472,7 @@
 				B0E8086D1C0D15170065EBC0 /* WMFCodingStyle.m in Sources */,
 				830ECAD61FBDE77F0080B1EF /* ReadingListsTests.swift in Sources */,
 				FA71B2C400000001000000AA /* SavedArticlesFetcherTests.swift in Sources */,
+				FA71B2C400000003000000AA /* CacheControllerCompletionTests.swift in Sources */,
 				67C6F74E27E2919B00B9C864 /* RemoteNotificationsModelController+TestExtensions.swift in Sources */,
 				D8800CB11E2FF5B70035D2DB /* QuadKeyTests.swift in Sources */,
 				8386BDE723857F87007EE89D /* URLParsingAndRoutingTests.swift in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -839,6 +839,7 @@
 		67D9D1F82970D8BE00BFCD4F /* BackgroundHighlightingButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D9D1F52970D8BE00BFCD4F /* BackgroundHighlightingButtonStyle.swift */; };
 		67DA31882720957B0035D40F /* RemoteNotificationsPagingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DA31872720957A0035D40F /* RemoteNotificationsPagingOperation.swift */; };
 		67DAEDA123CD1BC9003AA208 /* CacheGatekeeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA023CD1BC9003AA208 /* CacheGatekeeper.swift */; };
+		FA71B2C400000005000000AA /* CacheRequestThrottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA71B2C400000006000000AA /* CacheRequestThrottle.swift */; };
 		67DAEDA323CE24DA003AA208 /* SavedArticlesFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */; };
 		67DAEDA423CE24DA003AA208 /* SavedArticlesFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */; };
 		67DAEDA523CE24DA003AA208 /* SavedArticlesFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */; };
@@ -3372,6 +3373,7 @@
 		67D9D1F52970D8BE00BFCD4F /* BackgroundHighlightingButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundHighlightingButtonStyle.swift; sourceTree = "<group>"; };
 		67DA31872720957A0035D40F /* RemoteNotificationsPagingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationsPagingOperation.swift; sourceTree = "<group>"; };
 		67DAEDA023CD1BC9003AA208 /* CacheGatekeeper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheGatekeeper.swift; sourceTree = "<group>"; };
+		FA71B2C400000006000000AA /* CacheRequestThrottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheRequestThrottle.swift; sourceTree = "<group>"; };
 		67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedArticlesFetcher.swift; sourceTree = "<group>"; };
 		67DAEDD827E8DCBF005CF9B6 /* NotificationsCenterDetailViewModel+TextExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationsCenterDetailViewModel+TextExtensions.swift"; sourceTree = "<group>"; };
 		67DAEDDD27E8FB5F005CF9B6 /* NotificationsCenterDetailViewModelWelcomeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationsCenterDetailViewModelWelcomeTests.swift; sourceTree = "<group>"; };
@@ -5840,6 +5842,7 @@
 				6773B1FD240F02E40022A70E /* PermanentlyPersistableURLCache.swift */,
 				678C7C2923BE67F0001AC4D5 /* CacheController.swift */,
 				67DAEDA023CD1BC9003AA208 /* CacheGatekeeper.swift */,
+				FA71B2C400000006000000AA /* CacheRequestThrottle.swift */,
 				678C7C2D23BE705C001AC4D5 /* CacheDBWriting.swift */,
 				678C7C2F23BE7319001AC4D5 /* CacheDBWriterHelper.swift */,
 				678C7C3323BE75F9001AC4D5 /* CacheFileWriterHelper.swift */,
@@ -10325,6 +10328,7 @@
 				83CDC7D425122A1700A2F8A1 /* PermanentCacheController.swift in Sources */,
 				0E87683B1DDE00D600B8CACD /* WMFAnnouncementsFetcher.m in Sources */,
 				67DAEDA123CD1BC9003AA208 /* CacheGatekeeper.swift in Sources */,
+				FA71B2C400000005000000AA /* CacheRequestThrottle.swift in Sources */,
 				D881B1131E32874500D33F62 /* WMFArticle+QuadKey.swift in Sources */,
 				00669500265DA01000E23AE4 /* WidgetContentFetcher.swift in Sources */,
 				0015712C27D92F6B00F1EB26 /* RetryBlockTask.swift in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -839,6 +839,7 @@
 		67D9D1F82970D8BE00BFCD4F /* BackgroundHighlightingButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D9D1F52970D8BE00BFCD4F /* BackgroundHighlightingButtonStyle.swift */; };
 		67DA31882720957B0035D40F /* RemoteNotificationsPagingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DA31872720957A0035D40F /* RemoteNotificationsPagingOperation.swift */; };
 		67DAEDA123CD1BC9003AA208 /* CacheGatekeeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA023CD1BC9003AA208 /* CacheGatekeeper.swift */; };
+		FA71B2C400000007000000AA /* ImageInfoResponseSplitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA71B2C400000008000000AA /* ImageInfoResponseSplitter.swift */; };
 		FA71B2C400000005000000AA /* CacheRequestThrottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA71B2C400000006000000AA /* CacheRequestThrottle.swift */; };
 		67DAEDA323CE24DA003AA208 /* SavedArticlesFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */; };
 		67DAEDA423CE24DA003AA208 /* SavedArticlesFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */; };
@@ -3373,6 +3374,7 @@
 		67D9D1F52970D8BE00BFCD4F /* BackgroundHighlightingButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundHighlightingButtonStyle.swift; sourceTree = "<group>"; };
 		67DA31872720957A0035D40F /* RemoteNotificationsPagingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationsPagingOperation.swift; sourceTree = "<group>"; };
 		67DAEDA023CD1BC9003AA208 /* CacheGatekeeper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheGatekeeper.swift; sourceTree = "<group>"; };
+		FA71B2C400000008000000AA /* ImageInfoResponseSplitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageInfoResponseSplitter.swift; sourceTree = "<group>"; };
 		FA71B2C400000006000000AA /* CacheRequestThrottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheRequestThrottle.swift; sourceTree = "<group>"; };
 		67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedArticlesFetcher.swift; sourceTree = "<group>"; };
 		67DAEDD827E8DCBF005CF9B6 /* NotificationsCenterDetailViewModel+TextExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationsCenterDetailViewModel+TextExtensions.swift"; sourceTree = "<group>"; };
@@ -5842,6 +5844,7 @@
 				6773B1FD240F02E40022A70E /* PermanentlyPersistableURLCache.swift */,
 				678C7C2923BE67F0001AC4D5 /* CacheController.swift */,
 				67DAEDA023CD1BC9003AA208 /* CacheGatekeeper.swift */,
+				FA71B2C400000008000000AA /* ImageInfoResponseSplitter.swift */,
 				FA71B2C400000006000000AA /* CacheRequestThrottle.swift */,
 				678C7C2D23BE705C001AC4D5 /* CacheDBWriting.swift */,
 				678C7C2F23BE7319001AC4D5 /* CacheDBWriterHelper.swift */,
@@ -10328,6 +10331,7 @@
 				83CDC7D425122A1700A2F8A1 /* PermanentCacheController.swift in Sources */,
 				0E87683B1DDE00D600B8CACD /* WMFAnnouncementsFetcher.m in Sources */,
 				67DAEDA123CD1BC9003AA208 /* CacheGatekeeper.swift in Sources */,
+				FA71B2C400000007000000AA /* ImageInfoResponseSplitter.swift in Sources */,
 				FA71B2C400000005000000AA /* CacheRequestThrottle.swift in Sources */,
 				D881B1131E32874500D33F62 /* WMFArticle+QuadKey.swift in Sources */,
 				00669500265DA01000E23AE4 /* WidgetContentFetcher.swift in Sources */,

--- a/Wikipedia/Code/ArticleCacheDBWriter.swift
+++ b/Wikipedia/Code/ArticleCacheDBWriter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CocoaLumberjackSwift
 
 public enum ArticleCacheDBWriterError: Error {
     case unableToDetermineDatabaseKey
@@ -81,15 +82,22 @@ final class ArticleCacheDBWriter: ArticleCacheResourceDBWriting {
                 }
                 
                 // append image info URLRequests
-                for url in urls.imageInfoURLs {
-                    guard let urlRequest = self.imageInfoFetcher.urlRequestFor(from: url) else {
+                //
+                // These are registered as cache items like everything else, but they are
+                // NOT returned to the cache controller to download one by one — an
+                // image-heavy article would issue one api.php call per image. They are
+                // fetched in batches below and stored per title instead.
+                var imageInfoRequestsByTitle: [(title: String, urlRequest: URLRequest)] = []
+                for imageInfo in urls.imageInfo {
+                    guard let urlRequest = self.imageInfoFetcher.urlRequestFor(from: imageInfo.url) else {
                         completion(.failure(ArticleCacheDBWriterError.failureMakingRequestFromMustHaveResource))
                         return
                     }
-                    
+
                     mustHaveURLRequests.append(urlRequest)
+                    imageInfoRequestsByTitle.append((imageInfo.title, urlRequest))
                 }
-                
+
                 // send image urls straight to imageController to deal with
                 self.imageController.add(urls: urls.mediaListURLs, groupKey: groupKey, individualCompletion: { (result) in
                     
@@ -101,8 +109,23 @@ final class ArticleCacheDBWriter: ArticleCacheResourceDBWriting {
                 self.cacheURLs(groupKey: groupKey, mustHaveURLRequests: mustHaveURLRequests, niceToHaveURLRequests: []) { (result) in
                     switch result {
                     case .success:
-                        let result = CacheDBWritingResultWithURLRequests.success(mustHaveURLRequests)
-                        completion(result)
+                        // Everything except the image info, which the batched fetch below
+                        // downloads and stores itself.
+                        let imageInfoRequestURLs = Set(imageInfoRequestsByTitle.compactMap { $0.urlRequest.url })
+                        let remainingRequests = mustHaveURLRequests.filter { request in
+                            guard let url = request.url else {
+                                return true
+                            }
+                            return !imageInfoRequestURLs.contains(url)
+                        }
+
+                        self.cacheImageInfoInBatches(titledRequests: imageInfoRequestsByTitle, siteURL: url) { error in
+                            if let error = error {
+                                completion(.failure(error))
+                                return
+                            }
+                            completion(.success(remainingRequests))
+                        }
                     case .failure(let error):
                         let result = CacheDBWritingResultWithURLRequests.failure(error)
                         completion(result)
@@ -116,6 +139,117 @@ final class ArticleCacheDBWriter: ArticleCacheResourceDBWriting {
         }
     }
     
+    /// Titles per `action=query&prop=imageinfo` call.
+    ///
+    /// The API allows 50; a smaller batch keeps any single failure from costing a whole
+    /// article's metadata and keeps each response small enough to split cheaply.
+    static let imageInfoBatchSize = 10
+
+    /// Fetches image metadata in batches and stores one cache entry per title.
+    ///
+    /// Batches run one at a time rather than all at once. Firing every chunk together
+    /// would put one concurrent api.php call per ten images in flight, which undercuts
+    /// the point of batching for an image-heavy article; these are also outside the
+    /// per-article throttle, since the throttle lives on the cache controller.
+    ///
+    /// Calls back with the first error encountered, or nil if every batch stored.
+    private func cacheImageInfoInBatches(titledRequests: [(title: String, urlRequest: URLRequest)], siteURL: URL, completion: @escaping (Error?) -> Void) {
+
+        guard !titledRequests.isEmpty else {
+            completion(nil)
+            return
+        }
+
+        var requestsByTitle: [String: URLRequest] = [:]
+        for titledRequest in titledRequests {
+            requestsByTitle[titledRequest.title] = titledRequest.urlRequest
+        }
+
+        let batches = titledRequests.map { $0.title }.chunked(into: Self.imageInfoBatchSize)
+        fetchImageInfoBatches(batches, index: 0, siteURL: siteURL, requestsByTitle: requestsByTitle, completion: completion)
+    }
+
+    private func fetchImageInfoBatches(_ batches: [[String]], index: Int, siteURL: URL, requestsByTitle: [String: URLRequest], completion: @escaping (Error?) -> Void) {
+
+        guard index < batches.count else {
+            completion(nil)
+            return
+        }
+
+        let batch = batches[index]
+        imageInfoFetcher.fetchBatchedGalleryInfoJSON(forImageTitles: batch, fromSiteURL: siteURL, success: { [weak self] (result, response) in
+            guard let self = self else {
+                completion(nil)
+                return
+            }
+            self.storeImageInfo(from: result, response: response, requestedTitles: batch, requestsByTitle: requestsByTitle) { error in
+                if let error = error {
+                    completion(error)
+                    return
+                }
+                self.fetchImageInfoBatches(batches, index: index + 1, siteURL: siteURL, requestsByTitle: requestsByTitle, completion: completion)
+            }
+        }, failure: { error in
+            completion(error)
+        })
+    }
+
+    /// Splits one batched response and writes a cache entry per requested title,
+    /// keyed by the single-title URL the gallery will later ask for.
+    private func storeImageInfo(from result: [String: Any], response: HTTPURLResponse?, requestedTitles: [String], requestsByTitle: [String: URLRequest], completion: @escaping (Error?) -> Void) {
+
+        let split: ImageInfoResponseSplitter.SplitResult
+        do {
+            split = try ImageInfoResponseSplitter.split(response: result, requestedTitles: requestedTitles)
+        } catch let error {
+            completion(error)
+            return
+        }
+
+        if !split.missingTitles.isEmpty {
+            // The API answering "no such page" is a legitimate answer, not a download
+            // failure — a deleted or renamed file. Those entries simply stay uncached,
+            // and the gallery falls back to fetching them online.
+            DDLogDebug("No image info returned for: \(split.missingTitles)")
+        }
+
+        let headerFields = ImageInfoResponseSplitter.perTitleHeaderFields(from: response)
+        let statusCode = response?.statusCode ?? 200
+
+        let group = DispatchGroup()
+        let errorQueue = DispatchQueue(label: "org.wikimedia.cache.imageInfoStore")
+        var firstError: Error?
+
+        for (title, body) in split.bodiesByRequestedTitle {
+            guard let urlRequest = requestsByTitle[title],
+                  let url = urlRequest.url,
+                  let perTitleResponse = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: "HTTP/1.1", headerFields: headerFields) else {
+                continue
+            }
+
+            group.enter()
+            articleFetcher.cacheResponse(httpUrlResponse: perTitleResponse, content: .data(body), urlRequest: urlRequest, success: { [weak self] in
+                guard let self = self else {
+                    group.leave()
+                    return
+                }
+                self.markDownloaded(urlRequest: urlRequest, response: perTitleResponse) { markResult in
+                    if case .failure(let error) = markResult {
+                        errorQueue.sync { firstError = firstError ?? error }
+                    }
+                    group.leave()
+                }
+            }, failure: { error in
+                errorQueue.sync { firstError = firstError ?? error }
+                group.leave()
+            })
+        }
+
+        group.notify(queue: DispatchQueue.global(qos: .userInitiated)) {
+            completion(errorQueue.sync { firstError })
+        }
+    }
+
     func markDownloaded(urlRequest: URLRequest, response: HTTPURLResponse?, completion: @escaping (CacheDBWritingResult) -> Void) {
         
         guard let itemKey = fetcher.itemKeyForURLRequest(urlRequest) else {

--- a/Wikipedia/Code/ArticleCacheDBWriter.swift
+++ b/Wikipedia/Code/ArticleCacheDBWriter.swift
@@ -182,6 +182,18 @@ final class ArticleCacheDBWriter: ArticleCacheResourceDBWriting {
                 completion(nil)
                 return
             }
+
+            // Session.jsonDictionaryTask only special-cases 304 — every other status
+            // falls through to JSON parsing with a nil error, so a 429 would arrive
+            // here looking like a successful response carrying MediaWiki's error body.
+            // Recover the status code so a rate limit on this path is still a rate
+            // limit by the time SavedArticlesFetcher sees it, rather than a generic
+            // failure that brands the article and escalates its backoff.
+            if let statusCode = response?.statusCode, !HTTPStatusCode.isSuccessful(statusCode) {
+                completion(RequestError.from(code: statusCode, response: response))
+                return
+            }
+
             self.storeImageInfo(from: result, response: response, requestedTitles: batch, requestsByTitle: requestsByTitle) { error in
                 if let error = error {
                     completion(error)

--- a/Wikipedia/Code/MWKImageInfoFetcher.h
+++ b/Wikipedia/Code/MWKImageInfoFetcher.h
@@ -57,6 +57,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSURL *)galleryInfoURLForImageTitles: (NSArray *)imageTitles fromSiteURL: (NSURL *)siteURL;
 
+/**
+ * Fetch the raw imageinfo API response for a batch of image page titles.
+ *
+ * Unlike the other fetch methods this hands back the undigested response, so a caller
+ * can split it into one cached entry per title. That is what lets the offline download
+ * make one request per batch rather than one per image.
+ *
+ * Uses the same query parameters as @c galleryInfoURLForImageTitles:fromSiteURL:, so
+ * each page in the response carries exactly what a single-title request would have
+ * returned for that title.
+ *
+ * @param imageTitles One or more page titles, at most 50 (the API's limit).
+ */
+- (nullable NSURLSessionTask *)fetchBatchedGalleryInfoJSONForImageTitles:(NSArray<NSString *> *)imageTitles
+                                                             fromSiteURL:(NSURL *)siteURL
+                                                                 success:(void (^)(NSDictionary<NSString *, id> *result, NSHTTPURLResponse *_Nullable response))success
+                                                                 failure:(void (^)(NSError *error))failure
+    NS_SWIFT_NAME(fetchBatchedGalleryInfoJSON(forImageTitles:fromSiteURL:success:failure:));
+
 - (nullable NSURLRequest *)urlRequestForFromURL: (NSURL *)url;
 
 @property (weak, nonatomic) id<WMFPreferredLanguageInfoProvider> preferredLanguageDelegate;

--- a/Wikipedia/Code/MWKImageInfoFetcher.m
+++ b/Wikipedia/Code/MWKImageInfoFetcher.m
@@ -182,6 +182,42 @@ static CGSize MWKImageInfoSizeFromJSON(NSDictionary *json, NSString *widthKey, N
     return nil;
 }
 
+- (nullable NSURLSessionTask *)fetchBatchedGalleryInfoJSONForImageTitles:(NSArray<NSString *> *)imageTitles
+                                                             fromSiteURL:(NSURL *)siteURL
+                                                                 success:(void (^)(NSDictionary<NSString *, id> *result, NSHTTPURLResponse *_Nullable response))success
+                                                                 failure:(void (^)(NSError *error))failure {
+    NSParameterAssert([imageTitles count]);
+    NSAssert([imageTitles count] <= 50, @"Only 50 titles can be queried at a time.");
+    NSParameterAssert(siteURL);
+
+    NSDictionary *params = [self queryParametersForTitles:imageTitles
+                                              fromSiteURL:siteURL
+                                           thumbnailWidth:[NSNumber numberWithInteger:[ImageUtils articleImageWidth]]
+                                          extmetadataKeys:[MWKImageInfoFetcher galleryExtMetadataKeys]
+                                         metadataLanguage:siteURL.wmf_languageCode
+                                             useGenerator:NO];
+
+    NSURL *url = [self.configuration mediaWikiAPIURLForURL:siteURL withQueryParameters:params];
+    NSURLRequest *urlRequest = url ? [self urlRequestForFromURL:url] : nil;
+    if (!urlRequest) {
+        failure([WMFFetcher invalidParametersError]);
+        return nil;
+    }
+
+    return [self performMediaWikiAPIGETForURLRequest:urlRequest
+                                   completionHandler:^(NSDictionary<NSString *, id> *_Nullable result, NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
+                                       if (error) {
+                                           failure(error);
+                                           return;
+                                       }
+                                       if (!result) {
+                                           failure([WMFFetcher unexpectedResponseError]);
+                                           return;
+                                       }
+                                       success(result, response);
+                                   }];
+}
+
 - (NSDictionary *)queryParametersForTitles:(NSArray *)titles
      fromSiteURL:(NSURL *)siteURL
   thumbnailWidth:(NSNumber *)thumbnailWidth

--- a/Wikipedia/Code/RequestError.swift
+++ b/Wikipedia/Code/RequestError.swift
@@ -1,4 +1,6 @@
+import Foundation
 import WMFNativeLocalizations
+
 public enum RequestError: LocalizedError {
     case unknown
     case invalidParameters
@@ -7,19 +9,50 @@ public enum RequestError: LocalizedError {
     case noNewData
     case unauthenticated
     case http(Int)
+    /// HTTP 429. Distinct from `.http(429)` so callers can react to the server's
+    /// `Retry-After` when it sent one; `httpStatusCode` reports 429 for both.
+    case rateLimited(retryAfter: TimeInterval?)
     case api(String)
-    
+
     public var errorDescription: String? {
         switch self {
-        case .unexpectedResponse:
+        // .http and .rateLimited carry the same meaning as .unexpectedResponse from
+        // the user's point of view — the server answered with something the app
+        // can't use — so they share the message rather than falling back to the
+        // generic one.
+        case .unexpectedResponse, .http, .rateLimited:
             return WMFLocalizedString("fetcher-error-unexpected-response", value: "The app received an unexpected response from the server. Please try again later.", comment: "Error shown to the user for unexpected server responses.")
         default:
             return CommonStrings.genericErrorDescription
         }
     }
-    
-    public static func from(code: Int) -> RequestError {
-        return .http(code)
+
+    public static let rateLimitedStatusCode = 429
+
+    public var httpStatusCode: Int? {
+        switch self {
+        case .http(let code):
+            return code
+        case .rateLimited:
+            return RequestError.rateLimitedStatusCode
+        default:
+            return nil
+        }
+    }
+
+    /// The interval the server asked us to wait, when this error is a rate limit.
+    public var retryAfterInterval: TimeInterval? {
+        guard case .rateLimited(let retryAfter) = self else {
+            return nil
+        }
+        return retryAfter
+    }
+
+    public static func from(code: Int, response: HTTPURLResponse? = nil) -> RequestError {
+        guard code == rateLimitedStatusCode else {
+            return .http(code)
+        }
+        return .rateLimited(retryAfter: response?.retryAfterInterval)
     }
     
     public static func from(_ apiError: [String: Any]?) -> RequestError? {

--- a/Wikipedia/Code/SavedArticlesFetcher.swift
+++ b/Wikipedia/Code/SavedArticlesFetcher.swift
@@ -50,13 +50,37 @@ final class SavedArticlesFetcher: NSObject {
         unobserveSavedPages()
     }
 
-    private static let rateLimitCooldown: TimeInterval = 60
+    static let defaultRateLimitCooldown: TimeInterval = 60
+    /// Ceiling on a server-supplied Retry-After. Wikimedia's limiter can name a very
+    /// long window; downloading should resume within a session rather than parking
+    /// for hours, and the next 429 simply pauses again.
+    static let maximumRateLimitCooldown: TimeInterval = 600
 
-    func stopAndRestartAfterRateLimitCooldown() {
+    /// Spread of the cooldown, applied as a multiplier. Every device throttled in the
+    /// same window would otherwise come back in the same second and re-trigger the
+    /// limiter together.
+    static let rateLimitCooldownJitter: ClosedRange<Double> = 1.0...1.5
+
+    /// Resolves how long to wait before downloading again after a rate limit,
+    /// honouring the server's `Retry-After` when it sent a usable one.
+    /// Internal (not private) for unit testing.
+    static func rateLimitCooldown(retryAfter: TimeInterval?, jitter: Double) -> TimeInterval {
+        let base: TimeInterval
+        if let retryAfter = retryAfter, retryAfter > 0 {
+            base = min(retryAfter, maximumRateLimitCooldown)
+        } else {
+            base = defaultRateLimitCooldown
+        }
+        return base * jitter
+    }
+
+    func stopAndRestartAfterRateLimitCooldown(retryAfter: TimeInterval? = nil) {
         assert(Thread.isMainThread)
         stop()
+        let cooldown = Self.rateLimitCooldown(retryAfter: retryAfter, jitter: Double.random(in: Self.rateLimitCooldownJitter))
+        DDLogWarn("SavedArticlesFetcher: rate limited (HTTP 429), pausing saved article downloads for \(Int(cooldown))s")
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(restartAfterRateLimitCooldown), object: nil)
-        perform(#selector(restartAfterRateLimitCooldown), with: nil, afterDelay: Self.rateLimitCooldown)
+        perform(#selector(restartAfterRateLimitCooldown), with: nil, afterDelay: cooldown)
     }
 
     @objc private func restartAfterRateLimitCooldown() {
@@ -329,11 +353,14 @@ extension SavedArticlesFetcher {
             }
         }
         DDLogError("SavedArticlesFetcher: failed to download article \(article.key ?? "unknown"): \(underlyingError)")
-        if let requestError = underlyingError as? RequestError, case .http(429) = requestError {
+        if let requestError = underlyingError as? RequestError,
+           requestError.httpStatusCode == RequestError.rateLimitedStatusCode {
             // Rate limited — a global condition, not this article's fault. Pause all
             // downloading and retry the article as-is when the fetcher restarts,
             // instead of branding it with an error and escalating its backoff.
-            stopAndRestartAfterRateLimitCooldown()
+            // Matches both .rateLimited (which carries the server's Retry-After) and
+            // a bare .http(429) from any path that didn't see the response headers.
+            stopAndRestartAfterRateLimitCooldown(retryAfter: requestError.retryAfterInterval)
             return
         }
         if underlyingError is RequestError {

--- a/Wikipedia/Code/SavedArticlesFetcher.swift
+++ b/Wikipedia/Code/SavedArticlesFetcher.swift
@@ -50,6 +50,14 @@ final class SavedArticlesFetcher: NSObject {
         unobserveSavedPages()
     }
 
+    /// Gap between finishing one saved article and starting the next.
+    ///
+    /// Concurrency within an article is bounded by `CacheRequestThrottle`, and articles
+    /// are already processed one at a time, so this is a modest extra spacing rather
+    /// than the main control. Worth revisiting against measured request rates —
+    /// raising it slows a large list's first sync in direct proportion.
+    static let interArticleDelayMilliseconds = 250
+
     static let defaultRateLimitCooldown: TimeInterval = 60
     /// Ceiling on a server-supplied Retry-After. Wikimedia's limiter can name a very
     /// long window; downloading should resume within a session rather than parking
@@ -214,7 +222,7 @@ private extension SavedArticlesFetcher {
         }
         
         let updateAgain = {
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(Self.interArticleDelayMilliseconds)) {
                 self.isUpdating = false
                 self.endBackgroundTask()
                 self.update()

--- a/Wikipedia/Code/Session.swift
+++ b/Wikipedia/Code/Session.swift
@@ -609,6 +609,7 @@ extension Session {
 
 enum SessionPermanentCacheError: Error {
     case unexpectedURLCacheType
+    case missingPermanentCache
 }
 
 extension Session {
@@ -669,8 +670,17 @@ extension Session {
     }
     
     func cacheResponse(httpUrlResponse: HTTPURLResponse, content: CacheResponseContentType, urlRequest: URLRequest, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
-        
-        permanentCache?.urlCache.cacheResponse(httpUrlResponse: httpUrlResponse, content: content, urlRequest: urlRequest, success: success, failure: failure)
+
+        // Optional-chaining here would discard both closures when the permanent cache
+        // is gone, leaving CacheFileWriter.add's completion uncalled — which strands
+        // the DispatchGroup in finishDBAdd and, once requests are throttled, would
+        // permanently stall the download queue. Fail explicitly instead.
+        guard let permanentCache = permanentCache else {
+            failure(SessionPermanentCacheError.missingPermanentCache)
+            return
+        }
+
+        permanentCache.urlCache.cacheResponse(httpUrlResponse: httpUrlResponse, content: content, urlRequest: urlRequest, success: success, failure: failure)
     }
     
     func uniqueFileNameForItemKey(_ itemKey: CacheController.ItemKey, variant: String?) -> String? {

--- a/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
+++ b/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
@@ -1,0 +1,244 @@
+import XCTest
+import CoreData
+@testable import Wikipedia
+@testable import WMF
+
+/// Covers the completion contract of `CacheController.finishDBAdd`.
+///
+/// `finishDBAdd` used to register `group.notify` inside its request loop, so the
+/// group completion could fire before every request had been issued, and never fired
+/// at all when the request list was empty or every request was skipped. These tests
+/// drive it directly with fakes rather than going near the network.
+final class CacheControllerCompletionTests: XCTestCase {
+
+    private var context: NSManagedObjectContext!
+    private var fetcher: FakeCacheFetcher!
+
+    override func setUpWithError() throws {
+        let directory = URL(fileURLWithPath: WMFRandomTemporaryPath())
+        context = try XCTUnwrap(CacheController.createCacheContext(cacheURL: directory))
+        fetcher = FakeCacheFetcher(session: Session(configuration: Configuration.current), configuration: Configuration.current)
+    }
+
+    override func tearDown() {
+        context = nil
+        fetcher = nil
+        super.tearDown()
+    }
+
+    private func makeController(shouldDownloadVariant: Bool = true) -> CacheController {
+        let dbWriter = FakeCacheDBWriter(context: context, fetcher: fetcher, shouldDownload: shouldDownloadVariant)
+        let fileWriter = CacheFileWriter(fetcher: fetcher)
+        return CacheController(dbWriter: dbWriter, fileWriter: fileWriter)
+    }
+
+    private func requests(_ count: Int) -> [URLRequest] {
+        (0..<count).map { URLRequest(url: URL(string: "https://en.wikipedia.org/resource/\($0)")!) }
+    }
+
+    /// Runs `finishDBAdd` and returns the single group result it produces.
+    /// The group completion has to be queued on the gatekeeper the way `add` does it —
+    /// `finishDBAdd` runs gatekeeper-queued completions, not the block it is handed.
+    private func runFinishDBAdd(
+        controller: CacheController,
+        groupKey: String,
+        result: CacheDBWritingResultWithURLRequests,
+        timeout: TimeInterval = 10
+    ) -> CacheController.FinalGroupResult? {
+        let expectation = expectation(description: "group completion fires")
+        var groupResult: CacheController.FinalGroupResult?
+        var callCount = 0
+
+        controller.gatekeeper.queueGroupCompletion(groupKey: groupKey) { result in
+            callCount += 1
+            groupResult = result
+            if callCount == 1 {
+                expectation.fulfill()
+            }
+        }
+
+        controller.finishDBAdd(
+            groupKey: groupKey,
+            individualCompletion: { _ in },
+            groupCompletion: { _ in },
+            result: result
+        )
+
+        wait(for: [expectation], timeout: timeout)
+        return groupResult
+    }
+
+    func testGroupCompletionReportsEveryRequestWhenTheyCompleteAtDifferentTimes() throws {
+        // The premature-fire bug showed up here: staggered completions let the group
+        // reach zero while the loop was still issuing requests, so the result carried
+        // only the handful that had finished.
+        fetcher.completionDelay = { index in Double(index % 5) * 0.01 }
+        let controller = makeController()
+
+        let result = try XCTUnwrap(runFinishDBAdd(controller: controller, groupKey: "staggered", result: .success(requests(20))))
+
+        switch result {
+        case .success(let uniqueKeys):
+            XCTAssertEqual(Set(uniqueKeys).count, 20, "Every request should be represented in the group result")
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+    }
+
+    func testGroupCompletionFiresForAnEmptyRequestList() throws {
+        let controller = makeController()
+
+        let result = try XCTUnwrap(runFinishDBAdd(controller: controller, groupKey: "empty", result: .success([])))
+
+        switch result {
+        case .success(let uniqueKeys):
+            XCTAssertTrue(uniqueKeys.isEmpty)
+        case .failure(let error):
+            XCTFail("An empty request list should succeed, got \(error)")
+        }
+    }
+
+    func testGroupCompletionFiresWhenNoVariantShouldBeDownloaded() throws {
+        // Every iteration hits the shouldDownloadVariant guard, so nothing is issued.
+        let controller = makeController(shouldDownloadVariant: false)
+
+        let result = try XCTUnwrap(runFinishDBAdd(controller: controller, groupKey: "skipped", result: .success(requests(5))))
+
+        switch result {
+        case .success(let uniqueKeys):
+            XCTAssertTrue(uniqueKeys.isEmpty)
+        case .failure(let error):
+            XCTFail("Skipping every variant should still complete, got \(error)")
+        }
+    }
+
+    func testGroupCompletionFiresWhenEveryRequestFails() throws {
+        fetcher.shouldFail = true
+        let controller = makeController()
+
+        let result = try XCTUnwrap(runFinishDBAdd(controller: controller, groupKey: "failing", result: .success(requests(5))))
+
+        switch result {
+        case .success:
+            XCTFail("Expected a failure when every request fails")
+        case .failure(let error):
+            guard case CacheControllerError.atLeastOneItemFailedInFileWriter = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testGroupCompletionForwardsDBWriterFailure() throws {
+        let controller = makeController()
+
+        let result = try XCTUnwrap(runFinishDBAdd(controller: controller, groupKey: "dbfail", result: .failure(CacheFetchingError.missingURLResponse)))
+
+        switch result {
+        case .success:
+            XCTFail("Expected the db writer failure to be forwarded")
+        case .failure:
+            break
+        }
+    }
+}
+
+// MARK: - Fakes
+
+/// A `Fetcher` that conforms to `CacheFetching` with its own concrete members, so the
+/// `where Self: Fetcher` defaults (which all reach for a permanent cache that does not
+/// exist here) are bypassed for everything this path touches.
+private final class FakeCacheFetcher: Fetcher, CacheFetching {
+
+    /// Per-request delay before the completion fires, keyed by the index encoded in the URL.
+    var completionDelay: (Int) -> TimeInterval = { _ in 0 }
+    var shouldFail = false
+
+    private let queue = DispatchQueue(label: "FakeCacheFetcher", attributes: .concurrent)
+
+    private func index(for urlRequest: URLRequest) -> Int {
+        Int(urlRequest.url?.lastPathComponent ?? "") ?? 0
+    }
+
+    private func key(for urlRequest: URLRequest) -> String? {
+        urlRequest.url?.absoluteString.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
+    }
+
+    @discardableResult
+    func dataForURLRequest(_ urlRequest: URLRequest, completion: @escaping DataCompletion) -> URLSessionTask? {
+        let delay = completionDelay(index(for: urlRequest))
+        let shouldFail = self.shouldFail
+        queue.asyncAfter(deadline: .now() + delay) {
+            guard !shouldFail,
+                  let url = urlRequest.url,
+                  let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil) else {
+                completion(.failure(CacheFetchingError.missingURLResponse))
+                return
+            }
+            completion(.success(CacheFetchingResult(data: Data("body".utf8), response: response)))
+        }
+        return nil
+    }
+
+    func cacheResponse(httpUrlResponse: HTTPURLResponse, content: CacheResponseContentType, urlRequest: URLRequest, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+        success()
+    }
+
+    func uniqueFileNameForURLRequest(_ urlRequest: URLRequest) -> String? {
+        key(for: urlRequest)
+    }
+
+    func uniqueFileNameForItemKey(_ itemKey: CacheController.ItemKey, variant: String?) -> String? {
+        itemKey
+    }
+
+    func uniqueHeaderFileNameForItemKey(_ itemKey: CacheController.ItemKey, variant: String?) -> String? {
+        itemKey + "__header"
+    }
+
+    func itemKeyForURLRequest(_ urlRequest: URLRequest) -> String? {
+        key(for: urlRequest)
+    }
+
+    func variantForURLRequest(_ urlRequest: URLRequest) -> String? {
+        nil
+    }
+}
+
+private final class FakeCacheDBWriter: CacheDBWriting {
+
+    var groupedTasks: [String: [IdentifiedTask]] = [:]
+
+    let context: NSManagedObjectContext
+    let fetcher: CacheFetching
+    private let shouldDownload: Bool
+
+    init(context: NSManagedObjectContext, fetcher: CacheFetching, shouldDownload: Bool) {
+        self.context = context
+        self.fetcher = fetcher
+        self.shouldDownload = shouldDownload
+    }
+
+    func add(url: URL, groupKey: CacheController.GroupKey, completion: @escaping CacheDBWritingCompletionWithURLRequests) {
+        completion(.success([URLRequest(url: url)]))
+    }
+
+    func add(urls: [URL], groupKey: CacheController.GroupKey, completion: @escaping CacheDBWritingCompletionWithURLRequests) {
+        completion(.success(urls.map { URLRequest(url: $0) }))
+    }
+
+    func shouldDownloadVariant(itemKey: CacheController.ItemKey, variant: String?) -> Bool {
+        shouldDownload
+    }
+
+    func shouldDownloadVariant(urlRequest: URLRequest) -> Bool {
+        shouldDownload
+    }
+
+    func shouldDownloadVariantForAllVariantItems(variant: String?, _ allVariantItems: [CacheController.ItemKeyAndVariant]) -> Bool {
+        shouldDownload
+    }
+
+    func markDownloaded(urlRequest: URLRequest, response: HTTPURLResponse?, completion: @escaping (CacheDBWritingResult) -> Void) {
+        completion(.success)
+    }
+}

--- a/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
+++ b/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
@@ -26,10 +26,10 @@ final class CacheControllerCompletionTests: XCTestCase {
         super.tearDown()
     }
 
-    private func makeController(shouldDownloadVariant: Bool = true) -> CacheController {
+    private func makeController(shouldDownloadVariant: Bool = true, throttle: CacheRequestThrottle = CacheRequestThrottle()) -> CacheController {
         let dbWriter = FakeCacheDBWriter(context: context, fetcher: fetcher, shouldDownload: shouldDownloadVariant)
         let fileWriter = CacheFileWriter(fetcher: fetcher)
-        return CacheController(dbWriter: dbWriter, fileWriter: fileWriter)
+        return CacheController(dbWriter: dbWriter, fileWriter: fileWriter, throttle: throttle)
     }
 
     private func requests(_ count: Int) -> [URLRequest] {
@@ -128,6 +128,23 @@ final class CacheControllerCompletionTests: XCTestCase {
         }
     }
 
+    func testThrottleBoundsConcurrentRequestsForOneGroup() throws {
+        // Requests hold their slot for long enough that an unbounded loop would have
+        // all 12 in flight at once.
+        fetcher.completionDelay = { _ in 0.05 }
+        let controller = makeController(throttle: CacheRequestThrottle(maxConcurrentRequestsPerGroup: 3))
+
+        let result = try XCTUnwrap(runFinishDBAdd(controller: controller, groupKey: "bounded", result: .success(requests(12))))
+
+        XCTAssertLessThanOrEqual(fetcher.peakConcurrentRequests, 3, "The throttle should cap in-flight requests per group")
+        switch result {
+        case .success(let uniqueKeys):
+            XCTAssertEqual(Set(uniqueKeys).count, 12, "Queued requests should still all run")
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+    }
+
     func testGroupCompletionForwardsDBWriterFailure() throws {
         let controller = makeController()
 
@@ -153,7 +170,23 @@ private final class FakeCacheFetcher: Fetcher, CacheFetching {
     var completionDelay: (Int) -> TimeInterval = { _ in 0 }
     var shouldFail = false
 
+    /// Highest number of requests this fetcher had in flight at once.
+    private(set) var peakConcurrentRequests = 0
+    private var inFlight = 0
+
     private let queue = DispatchQueue(label: "FakeCacheFetcher", attributes: .concurrent)
+    private let countingQueue = DispatchQueue(label: "FakeCacheFetcher.counting")
+
+    private func requestStarted() {
+        countingQueue.sync {
+            inFlight += 1
+            peakConcurrentRequests = max(peakConcurrentRequests, inFlight)
+        }
+    }
+
+    private func requestFinished() {
+        countingQueue.sync { inFlight -= 1 }
+    }
 
     private func index(for urlRequest: URLRequest) -> Int {
         Int(urlRequest.url?.lastPathComponent ?? "") ?? 0
@@ -167,7 +200,11 @@ private final class FakeCacheFetcher: Fetcher, CacheFetching {
     func dataForURLRequest(_ urlRequest: URLRequest, completion: @escaping DataCompletion) -> URLSessionTask? {
         let delay = completionDelay(index(for: urlRequest))
         let shouldFail = self.shouldFail
-        queue.asyncAfter(deadline: .now() + delay) {
+        requestStarted()
+        queue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            defer {
+                self?.requestFinished()
+            }
             guard !shouldFail,
                   let url = urlRequest.url,
                   let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil) else {
@@ -240,5 +277,114 @@ private final class FakeCacheDBWriter: CacheDBWriting {
 
     func markDownloaded(urlRequest: URLRequest, response: HTTPURLResponse?, completion: @escaping (CacheDBWritingResult) -> Void) {
         completion(.success)
+    }
+}
+
+
+/// Unit tests for the limiter itself, independent of the cache controller.
+final class CacheRequestThrottleTests: XCTestCase {
+
+    /// Tracks how many pieces of work are running at once.
+    private final class ConcurrencyRecorder {
+        private let queue = DispatchQueue(label: "ConcurrencyRecorder")
+        private var current = 0
+        private(set) var peak = 0
+
+        func started() {
+            queue.sync {
+                current += 1
+                peak = max(peak, current)
+            }
+        }
+
+        func finished() {
+            queue.sync { current -= 1 }
+        }
+
+        var peakValue: Int {
+            queue.sync { peak }
+        }
+    }
+
+    func testNeverExceedsTheBoundAndStillRunsEverything() {
+        let throttle = CacheRequestThrottle(maxConcurrentRequestsPerGroup: 4)
+        let recorder = ConcurrencyRecorder()
+        let workQueue = DispatchQueue(label: "work", attributes: .concurrent)
+        let allDone = expectation(description: "all work runs")
+        allDone.expectedFulfillmentCount = 30
+
+        for _ in 0..<30 {
+            throttle.enqueue(groupKey: "group") { done in
+                recorder.started()
+                workQueue.asyncAfter(deadline: .now() + 0.01) {
+                    recorder.finished()
+                    allDone.fulfill()
+                    done()
+                }
+            }
+        }
+
+        wait(for: [allDone], timeout: 20)
+        XCTAssertLessThanOrEqual(recorder.peakValue, 4)
+    }
+
+    func testReleasingASlotTwiceDoesNotWidenTheBound() {
+        let throttle = CacheRequestThrottle(maxConcurrentRequestsPerGroup: 2)
+        let recorder = ConcurrencyRecorder()
+        let workQueue = DispatchQueue(label: "work", attributes: .concurrent)
+        let allDone = expectation(description: "all work runs")
+        allDone.expectedFulfillmentCount = 12
+
+        for _ in 0..<12 {
+            throttle.enqueue(groupKey: "group") { done in
+                recorder.started()
+                workQueue.asyncAfter(deadline: .now() + 0.01) {
+                    recorder.finished()
+                    allDone.fulfill()
+                    // Success and failure arrive on different queues in the real path,
+                    // so a doubled release is plausible and must not free two slots.
+                    done()
+                    done()
+                }
+            }
+        }
+
+        wait(for: [allDone], timeout: 20)
+        XCTAssertLessThanOrEqual(recorder.peakValue, 2)
+    }
+
+    func testGroupsHaveIndependentBudgets() {
+        let throttle = CacheRequestThrottle(maxConcurrentRequestsPerGroup: 1)
+        let firstStarted = expectation(description: "first group starts")
+        let secondStarted = expectation(description: "second group starts")
+
+        // Neither call the done block, so each group keeps its only slot occupied.
+        throttle.enqueue(groupKey: "a") { _ in firstStarted.fulfill() }
+        throttle.enqueue(groupKey: "b") { _ in secondStarted.fulfill() }
+
+        wait(for: [firstStarted, secondStarted], timeout: 10)
+        XCTAssertEqual(throttle.inFlightCount(for: "a"), 1)
+        XCTAssertEqual(throttle.inFlightCount(for: "b"), 1)
+    }
+
+    func testWorkBeyondTheBoundWaitsForASlot() {
+        let throttle = CacheRequestThrottle(maxConcurrentRequestsPerGroup: 1)
+        let firstStarted = expectation(description: "first starts")
+        let secondStarted = expectation(description: "second starts once a slot frees")
+
+        var release: (() -> Void)?
+        throttle.enqueue(groupKey: "group") { done in
+            release = done
+            firstStarted.fulfill()
+        }
+        wait(for: [firstStarted], timeout: 10)
+
+        throttle.enqueue(groupKey: "group") { _ in secondStarted.fulfill() }
+        // inFlightCount hops onto the same serial queue as enqueue, so this observes
+        // the state after the enqueue above rather than racing it.
+        XCTAssertEqual(throttle.inFlightCount(for: "group"), 1, "The second piece of work should be waiting, not running")
+
+        release?()
+        wait(for: [secondStarted], timeout: 10)
     }
 }

--- a/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
+++ b/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
@@ -388,3 +388,118 @@ final class CacheRequestThrottleTests: XCTestCase {
         wait(for: [secondStarted], timeout: 10)
     }
 }
+
+/// Covers splitting a batched `imageinfo` response into the per-title bodies the
+/// offline gallery reads back. A key mismatch here fails silently — captions just
+/// stop appearing offline — so the title mapping is tested directly.
+final class ImageInfoResponseSplitterTests: XCTestCase {
+
+    private func page(id: String, title: String, description: String) -> [String: Any] {
+        [
+            "pageid": Int(id) ?? 0,
+            "title": title,
+            "imageinfo": [[
+                "url": "https://upload.wikimedia.org/\(title).jpg",
+                "extmetadata": ["ImageDescription": ["value": description]]
+            ]]
+        ]
+    }
+
+    private func response(pages: [String: Any], normalized: [[String: String]]? = nil) -> [String: Any] {
+        var query: [String: Any] = ["pages": pages]
+        if let normalized = normalized {
+            query["normalized"] = normalized
+        }
+        return ["query": query]
+    }
+
+    func testSplitsOneBodyPerRequestedTitle() throws {
+        let batch = response(pages: [
+            "1": page(id: "1", title: "File:A.jpg", description: "a"),
+            "2": page(id: "2", title: "File:B.jpg", description: "b")
+        ])
+
+        let result = try ImageInfoResponseSplitter.split(response: batch, requestedTitles: ["File:A.jpg", "File:B.jpg"])
+
+        XCTAssertEqual(Set(result.bodiesByRequestedTitle.keys), ["File:A.jpg", "File:B.jpg"])
+        XCTAssertTrue(result.missingTitles.isEmpty)
+    }
+
+    func testEachBodyKeepsTheShapeTheReadPathParses() throws {
+        let batch = response(pages: [
+            "1": page(id: "1", title: "File:A.jpg", description: "a"),
+            "2": page(id: "2", title: "File:B.jpg", description: "b")
+        ])
+
+        let result = try ImageInfoResponseSplitter.split(response: batch, requestedTitles: ["File:A.jpg"])
+        let body = try XCTUnwrap(result.bodiesByRequestedTitle["File:A.jpg"])
+        let parsed = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        // MWKImageInfoFetcher.responseObjectForJSON: reads exactly query.pages.
+        let pages = try XCTUnwrap((parsed["query"] as? [String: Any])?["pages"] as? [String: Any])
+        XCTAssertEqual(pages.count, 1, "A split body should carry only its own page")
+        let onlyPage = try XCTUnwrap(pages["1"] as? [String: Any])
+        XCTAssertEqual(onlyPage["title"] as? String, "File:A.jpg")
+    }
+
+    func testMapsTitlesTheAPINormalised() throws {
+        // The API rewrites underscores to spaces and reports it in query.normalized.
+        let batch = response(
+            pages: ["7": page(id: "7", title: "File:Some Image.jpg", description: "x")],
+            normalized: [["from": "File:Some_Image.jpg", "to": "File:Some Image.jpg"]]
+        )
+
+        let result = try ImageInfoResponseSplitter.split(response: batch, requestedTitles: ["File:Some_Image.jpg"])
+
+        XCTAssertNotNil(result.bodiesByRequestedTitle["File:Some_Image.jpg"], "The body should be keyed by the title we asked for, not the normalised one")
+        XCTAssertTrue(result.missingTitles.isEmpty)
+    }
+
+    func testUnderscoreAndSpaceFormsMatchWithoutANormalisedSection() throws {
+        let batch = response(pages: ["7": page(id: "7", title: "File:Some Image.jpg", description: "x")])
+
+        let result = try ImageInfoResponseSplitter.split(response: batch, requestedTitles: ["File:Some_Image.jpg"])
+
+        XCTAssertNotNil(result.bodiesByRequestedTitle["File:Some_Image.jpg"])
+    }
+
+    func testReportsTitlesWithNoPage() throws {
+        let batch = response(pages: ["1": page(id: "1", title: "File:A.jpg", description: "a")])
+
+        let result = try ImageInfoResponseSplitter.split(response: batch, requestedTitles: ["File:A.jpg", "File:Gone.jpg"])
+
+        XCTAssertEqual(result.missingTitles, ["File:Gone.jpg"])
+        XCTAssertNil(result.bodiesByRequestedTitle["File:Gone.jpg"])
+    }
+
+    func testThrowsOnAResponseWithNoPages() {
+        XCTAssertThrowsError(try ImageInfoResponseSplitter.split(response: ["query": [:]], requestedTitles: ["File:A.jpg"]))
+    }
+
+    func testDropsHeadersThatDescribeTheBatch() throws {
+        let url = try XCTUnwrap(URL(string: "https://en.wikipedia.org/w/api.php"))
+        let response = try XCTUnwrap(HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: [
+                "Etag": "\"batch-etag\"",
+                "Content-Length": "4096",
+                "Content-Type": "application/json"
+            ]
+        ))
+
+        let fields = ImageInfoResponseSplitter.perTitleHeaderFields(from: response)
+
+        // Etag belongs to the batch URL and is read back into If-None-Match;
+        // Content-Length describes the batch body.
+        XCTAssertNil(fields.first { $0.key.lowercased() == "etag" })
+        XCTAssertNil(fields.first { $0.key.lowercased() == "content-length" })
+        XCTAssertEqual(fields["Content-Type"], "application/json")
+    }
+
+    func testBatchSizeIsWithinTheAPILimit() {
+        XCTAssertLessThanOrEqual(ArticleCacheDBWriter.imageInfoBatchSize, 50, "MWKImageInfoFetcher asserts at most 50 titles per request")
+        XCTAssertGreaterThan(ArticleCacheDBWriter.imageInfoBatchSize, 1, "A batch of one would be no better than the per-image requests this replaces")
+    }
+}

--- a/WikipediaUnitTests/Code/SavedArticlesFetcherTests.swift
+++ b/WikipediaUnitTests/Code/SavedArticlesFetcherTests.swift
@@ -61,4 +61,149 @@ class SavedArticlesFetcherTests: XCTestCase {
         XCTAssertEqual(article.downloadAttemptCount, 0, "Rate limiting should not escalate the article's retry backoff")
         XCTAssertNil(article.downloadRetryDate)
     }
+
+    // MARK: - Production-shaped rate limits
+    //
+    // handleFailure never receives a bare RequestError from the download path — the
+    // cache layer wraps it. These cover the shapes that actually reach it, which is
+    // what the earlier 429 handling missed.
+
+    func testRateLimitWrappedInFileWriterErrorDoesNotFlagArticle() throws {
+        let article = try makeSavedArticle()
+
+        let error = CacheControllerError.atLeastOneItemFailedInFileWriter(RequestError.rateLimited(retryAfter: nil))
+        fetcher.handleFailure(with: article, error: error)
+
+        XCTAssertEqual(article.error, .none, "A 429 arriving through the file writer is still a global condition")
+        XCTAssertEqual(article.downloadAttemptCount, 0)
+        XCTAssertNil(article.downloadRetryDate)
+    }
+
+    func testRateLimitWrappedInSyncErrorDoesNotFlagArticle() throws {
+        let article = try makeSavedArticle()
+
+        let error = CacheControllerError.atLeastOneItemFailedInSync(RequestError.rateLimited(retryAfter: 30))
+        fetcher.handleFailure(with: article, error: error)
+
+        XCTAssertEqual(article.error, .none)
+        XCTAssertEqual(article.downloadAttemptCount, 0)
+        XCTAssertNil(article.downloadRetryDate)
+    }
+
+    func testRateLimitFromMediaListDoesNotFlagArticle() throws {
+        let article = try makeSavedArticle()
+
+        let error = ArticleCacheDBWriterError.failureFetchingMediaList(RequestError.rateLimited(retryAfter: nil))
+        fetcher.handleFailure(with: article, error: error)
+
+        XCTAssertEqual(article.error, .none, "A 429 from the media-list fetch is still a global condition")
+        XCTAssertEqual(article.downloadAttemptCount, 0)
+        XCTAssertNil(article.downloadRetryDate)
+    }
+
+    func testRateLimitFromOfflineResourceListDoesNotFlagArticle() throws {
+        let article = try makeSavedArticle()
+
+        let error = ArticleCacheDBWriterError.failureFetchingOfflineResourceList(RequestError.rateLimited(retryAfter: nil))
+        fetcher.handleFailure(with: article, error: error)
+
+        XCTAssertEqual(article.error, .none)
+        XCTAssertEqual(article.downloadAttemptCount, 0)
+        XCTAssertNil(article.downloadRetryDate)
+    }
+
+    func testWrappedServerErrorStillFlagsArticleAndSchedulesRetry() throws {
+        let article = try makeSavedArticle()
+
+        let error = CacheControllerError.atLeastOneItemFailedInFileWriter(RequestError.http(503))
+        fetcher.handleFailure(with: article, error: error)
+
+        XCTAssertEqual(article.error, .apiFailed, "A non-429 HTTP failure is still this article's problem")
+        XCTAssertEqual(article.downloadAttemptCount, 1)
+        XCTAssertNotNil(article.downloadRetryDate)
+    }
+
+    // MARK: - Cooldown resolution
+
+    func testCooldownFallsBackToDefaultWithoutRetryAfter() {
+        let cooldown = SavedArticlesFetcher.rateLimitCooldown(retryAfter: nil, jitter: 1)
+        XCTAssertEqual(cooldown, SavedArticlesFetcher.defaultRateLimitCooldown)
+    }
+
+    func testCooldownHonoursRetryAfter() {
+        let cooldown = SavedArticlesFetcher.rateLimitCooldown(retryAfter: 120, jitter: 1)
+        XCTAssertEqual(cooldown, 120)
+    }
+
+    func testCooldownClampsExcessiveRetryAfter() {
+        let cooldown = SavedArticlesFetcher.rateLimitCooldown(retryAfter: 86400, jitter: 1)
+        XCTAssertEqual(cooldown, SavedArticlesFetcher.maximumRateLimitCooldown, "A very long Retry-After should not park downloads for hours")
+    }
+
+    func testCooldownIgnoresNonPositiveRetryAfter() {
+        let cooldown = SavedArticlesFetcher.rateLimitCooldown(retryAfter: 0, jitter: 1)
+        XCTAssertEqual(cooldown, SavedArticlesFetcher.defaultRateLimitCooldown)
+    }
+
+    func testCooldownAppliesJitter() {
+        let cooldown = SavedArticlesFetcher.rateLimitCooldown(retryAfter: 100, jitter: 1.5)
+        XCTAssertEqual(cooldown, 150)
+    }
+}
+
+final class RequestErrorRateLimitTests: XCTestCase {
+
+    private func response(headerFields: [String: String]?) throws -> HTTPURLResponse {
+        try XCTUnwrap(HTTPURLResponse(
+            url: URL(string: "https://en.wikipedia.org/w/api.php")!,
+            statusCode: 429,
+            httpVersion: "HTTP/1.1",
+            headerFields: headerFields
+        ))
+    }
+
+    func testFromCodeProducesRateLimitedFor429() throws {
+        let error = RequestError.from(code: 429, response: try response(headerFields: ["Retry-After": "45"]))
+        XCTAssertEqual(error.httpStatusCode, 429)
+        XCTAssertEqual(error.retryAfterInterval, 45)
+    }
+
+    func testFromCodeProducesHTTPForOtherCodes() {
+        let error = RequestError.from(code: 503)
+        XCTAssertEqual(error.httpStatusCode, 503)
+        XCTAssertNil(error.retryAfterInterval)
+    }
+
+    func testBareHTTP429StillReportsRateLimitedStatusCode() {
+        XCTAssertEqual(RequestError.http(429).httpStatusCode, RequestError.rateLimitedStatusCode)
+    }
+
+    func testRetryAfterDeltaSeconds() throws {
+        XCTAssertEqual(try response(headerFields: ["Retry-After": "90"]).retryAfterInterval, 90)
+    }
+
+    func testRetryAfterIsCaseInsensitive() throws {
+        // HTTP/2 lowercases header names.
+        XCTAssertEqual(try response(headerFields: ["retry-after": "90"]).retryAfterInterval, 90)
+    }
+
+    func testRetryAfterHTTPDate() throws {
+        let target = Date(timeIntervalSinceNow: 120)
+        let value = DateFormatter.wmf_httpDateFormatter.string(from: target)
+        let interval = try XCTUnwrap(response(headerFields: ["Retry-After": value]).retryAfterInterval)
+        XCTAssertEqual(interval, 120, accuracy: 2)
+    }
+
+    func testRetryAfterPastHTTPDateIsZero() throws {
+        let value = DateFormatter.wmf_httpDateFormatter.string(from: Date(timeIntervalSinceNow: -120))
+        XCTAssertEqual(try response(headerFields: ["Retry-After": value]).retryAfterInterval, 0)
+    }
+
+    func testRetryAfterAbsent() throws {
+        XCTAssertNil(try response(headerFields: [:]).retryAfterInterval)
+    }
+
+    func testRetryAfterUnparseable() throws {
+        XCTAssertNil(try response(headerFields: ["Retry-After": "soon"]).retryAfterInterval)
+    }
 }

--- a/WikipediaUnitTests/Code/SavedArticlesFetcherTests.swift
+++ b/WikipediaUnitTests/Code/SavedArticlesFetcherTests.swift
@@ -79,6 +79,18 @@ class SavedArticlesFetcherTests: XCTestCase {
         XCTAssertNil(article.downloadRetryDate)
     }
 
+    func testBareRateLimitDoesNotFlagArticle() throws {
+        // The batched image-info fetch reports a 429 as a bare RequestError, not
+        // wrapped by the cache layer, because it does not go through CacheFileWriter.
+        let article = try makeSavedArticle()
+
+        fetcher.handleFailure(with: article, error: RequestError.rateLimited(retryAfter: 30))
+
+        XCTAssertEqual(article.error, .none)
+        XCTAssertEqual(article.downloadAttemptCount, 0)
+        XCTAssertNil(article.downloadRetryDate)
+    }
+
     func testRateLimitWrappedInSyncErrorDoesNotFlagArticle() throws {
         let article = try makeSavedArticle()
 


### PR DESCRIPTION
SavedArticlesFetcher already pauses all downloading when it sees a 429, but
nothing on the download path ever produced that error, so the handling was
unreachable:

- CacheFetching.dataForURLRequest flattened every non-200 into
  RequestError.unexpectedResponse.
- Session.jsonDecodableTask reports a non-200 as (nil, response, nil) — a nil
  error — which trackedJSONDecodableTask also turned into .unexpectedResponse.

Every real rate limit therefore looked like an ordinary failure: the article was
branded .apiFailed, its backoff escalated, and the fetcher moved on to the next
article and kept going.

Carry the status code through both paths instead. trackedJSONDecodableTask is
changed rather than Session.jsonDecodableTask so the blast radius stays on the
three ArticleFetcher call sites this concerns, rather than the dozen unrelated
callers that currently rely on the silent nil-error behaviour.

Add RequestError.rateLimited, which carries the server's Retry-After, and honour
it when pausing — clamped so downloading resumes within a session, and jittered
so devices throttled together do not all return in the same second. Both
.rateLimited and a bare .http(429) are recognised, via httpStatusCode.

Also close the one HTTP-logging gap on this path. Session.handleResponse covers
the JSON task methods and SessionDelegate covers the delegate-driven tasks the
SchemeHandler uses, but neither covers the permanent-cache downloads:
Session.dataTask(with:completionHandler:) does not call handleResponse, and its
completion-handler task suppresses the data-delegate callbacks. Log 429 and 5xx
from there under a distinct source so download-driven throttling can be told
apart from throttling while reading an article. 404s are deliberately excluded —
this path sees routine ones for resources an article no longer references.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CjLA9cfAZ4qJL6qeFSNsJ1