### PR TITLE
When zooming into an article with gesture, also zoom the header image to match

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -92,6 +92,7 @@ import WMFData
         let showYiR2025 = WMFFormItemSelectViewModel(title: "Show Year in Review 2025", isSelected: WMFDeveloperSettingsDataController.shared.showYiR2025)
         let forceHcaptchaChallenge = WMFFormItemSelectViewModel(title: "Force hCaptcha Challenge", isSelected: WMFDeveloperSettingsDataController.shared.forceHCaptchaChallenge)
         let allowGestureZoomArticleWebview = WMFFormItemSelectViewModel(title: "Allow pinch to zoom when reading articles", isSelected: WMFDeveloperSettingsDataController.shared.allowGestureZoomArticleWebview)
+        let alsoZoomLeadImageWithArticleWebview = WMFFormItemSelectViewModel(title: "Zoom lead image along with article when pinching", isSelected: WMFDeveloperSettingsDataController.shared.alsoZoomLeadImageWithArticleWebview)
         let enableHomePhase2 = WMFFormItemSelectViewModel(title: "Enable Home Phase 2", isSelected: WMFDeveloperSettingsDataController.shared.enableHomePhase2)
 
         formViewModel = WMFFormViewModel(sections: [
@@ -105,7 +106,8 @@ import WMFData
                 enableMoreDynamicTabsV2GroupC,
                 showYiR2025,
                 forceHcaptchaChallenge,
-                allowGestureZoomArticleWebview
+                allowGestureZoomArticleWebview,
+                alsoZoomLeadImageWithArticleWebview
             ], selectType: .multi)
         ])
 
@@ -139,6 +141,10 @@ import WMFData
 
         allowGestureZoomArticleWebview.$isSelected
             .sink { isSelected in WMFDeveloperSettingsDataController.shared.allowGestureZoomArticleWebview = isSelected }
+            .store(in: &subscribers)
+
+        alsoZoomLeadImageWithArticleWebview.$isSelected
+            .sink { isSelected in WMFDeveloperSettingsDataController.shared.alsoZoomLeadImageWithArticleWebview = isSelected }
             .store(in: &subscribers)
 
         enableHomePhase2.$isSelected

--- a/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
@@ -157,6 +157,11 @@ public protocol WMFDeveloperSettingsDataControlling: AnyObject {
         set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.allowGestureZoomArticleWebview.rawValue, value: newValue) }
     }
 
+    public var alsoZoomLeadImageWithArticleWebview: Bool {
+        get { (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.alsoZoomLeadImageWithArticleWebview.rawValue)) ?? false }
+        set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.alsoZoomLeadImageWithArticleWebview.rawValue, value: newValue) }
+    }
+
     public var showGamesV2: Bool {
         get { (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.developerSettingsShowGamesV2.rawValue)) ?? false }
         set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.developerSettingsShowGamesV2.rawValue, value: newValue) }

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -51,6 +51,8 @@ public enum WMFUserDefaultsKey: String {
     case donationReminder = "donation-reminder"
 
     case allowGestureZoomArticleWebview = "allow-gesture-zoom-article-webview"
+    case alsoZoomLeadImageWithArticleWebview = "zoom-lead-image-with-article-webview"
+
     // Reading Challenge 2026 (feature removed, see WMFReadingChallengeCompletionDataController)
     case completedReadingChallenge2026 = "completed-reading-challenge-2026"
     case didRecoverReadingChallenge2026Completion = "did-recover-reading-challenge-2026-completion"

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -408,6 +408,7 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
         defaultUpdateBlock()
 
         updateLeadImageMargins()
+        updateLeadImageZoomTransform()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -1388,6 +1389,36 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
         }
     }
 
+    func scrollViewDidZoom(_ scrollView: UIScrollView) {
+        updateLeadImageZoomTransform()
+    }
+
+    /// Scales the lead image, rendered outside the web view, to match the web view's zoom
+    ///
+    /// Scale about the content origin so the image stays edge-aligned with the
+    /// zoomed contents of the web view
+    func updateLeadImageZoomTransform() {
+        guard WMFDeveloperSettingsDataController.shared.allowGestureZoomArticleWebview,
+              WMFDeveloperSettingsDataController.shared.alsoZoomLeadImageWithArticleWebview else {
+            return
+        }
+
+        let scale = webView.scrollView.zoomScale
+        guard scale != 1 else {
+            leadImageContainerView.transform = .identity
+            return
+        }
+        let baseSize = leadImageContainerView.bounds.size
+        guard baseSize.width > 0, baseSize.height > 0 else {
+            return
+        }
+        // Scaling happens about the center; translate to keep the top-left at the content origin.
+        let dx = baseSize.width * (scale - 1) / 2
+        let dy = baseSize.height * (scale - 1) / 2
+        leadImageContainerView.transform = CGAffineTransform(translationX: dx, y: dy)
+            .scaledBy(x: scale, y: scale)
+    }
+
     func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
         updateTableOfContentsHighlight()
         navigationController?.setNavigationBarHidden(false, animated: true)
