### PR TITLE
Fetch saved-article image metadata in batches instead of one call per image

### DIFF
--- a/WMF Framework/ArticleCacheResourceDBWriting.swift
+++ b/WMF Framework/ArticleCacheResourceDBWriting.swift
@@ -3,7 +3,19 @@ import Foundation
 struct ImageAndResourceURLs {
     let offlineResourcesURLs: [URL]
     let mediaListURLs: [URL]
-    let imageInfoURLs: [URL]
+    // titles are kept alongside the URLs because the download fetches in batches but stores per single-title URL
+    let imageInfo: [ImageInfoURL]
+}
+
+struct ImageInfoURL {
+    let title: String
+    let url: URL
+}
+
+extension ImageAndResourceURLs {
+    var imageInfoURLs: [URL] {
+        imageInfo.map { $0.url }
+    }
 }
 
 enum ImageAndResourceResult {
@@ -135,7 +147,7 @@ extension ArticleCacheResourceDBWriting {
         
         var mobileHtmlOfflineResourceURLs: [URL] = []
         var mediaListURLs: [URL] = []
-        var imageInfoURLs: [URL] = []
+        var imageInfo: [ImageInfoURL] = []
         
         var mediaListError: Error?
         var mobileHtmlOfflineResourceError: Error?
@@ -172,11 +184,11 @@ extension ArticleCacheResourceDBWriting {
                 
                 let imageTitles = items.map { $0.imageTitle }
                 let dedupedTitles = Set(imageTitles)
-                
+
                 // add imageInfoFetcher's urls for deduped titles (for captions/licensing info in gallery)
                 for title in dedupedTitles {
                     if let imageInfoURL = self.imageInfoFetcher.galleryInfoURL(forImageTitles: [title], fromSiteURL: articleURL) {
-                        imageInfoURLs.append(imageInfoURL)
+                        imageInfo.append(ImageInfoURL(title: title, url: imageInfoURL))
                     }
                 }
                 
@@ -199,7 +211,7 @@ extension ArticleCacheResourceDBWriting {
                 return
             }
             
-            let result = ImageAndResourceURLs(offlineResourcesURLs: mobileHtmlOfflineResourceURLs, mediaListURLs: mediaListURLs, imageInfoURLs: imageInfoURLs)
+            let result = ImageAndResourceURLs(offlineResourcesURLs: mobileHtmlOfflineResourceURLs, mediaListURLs: mediaListURLs, imageInfo: imageInfo)
             completion(.success(result))
         }
     }

--- a/WMF Framework/ImageInfoResponseSplitter.swift
+++ b/WMF Framework/ImageInfoResponseSplitter.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Splits one batched `action=query&prop=imageinfo` response into per-title bodies.
+///
+/// The gallery reads image metadata back one title at a time and the permanent cache is keyed by the
+/// literal request URL, so each page of a batched response is stored under its single-title URL.
+enum ImageInfoResponseSplitter {
+
+    enum SplitError: Error {
+        case malformedResponse
+    }
+
+    struct SplitResult {
+        let bodiesByRequestedTitle: [String: Data]
+        let missingTitles: [String]
+    }
+
+    // Etag is read back into If-None-Match and belongs to the batch URL; Content-Length describes the batch body
+    private static let droppedHeaderFields = ["etag", "content-length"]
+
+    static func perTitleHeaderFields(from response: HTTPURLResponse?) -> [String: String] {
+        guard let response = response else {
+            return [:]
+        }
+
+        var fields: [String: String] = [:]
+        for (rawKey, rawValue) in response.allHeaderFields {
+            guard let key = rawKey as? String, let value = rawValue as? String else {
+                continue
+            }
+            guard !droppedHeaderFields.contains(key.lowercased()) else {
+                continue
+            }
+            fields[key] = value
+        }
+        return fields
+    }
+
+    /// Rebuilds one single-title body per requested title, keeping the shape responseObjectForJSON: reads.
+    static func split(response: [String: Any], requestedTitles: [String]) throws -> SplitResult {
+        guard let query = response["query"] as? [String: Any],
+              let pages = query["pages"] as? [String: Any] else {
+            throw SplitError.malformedResponse
+        }
+
+        // note, the API normalises titles and reports what it did in query.normalized, so a returned page's title often isn't what we asked for
+        var normalisedByRequested: [String: String] = [:]
+        if let normalized = query["normalized"] as? [[String: Any]] {
+            for entry in normalized {
+                guard let from = entry["from"] as? String, let to = entry["to"] as? String else {
+                    continue
+                }
+                normalisedByRequested[canonicalised(from)] = to
+            }
+        }
+
+        var pagesByTitle: [String: (pageID: String, page: Any)] = [:]
+        for (pageID, page) in pages {
+            guard let page = page as? [String: Any], let title = page["title"] as? String else {
+                continue
+            }
+            pagesByTitle[canonicalised(title)] = (pageID, page)
+        }
+
+        var bodies: [String: Data] = [:]
+        var missing: [String] = []
+
+        for requestedTitle in requestedTitles {
+            let canonicalRequested = canonicalised(requestedTitle)
+            let lookup = normalisedByRequested[canonicalRequested].map(canonicalised) ?? canonicalRequested
+
+            guard let match = pagesByTitle[lookup] else {
+                missing.append(requestedTitle)
+                continue
+            }
+
+            let body: [String: Any] = ["query": ["pages": [match.pageID: match.page]]]
+            guard JSONSerialization.isValidJSONObject(body),
+                  let data = try? JSONSerialization.data(withJSONObject: body) else {
+                missing.append(requestedTitle)
+                continue
+            }
+
+            bodies[requestedTitle] = data
+        }
+
+        return SplitResult(bodiesByRequestedTitle: bodies, missingTitles: missing)
+    }
+
+    // underscores and spaces are interchangeable in MediaWiki titles, so compare on one of them
+    private static func canonicalised(_ title: String) -> String {
+        title.replacingOccurrences(of: "_", with: " ").precomposedStringWithCanonicalMapping
+    }
+}

--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -839,6 +839,7 @@
 		67D9D1F82970D8BE00BFCD4F /* BackgroundHighlightingButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D9D1F52970D8BE00BFCD4F /* BackgroundHighlightingButtonStyle.swift */; };
 		67DA31882720957B0035D40F /* RemoteNotificationsPagingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DA31872720957A0035D40F /* RemoteNotificationsPagingOperation.swift */; };
 		67DAEDA123CD1BC9003AA208 /* CacheGatekeeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA023CD1BC9003AA208 /* CacheGatekeeper.swift */; };
