### PR TITLE
Bound concurrent downloads per article in the permanent cache

### DIFF
--- a/WMF Framework/ArticleCacheController.swift
+++ b/WMF Framework/ArticleCacheController.swift
@@ -2,14 +2,14 @@ import Foundation
 
 public final class ArticleCacheController: CacheController {
     
-    init(moc: NSManagedObjectContext, imageCacheController: ImageCacheController, session: Session, configuration: Configuration, preferredLanguageDelegate: WMFPreferredLanguageInfoProvider) {
+    init(moc: NSManagedObjectContext, imageCacheController: ImageCacheController, session: Session, configuration: Configuration, preferredLanguageDelegate: WMFPreferredLanguageInfoProvider, throttle: CacheRequestThrottle = CacheRequestThrottle()) {
         let articleFetcher = ArticleFetcher(session: session, configuration: configuration)
         let imageInfoFetcher = MWKImageInfoFetcher(session: session, configuration: configuration)
         imageInfoFetcher.preferredLanguageDelegate = preferredLanguageDelegate
         let cacheFileWriter = CacheFileWriter(fetcher: articleFetcher)
-        
+
         let articleDBWriter = ArticleCacheDBWriter(articleFetcher: articleFetcher, cacheBackgroundContext: moc, imageController: imageCacheController, imageInfoFetcher: imageInfoFetcher)
-        super.init(dbWriter: articleDBWriter, fileWriter: cacheFileWriter)
+        super.init(dbWriter: articleDBWriter, fileWriter: cacheFileWriter, throttle: throttle)
     }
 
     enum ArticleCacheControllerError: Error {
@@ -29,45 +29,54 @@ public final class ArticleCacheController: CacheController {
             case .success(let syncResult):
             
                 let group = DispatchGroup()
-                
+
                 var successfulAddKeys: [CacheController.UniqueKey] = []
                 var failedAddKeys: [(CacheController.UniqueKey, Error)] = []
                 var successfulRemoveKeys: [CacheController.UniqueKey] = []
                 var failedRemoveKeys: [(CacheController.UniqueKey, Error)] = []
+
+                // serialises the result arrays, which are appended to from concurrent callbacks
+                let syncResultsQueue = DispatchQueue(label: "org.wikimedia.cache.article.syncResults")
                 
                 // add new urls in file system
                 for urlRequest in syncResult.addURLRequests {
-                    
+
                     guard let uniqueKey = self.fileWriter.uniqueFileNameForURLRequest(urlRequest), urlRequest.url != nil else {
                         continue
                     }
-                    
+
                     group.enter()
-                    
-                    self.fileWriter.add(groupKey: groupKey, urlRequest: urlRequest) { (fileWriterResult) in
-                        switch fileWriterResult {
-                        case .success(let response, _):
-                            
-                            self.dbWriter.markDownloaded(urlRequest: urlRequest, response: response) { (dbWriterResult) in
-                            
+
+                    // note, this runs in the foreground on every open of a saved article, competing with the WebView's own loads
+                    self.throttle.enqueue(groupKey: groupKey) { done in
+
+                        self.fileWriter.add(groupKey: groupKey, urlRequest: urlRequest) { (fileWriterResult) in
+                            switch fileWriterResult {
+                            case .success(let response, _):
+
+                                self.dbWriter.markDownloaded(urlRequest: urlRequest, response: response) { (dbWriterResult) in
+
+                                    defer {
+                                        done()
+                                        group.leave()
+                                    }
+
+                                    switch dbWriterResult {
+                                    case .success:
+                                        syncResultsQueue.sync { successfulAddKeys.append(uniqueKey) }
+                                    case .failure(let error):
+                                        syncResultsQueue.sync { failedAddKeys.append((uniqueKey, error)) }
+                                    }
+                                }
+                            case .failure(let error):
+
                                 defer {
+                                    done()
                                     group.leave()
                                 }
-                                    
-                                switch dbWriterResult {
-                                case .success:
-                                    successfulAddKeys.append(uniqueKey)
-                                case .failure(let error):
-                                    failedAddKeys.append((uniqueKey, error))
-                                }
+
+                                syncResultsQueue.sync { failedAddKeys.append((uniqueKey, error)) }
                             }
-                        case .failure(let error):
-                            
-                            defer {
-                                group.leave()
-                            }
-                            
-                            failedAddKeys.append((uniqueKey, error))
                         }
                     }
                 }
@@ -94,29 +103,29 @@ public final class ArticleCacheController: CacheController {
                                 
                                 switch dbWriterResult {
                                 case .success:
-                                    successfulRemoveKeys.append(uniqueKey)
+                                    syncResultsQueue.sync { successfulRemoveKeys.append(uniqueKey) }
                                 case .failure(let error):
-                                    failedRemoveKeys.append((uniqueKey, error))
+                                    syncResultsQueue.sync { failedRemoveKeys.append((uniqueKey, error)) }
                                 }
                             }
                         case .failure(let error):
                             defer {
                                 group.leave()
                             }
-                            
-                            failedRemoveKeys.append((uniqueKey, error))
+
+                            syncResultsQueue.sync { failedRemoveKeys.append((uniqueKey, error)) }
                         }
                     }
                 }
                 
                 group.notify(queue: DispatchQueue.global(qos: .userInitiated)) {
-                    if let error = failedAddKeys.first?.1 ?? failedRemoveKeys.first?.1 {
-                        groupCompletion(.failure(error: CacheControllerError.atLeastOneItemFailedInSync(error)))
-                        return
+                    let result: FinalGroupResult = syncResultsQueue.sync { () -> FinalGroupResult in
+                        if let error = failedAddKeys.first?.1 ?? failedRemoveKeys.first?.1 {
+                            return .failure(error: CacheControllerError.atLeastOneItemFailedInSync(error))
+                        }
+                        return .success(uniqueKeys: successfulAddKeys + successfulRemoveKeys)
                     }
-                    
-                    let successKeys = successfulAddKeys + successfulRemoveKeys
-                    groupCompletion(.success(uniqueKeys: successKeys))
+                    groupCompletion(result)
                 }
                 
             case .failure(let error):

--- a/WMF Framework/ArticleCacheController.swift
+++ b/WMF Framework/ArticleCacheController.swift
@@ -120,7 +120,7 @@ public final class ArticleCacheController: CacheController {
                 
                 group.notify(queue: DispatchQueue.global(qos: .userInitiated)) {
                     let result: FinalGroupResult = syncResultsQueue.sync { () -> FinalGroupResult in
-                        if let error = failedAddKeys.first?.1 ?? failedRemoveKeys.first?.1 {
+                        if let error = CacheFailureSelection.representativeError(from: failedAddKeys + failedRemoveKeys) {
                             return .failure(error: CacheControllerError.atLeastOneItemFailedInSync(error))
                         }
                         return .success(uniqueKeys: successfulAddKeys + successfulRemoveKeys)

--- a/WMF Framework/CacheController.swift
+++ b/WMF Framework/CacheController.swift
@@ -7,6 +7,16 @@ public enum CacheControllerError: Error {
     case atLeastOneItemFailedInSync(Error)
 }
 
+enum CacheFailureSelection {
+    // note, this path routinely sees 404s, so a rate limit must win or the global pause never fires
+    static func representativeError(from failures: [(CacheController.UniqueKey, Error)]) -> Error? {
+        let rateLimited = failures.first { failure in
+            (failure.1 as? RequestError)?.httpStatusCode == RequestError.rateLimitedStatusCode
+        }
+        return rateLimited?.1 ?? failures.first?.1
+    }
+}
+
 public class CacheController {
     
     #if TEST
@@ -294,7 +304,7 @@ public class CacheController {
 
             group.notify(queue: DispatchQueue.global(qos: .userInitiated)) {
                 let groupResult: FinalGroupResult = resultsQueue.sync { () -> FinalGroupResult in
-                    if let error = failedKeys.first?.1 {
+                    if let error = CacheFailureSelection.representativeError(from: failedKeys) {
                         return FinalGroupResult.failure(error: CacheControllerError.atLeastOneItemFailedInFileWriter(error))
                     }
                     return FinalGroupResult.success(uniqueKeys: successfulKeys)

--- a/WMF Framework/CacheController.swift
+++ b/WMF Framework/CacheController.swift
@@ -140,6 +140,9 @@ public class CacheController {
     let dbWriter: CacheDBWriting
     let fileWriter: CacheFileWriter
     let gatekeeper = CacheGatekeeper()
+
+    // serialises the finishDBAdd result arrays, which are appended to from concurrent callbacks
+    private let resultsQueue = DispatchQueue(label: "org.wikimedia.cache.controller.results")
     
     init(dbWriter: CacheDBWriting, fileWriter: CacheFileWriter) {
         self.dbWriter = dbWriter
@@ -196,8 +199,13 @@ public class CacheController {
 
             var successfulKeys: [CacheController.UniqueKey] = []
             var failedKeys: [(CacheController.UniqueKey, Error)] = []
+            let resultsQueue = self.resultsQueue
 
             let group = DispatchGroup()
+
+            // note, holding the group open across the loop stops it reaching zero before every request is issued, and lets the empty case complete
+            group.enter()
+
             for urlRequest in urlRequests {
 
                 guard let uniqueKey = fileWriter.uniqueFileNameForURLRequest(urlRequest),
@@ -225,6 +233,7 @@ public class CacheController {
                 fileWriter.add(groupKey: groupKey, urlRequest: urlRequest) { [weak self] (result) in
 
                     guard let self = self else {
+                        group.leave()
                         return
                     }
 
@@ -241,11 +250,11 @@ public class CacheController {
 
                             switch result {
                             case .success:
-                                successfulKeys.append(uniqueKey)
+                                resultsQueue.sync { successfulKeys.append(uniqueKey) }
                                 individualResult = FinalIndividualResult.success(uniqueKey: uniqueKey)
 
                             case .failure(let error):
-                                failedKeys.append((uniqueKey, error))
+                                resultsQueue.sync { failedKeys.append((uniqueKey, error)) }
                                 individualResult = FinalIndividualResult.failure(error: error)
                             }
 
@@ -260,22 +269,24 @@ public class CacheController {
                             group.leave()
                         }
 
-                        failedKeys.append((uniqueKey, error))
+                        resultsQueue.sync { failedKeys.append((uniqueKey, error)) }
                         let individualResult = FinalIndividualResult.failure(error: error)
                         self.gatekeeper.runAndRemoveIndividualCompletions(uniqueKey: uniqueKey, individualResult: individualResult)
                     }
                 }
-
-                group.notify(queue: DispatchQueue.global(qos: .userInitiated)) {
-                    let groupResult: FinalGroupResult
-                    if let error = failedKeys.first?.1 {
-                        groupResult = FinalGroupResult.failure(error: CacheControllerError.atLeastOneItemFailedInFileWriter(error))
-                    } else {
-                        groupResult = FinalGroupResult.success(uniqueKeys: successfulKeys)
-                    }
-                    groupCompleteBlock(groupResult)
-                }
             }
+
+            group.notify(queue: DispatchQueue.global(qos: .userInitiated)) {
+                let groupResult: FinalGroupResult = resultsQueue.sync { () -> FinalGroupResult in
+                    if let error = failedKeys.first?.1 {
+                        return FinalGroupResult.failure(error: CacheControllerError.atLeastOneItemFailedInFileWriter(error))
+                    }
+                    return FinalGroupResult.success(uniqueKeys: successfulKeys)
+                }
+                groupCompleteBlock(groupResult)
+            }
+
+            group.leave()
 
         case .failure(let error):
             let groupResult = FinalGroupResult.failure(error: error)

--- a/WMF Framework/CacheController.swift
+++ b/WMF Framework/CacheController.swift
@@ -143,10 +143,14 @@ public class CacheController {
 
     // serialises the finishDBAdd result arrays, which are appended to from concurrent callbacks
     private let resultsQueue = DispatchQueue(label: "org.wikimedia.cache.controller.results")
-    
-    init(dbWriter: CacheDBWriting, fileWriter: CacheFileWriter) {
+
+    // shared with the other cache controller so one article's budget covers its resources and images together
+    let throttle: CacheRequestThrottle
+
+    init(dbWriter: CacheDBWriting, fileWriter: CacheFileWriter, throttle: CacheRequestThrottle = CacheRequestThrottle()) {
         self.dbWriter = dbWriter
         self.fileWriter = fileWriter
+        self.throttle = throttle
     }
 
     public func add(url: URL, groupKey: GroupKey, individualCompletion: @escaping IndividualCompletionBlock, groupCompletion: @escaping GroupCompletionBlock) {
@@ -230,48 +234,60 @@ public class CacheController {
                     continue
                 }
 
-                fileWriter.add(groupKey: groupKey, urlRequest: urlRequest) { [weak self] (result) in
+                throttle.enqueue(groupKey: groupKey) { [weak self] done in
 
                     guard let self = self else {
+                        done()
                         group.leave()
                         return
                     }
 
-                    switch result {
-                    case .success(let response, let data):
+                    self.fileWriter.add(groupKey: groupKey, urlRequest: urlRequest) { [weak self] (result) in
 
-                        self.dbWriter.markDownloaded(urlRequest: urlRequest, response: response) { (result) in
+                        guard let self = self else {
+                            done()
+                            group.leave()
+                            return
+                        }
+
+                        switch result {
+                        case .success(let response, let data):
+
+                            self.dbWriter.markDownloaded(urlRequest: urlRequest, response: response) { (result) in
+
+                                defer {
+                                    done()
+                                    group.leave()
+                                }
+
+                                let individualResult: FinalIndividualResult
+
+                                switch result {
+                                case .success:
+                                    resultsQueue.sync { successfulKeys.append(uniqueKey) }
+                                    individualResult = FinalIndividualResult.success(uniqueKey: uniqueKey)
+
+                                case .failure(let error):
+                                    resultsQueue.sync { failedKeys.append((uniqueKey, error)) }
+                                    individualResult = FinalIndividualResult.failure(error: error)
+                                }
+
+                                self.gatekeeper.runAndRemoveIndividualCompletions(uniqueKey: uniqueKey, individualResult: individualResult)
+                            }
+
+                            self.finishFileSave(data: data, mimeType: response.mimeType, uniqueKey: uniqueKey, url: url)
+
+                        case .failure(let error):
 
                             defer {
+                                done()
                                 group.leave()
                             }
 
-                            let individualResult: FinalIndividualResult
-
-                            switch result {
-                            case .success:
-                                resultsQueue.sync { successfulKeys.append(uniqueKey) }
-                                individualResult = FinalIndividualResult.success(uniqueKey: uniqueKey)
-
-                            case .failure(let error):
-                                resultsQueue.sync { failedKeys.append((uniqueKey, error)) }
-                                individualResult = FinalIndividualResult.failure(error: error)
-                            }
-
+                            resultsQueue.sync { failedKeys.append((uniqueKey, error)) }
+                            let individualResult = FinalIndividualResult.failure(error: error)
                             self.gatekeeper.runAndRemoveIndividualCompletions(uniqueKey: uniqueKey, individualResult: individualResult)
                         }
-
-                        self.finishFileSave(data: data, mimeType: response.mimeType, uniqueKey: uniqueKey, url: url)
-
-                    case .failure(let error):
-
-                        defer {
-                            group.leave()
-                        }
-
-                        resultsQueue.sync { failedKeys.append((uniqueKey, error)) }
-                        let individualResult = FinalIndividualResult.failure(error: error)
-                        self.gatekeeper.runAndRemoveIndividualCompletions(uniqueKey: uniqueKey, individualResult: individualResult)
                     }
                 }
             }

--- a/WMF Framework/CacheRequestThrottle.swift
+++ b/WMF Framework/CacheRequestThrottle.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Bounds how many permanent-cache download requests are in flight for one group (an article).
+///
+/// Non-blocking by design: finishDBAdd runs on the cache moc's private queue and the completion it would
+/// wait on hops back onto that same context via markDownloaded, so a blocking wait here would deadlock.
+final class CacheRequestThrottle {
+
+    static let defaultMaxConcurrentRequestsPerGroup = 6
+
+    let maxConcurrentRequestsPerGroup: Int
+
+    private let queue = DispatchQueue(label: "org.wikimedia.cache.throttle")
+    private var inFlightByGroup: [CacheController.GroupKey: Int] = [:]
+    private var pendingByGroup: [CacheController.GroupKey: [Work]] = [:]
+
+    /// Work given a `done` block, which it must call once its request has finished.
+    typealias Work = (@escaping () -> Void) -> Void
+
+    init(maxConcurrentRequestsPerGroup: Int = CacheRequestThrottle.defaultMaxConcurrentRequestsPerGroup) {
+        self.maxConcurrentRequestsPerGroup = max(1, maxConcurrentRequestsPerGroup)
+    }
+
+    /// Runs `work` as soon as a slot is free for `groupKey`. Its `done` block is safe to call
+    /// from any thread and more than once - only the first call releases the slot.
+    func enqueue(groupKey: CacheController.GroupKey, work: @escaping Work) {
+        queue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            guard self.inFlightByGroup[groupKey, default: 0] < self.maxConcurrentRequestsPerGroup else {
+                self.pendingByGroup[groupKey, default: []].append(work)
+                return
+            }
+
+            self.startOnQueue(groupKey: groupKey, work: work)
+        }
+    }
+
+    // test seam
+    func inFlightCount(for groupKey: CacheController.GroupKey) -> Int {
+        queue.sync { inFlightByGroup[groupKey] ?? 0 }
+    }
+
+    // MARK: - Private, all called on `queue`
+
+    private func startOnQueue(groupKey: CacheController.GroupKey, work: @escaping Work) {
+        inFlightByGroup[groupKey, default: 0] += 1
+        work(makeDoneBlock(for: groupKey))
+    }
+
+    private func makeDoneBlock(for groupKey: CacheController.GroupKey) -> () -> Void {
+        var released = false
+        return { [weak self] in
+            guard let self = self else {
+                return
+            }
+            // note, hopping onto the queue is what makes `released` safe from whichever thread completed
+            self.queue.async {
+                guard !released else {
+                    return
+                }
+                released = true
+                self.releaseSlotOnQueue(groupKey: groupKey)
+            }
+        }
+    }
+
+    private func releaseSlotOnQueue(groupKey: CacheController.GroupKey) {
+        inFlightByGroup[groupKey] = max(0, (inFlightByGroup[groupKey] ?? 0) - 1)
+
+        if var pending = pendingByGroup[groupKey], !pending.isEmpty {
+            let next = pending.removeFirst()
+            pendingByGroup[groupKey] = pending.isEmpty ? nil : pending
+            startOnQueue(groupKey: groupKey, work: next)
+            return
+        }
+
+        pendingByGroup[groupKey] = nil
+        if inFlightByGroup[groupKey] == 0 {
+            inFlightByGroup[groupKey] = nil
+        }
+    }
+}

--- a/WMF Framework/ImageCacheController.swift
+++ b/WMF Framework/ImageCacheController.swift
@@ -37,13 +37,13 @@ public final class ImageCacheController: CacheController {
     private let imageFetcher: ImageFetcher
     fileprivate let memoryCache: NSCache<NSString, Image>
     
-    init(moc: NSManagedObjectContext, session: Session, configuration: Configuration) {
+    init(moc: NSManagedObjectContext, session: Session, configuration: Configuration, throttle: CacheRequestThrottle = CacheRequestThrottle()) {
         self.imageFetcher = ImageFetcher(session: session, configuration: configuration)
         memoryCache = NSCache<NSString, Image>()
         memoryCache.totalCostLimit = 10000000 // pixel count
         let fileWriter = CacheFileWriter(fetcher: imageFetcher)
         let dbWriter = ImageCacheDBWriter(imageFetcher: imageFetcher, cacheBackgroundContext: moc)
-        super.init(dbWriter: dbWriter, fileWriter: fileWriter)
+        super.init(dbWriter: dbWriter, fileWriter: fileWriter, throttle: throttle)
     }
     
     struct FetchResult {

--- a/WMF Framework/PermanentCacheController.swift
+++ b/WMF Framework/PermanentCacheController.swift
@@ -12,8 +12,10 @@ public final class PermanentCacheController: NSObject {
     /// - Parameter configuration: the configuration to utilize for configuring requests
     /// - Parameter preferredLanguageDelegate: the preferredLanguageDelegate to utilize for determining the user's preferred languages
     @objc public init(moc: NSManagedObjectContext, session: Session, configuration: Configuration, preferredLanguageDelegate: WMFPreferredLanguageInfoProvider) {
-        imageCache = ImageCacheController(moc: moc, session: session, configuration: configuration)
-        articleCache = ArticleCacheController(moc: moc, imageCacheController: imageCache, session: session, configuration: configuration, preferredLanguageDelegate: preferredLanguageDelegate)
+        // note, one throttle for both: a single article fans out through both caches under one group key
+        let throttle = CacheRequestThrottle()
+        imageCache = ImageCacheController(moc: moc, session: session, configuration: configuration, throttle: throttle)
+        articleCache = ArticleCacheController(moc: moc, imageCacheController: imageCache, session: session, configuration: configuration, preferredLanguageDelegate: preferredLanguageDelegate, throttle: throttle)
         urlCache = PermanentlyPersistableURLCache(moc: moc)
         managedObjectContext = moc
         super.init()

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -2631,6 +2631,7 @@
 		F1A700000000000000000012 /* TestHTTPClientProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A700000000000000000011 /* TestHTTPClientProfile.swift */; };
 		F1A700000000000000000013 /* TestNetworkFixtureURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A700000000000000000014 /* TestNetworkFixtureURLSession.swift */; };
 		FA71B2C400000001000000AA /* SavedArticlesFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA71B2C400000002000000AA /* SavedArticlesFetcherTests.swift */; };
+		FA71B2C400000003000000AA /* CacheControllerCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA71B2C400000004000000AA /* CacheControllerCompletionTests.swift */; };
 		FACE0000000000000000FE02 /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE0000000000000000FE01 /* HomeCoordinator.swift */; };
 		FACE0000000000000000FE03 /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE0000000000000000FE01 /* HomeCoordinator.swift */; };
 		FACE0000000000000000FE04 /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE0000000000000000FE01 /* HomeCoordinator.swift */; };
@@ -4344,6 +4345,7 @@
 		F1A700000000000000000011 /* TestHTTPClientProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHTTPClientProfile.swift; sourceTree = "<group>"; };
 		F1A700000000000000000014 /* TestNetworkFixtureURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNetworkFixtureURLSession.swift; sourceTree = "<group>"; };
 		FA71B2C400000002000000AA /* SavedArticlesFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedArticlesFetcherTests.swift; sourceTree = "<group>"; };
+		FA71B2C400000004000000AA /* CacheControllerCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheControllerCompletionTests.swift; sourceTree = "<group>"; };
 		FACE0000000000000000FE01 /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		FACE0000000000000000FE05 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		FACE0000000000000000FE11 /* HomeFeedSettingsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFeedSettingsCoordinator.swift; sourceTree = "<group>"; };
@@ -7329,6 +7331,7 @@
 				B389CFCA1E6784B600483C06 /* WMFDatabaseHousekeeperTests.swift */,
 				830ECAD51FBDE77F0080B1EF /* ReadingListsTests.swift */,
 				FA71B2C400000002000000AA /* SavedArticlesFetcherTests.swift */,
+				FA71B2C400000004000000AA /* CacheControllerCompletionTests.swift */,
 				B0C06B9E218240CA00E481CC /* Collection+AsyncMapTests.swift */,
 				D8396D1A22CF7052005625D8 /* WMFArticleTests.swift */,
 				8386BDE623857F87007EE89D /* URLParsingAndRoutingTests.swift */,
@@ -9469,6 +9472,7 @@
 				B0E8086D1C0D15170065EBC0 /* WMFCodingStyle.m in Sources */,
 				830ECAD61FBDE77F0080B1EF /* ReadingListsTests.swift in Sources */,
 				FA71B2C400000001000000AA /* SavedArticlesFetcherTests.swift in Sources */,
+				FA71B2C400000003000000AA /* CacheControllerCompletionTests.swift in Sources */,
 				67C6F74E27E2919B00B9C864 /* RemoteNotificationsModelController+TestExtensions.swift in Sources */,
 				D8800CB11E2FF5B70035D2DB /* QuadKeyTests.swift in Sources */,
 				8386BDE723857F87007EE89D /* URLParsingAndRoutingTests.swift in Sources */,

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -839,6 +839,7 @@
 		67D9D1F82970D8BE00BFCD4F /* BackgroundHighlightingButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D9D1F52970D8BE00BFCD4F /* BackgroundHighlightingButtonStyle.swift */; };
 		67DA31882720957B0035D40F /* RemoteNotificationsPagingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DA31872720957A0035D40F /* RemoteNotificationsPagingOperation.swift */; };
 		67DAEDA123CD1BC9003AA208 /* CacheGatekeeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA023CD1BC9003AA208 /* CacheGatekeeper.swift */; };
+		FA71B2C400000005000000AA /* CacheRequestThrottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA71B2C400000006000000AA /* CacheRequestThrottle.swift */; };
 		67DAEDA323CE24DA003AA208 /* SavedArticlesFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */; };
 		67DAEDA423CE24DA003AA208 /* SavedArticlesFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */; };
 		67DAEDA523CE24DA003AA208 /* SavedArticlesFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */; };
@@ -3372,6 +3373,7 @@
 		67D9D1F52970D8BE00BFCD4F /* BackgroundHighlightingButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundHighlightingButtonStyle.swift; sourceTree = "<group>"; };
 		67DA31872720957A0035D40F /* RemoteNotificationsPagingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationsPagingOperation.swift; sourceTree = "<group>"; };
 		67DAEDA023CD1BC9003AA208 /* CacheGatekeeper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheGatekeeper.swift; sourceTree = "<group>"; };
+		FA71B2C400000006000000AA /* CacheRequestThrottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheRequestThrottle.swift; sourceTree = "<group>"; };
 		67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedArticlesFetcher.swift; sourceTree = "<group>"; };
 		67DAEDD827E8DCBF005CF9B6 /* NotificationsCenterDetailViewModel+TextExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationsCenterDetailViewModel+TextExtensions.swift"; sourceTree = "<group>"; };
 		67DAEDDD27E8FB5F005CF9B6 /* NotificationsCenterDetailViewModelWelcomeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationsCenterDetailViewModelWelcomeTests.swift; sourceTree = "<group>"; };
@@ -5840,6 +5842,7 @@
 				6773B1FD240F02E40022A70E /* PermanentlyPersistableURLCache.swift */,
 				678C7C2923BE67F0001AC4D5 /* CacheController.swift */,
 				67DAEDA023CD1BC9003AA208 /* CacheGatekeeper.swift */,
+				FA71B2C400000006000000AA /* CacheRequestThrottle.swift */,
 				678C7C2D23BE705C001AC4D5 /* CacheDBWriting.swift */,
 				678C7C2F23BE7319001AC4D5 /* CacheDBWriterHelper.swift */,
 				678C7C3323BE75F9001AC4D5 /* CacheFileWriterHelper.swift */,
@@ -10325,6 +10328,7 @@
 				83CDC7D425122A1700A2F8A1 /* PermanentCacheController.swift in Sources */,
 				0E87683B1DDE00D600B8CACD /* WMFAnnouncementsFetcher.m in Sources */,
 				67DAEDA123CD1BC9003AA208 /* CacheGatekeeper.swift in Sources */,
+				FA71B2C400000005000000AA /* CacheRequestThrottle.swift in Sources */,
 				D881B1131E32874500D33F62 /* WMFArticle+QuadKey.swift in Sources */,
 				00669500265DA01000E23AE4 /* WidgetContentFetcher.swift in Sources */,
 				0015712C27D92F6B00F1EB26 /* RetryBlockTask.swift in Sources */,

--- a/Wikipedia/Code/SavedArticlesFetcher.swift
+++ b/Wikipedia/Code/SavedArticlesFetcher.swift
@@ -50,6 +50,9 @@ final class SavedArticlesFetcher: NSObject {
         unobserveSavedPages()
     }
 
+    // gap between finishing one saved article and starting the next
+    static let interArticleDelayMilliseconds = 250
+
     static let defaultRateLimitCooldown: TimeInterval = 60
     // ceiling on a server-supplied Retry-After, so downloading resumes within a session
     static let maximumRateLimitCooldown: TimeInterval = 600
@@ -208,7 +211,7 @@ private extension SavedArticlesFetcher {
         }
         
         let updateAgain = {
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(Self.interArticleDelayMilliseconds)) {
                 self.isUpdating = false
                 self.endBackgroundTask()
                 self.update()

--- a/Wikipedia/Code/Session.swift
+++ b/Wikipedia/Code/Session.swift
@@ -609,6 +609,7 @@ extension Session {
 
 enum SessionPermanentCacheError: Error {
     case unexpectedURLCacheType
+    case missingPermanentCache
 }
 
 extension Session {
@@ -669,8 +670,14 @@ extension Session {
     }
     
     func cacheResponse(httpUrlResponse: HTTPURLResponse, content: CacheResponseContentType, urlRequest: URLRequest, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
-        
-        permanentCache?.urlCache.cacheResponse(httpUrlResponse: httpUrlResponse, content: content, urlRequest: urlRequest, success: success, failure: failure)
+
+        // note, optional chaining here would discard both closures, leaving CacheFileWriter.add's completion uncalled
+        guard let permanentCache = permanentCache else {
+            failure(SessionPermanentCacheError.missingPermanentCache)
+            return
+        }
+
+        permanentCache.urlCache.cacheResponse(httpUrlResponse: httpUrlResponse, content: content, urlRequest: urlRequest, success: success, failure: failure)
     }
     
     func uniqueFileNameForItemKey(_ itemKey: CacheController.ItemKey, variant: String?) -> String? {

--- a/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
+++ b/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
@@ -20,10 +20,10 @@ final class CacheControllerCompletionTests: XCTestCase {
         super.tearDown()
     }
 
-    private func makeController(shouldDownloadVariant: Bool = true) -> CacheController {
+    private func makeController(shouldDownloadVariant: Bool = true, throttle: CacheRequestThrottle = CacheRequestThrottle()) -> CacheController {
         let dbWriter = FakeCacheDBWriter(context: context, fetcher: fetcher, shouldDownload: shouldDownloadVariant)
         let fileWriter = CacheFileWriter(fetcher: fetcher)
-        return CacheController(dbWriter: dbWriter, fileWriter: fileWriter)
+        return CacheController(dbWriter: dbWriter, fileWriter: fileWriter, throttle: throttle)
     }
 
     private func requests(_ count: Int) -> [URLRequest] {
@@ -116,6 +116,21 @@ final class CacheControllerCompletionTests: XCTestCase {
         }
     }
 
+    func testThrottleBoundsConcurrentRequestsForOneGroup() throws {
+        fetcher.completionDelay = { _ in 0.05 }
+        let controller = makeController(throttle: CacheRequestThrottle(maxConcurrentRequestsPerGroup: 3))
+
+        let result = try XCTUnwrap(runFinishDBAdd(controller: controller, groupKey: "bounded", result: .success(requests(12))))
+
+        XCTAssertLessThanOrEqual(fetcher.peakConcurrentRequests, 3, "The throttle should cap in-flight requests per group")
+        switch result {
+        case .success(let uniqueKeys):
+            XCTAssertEqual(Set(uniqueKeys).count, 12, "Queued requests should still all run")
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+    }
+
     func testGroupCompletionForwardsDBWriterFailure() throws {
         let controller = makeController()
 
@@ -138,7 +153,22 @@ private final class FakeCacheFetcher: Fetcher, CacheFetching {
     var completionDelay: (Int) -> TimeInterval = { _ in 0 }
     var shouldFail = false
 
+    private(set) var peakConcurrentRequests = 0
+    private var inFlight = 0
+
     private let queue = DispatchQueue(label: "FakeCacheFetcher", attributes: .concurrent)
+    private let countingQueue = DispatchQueue(label: "FakeCacheFetcher.counting")
+
+    private func requestStarted() {
+        countingQueue.sync {
+            inFlight += 1
+            peakConcurrentRequests = max(peakConcurrentRequests, inFlight)
+        }
+    }
+
+    private func requestFinished() {
+        countingQueue.sync { inFlight -= 1 }
+    }
 
     private func index(for urlRequest: URLRequest) -> Int {
         Int(urlRequest.url?.lastPathComponent ?? "") ?? 0
@@ -152,7 +182,11 @@ private final class FakeCacheFetcher: Fetcher, CacheFetching {
     func dataForURLRequest(_ urlRequest: URLRequest, completion: @escaping DataCompletion) -> URLSessionTask? {
         let delay = completionDelay(index(for: urlRequest))
         let shouldFail = self.shouldFail
-        queue.asyncAfter(deadline: .now() + delay) {
+        requestStarted()
+        queue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            defer {
+                self?.requestFinished()
+            }
             guard !shouldFail,
                   let url = urlRequest.url,
                   let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil) else {
@@ -225,5 +259,107 @@ private final class FakeCacheDBWriter: CacheDBWriting {
 
     func markDownloaded(urlRequest: URLRequest, response: HTTPURLResponse?, completion: @escaping (CacheDBWritingResult) -> Void) {
         completion(.success)
+    }
+}
+
+
+final class CacheRequestThrottleTests: XCTestCase {
+
+    private final class ConcurrencyRecorder {
+        private let queue = DispatchQueue(label: "ConcurrencyRecorder")
+        private var current = 0
+        private(set) var peak = 0
+
+        func started() {
+            queue.sync {
+                current += 1
+                peak = max(peak, current)
+            }
+        }
+
+        func finished() {
+            queue.sync { current -= 1 }
+        }
+
+        var peakValue: Int {
+            queue.sync { peak }
+        }
+    }
+
+    func testNeverExceedsTheBoundAndStillRunsEverything() {
+        let throttle = CacheRequestThrottle(maxConcurrentRequestsPerGroup: 4)
+        let recorder = ConcurrencyRecorder()
+        let workQueue = DispatchQueue(label: "work", attributes: .concurrent)
+        let allDone = expectation(description: "all work runs")
+        allDone.expectedFulfillmentCount = 30
+
+        for _ in 0..<30 {
+            throttle.enqueue(groupKey: "group") { done in
+                recorder.started()
+                workQueue.asyncAfter(deadline: .now() + 0.01) {
+                    recorder.finished()
+                    allDone.fulfill()
+                    done()
+                }
+            }
+        }
+
+        wait(for: [allDone], timeout: 20)
+        XCTAssertLessThanOrEqual(recorder.peakValue, 4)
+    }
+
+    func testReleasingASlotTwiceDoesNotWidenTheBound() {
+        let throttle = CacheRequestThrottle(maxConcurrentRequestsPerGroup: 2)
+        let recorder = ConcurrencyRecorder()
+        let workQueue = DispatchQueue(label: "work", attributes: .concurrent)
+        let allDone = expectation(description: "all work runs")
+        allDone.expectedFulfillmentCount = 12
+
+        for _ in 0..<12 {
+            throttle.enqueue(groupKey: "group") { done in
+                recorder.started()
+                workQueue.asyncAfter(deadline: .now() + 0.01) {
+                    recorder.finished()
+                    allDone.fulfill()
+                    done()
+                    done()
+                }
+            }
+        }
+
+        wait(for: [allDone], timeout: 20)
+        XCTAssertLessThanOrEqual(recorder.peakValue, 2)
+    }
+
+    func testGroupsHaveIndependentBudgets() {
+        let throttle = CacheRequestThrottle(maxConcurrentRequestsPerGroup: 1)
+        let firstStarted = expectation(description: "first group starts")
+        let secondStarted = expectation(description: "second group starts")
+
+        throttle.enqueue(groupKey: "a") { _ in firstStarted.fulfill() }
+        throttle.enqueue(groupKey: "b") { _ in secondStarted.fulfill() }
+
+        wait(for: [firstStarted, secondStarted], timeout: 10)
+        XCTAssertEqual(throttle.inFlightCount(for: "a"), 1)
+        XCTAssertEqual(throttle.inFlightCount(for: "b"), 1)
+    }
+
+    func testWorkBeyondTheBoundWaitsForASlot() {
+        let throttle = CacheRequestThrottle(maxConcurrentRequestsPerGroup: 1)
+        let firstStarted = expectation(description: "first starts")
+        let secondStarted = expectation(description: "second starts once a slot frees")
+
+        var release: (() -> Void)?
+        throttle.enqueue(groupKey: "group") { done in
+            release = done
+            firstStarted.fulfill()
+        }
+        wait(for: [firstStarted], timeout: 10)
+
+        throttle.enqueue(groupKey: "group") { _ in secondStarted.fulfill() }
+        XCTAssertEqual(throttle.inFlightCount(for: "group"), 1, "The second piece of work should be waiting, not running")
+
+        release?()
+        wait(for: [secondStarted], timeout: 10)
     }
 }

--- a/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
+++ b/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
@@ -1,0 +1,229 @@
+import XCTest
+import CoreData
+@testable import Wikipedia
+@testable import WMF
+
+final class CacheControllerCompletionTests: XCTestCase {
+
+    private var context: NSManagedObjectContext!
+    private var fetcher: FakeCacheFetcher!
+
+    override func setUpWithError() throws {
+        let directory = URL(fileURLWithPath: WMFRandomTemporaryPath())
+        context = try XCTUnwrap(CacheController.createCacheContext(cacheURL: directory))
+        fetcher = FakeCacheFetcher(session: Session(configuration: Configuration.current), configuration: Configuration.current)
+    }
+
+    override func tearDown() {
+        context = nil
+        fetcher = nil
+        super.tearDown()
+    }
+
+    private func makeController(shouldDownloadVariant: Bool = true) -> CacheController {
+        let dbWriter = FakeCacheDBWriter(context: context, fetcher: fetcher, shouldDownload: shouldDownloadVariant)
+        let fileWriter = CacheFileWriter(fetcher: fetcher)
+        return CacheController(dbWriter: dbWriter, fileWriter: fileWriter)
+    }
+
+    private func requests(_ count: Int) -> [URLRequest] {
+        (0..<count).map { URLRequest(url: URL(string: "https://en.wikipedia.org/resource/\($0)")!) }
+    }
+
+    // note, the group completion must be queued on the gatekeeper the way add does it - finishDBAdd runs those, not the block it is handed
+    private func runFinishDBAdd(
+        controller: CacheController,
+        groupKey: String,
+        result: CacheDBWritingResultWithURLRequests,
+        timeout: TimeInterval = 10
+    ) -> CacheController.FinalGroupResult? {
+        let expectation = expectation(description: "group completion fires")
+        var groupResult: CacheController.FinalGroupResult?
+        var callCount = 0
+
+        controller.gatekeeper.queueGroupCompletion(groupKey: groupKey) { result in
+            callCount += 1
+            groupResult = result
+            if callCount == 1 {
+                expectation.fulfill()
+            }
+        }
+
+        controller.finishDBAdd(
+            groupKey: groupKey,
+            individualCompletion: { _ in },
+            groupCompletion: { _ in },
+            result: result
+        )
+
+        wait(for: [expectation], timeout: timeout)
+        return groupResult
+    }
+
+    func testGroupCompletionReportsEveryRequestWhenTheyCompleteAtDifferentTimes() throws {
+        fetcher.completionDelay = { index in Double(index % 5) * 0.01 }
+        let controller = makeController()
+
+        let result = try XCTUnwrap(runFinishDBAdd(controller: controller, groupKey: "staggered", result: .success(requests(20))))
+
+        switch result {
+        case .success(let uniqueKeys):
+            XCTAssertEqual(Set(uniqueKeys).count, 20, "Every request should be represented in the group result")
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+    }
+
+    func testGroupCompletionFiresForAnEmptyRequestList() throws {
+        let controller = makeController()
+
+        let result = try XCTUnwrap(runFinishDBAdd(controller: controller, groupKey: "empty", result: .success([])))
+
+        switch result {
+        case .success(let uniqueKeys):
+            XCTAssertTrue(uniqueKeys.isEmpty)
+        case .failure(let error):
+            XCTFail("An empty request list should succeed, got \(error)")
+        }
+    }
+
+    func testGroupCompletionFiresWhenNoVariantShouldBeDownloaded() throws {
+        let controller = makeController(shouldDownloadVariant: false)
+
+        let result = try XCTUnwrap(runFinishDBAdd(controller: controller, groupKey: "skipped", result: .success(requests(5))))
+
+        switch result {
+        case .success(let uniqueKeys):
+            XCTAssertTrue(uniqueKeys.isEmpty)
+        case .failure(let error):
+            XCTFail("Skipping every variant should still complete, got \(error)")
+        }
+    }
+
+    func testGroupCompletionFiresWhenEveryRequestFails() throws {
+        fetcher.shouldFail = true
+        let controller = makeController()
+
+        let result = try XCTUnwrap(runFinishDBAdd(controller: controller, groupKey: "failing", result: .success(requests(5))))
+
+        switch result {
+        case .success:
+            XCTFail("Expected a failure when every request fails")
+        case .failure(let error):
+            guard case CacheControllerError.atLeastOneItemFailedInFileWriter = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testGroupCompletionForwardsDBWriterFailure() throws {
+        let controller = makeController()
+
+        let result = try XCTUnwrap(runFinishDBAdd(controller: controller, groupKey: "dbfail", result: .failure(CacheFetchingError.missingURLResponse)))
+
+        switch result {
+        case .success:
+            XCTFail("Expected the db writer failure to be forwarded")
+        case .failure:
+            break
+        }
+    }
+}
+
+// MARK: - Fakes
+
+// note, concrete members are declared here so the `where Self: Fetcher` defaults, which reach for a permanent cache that doesn't exist in tests, are bypassed
+private final class FakeCacheFetcher: Fetcher, CacheFetching {
+
+    var completionDelay: (Int) -> TimeInterval = { _ in 0 }
+    var shouldFail = false
+
+    private let queue = DispatchQueue(label: "FakeCacheFetcher", attributes: .concurrent)
+
+    private func index(for urlRequest: URLRequest) -> Int {
+        Int(urlRequest.url?.lastPathComponent ?? "") ?? 0
+    }
+
+    private func key(for urlRequest: URLRequest) -> String? {
+        urlRequest.url?.absoluteString.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
+    }
+
+    @discardableResult
+    func dataForURLRequest(_ urlRequest: URLRequest, completion: @escaping DataCompletion) -> URLSessionTask? {
+        let delay = completionDelay(index(for: urlRequest))
+        let shouldFail = self.shouldFail
+        queue.asyncAfter(deadline: .now() + delay) {
+            guard !shouldFail,
+                  let url = urlRequest.url,
+                  let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil) else {
+                completion(.failure(CacheFetchingError.missingURLResponse))
+                return
+            }
+            completion(.success(CacheFetchingResult(data: Data("body".utf8), response: response)))
+        }
+        return nil
+    }
+
+    func cacheResponse(httpUrlResponse: HTTPURLResponse, content: CacheResponseContentType, urlRequest: URLRequest, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+        success()
+    }
+
+    func uniqueFileNameForURLRequest(_ urlRequest: URLRequest) -> String? {
+        key(for: urlRequest)
+    }
+
+    func uniqueFileNameForItemKey(_ itemKey: CacheController.ItemKey, variant: String?) -> String? {
+        itemKey
+    }
+
+    func uniqueHeaderFileNameForItemKey(_ itemKey: CacheController.ItemKey, variant: String?) -> String? {
+        itemKey + "__header"
+    }
+
+    func itemKeyForURLRequest(_ urlRequest: URLRequest) -> String? {
+        key(for: urlRequest)
+    }
+
+    func variantForURLRequest(_ urlRequest: URLRequest) -> String? {
+        nil
+    }
+}
+
+private final class FakeCacheDBWriter: CacheDBWriting {
+
+    var groupedTasks: [String: [IdentifiedTask]] = [:]
+
+    let context: NSManagedObjectContext
+    let fetcher: CacheFetching
+    private let shouldDownload: Bool
+
+    init(context: NSManagedObjectContext, fetcher: CacheFetching, shouldDownload: Bool) {
+        self.context = context
+        self.fetcher = fetcher
+        self.shouldDownload = shouldDownload
+    }
+
+    func add(url: URL, groupKey: CacheController.GroupKey, completion: @escaping CacheDBWritingCompletionWithURLRequests) {
+        completion(.success([URLRequest(url: url)]))
+    }
+
+    func add(urls: [URL], groupKey: CacheController.GroupKey, completion: @escaping CacheDBWritingCompletionWithURLRequests) {
+        completion(.success(urls.map { URLRequest(url: $0) }))
+    }
+
+    func shouldDownloadVariant(itemKey: CacheController.ItemKey, variant: String?) -> Bool {
+        shouldDownload
+    }
+
+    func shouldDownloadVariant(urlRequest: URLRequest) -> Bool {
+        shouldDownload
+    }
+
+    func shouldDownloadVariantForAllVariantItems(variant: String?, _ allVariantItems: [CacheController.ItemKeyAndVariant]) -> Bool {
+        shouldDownload
+    }
+
+    func markDownloaded(urlRequest: URLRequest, response: HTTPURLResponse?, completion: @escaping (CacheDBWritingResult) -> Void) {
+        completion(.success)
+    }
+}

--- a/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
+++ b/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
@@ -57,6 +57,12 @@ final class CacheControllerCompletionTests: XCTestCase {
         )
 
         wait(for: [expectation], timeout: timeout)
+
+        // give a duplicate a chance to land before asserting - without this the "fires
+        // exactly once" tests cannot fail on a double fire, which is the point of them
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+        XCTAssertEqual(callCount, 1, "The group completion must fire exactly once")
+
         return groupResult
     }
 
@@ -184,15 +190,16 @@ private final class FakeCacheFetcher: Fetcher, CacheFetching {
         let shouldFail = self.shouldFail
         requestStarted()
         queue.asyncAfter(deadline: .now() + delay) { [weak self] in
-            defer {
-                self?.requestFinished()
-            }
+            // note, the slot is released inside completion's chain, so this must decrement
+            // first or the next request starts before the count drops
             guard !shouldFail,
                   let url = urlRequest.url,
                   let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil) else {
+                self?.requestFinished()
                 completion(.failure(CacheFetchingError.missingURLResponse))
                 return
             }
+            self?.requestFinished()
             completion(.success(CacheFetchingResult(data: Data("body".utf8), response: response)))
         }
         return nil


### PR DESCRIPTION
**Phabricator:** T421064

> **Stacked on #6136** — base is `claude/rate-limit-detection-pw7gkk`, so review that first. GitHub will re-target this to `main` automatically when #6136 merges.

### Notes

Second of three stacked PRs reducing API rate-limit pressure from saved-article downloads. **Two commits, reviewable independently:**

**1. `0df1857b` — make the group completion fire exactly once.** Pure correctness, no behaviour change intended. It has to land before the throttle, because throttling *activates* a latent bug rather than working around it.

`finishDBAdd` registered `group.notify` inside its request loop, so it was registered once per request. Two consequences:

* The first notify is registered while the group balance is 1. If that request completes before the loop reaches the next `group.enter()`, the group hits zero early and the completion fires with a partial result — the article is marked downloaded before its remaining resources are fetched. The window is small today; **with a concurrency bound it becomes routine**, because the first N completions can drain the group while the loop is still issuing the rest.
* An empty request list, or one where every iteration hit the `uniqueKey` guard, registered no notify at all. The completion never ran, so `removeCurrentlyAddingGroupKey` never ran either and the group key stayed in the gatekeeper's `currentlyAdding` list permanently, wedging every later add **and** remove for that key.

Both are fixed by one mechanism: hold the group open across the loop with a matching enter/leave, and register notify once, after the loop and before the balancing leave. `successfulKeys`/`failedKeys` are also serialised — they were appended from concurrent URLSession and global-queue callbacks with no synchronisation, and read unsynchronised in the notify block. Two dropped-completion paths are closed as well, since a throttle that frees a slot in the completion would leak slots and stall permanently.

**2. `cf6b6645` — the throttle.** Saving one article fanned out into a single unbounded burst: a mobile-html request, one per offline resource, one `imageinfo` call per image, one download per image — all at once. Worse, it was *two* bursts, because `ArticleCacheDBWriter` kicks off `imageController.add(urls:)` fire-and-forget under the same group key. Nothing sets `httpMaximumConnectionsPerHost`, and the three request families sit on different hosts, so URLSession's per-host default didn't bound the total either.

New `CacheRequestThrottle` bounds requests per group, applied to `finishDBAdd` (which serves the article and image paths alike) and to `ArticleCacheController.syncCachedResources` — the latter fires in the foreground every time an already-saved article is opened, competing with the WebView's own resource loads.

**Design constraints worth knowing**

* **One throttle, shared.** `PermanentCacheController` creates it and injects it into both cache controllers, because a single article drives two concurrent `finishDBAdd` runs under one group key from two different `CacheController` instances. A per-instance limiter would give 2N per article.
* **Non-blocking by construction.** On the article path `finishDBAdd` runs on the cache managed object context's private queue, and the completion it would wait on hops back onto that same context via `markDownloaded` — a `DispatchSemaphore.wait()` here would deadlock. All state is mutated inside the throttle's serial queue and no caller ever waits.
* **Idempotent slot release.** Success and failure arrive on different queues; a doubled release would let a group exceed its budget, a dropped one would stall it for good.
* There is no existing bounded-concurrency machinery in the repo to reuse — every `maxConcurrentOperationCount` is 1 and every `DispatchSemaphore` is a mutex — so this is new code rather than a reinvention.

**The bound of 6 is a starting guess and wants measuring.** Because the throttle is shared per article, image downloads now share the budget with the `api.php` calls that are the actual rate-limit pressure. One media list is larger than it looks — the checked-in Dog fixture yields 36 image requests from 23 items, since every srcset entry becomes its own request. Too low a bound slows saving without helping, since images go to `upload.wikimedia.org`, which isn't throttled. Per-host budgets are the natural future refinement.

The inter-article gap also moved from 100 ms to 250 ms as a named constant. Honestly it's the weaker lever — articles are already processed one at a time, so the throttle is what actually bounds things — and it's worth deciding whether it earns its place.

### Test Steps

1. Run the unit tests. This adds the **first** tests for `CacheController` / `CacheFileWriter` / the throttle — there were none. They drive `finishDBAdd` directly through a fake `CacheDBWriting` and a `Fetcher`-backed `CacheFetching` double, covering staggered completions, empty and all-skipped request lists, all-failed, peak in-flight never exceeding the bound, idempotent release, and independent per-group budgets.
2. Save an image-heavy article on a fresh install and confirm peak concurrent requests stay at the bound (Charles/Proxyman, or a temporary counter in `CacheFileWriter.add`).
3. Open an already-saved article and confirm `syncCachedResources` no longer spikes, and rendering is not visibly slower.
4. With a large list already in a failed state, pull to refresh on Saved and confirm the re-download is paced rather than a spike. `retryFailedArticleDownloads` still resets every entry by design, so this is the case the pacing has to absorb — if it still bursts, that's the signal to revisit the reset scoping.

### Checklist

- [ ] Checked against Swift 6 strict concurrency

> Not ticked deliberately: this is Swift 5 legacy in the WMF framework. The new concurrency code follows the framework's existing labelled-serial-queue convention (as `CacheGatekeeper` does) rather than introducing actors into completion-handler code.

### Screenshots/Videos

n/a — no UI changes.

---

⚠️ **Not compiled or run** — authored without an Xcode toolchain. Please build before reviewing. This PR also hand-edits `project.pbxproj` to add two files; membership was verified by re-parsing the project file, but that is not a substitute for opening it in Xcode.

**Known follow-ups:**

* **A 429 can still be masked** (Copilot, on the superseded PR): `finishDBAdd` and `syncCachedResources` collapse concurrent failures to `failedKeys.first`, and this path routinely sees 404s, so an earlier 404 can be wrapped instead of a 429 — defeating #6136's pause. This is the most substantive open finding and lands squarely in this PR's code.
* Task cancellation is entirely broken today and left alone here: `CacheTaskTracking.trackTask` appends to a dictionary key nothing ever seeds, so `cancelTasks`/`cancelAllTasks` are no-ops, and `untrackTask`'s filter is inverted. The throttle keeps a per-group pending list specifically so cancellation can be wired in without rework.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CjLA9cfAZ4qJL6qeFSNsJ1)_