@@ -1553,17 +1584,48 @@ private extension ArticleViewController {
         webView.customUserAgent = WikipediaAppUtils.versionedUserAgent()
     }
 
+    /// The constraints that position the lead image container within the web view's scroll view.
+    private var leadImageContainerPositioningConstraints: [NSLayoutConstraint] {
+        guard WMFDeveloperSettingsDataController.shared.allowGestureZoomArticleWebview,
+              WMFDeveloperSettingsDataController.shared.alsoZoomLeadImageWithArticleWebview else {
+            return [
+                leadImageContainerView.topAnchor.constraint(equalTo: webView.scrollView.topAnchor),
+                leadImageContainerView.leadingAnchor.constraint(equalTo: webView.leadingAnchor),
+                leadImageContainerView.trailingAnchor.constraint(equalTo: webView.trailingAnchor)
+            ]
+        }
+
+        // Pin to the content layout guide, not the web view's frame anchors — frame-anchor
+        // constraints re-resolve against contentOffset during pinch-zooming, causing jitter.
+        let contentGuide = webView.scrollView.contentLayoutGuide
+        return [
+            leadImageContainerView.topAnchor.constraint(equalTo: contentGuide.topAnchor),
+            leadImageContainerView.leadingAnchor.constraint(equalTo: contentGuide.leadingAnchor),
+            // Width rather than a trailing pin: the content guide's trailing edge tracks the
+            // zoomed content width, which would stretch the container.
+            leadImageContainerView.widthAnchor.constraint(equalTo: webView.widthAnchor)
+        ]
+    }
+
     /// Adds the lead image view to the web view's scroll view and configures the associated constraints
     func setupLeadImageView() {
         webView.scrollView.addSubview(leadImageContainerView)
 
-        let leadingConstraint =  leadImageContainerView.leadingAnchor.constraint(equalTo: webView.leadingAnchor)
-        let trailingConstraint =  webView.trailingAnchor.constraint(equalTo: leadImageContainerView.trailingAnchor)
-        let topConstraint = webView.scrollView.topAnchor.constraint(equalTo: leadImageContainerView.topAnchor)
+        var constraints = leadImageContainerPositioningConstraints
+
         let imageTopConstraint = leadImageView.topAnchor.constraint(equalTo:  leadImageContainerView.topAnchor)
         imageTopConstraint.priority = UILayoutPriority(rawValue: 999)
         let imageBottomConstraint = leadImageContainerView.bottomAnchor.constraint(equalTo: leadImageView.bottomAnchor, constant: leadImageBorderHeight)
-        NSLayoutConstraint.activate([topConstraint, leadingConstraint, trailingConstraint, leadImageHeightConstraint, imageTopConstraint, imageBottomConstraint, leadImageLeadingMarginConstraint, leadImageTrailingMarginConstraint])
+
+        constraints.append(contentsOf: [
+            imageTopConstraint,
+            imageBottomConstraint,
+            leadImageHeightConstraint,
+            leadImageLeadingMarginConstraint,
+            leadImageTrailingMarginConstraint
+        ])
+
+        NSLayoutConstraint.activate(constraints)
     }
 
     func setupPageContentServiceJavaScriptInterface(with completion: @escaping () -> Void) {


### PR DESCRIPTION
**Phabricator:** 

https://phabricator.wikimedia.org/T424079

### Notes

When the feature is enabled, the user may use the pinch to zoom gesture to zoom into the article as before. In addition to the article zooming, the native header image will zoom to match the scale of the article.

Note the changes to the constraints for the lead image - it is now pinned to the web view scroll view's contentLayoutGuide with a width constraint. During zoom, the image is transformed with the top left corner pinned. The visual effect is identical to before when the user does not use the zoom gesture.

Please let me know if there are specifications for the lead image and if there is additional behavior to test.

* Previous PR https://github.com/wikimedia/wikipedia-ios/pull/5821
* Adds an additional developer setting to enable features added in this PR

### Test Steps
1. Test iOS wikipedia app with this change. Pinch to zoom in article webviews matches behavior in Safari. Header image zooms to match
2. When the developer setting is off there is no difference in behavior
3. No jitter during zooming

### Checklist
- [X] Checked against Swift 6 strict concurrency
     - changes do not introduce any issues

### Screenshots/Videos