+		FA71B2C400000007000000AA /* ImageInfoResponseSplitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA71B2C400000008000000AA /* ImageInfoResponseSplitter.swift */; };
 		FA71B2C400000005000000AA /* CacheRequestThrottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA71B2C400000006000000AA /* CacheRequestThrottle.swift */; };
 		67DAEDA323CE24DA003AA208 /* SavedArticlesFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */; };
 		67DAEDA423CE24DA003AA208 /* SavedArticlesFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */; };
@@ -3373,6 +3374,7 @@
 		67D9D1F52970D8BE00BFCD4F /* BackgroundHighlightingButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundHighlightingButtonStyle.swift; sourceTree = "<group>"; };
 		67DA31872720957A0035D40F /* RemoteNotificationsPagingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationsPagingOperation.swift; sourceTree = "<group>"; };
 		67DAEDA023CD1BC9003AA208 /* CacheGatekeeper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheGatekeeper.swift; sourceTree = "<group>"; };
+		FA71B2C400000008000000AA /* ImageInfoResponseSplitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageInfoResponseSplitter.swift; sourceTree = "<group>"; };
 		FA71B2C400000006000000AA /* CacheRequestThrottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheRequestThrottle.swift; sourceTree = "<group>"; };
 		67DAEDA223CE24DA003AA208 /* SavedArticlesFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedArticlesFetcher.swift; sourceTree = "<group>"; };
 		67DAEDD827E8DCBF005CF9B6 /* NotificationsCenterDetailViewModel+TextExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationsCenterDetailViewModel+TextExtensions.swift"; sourceTree = "<group>"; };
@@ -5842,6 +5844,7 @@
 				6773B1FD240F02E40022A70E /* PermanentlyPersistableURLCache.swift */,
 				678C7C2923BE67F0001AC4D5 /* CacheController.swift */,
 				67DAEDA023CD1BC9003AA208 /* CacheGatekeeper.swift */,
+				FA71B2C400000008000000AA /* ImageInfoResponseSplitter.swift */,
 				FA71B2C400000006000000AA /* CacheRequestThrottle.swift */,
 				678C7C2D23BE705C001AC4D5 /* CacheDBWriting.swift */,
 				678C7C2F23BE7319001AC4D5 /* CacheDBWriterHelper.swift */,
