### PR TITLE
Make saved-article rate limiting detectable and act on it

### DIFF
--- a/WMF Framework/CacheFetching.swift
+++ b/WMF Framework/CacheFetching.swift
@@ -1,4 +1,6 @@
 import Foundation
+import CocoaLumberjackSwift
+import WMFData
 
 public struct CacheFetchingResult {
     let data: Data
@@ -38,8 +40,33 @@ public protocol CacheFetching {
     func writeBundledFiles(mimeType: String, bundledFileURL: URL, urlRequest: URLRequest, completion: @escaping (Result<Void, Error>) -> Void)
 }
 
+// note, Session.handleResponse and SessionDelegate don't cover this path, so HTTP failures here are otherwise unlogged
+enum CacheFetchingHTTPErrorLogger {
+
+    static let source = "CacheFetching"
+
+    static func logIfNeeded(httpResponse: HTTPURLResponse, urlRequest: URLRequest) {
+        // 404s are routine here for resources an article no longer references, so only log rate limits and server errors
+        let statusCode = httpResponse.statusCode
+        guard statusCode == RequestError.rateLimitedStatusCode || (500...599).contains(statusCode) else {
+            return
+        }
+
+        DDLogError("CacheFetching: HTTP \(statusCode) for \(urlRequest.url?.absoluteString ?? "unknown URL")")
+
+        ClientErrorFunnel.shared.logHTTPError(
+            info: WMFHTTPErrorInfo(
+                statusCode: statusCode,
+                method: urlRequest.httpMethod,
+                url: urlRequest.url?.absoluteString,
+                source: source
+            )
+        )
+    }
+}
+
 extension CacheFetching where Self:Fetcher {
-    
+
     @discardableResult public func dataForURLRequest(_ urlRequest: URLRequest, completion: @escaping DataCompletion) -> URLSessionTask? {
         
         let task = session.dataTask(with: urlRequest) { (data, urlResponse, error) in
@@ -53,8 +80,10 @@ extension CacheFetching where Self:Fetcher {
                 return
             }
             
+            // note, the status code is carried through so SavedArticlesFetcher can tell a 429 from an ordinary failure
             if let httpResponse = unwrappedResponse as? HTTPURLResponse, httpResponse.statusCode != 200 {
-                completion(.failure(RequestError.unexpectedResponse))
+                CacheFetchingHTTPErrorLogger.logIfNeeded(httpResponse: httpResponse, urlRequest: urlRequest)
+                completion(.failure(RequestError.from(code: httpResponse.statusCode, response: httpResponse)))
                 return
             }
             

--- a/WMF Framework/Fetcher.swift
+++ b/WMF Framework/Fetcher.swift
@@ -399,11 +399,21 @@ open class Fetcher: NSObject {
             defer {
                  self.untrack(taskFor: key)
             }
+            let httpResponse = response as? HTTPURLResponse
             guard let result = result else {
-                completionHandler(.failure(error ?? RequestError.unexpectedResponse), response as? HTTPURLResponse)
+                // note, Session.jsonDecodableTask reports a non-200 as (nil, response, nil), so recover the status code here
+                let resolvedError: Error
+                if let error = error {
+                    resolvedError = error
+                } else if let statusCode = httpResponse?.statusCode, !HTTPStatusCode.isSuccessful(statusCode) {
+                    resolvedError = RequestError.from(code: statusCode, response: httpResponse)
+                } else {
+                    resolvedError = RequestError.unexpectedResponse
+                }
+                completionHandler(.failure(resolvedError), httpResponse)
                 return
             }
-            completionHandler(.success(result), response as? HTTPURLResponse)
+            completionHandler(.success(result), httpResponse)
         }
         
         track(task: task, for: key)

--- a/WMF Framework/PermanentlyPersistableURLCache.swift
+++ b/WMF Framework/PermanentlyPersistableURLCache.swift
@@ -699,6 +699,37 @@ public extension HTTPURLResponse {
     static let etagHeaderKey = "Etag"
     static let varyHeaderKey = "Vary"
     static let acceptLanguageHeaderValue = "Accept-Language"
+    static let retryAfterHeaderKey = "Retry-After"
+
+    /// The Retry-After header as an interval from now, handling both delta-seconds and an HTTP-date.
+    var retryAfterInterval: TimeInterval? {
+        // note, value(forHTTPHeaderField:) is case insensitive, unlike allHeaderFields - HTTP/2 lowercases header names
+        guard let value = value(forHTTPHeaderField: HTTPURLResponse.retryAfterHeaderKey)?
+            .trimmingCharacters(in: .whitespaces), !value.isEmpty else {
+            return nil
+        }
+
+        if let seconds = TimeInterval(value) {
+            return max(0, seconds)
+        }
+
+        guard let date = DateFormatter.wmf_httpDateFormatter.date(from: value) else {
+            return nil
+        }
+
+        return max(0, date.timeIntervalSinceNow)
+    }
+}
+
+public extension DateFormatter {
+    /// IMF-fixdate, the preferred HTTP-date format (RFC 9110).
+    static let wmf_httpDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        return formatter
+    }()
 }
 
 public extension URLRequest {

--- a/Wikipedia/Code/RequestError.swift
+++ b/Wikipedia/Code/RequestError.swift
@@ -1,4 +1,6 @@
+import Foundation
 import WMFNativeLocalizations
+
 public enum RequestError: LocalizedError {
     case unknown
     case invalidParameters
@@ -7,19 +9,44 @@ public enum RequestError: LocalizedError {
     case noNewData
     case unauthenticated
     case http(Int)
+    /// HTTP 429, carrying the server's Retry-After when it sent one. httpStatusCode reports 429 for this and .http(429).
+    case rateLimited(retryAfter: TimeInterval?)
     case api(String)
-    
+
     public var errorDescription: String? {
         switch self {
-        case .unexpectedResponse:
+        case .unexpectedResponse, .http, .rateLimited:
             return WMFLocalizedString("fetcher-error-unexpected-response", value: "The app received an unexpected response from the server. Please try again later.", comment: "Error shown to the user for unexpected server responses.")
         default:
             return CommonStrings.genericErrorDescription
         }
     }
-    
-    public static func from(code: Int) -> RequestError {
-        return .http(code)
+
+    public static let rateLimitedStatusCode = 429
+
+    public var httpStatusCode: Int? {
+        switch self {
+        case .http(let code):
+            return code
+        case .rateLimited:
+            return RequestError.rateLimitedStatusCode
+        default:
+            return nil
+        }
+    }
+
+    public var retryAfterInterval: TimeInterval? {
+        guard case .rateLimited(let retryAfter) = self else {
+            return nil
+        }
+        return retryAfter
+    }
+
+    public static func from(code: Int, response: HTTPURLResponse? = nil) -> RequestError {
+        guard code == rateLimitedStatusCode else {
+            return .http(code)
+        }
+        return .rateLimited(retryAfter: response?.retryAfterInterval)
     }
     
     public static func from(_ apiError: [String: Any]?) -> RequestError? {

--- a/Wikipedia/Code/SavedArticlesFetcher.swift
+++ b/Wikipedia/Code/SavedArticlesFetcher.swift
@@ -50,13 +50,31 @@ final class SavedArticlesFetcher: NSObject {
         unobserveSavedPages()
     }
 
-    private static let rateLimitCooldown: TimeInterval = 60
+    static let defaultRateLimitCooldown: TimeInterval = 60
+    // ceiling on a server-supplied Retry-After, so downloading resumes within a session
+    static let maximumRateLimitCooldown: TimeInterval = 600
 
-    func stopAndRestartAfterRateLimitCooldown() {
+    // spread, so devices throttled in the same window don't all come back at once
+    static let rateLimitCooldownJitter: ClosedRange<Double> = 1.0...1.5
+
+    // internal for unit testing
+    static func rateLimitCooldown(retryAfter: TimeInterval?, jitter: Double) -> TimeInterval {
+        let base: TimeInterval
+        if let retryAfter = retryAfter, retryAfter > 0 {
+            base = min(retryAfter, maximumRateLimitCooldown)
+        } else {
+            base = defaultRateLimitCooldown
+        }
+        return base * jitter
+    }
+
+    func stopAndRestartAfterRateLimitCooldown(retryAfter: TimeInterval? = nil) {
         assert(Thread.isMainThread)
         stop()
+        let cooldown = Self.rateLimitCooldown(retryAfter: retryAfter, jitter: Double.random(in: Self.rateLimitCooldownJitter))
+        DDLogWarn("SavedArticlesFetcher: rate limited (HTTP 429), pausing saved article downloads for \(Int(cooldown))s")
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(restartAfterRateLimitCooldown), object: nil)
-        perform(#selector(restartAfterRateLimitCooldown), with: nil, afterDelay: Self.rateLimitCooldown)
+        perform(#selector(restartAfterRateLimitCooldown), with: nil, afterDelay: cooldown)
     }
 
     @objc private func restartAfterRateLimitCooldown() {
@@ -329,11 +347,12 @@ extension SavedArticlesFetcher {
             }
         }
         DDLogError("SavedArticlesFetcher: failed to download article \(article.key ?? "unknown"): \(underlyingError)")
-        if let requestError = underlyingError as? RequestError, case .http(429) = requestError {
+        if let requestError = underlyingError as? RequestError,
+           requestError.httpStatusCode == RequestError.rateLimitedStatusCode {
             // Rate limited — a global condition, not this article's fault. Pause all
             // downloading and retry the article as-is when the fetcher restarts,
             // instead of branding it with an error and escalating its backoff.
-            stopAndRestartAfterRateLimitCooldown()
+            stopAndRestartAfterRateLimitCooldown(retryAfter: requestError.retryAfterInterval)
             return
         }
         if underlyingError is RequestError {

--- a/WikipediaUnitTests/Code/SavedArticlesFetcherTests.swift
+++ b/WikipediaUnitTests/Code/SavedArticlesFetcherTests.swift
@@ -61,4 +61,145 @@ class SavedArticlesFetcherTests: XCTestCase {
         XCTAssertEqual(article.downloadAttemptCount, 0, "Rate limiting should not escalate the article's retry backoff")
         XCTAssertNil(article.downloadRetryDate)
     }
+
+    // MARK: - Production-shaped rate limits
+
+    func testRateLimitWrappedInFileWriterErrorDoesNotFlagArticle() throws {
+        let article = try makeSavedArticle()
+
+        let error = CacheControllerError.atLeastOneItemFailedInFileWriter(RequestError.rateLimited(retryAfter: nil))
+        fetcher.handleFailure(with: article, error: error)
+
+        XCTAssertEqual(article.error, .none, "A 429 arriving through the file writer is still a global condition")
+        XCTAssertEqual(article.downloadAttemptCount, 0)
+        XCTAssertNil(article.downloadRetryDate)
+    }
+
+    func testRateLimitWrappedInSyncErrorDoesNotFlagArticle() throws {
+        let article = try makeSavedArticle()
+
+        let error = CacheControllerError.atLeastOneItemFailedInSync(RequestError.rateLimited(retryAfter: 30))
+        fetcher.handleFailure(with: article, error: error)
+
+        XCTAssertEqual(article.error, .none)
+        XCTAssertEqual(article.downloadAttemptCount, 0)
+        XCTAssertNil(article.downloadRetryDate)
+    }
+
+    func testRateLimitFromMediaListDoesNotFlagArticle() throws {
+        let article = try makeSavedArticle()
+
+        let error = ArticleCacheDBWriterError.failureFetchingMediaList(RequestError.rateLimited(retryAfter: nil))
+        fetcher.handleFailure(with: article, error: error)
+
+        XCTAssertEqual(article.error, .none, "A 429 from the media-list fetch is still a global condition")
+        XCTAssertEqual(article.downloadAttemptCount, 0)
+        XCTAssertNil(article.downloadRetryDate)
+    }
+
+    func testRateLimitFromOfflineResourceListDoesNotFlagArticle() throws {
+        let article = try makeSavedArticle()
+
+        let error = ArticleCacheDBWriterError.failureFetchingOfflineResourceList(RequestError.rateLimited(retryAfter: nil))
+        fetcher.handleFailure(with: article, error: error)
+
+        XCTAssertEqual(article.error, .none)
+        XCTAssertEqual(article.downloadAttemptCount, 0)
+        XCTAssertNil(article.downloadRetryDate)
+    }
+
+    func testWrappedServerErrorStillFlagsArticleAndSchedulesRetry() throws {
+        let article = try makeSavedArticle()
+
+        let error = CacheControllerError.atLeastOneItemFailedInFileWriter(RequestError.http(503))
+        fetcher.handleFailure(with: article, error: error)
+
+        XCTAssertEqual(article.error, .apiFailed, "A non-429 HTTP failure is still this article's problem")
+        XCTAssertEqual(article.downloadAttemptCount, 1)
+        XCTAssertNotNil(article.downloadRetryDate)
+    }
+
+    // MARK: - Cooldown resolution
+
+    func testCooldownFallsBackToDefaultWithoutRetryAfter() {
+        let cooldown = SavedArticlesFetcher.rateLimitCooldown(retryAfter: nil, jitter: 1)
+        XCTAssertEqual(cooldown, SavedArticlesFetcher.defaultRateLimitCooldown)
+    }
+
+    func testCooldownHonoursRetryAfter() {
+        let cooldown = SavedArticlesFetcher.rateLimitCooldown(retryAfter: 120, jitter: 1)
+        XCTAssertEqual(cooldown, 120)
+    }
+
+    func testCooldownClampsExcessiveRetryAfter() {
+        let cooldown = SavedArticlesFetcher.rateLimitCooldown(retryAfter: 86400, jitter: 1)
+        XCTAssertEqual(cooldown, SavedArticlesFetcher.maximumRateLimitCooldown, "A very long Retry-After should not park downloads for hours")
+    }
+
+    func testCooldownIgnoresNonPositiveRetryAfter() {
+        let cooldown = SavedArticlesFetcher.rateLimitCooldown(retryAfter: 0, jitter: 1)
+        XCTAssertEqual(cooldown, SavedArticlesFetcher.defaultRateLimitCooldown)
+    }
+
+    func testCooldownAppliesJitter() {
+        let cooldown = SavedArticlesFetcher.rateLimitCooldown(retryAfter: 100, jitter: 1.5)
+        XCTAssertEqual(cooldown, 150)
+    }
+}
+
+final class RequestErrorRateLimitTests: XCTestCase {
+
+    private func response(headerFields: [String: String]?) throws -> HTTPURLResponse {
+        try XCTUnwrap(HTTPURLResponse(
+            url: URL(string: "https://en.wikipedia.org/w/api.php")!,
+            statusCode: 429,
+            httpVersion: "HTTP/1.1",
+            headerFields: headerFields
+        ))
+    }
+
+    func testFromCodeProducesRateLimitedFor429() throws {
+        let error = RequestError.from(code: 429, response: try response(headerFields: ["Retry-After": "45"]))
+        XCTAssertEqual(error.httpStatusCode, 429)
+        XCTAssertEqual(error.retryAfterInterval, 45)
+    }
+
+    func testFromCodeProducesHTTPForOtherCodes() {
+        let error = RequestError.from(code: 503)
+        XCTAssertEqual(error.httpStatusCode, 503)
+        XCTAssertNil(error.retryAfterInterval)
+    }
+
+    func testBareHTTP429StillReportsRateLimitedStatusCode() {
+        XCTAssertEqual(RequestError.http(429).httpStatusCode, RequestError.rateLimitedStatusCode)
+    }
+
+    func testRetryAfterDeltaSeconds() throws {
+        XCTAssertEqual(try response(headerFields: ["Retry-After": "90"]).retryAfterInterval, 90)
+    }
+
+    func testRetryAfterIsCaseInsensitive() throws {
+        // HTTP/2 lowercases header names.
+        XCTAssertEqual(try response(headerFields: ["retry-after": "90"]).retryAfterInterval, 90)
+    }
+
+    func testRetryAfterHTTPDate() throws {
+        let target = Date(timeIntervalSinceNow: 120)
+        let value = DateFormatter.wmf_httpDateFormatter.string(from: target)
+        let interval = try XCTUnwrap(response(headerFields: ["Retry-After": value]).retryAfterInterval)
+        XCTAssertEqual(interval, 120, accuracy: 2)
+    }
+
+    func testRetryAfterPastHTTPDateIsZero() throws {
+        let value = DateFormatter.wmf_httpDateFormatter.string(from: Date(timeIntervalSinceNow: -120))
+        XCTAssertEqual(try response(headerFields: ["Retry-After": value]).retryAfterInterval, 0)
+    }
+
+    func testRetryAfterAbsent() throws {
+        XCTAssertNil(try response(headerFields: [:]).retryAfterInterval)
+    }
+
+    func testRetryAfterUnparseable() throws {
+        XCTAssertNil(try response(headerFields: ["Retry-After": "soon"]).retryAfterInterval)
+    }
 }


### PR DESCRIPTION
**Phabricator:** T421064

### Notes

First of three stacked PRs reducing the API rate-limit pressure that saved-article offline downloads put on `api.php`. This one changes almost no request volume — it makes throttling *visible and actionable*, so the other two can be measured.

`SavedArticlesFetcher` already pauses all downloading when it sees a 429, but nothing on the download path ever produced that error, so the handling was unreachable:

* `CacheFetching.dataForURLRequest` flattened every non-200 into `RequestError.unexpectedResponse`.
* `Session.jsonDecodableTask` reports a non-200 as `(nil, response, nil)` — a **nil error** — which `trackedJSONDecodableTask` also turned into `.unexpectedResponse`.

So every real rate limit looked like an ordinary failure: the article was branded `.apiFailed`, its backoff escalated (30s → 15m → 7.5h → 9d → 28d), and the fetcher moved to the next article and kept going. The existing test passed only because it constructed a synthetic `RequestError.http(429)` directly.

**What changed**

* Carry the status code through both paths. `Fetcher.trackedJSONDecodableTask` is changed rather than `Session.jsonDecodableTask`, so the blast radius stays on the three `ArticleFetcher` call sites this concerns instead of the ~12 unrelated callers that rely on the silent nil-error behaviour today.
* New `RequestError.rateLimited(retryAfter:)` carrying the server's `Retry-After`, honoured when pausing — clamped to 600s so downloading resumes within a session, and jittered 1.0–1.5× so devices throttled together don't all return in the same second. Both `.rateLimited` and a bare `.http(429)` are recognised via `httpStatusCode`.
* Close the one HTTP-logging gap on this path. `Session.handleResponse` covers the JSON task methods and `SessionDelegate` covers the delegate-driven tasks the SchemeHandler uses, but neither covers permanent-cache downloads: `Session.dataTask(with:completionHandler:)` doesn't call `handleResponse`, and its completion-handler task suppresses the data-delegate callbacks. 429s and 5xx are now logged from there under a distinct source, so download-driven throttling is separable in Logstash from throttling while reading an article. 404s are deliberately excluded — this path sees routine ones for resources an article no longer references.

**Worth a reviewer's attention**

* `RequestError.errorDescription` now returns the "unexpected response" string for `.http` and `.rateLimited` too, not the generic one. Without this the cache and image paths would silently lose their existing copy — but it does change copy for other pre-existing `.http` producers.
* `Retry-After` is read via `value(forHTTPHeaderField:)` rather than an `allHeaderFields` subscript, because HTTP/2 lowercases header names and an exact-case lookup would miss it.

**Before merging, worth running:** break the existing 429s in the `clientError` stream down by `error_class`. If they are overwhelmingly `"SessionDelegate"`, download-path throttling is currently invisible and this PR is what makes it visible. If a material share are `"Session"`, the list-sync calls are being throttled too, which would raise the priority of pacing the sync itself.

### Test Steps

1. Run the unit tests: `xcodebuild -scheme Wikipedia -project Wikipedia.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' test`. New coverage in `SavedArticlesFetcherTests` for the production-shaped 429s (wrapped in `CacheControllerError` / `ArticleCacheDBWriterError`), the non-429 regression, cooldown resolution, and `Retry-After` parsing including the lowercase-header case.
2. Confirm a non-429 HTTP failure still brands the article `.apiFailed` and escalates `downloadRetryDate`.
3. With a proxy returning 429 for `api.php`, save a reading list and confirm downloading pauses rather than marking articles failed, and that a `429` appears in `ClientErrorFunnel` under the new source.

### Checklist

- [ ] Checked against Swift 6 strict concurrency

> Not ticked deliberately: these files are Swift 5 legacy in the WMF framework and the change keeps their existing completion-handler idiom rather than half-migrating them.

### Screenshots/Videos

n/a — no UI changes.

---

⚠️ **This was authored in an environment with no Xcode toolchain, so it has not been compiled or run.** Please build before reviewing. Target membership of every touched file was verified against `project.pbxproj` instead.

**Known follow-ups**, raised by Copilot on the superseded PR and not yet addressed:

* A 429 can still be masked: `finishDBAdd` and `syncCachedResources` collapse concurrent failures to `failedKeys.first`, and this path routinely sees 404s, so an earlier 404 can be wrapped instead of the 429. Lands in PR 2's code.
* `imageController.add` is called with both completions ignored, so a 429 from image downloads is logged but never reaches `SavedArticlesFetcher`.
* The `Retry-After` HTTP-date parser only handles IMF-fixdate; RFC 9110 also requires RFC 850 and asctime forms.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CjLA9cfAZ4qJL6qeFSNsJ1)_