@@ -10328,6 +10331,7 @@
 				83CDC7D425122A1700A2F8A1 /* PermanentCacheController.swift in Sources */,
 				0E87683B1DDE00D600B8CACD /* WMFAnnouncementsFetcher.m in Sources */,
 				67DAEDA123CD1BC9003AA208 /* CacheGatekeeper.swift in Sources */,
+				FA71B2C400000007000000AA /* ImageInfoResponseSplitter.swift in Sources */,
 				FA71B2C400000005000000AA /* CacheRequestThrottle.swift in Sources */,
 				D881B1131E32874500D33F62 /* WMFArticle+QuadKey.swift in Sources */,
 				00669500265DA01000E23AE4 /* WidgetContentFetcher.swift in Sources */,

--- a/Wikipedia/Code/ArticleCacheDBWriter.swift
+++ b/Wikipedia/Code/ArticleCacheDBWriter.swift
@@ -172,20 +172,37 @@ final class ArticleCacheDBWriter: ArticleCacheResourceDBWriting {
 
             // note, Session.jsonDictionaryTask only special-cases 304, so a 429 arrives here looking like a success carrying an error body
             if let statusCode = response?.statusCode, !HTTPStatusCode.isSuccessful(statusCode) {
-                completion(RequestError.from(code: statusCode, response: response))
+                self.continueAfterImageInfoFailure(RequestError.from(code: statusCode, response: response), batches: batches, index: index, siteURL: siteURL, requestsByTitle: requestsByTitle, completion: completion)
                 return
             }
 
             self.storeImageInfo(from: result, response: response, requestedTitles: batch, requestsByTitle: requestsByTitle) { error in
                 if let error = error {
-                    completion(error)
+                    self.continueAfterImageInfoFailure(error, batches: batches, index: index, siteURL: siteURL, requestsByTitle: requestsByTitle, completion: completion)
                     return
                 }
                 self.fetchImageInfoBatches(batches, index: index + 1, siteURL: siteURL, requestsByTitle: requestsByTitle, completion: completion)
             }
-        }, failure: { error in
-            completion(error)
+        }, failure: { [weak self] error in
+            guard let self = self else {
+                completion(nil)
+                return
+            }
+            self.continueAfterImageInfoFailure(error, batches: batches, index: index, siteURL: siteURL, requestsByTitle: requestsByTitle, completion: completion)
         })
+    }
+
+    // note, only a rate limit fails the article - any other metadata failure leaves those captions
+    // uncached rather than costing the whole download, which is what the caller retries
+    private func continueAfterImageInfoFailure(_ error: Error, batches: [[String]], index: Int, siteURL: URL, requestsByTitle: [String: URLRequest], completion: @escaping (Error?) -> Void) {
+
+        if let requestError = error as? RequestError, requestError.httpStatusCode == RequestError.rateLimitedStatusCode {
+            completion(error)
+            return
+        }
+
+        DDLogWarn("Image info batch failed, leaving those entries uncached: \(error)")
+        fetchImageInfoBatches(batches, index: index + 1, siteURL: siteURL, requestsByTitle: requestsByTitle, completion: completion)
     }
 
     /// Splits one batched response and writes a cache entry per title, keyed by the URL the gallery will ask for.

--- a/Wikipedia/Code/ArticleCacheDBWriter.swift
+++ b/Wikipedia/Code/ArticleCacheDBWriter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CocoaLumberjackSwift
 
 public enum ArticleCacheDBWriterError: Error {
     case unableToDetermineDatabaseKey
@@ -81,15 +82,18 @@ final class ArticleCacheDBWriter: ArticleCacheResourceDBWriting {
                 }
                 
                 // append image info URLRequests
-                for url in urls.imageInfoURLs {
-                    guard let urlRequest = self.imageInfoFetcher.urlRequestFor(from: url) else {
+                // note, these are registered as cache items but not returned for individual download - they're fetched in batches below
+                var imageInfoRequestsByTitle: [(title: String, urlRequest: URLRequest)] = []
+                for imageInfo in urls.imageInfo {
+                    guard let urlRequest = self.imageInfoFetcher.urlRequestFor(from: imageInfo.url) else {
                         completion(.failure(ArticleCacheDBWriterError.failureMakingRequestFromMustHaveResource))
                         return
                     }
-                    
+
                     mustHaveURLRequests.append(urlRequest)
+                    imageInfoRequestsByTitle.append((imageInfo.title, urlRequest))
                 }
-                
+
                 // send image urls straight to imageController to deal with
                 self.imageController.add(urls: urls.mediaListURLs, groupKey: groupKey, individualCompletion: { (result) in
                     
@@ -101,8 +105,21 @@ final class ArticleCacheDBWriter: ArticleCacheResourceDBWriting {
                 self.cacheURLs(groupKey: groupKey, mustHaveURLRequests: mustHaveURLRequests, niceToHaveURLRequests: []) { (result) in
                     switch result {
                     case .success:
-                        let result = CacheDBWritingResultWithURLRequests.success(mustHaveURLRequests)
-                        completion(result)
+                        let imageInfoRequestURLs = Set(imageInfoRequestsByTitle.compactMap { $0.urlRequest.url })
+                        let remainingRequests = mustHaveURLRequests.filter { request in
+                            guard let url = request.url else {
+                                return true
+                            }
+                            return !imageInfoRequestURLs.contains(url)
+                        }
+
+                        self.cacheImageInfoInBatches(titledRequests: imageInfoRequestsByTitle, siteURL: url) { error in
+                            if let error = error {
+                                completion(.failure(error))
+                                return
+                            }
+                            completion(.success(remainingRequests))
+                        }
                     case .failure(let error):
                         let result = CacheDBWritingResultWithURLRequests.failure(error)
                         completion(result)
@@ -116,6 +133,107 @@ final class ArticleCacheDBWriter: ArticleCacheResourceDBWriting {
         }
     }
     
+    // titles per imageinfo call - the API allows 50, a smaller batch limits what one failure costs
+    static let imageInfoBatchSize = 10
+
+    /// Fetches image metadata in batches and stores one cache entry per title, calling back with the first error.
+    ///
+    /// Batches run one at a time: these sit outside the per-article throttle, and firing every chunk
+    /// together would put one concurrent api.php call per ten images in flight.
+    private func cacheImageInfoInBatches(titledRequests: [(title: String, urlRequest: URLRequest)], siteURL: URL, completion: @escaping (Error?) -> Void) {
+
+        guard !titledRequests.isEmpty else {
+            completion(nil)
+            return
+        }
+
+        var requestsByTitle: [String: URLRequest] = [:]
+        for titledRequest in titledRequests {
+            requestsByTitle[titledRequest.title] = titledRequest.urlRequest
+        }
+
+        let batches = titledRequests.map { $0.title }.chunked(into: Self.imageInfoBatchSize)
+        fetchImageInfoBatches(batches, index: 0, siteURL: siteURL, requestsByTitle: requestsByTitle, completion: completion)
+    }
+
+    private func fetchImageInfoBatches(_ batches: [[String]], index: Int, siteURL: URL, requestsByTitle: [String: URLRequest], completion: @escaping (Error?) -> Void) {
+
+        guard index < batches.count else {
+            completion(nil)
+            return
+        }
+
+        let batch = batches[index]
+        imageInfoFetcher.fetchBatchedGalleryInfoJSON(forImageTitles: batch, fromSiteURL: siteURL, success: { [weak self] (result, response) in
+            guard let self = self else {
+                completion(nil)
+                return
+            }
+            self.storeImageInfo(from: result, response: response, requestedTitles: batch, requestsByTitle: requestsByTitle) { error in
+                if let error = error {
+                    completion(error)
+                    return
+                }
+                self.fetchImageInfoBatches(batches, index: index + 1, siteURL: siteURL, requestsByTitle: requestsByTitle, completion: completion)
+            }
+        }, failure: { error in
+            completion(error)
+        })
+    }
+
+    /// Splits one batched response and writes a cache entry per title, keyed by the URL the gallery will ask for.
+    private func storeImageInfo(from result: [String: Any], response: HTTPURLResponse?, requestedTitles: [String], requestsByTitle: [String: URLRequest], completion: @escaping (Error?) -> Void) {
+
+        let split: ImageInfoResponseSplitter.SplitResult
+        do {
+            split = try ImageInfoResponseSplitter.split(response: result, requestedTitles: requestedTitles)
+        } catch let error {
+            completion(error)
+            return
+        }
+
+        if !split.missingTitles.isEmpty {
+            // note, "no such page" is a legitimate answer for a deleted or renamed file, not a download failure
+            DDLogDebug("No image info returned for: \(split.missingTitles)")
+        }
+
+        let headerFields = ImageInfoResponseSplitter.perTitleHeaderFields(from: response)
+        let statusCode = response?.statusCode ?? 200
+
+        let group = DispatchGroup()
+        let errorQueue = DispatchQueue(label: "org.wikimedia.cache.imageInfoStore")
+        var firstError: Error?
+
+        for (title, body) in split.bodiesByRequestedTitle {
+            guard let urlRequest = requestsByTitle[title],
+                  let url = urlRequest.url,
+                  let perTitleResponse = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: "HTTP/1.1", headerFields: headerFields) else {
+                continue
+            }
+
+            group.enter()
+            articleFetcher.cacheResponse(httpUrlResponse: perTitleResponse, content: .data(body), urlRequest: urlRequest, success: { [weak self] in
+                guard let self = self else {
+                    group.leave()
+                    return
+                }
+                self.markDownloaded(urlRequest: urlRequest, response: perTitleResponse) { markResult in
+                    if case .failure(let error) = markResult {
+                        errorQueue.sync { firstError = firstError ?? error }
+                    }
+                    group.leave()
+                }
+            }, failure: { error in
+                errorQueue.sync { firstError = firstError ?? error }
+                group.leave()
+            })
+        }
+
+        group.notify(queue: DispatchQueue.global(qos: .userInitiated)) {
+            completion(errorQueue.sync { firstError })
+        }
+    }
+
     func markDownloaded(urlRequest: URLRequest, response: HTTPURLResponse?, completion: @escaping (CacheDBWritingResult) -> Void) {
         
         guard let itemKey = fetcher.itemKeyForURLRequest(urlRequest) else {

--- a/Wikipedia/Code/ArticleCacheDBWriter.swift
+++ b/Wikipedia/Code/ArticleCacheDBWriter.swift
@@ -169,6 +169,13 @@ final class ArticleCacheDBWriter: ArticleCacheResourceDBWriting {
                 completion(nil)
                 return
             }
+
+            // note, Session.jsonDictionaryTask only special-cases 304, so a 429 arrives here looking like a success carrying an error body
+            if let statusCode = response?.statusCode, !HTTPStatusCode.isSuccessful(statusCode) {
+                completion(RequestError.from(code: statusCode, response: response))
+                return
+            }
+
             self.storeImageInfo(from: result, response: response, requestedTitles: batch, requestsByTitle: requestsByTitle) { error in
                 if let error = error {
                     completion(error)

--- a/Wikipedia/Code/MWKImageInfoFetcher.h
+++ b/Wikipedia/Code/MWKImageInfoFetcher.h
@@ -57,6 +57,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSURL *)galleryInfoURLForImageTitles: (NSArray *)imageTitles fromSiteURL: (NSURL *)siteURL;
 
+/**
+ * Fetch the raw imageinfo API response for a batch of image page titles.
+ *
+ * Hands back the undigested response so a caller can split it into one cached entry per title. Uses the
+ * same query parameters as @c galleryInfoURLForImageTitles:fromSiteURL:.
+ *
+ * @param imageTitles One or more page titles, at most 50 (the API's limit).
+ */
+- (nullable NSURLSessionTask *)fetchBatchedGalleryInfoJSONForImageTitles:(NSArray<NSString *> *)imageTitles
+                                                             fromSiteURL:(NSURL *)siteURL
+                                                                 success:(void (^)(NSDictionary<NSString *, id> *result, NSHTTPURLResponse *_Nullable response))success
+                                                                 failure:(void (^)(NSError *error))failure
+    NS_SWIFT_NAME(fetchBatchedGalleryInfoJSON(forImageTitles:fromSiteURL:success:failure:));
+
 - (nullable NSURLRequest *)urlRequestForFromURL: (NSURL *)url;
 
 @property (weak, nonatomic) id<WMFPreferredLanguageInfoProvider> preferredLanguageDelegate;

--- a/Wikipedia/Code/MWKImageInfoFetcher.m
+++ b/Wikipedia/Code/MWKImageInfoFetcher.m
@@ -182,6 +182,42 @@ static CGSize MWKImageInfoSizeFromJSON(NSDictionary *json, NSString *widthKey, N
     return nil;
 }
 
+- (nullable NSURLSessionTask *)fetchBatchedGalleryInfoJSONForImageTitles:(NSArray<NSString *> *)imageTitles
+                                                             fromSiteURL:(NSURL *)siteURL
+                                                                 success:(void (^)(NSDictionary<NSString *, id> *result, NSHTTPURLResponse *_Nullable response))success
+                                                                 failure:(void (^)(NSError *error))failure {
+    NSParameterAssert([imageTitles count]);
+    NSAssert([imageTitles count] <= 50, @"Only 50 titles can be queried at a time.");
+    NSParameterAssert(siteURL);
+
+    NSDictionary *params = [self queryParametersForTitles:imageTitles
+                                              fromSiteURL:siteURL
+                                           thumbnailWidth:[NSNumber numberWithInteger:[ImageUtils articleImageWidth]]
+                                          extmetadataKeys:[MWKImageInfoFetcher galleryExtMetadataKeys]
+                                         metadataLanguage:siteURL.wmf_languageCode
+                                             useGenerator:NO];
+
+    NSURL *url = [self.configuration mediaWikiAPIURLForURL:siteURL withQueryParameters:params];
+    NSURLRequest *urlRequest = url ? [self urlRequestForFromURL:url] : nil;
+    if (!urlRequest) {
+        failure([WMFFetcher invalidParametersError]);
+        return nil;
+    }
+
+    return [self performMediaWikiAPIGETForURLRequest:urlRequest
+                                   completionHandler:^(NSDictionary<NSString *, id> *_Nullable result, NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
+                                       if (error) {
+                                           failure(error);
+                                           return;
+                                       }
+                                       if (!result) {
+                                           failure([WMFFetcher unexpectedResponseError]);
+                                           return;
+                                       }
+                                       success(result, response);
+                                   }];
+}
+
 - (NSDictionary *)queryParametersForTitles:(NSArray *)titles
      fromSiteURL:(NSURL *)siteURL
   thumbnailWidth:(NSNumber *)thumbnailWidth

--- a/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
+++ b/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
@@ -370,3 +370,111 @@ final class CacheRequestThrottleTests: XCTestCase {
         wait(for: [secondStarted], timeout: 10)
     }
 }
+
+final class ImageInfoResponseSplitterTests: XCTestCase {
+
+    private func page(id: String, title: String, description: String) -> [String: Any] {
+        [
+            "pageid": Int(id) ?? 0,
+            "title": title,
+            "imageinfo": [[
+                "url": "https://upload.wikimedia.org/\(title).jpg",
+                "extmetadata": ["ImageDescription": ["value": description]]
+            ]]
+        ]
+    }
+
+    private func response(pages: [String: Any], normalized: [[String: String]]? = nil) -> [String: Any] {
+        var query: [String: Any] = ["pages": pages]
+        if let normalized = normalized {
+            query["normalized"] = normalized
+        }
+        return ["query": query]
+    }
+
+    func testSplitsOneBodyPerRequestedTitle() throws {
+        let batch = response(pages: [
+            "1": page(id: "1", title: "File:A.jpg", description: "a"),
+            "2": page(id: "2", title: "File:B.jpg", description: "b")
+        ])
+
+        let result = try ImageInfoResponseSplitter.split(response: batch, requestedTitles: ["File:A.jpg", "File:B.jpg"])
+
+        XCTAssertEqual(Set(result.bodiesByRequestedTitle.keys), ["File:A.jpg", "File:B.jpg"])
+        XCTAssertTrue(result.missingTitles.isEmpty)
+    }
+
+    func testEachBodyKeepsTheShapeTheReadPathParses() throws {
+        let batch = response(pages: [
+            "1": page(id: "1", title: "File:A.jpg", description: "a"),
+            "2": page(id: "2", title: "File:B.jpg", description: "b")
+        ])
+
+        let result = try ImageInfoResponseSplitter.split(response: batch, requestedTitles: ["File:A.jpg"])
+        let body = try XCTUnwrap(result.bodiesByRequestedTitle["File:A.jpg"])
+        let parsed = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        let pages = try XCTUnwrap((parsed["query"] as? [String: Any])?["pages"] as? [String: Any])
+        XCTAssertEqual(pages.count, 1, "A split body should carry only its own page")
+        let onlyPage = try XCTUnwrap(pages["1"] as? [String: Any])
+        XCTAssertEqual(onlyPage["title"] as? String, "File:A.jpg")
+    }
+
+    func testMapsTitlesTheAPINormalised() throws {
+        let batch = response(
+            pages: ["7": page(id: "7", title: "File:Some Image.jpg", description: "x")],
+            normalized: [["from": "File:Some_Image.jpg", "to": "File:Some Image.jpg"]]
+        )
+
+        let result = try ImageInfoResponseSplitter.split(response: batch, requestedTitles: ["File:Some_Image.jpg"])
+
+        XCTAssertNotNil(result.bodiesByRequestedTitle["File:Some_Image.jpg"], "The body should be keyed by the title we asked for, not the normalised one")
+        XCTAssertTrue(result.missingTitles.isEmpty)
+    }
+
+    func testUnderscoreAndSpaceFormsMatchWithoutANormalisedSection() throws {
+        let batch = response(pages: ["7": page(id: "7", title: "File:Some Image.jpg", description: "x")])
+
+        let result = try ImageInfoResponseSplitter.split(response: batch, requestedTitles: ["File:Some_Image.jpg"])
+
+        XCTAssertNotNil(result.bodiesByRequestedTitle["File:Some_Image.jpg"])
+    }
+
+    func testReportsTitlesWithNoPage() throws {
+        let batch = response(pages: ["1": page(id: "1", title: "File:A.jpg", description: "a")])
+
+        let result = try ImageInfoResponseSplitter.split(response: batch, requestedTitles: ["File:A.jpg", "File:Gone.jpg"])
+
+        XCTAssertEqual(result.missingTitles, ["File:Gone.jpg"])
+        XCTAssertNil(result.bodiesByRequestedTitle["File:Gone.jpg"])
+    }
+
+    func testThrowsOnAResponseWithNoPages() {
+        XCTAssertThrowsError(try ImageInfoResponseSplitter.split(response: ["query": [:]], requestedTitles: ["File:A.jpg"]))
+    }
+
+    func testDropsHeadersThatDescribeTheBatch() throws {
+        let url = try XCTUnwrap(URL(string: "https://en.wikipedia.org/w/api.php"))
+        let response = try XCTUnwrap(HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: [
+                "Etag": "\"batch-etag\"",
+                "Content-Length": "4096",
+                "Content-Type": "application/json"
+            ]
+        ))
+
+        let fields = ImageInfoResponseSplitter.perTitleHeaderFields(from: response)
+
+        XCTAssertNil(fields.first { $0.key.lowercased() == "etag" })
+        XCTAssertNil(fields.first { $0.key.lowercased() == "content-length" })
+        XCTAssertEqual(fields["Content-Type"], "application/json")
+    }
+
+    func testBatchSizeIsWithinTheAPILimit() {
+        XCTAssertLessThanOrEqual(ArticleCacheDBWriter.imageInfoBatchSize, 50, "MWKImageInfoFetcher asserts at most 50 titles per request")
+        XCTAssertGreaterThan(ArticleCacheDBWriter.imageInfoBatchSize, 1, "A batch of one would be no better than the per-image requests this replaces")
+    }
+}

--- a/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
+++ b/WikipediaUnitTests/Code/CacheControllerCompletionTests.swift
@@ -450,7 +450,7 @@ final class ImageInfoResponseSplitterTests: XCTestCase {
     }
 
     func testThrowsOnAResponseWithNoPages() {
-        XCTAssertThrowsError(try ImageInfoResponseSplitter.split(response: ["query": [:]], requestedTitles: ["File:A.jpg"]))
+        XCTAssertThrowsError(try ImageInfoResponseSplitter.split(response: ["query": [String: Any]()], requestedTitles: ["File:A.jpg"]))
     }
 
     func testDropsHeadersThatDescribeTheBatch() throws {

--- a/WikipediaUnitTests/Code/SavedArticlesFetcherTests.swift
+++ b/WikipediaUnitTests/Code/SavedArticlesFetcherTests.swift
@@ -75,6 +75,16 @@ class SavedArticlesFetcherTests: XCTestCase {
         XCTAssertNil(article.downloadRetryDate)
     }
 
+    func testBareRateLimitDoesNotFlagArticle() throws {
+        let article = try makeSavedArticle()
+
+        fetcher.handleFailure(with: article, error: RequestError.rateLimited(retryAfter: 30))
+
+        XCTAssertEqual(article.error, .none)
+        XCTAssertEqual(article.downloadAttemptCount, 0)
+        XCTAssertNil(article.downloadRetryDate)
+    }
+
     func testRateLimitWrappedInSyncErrorDoesNotFlagArticle() throws {
         let article = try makeSavedArticle()
 


### PR DESCRIPTION
**Phabricator:** T421064

> **Stacked on #6137**, which is stacked on #6136 — base is `claude/cache-download-concurrency-pw7gkk`. Review those first; GitHub re-targets this automatically as they merge.

### Notes

Third of three stacked PRs, and the one that actually cuts request volume — roughly **10× fewer `api.php` calls** for an image-heavy article.

Saving an article issued one `action=query&prop=imageinfo` call **per image**, because each image's metadata URL was added as its own mustHave request for the cache controller to download individually. A hundred-image article made a hundred calls. And since imageinfo is mustHave, one throttled call failed the whole article. The API takes up to 50 titles per request and `queryParametersForTitles:` already joins them — the capability was there and unused.

**The constraint is the read side.** The permanent cache is keyed by the literal request URL (`imageInfoItemKeyForURL` is the absolute string), and the gallery asks for one title at a time. So the fetch is batched while storage stays per title. Two things make that tractable:

* The per-title cache URLs are still built by the existing `galleryInfoURLForImageTitles:` call rather than by hand — that's what keeps the keys matching what the gallery later requests, exactly as reliably as today.
* `cacheResponse` derives its file names from the request URL and doesn't care where the bytes came from, so storing a split body needed no new file-writing code and inherits the existing rollback-on-partial-failure logic.

Splitting keeps the `{"query": {"pages": {<pageid>: <page>}}}` shape that `responseObjectForJSON:` reads, so **the read path is untouched**.

**Two judgement calls worth a reviewer's eye**

* **Batches run sequentially.** My first cut fired all chunks at once, which for a 100-image article would mean 10 concurrent `api.php` calls — undercutting #6137 for exactly the articles this targets. These also don't pass through the per-article throttle, which lives on the cache controller. Sequential costs wall-clock on huge articles but is gentlest on the limiter.
* **Titles the API reports no page for are logged and left uncached, not treated as failures.** "No such file" is a legitimate answer for a deleted or renamed image; failing the article would block it permanently on one bad image. Verified safe: `mustHaveCacheItems` is written but never read anywhere in the codebase, and `isCached` only checks the mobile-html request, so an un-downloaded imageinfo item has no downstream effect.

**The riskiest part is title normalisation.** The API rewrites underscores and casing and reports the mapping in the response's `normalized` section, so a returned page's title often isn't the string we asked for. Requested titles are mapped through that, with an underscore/space fallback. Get this wrong and it fails *silently* — entries stored under the wrong key, captions simply missing offline. There are direct tests, but the airplane-mode check below is what actually proves it.

`Etag` and `Content-Length` are dropped from the stored per-title headers: the Etag belongs to the batch URL and is read back into `If-None-Match`, so keeping it would send the server a validator for a different resource.

The second commit fixes an incompatibility this PR introduced against #6136: `Session.jsonDictionaryTask` only special-cases 304, so a 429 on the batched fetch arrived looking like a successful response carrying MediaWiki's error body, and the article failed generically with no global pause — on the one `api.php` call this work most expects to be throttled.

### Test Steps

1. Run the unit tests. New coverage for splitting: one body per requested title, the round-trip shape the read path parses, API-normalised titles mapping back to the requested URL, missing titles reported rather than thrown, dropped headers, and a bare `.rateLimited` reaching `handleFailure` unwrapped.
2. On a fresh install, save an image-heavy article and count requests to `api.php` (Charles/Proxyman). Expect roughly a tenth of the previous count — for the Dog fixture, 23 calls becoming 3.
3. **The one that matters most, because a key mismatch fails silently:** after saving an image-heavy article, go into airplane mode, open it, tap an image to open the gallery, and confirm captions, description, licence name and attribution all still render. Do this on an article whose image titles the API normalises (mixed case or underscores) as well as a plain one.

### Checklist

- [ ] Checked against Swift 6 strict concurrency

> Not ticked deliberately: Swift 5 legacy code in the WMF framework, keeping its existing completion-handler idiom.

### Screenshots/Videos

n/a — no UI changes, though step 3 above is worth capturing.

---

⚠️ **Not compiled or run** — authored without an Xcode toolchain. Please build before reviewing. This PR adds a new Objective-C method with an `NS_SWIFT_NAME` annotation whose bridging I could not verify, and hand-edits `project.pbxproj` to add one file.

**Known follow-up:** the *sync* path still fetches imageinfo per title. This PR only changed the add path, so `syncCachedResources` will individually re-request any title the add left uncached — in practice only deleted or renamed files, and bounded by #6137's throttle.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CjLA9cfAZ4qJL6qeFSNsJ1)_