### PR TITLE
Expand WMFActivityTabDataController test coverage

### DIFF
--- a/WMFData/Tests/WMFDataTests/WMFActivityTabDataControllerPreferencesTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFActivityTabDataControllerPreferencesTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Testing
+import WMFDataTestSupport
+@testable import WMFData
+@testable import WMFDataMocks
+
+/// The customization toggles, the onboarding flag, the survey gate and the two account-scoped
+/// fetches all read through `WMFDataEnvironment.current` rather than through an injected store,
+/// so this suite leases the global environment instead of constructing one.
+@Suite(.serialized)
+final class WMFActivityTabDataControllerPreferencesTests {
+
+    private let fixture = WMFDataTestFixture()
+
+    private func configureEnvironment() async {
+        WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
+        WMFDataEnvironment.current.appData = WMFAppData(appLanguages: [])
+    }
+
+    /// Every Activity tab module is opt-out: with nothing written yet, all four read as on.
+    @Test
+    func customizationTogglesDefaultToOn() async {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let dataController = WMFActivityTabDataController()
+
+            #expect(await dataController.isTimeSpentReadingOn)
+            #expect(await dataController.isReadingInsightsOn)
+            #expect(await dataController.isEditingInsightsOn)
+            #expect(await dataController.isTimelineOfBehaviorOn)
+        }
+    }
+
+    /// Each toggle has to survive a write and come back, in both directions - a store that silently
+    /// dropped the value would otherwise look identical to the opt-out default.
+    @Test
+    func customizationTogglesRoundTripThroughTheStore() async {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let dataController = WMFActivityTabDataController()
+
+            await dataController.updateIsTimeSpentReadingOn(false)
+            await dataController.updateIsReadingInsightsOn(false)
+            await dataController.updateIsEditingInsightsOn(false)
+            await dataController.updateIsTimelineOfBehaviorOn(false)
+
+            #expect(await dataController.isTimeSpentReadingOn == false)
+            #expect(await dataController.isReadingInsightsOn == false)
+            #expect(await dataController.isEditingInsightsOn == false)
+            #expect(await dataController.isTimelineOfBehaviorOn == false)
+
+            await dataController.updateIsTimeSpentReadingOn(true)
+            #expect(await dataController.isTimeSpentReadingOn, "Turning a module back on has to stick too.")
+        }
+    }
+
+    /// The four toggles are near-identical accessors over four different keys, which is exactly the
+    /// shape a copy-paste mistake hides in. Turning one off must leave the other three alone.
+    @Test
+    func turningOffOneToggleLeavesTheOthersOn() async {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let dataController = WMFActivityTabDataController()
+
+            await dataController.updateIsEditingInsightsOn(false)
+
+            #expect(await dataController.isEditingInsightsOn == false)
+            #expect(await dataController.isTimeSpentReadingOn)
+            #expect(await dataController.isReadingInsightsOn)
+            #expect(await dataController.isTimelineOfBehaviorOn)
+        }
+    }
+
+    /// Onboarding is the inverse default of the toggles: unseen until it is explicitly recorded.
+    @Test
+    func hasSeenActivityTabDefaultsToFalseAndRoundTrips() async {
+        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let dataController = WMFActivityTabDataController()
+
+            #expect(await dataController.getHasSeenActivityTab() == false)
+
+            await dataController.setHasSeenActivityTab(true)
+            #expect(await dataController.getHasSeenActivityTab())
+        }
+    }
+
+    /// The survey has three gates: at least three visits, not already dismissed, and a hard end date
+    /// of 2026-04-15. That date has passed, so the survey is now off for everyone regardless of the
+    /// first two gates. This pins both the date and the fact that it is what closes the survey - if
+    /// the window is ever reopened, the date expectations below fail and say so.
+    @Test
+    func surveyIsGatedOffOnceItsEndDateHasPassed() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let dataController = WMFActivityTabDataController()
+
+            let endDate = try #require(await dataController.surveyEndDate)
+            let components = Calendar.current.dateComponents([.year, .month, .day], from: endDate)
+            #expect(components.year == 2026)
+            #expect(components.month == 4)
+            #expect(components.day == 15)
+            #expect(endDate < Date(), "The survey window has closed; the expectations below depend on it.")
+
+            // Gate one: fewer than three visits.
+            #expect(await dataController.shouldShowSurvey() == false)
+
+            for _ in 0..<3 {
+                await dataController.incrementActivityTabVisitCount()
+            }
+
+            // Three visits and never dismissed, but the end date still shuts it off.
+            #expect(await dataController.shouldShowSurvey() == false)
+
+            // Gate two, for completeness.
+            await dataController.setHasSeenSurvey(value: true)
+            #expect(await dataController.shouldShowSurvey() == false)
+        }
+    }
+
+    /// With no app language configured there is no project to build a request for. Both account
+    /// fetches must throw rather than force-unwrap their way into a crash.
+    @Test
+    func accountFetchesThrowWhenThereIsNoAppLanguage() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let dataController = WMFActivityTabDataController()
+
+            #expect(WMFDataEnvironment.current.primaryAppLanguage == nil, "Premise of this test.")
+
+            await #expect(throws: WMFActivityTabDataController.CustomError.self) {
+                _ = try await dataController.getGlobalEditCount()
+            }
+
+            await #expect(throws: WMFDataControllerError.self) {
+                _ = try await dataController.getUserImpactData(userID: 1)
+            }
+        }
+    }
+}

--- a/WMFData/Tests/WMFDataTests/WMFActivityTabDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFActivityTabDataControllerTests.swift
@@ -53,4 +53,192 @@ struct WMFActivityTabDataControllerTests {
         #expect(timeRead.0 == 2)
         #expect(timeRead.1 == 0)
     }
+
+    /// Articles read is a rolling thirty day window, so a read from thirty-one days ago must not
+    /// keep inflating the number.
+    @Test
+    func articlesReadCountsOnlyTheLastThirtyDays() async throws {
+        let store = try await fixture.makeTemporaryCoreDataStore()
+        let pageViewsDataController = try WMFPageViewsDataController(coreDataStore: store)
+
+        let calendar = Calendar.current
+        let now = Date()
+        let inside = try #require(calendar.date(byAdding: .day, value: -29, to: now))
+        let outside = try #require(calendar.date(byAdding: .day, value: -31, to: now))
+
+        _ = try await pageViewsDataController.addPageView(title: "Cat", namespaceID: 0, project: enProject, previousPageViewObjectID: nil, timestamp: inside)
+        _ = try await pageViewsDataController.addPageView(title: "Dog", namespaceID: 0, project: enProject, previousPageViewObjectID: nil, timestamp: outside)
+
+        let dataController = WMFActivityTabDataController(coreDataStore: store)
+        let articlesRead = try await dataController.getArticlesRead()
+
+        #expect(articlesRead == 1, "Only the read inside the thirty day window should be counted.")
+    }
+
+    /// The four weekly buckets come back oldest first, so the chart reads left to right in time
+    /// order. Each read uses its own title so a bucket's total is just its number of reads.
+    @Test
+    func weeklyReadsThisMonthReturnsFourBucketsOldestFirst() async throws {
+        let store = try await fixture.makeTemporaryCoreDataStore()
+        let pageViewsDataController = try WMFPageViewsDataController(coreDataStore: store)
+
+        let calendar = Calendar.current
+        let now = Date()
+        let readsByWeek: [(dayOffset: Int, titles: [String])] = [
+            (-1, ["A1"]),
+            (-8, ["B1", "B2"]),
+            (-15, ["C1", "C2", "C3"]),
+            (-22, ["D1", "D2", "D3", "D4"])
+        ]
+
+        for (dayOffset, titles) in readsByWeek {
+            let timestamp = try #require(calendar.date(byAdding: .day, value: dayOffset, to: now))
+            for title in titles {
+                _ = try await pageViewsDataController.addPageView(title: title, namespaceID: 0, project: enProject, previousPageViewObjectID: nil, timestamp: timestamp)
+            }
+        }
+
+        let dataController = WMFActivityTabDataController(coreDataStore: store)
+        let weeklyReads = try await dataController.getWeeklyReadsThisMonth()
+
+        #expect(weeklyReads == [4, 3, 2, 1], "Three weeks back through this week, oldest bucket first.")
+    }
+
+    /// Reading the same article twice in a day collapses to one timeline entry, and the entry kept
+    /// is the first visit of that day rather than the most recent one.
+    @Test
+    func timelineReadArticlesKeepsTheFirstVisitOfEachDay() async throws {
+        let store = try await fixture.makeTemporaryCoreDataStore()
+        let pageViewsDataController = try WMFPageViewsDataController(coreDataStore: store)
+
+        let calendar = Calendar.current
+        let day = try #require(calendar.date(byAdding: .day, value: -2, to: calendar.startOfDay(for: Date())))
+        let morning = day.addingTimeInterval(9 * 3600)
+        let afternoon = day.addingTimeInterval(15 * 3600)
+        let previousDay = try #require(calendar.date(byAdding: .day, value: -1, to: day)).addingTimeInterval(11 * 3600)
+
+        _ = try await pageViewsDataController.addPageView(title: "Cat", namespaceID: 0, project: enProject, previousPageViewObjectID: nil, timestamp: morning)
+        _ = try await pageViewsDataController.addPageView(title: "Cat", namespaceID: 0, project: enProject, previousPageViewObjectID: nil, timestamp: afternoon)
+        _ = try await pageViewsDataController.addPageView(title: "Dog", namespaceID: 0, project: enProject, previousPageViewObjectID: nil, timestamp: afternoon)
+        _ = try await pageViewsDataController.addPageView(title: "Emu", namespaceID: 0, project: enProject, previousPageViewObjectID: nil, timestamp: previousDay)
+
+        let dataController = WMFActivityTabDataController(coreDataStore: store)
+        let timeline = try await dataController.fetchTimelineReadArticles()
+
+        #expect(timeline.count == 2, "One bucket per calendar day of reading.")
+
+        let dayItems = try #require(timeline[day])
+        #expect(dayItems.map(\.pageTitle) == ["Cat", "Dog"], "Items within a day are sorted oldest first.")
+        #expect(dayItems.allSatisfy { $0.itemType == .read })
+
+        let cat = try #require(dayItems.first)
+        #expect(abs(cat.date.timeIntervalSince(morning)) < 1, "The repeated Cat read collapses to the first visit of the day.")
+    }
+
+    /// The most recent read drives the reading-streak copy, so it must be the newest page view, and
+    /// nil rather than a placeholder date when nothing has been read.
+    @Test
+    func mostRecentReadDateTimeReturnsTheNewestPageViewOrNil() async throws {
+        let store = try await fixture.makeTemporaryCoreDataStore()
+        let pageViewsDataController = try WMFPageViewsDataController(coreDataStore: store)
+
+        let calendar = Calendar.current
+        let older = try #require(calendar.date(byAdding: .day, value: -3, to: Date()))
+        let newer = try #require(calendar.date(byAdding: .day, value: -1, to: Date()))
+
+        _ = try await pageViewsDataController.addPageView(title: "Cat", namespaceID: 0, project: enProject, previousPageViewObjectID: nil, timestamp: older)
+        _ = try await pageViewsDataController.addPageView(title: "Dog", namespaceID: 0, project: enProject, previousPageViewObjectID: nil, timestamp: newer)
+
+        let dataController = WMFActivityTabDataController(coreDataStore: store)
+        let mostRecent = try #require(try await dataController.getMostRecentReadDateTime())
+        #expect(abs(mostRecent.timeIntervalSince(newer)) < 1)
+
+        let emptyStore = try await fixture.makeTemporaryCoreDataStore()
+        let emptyDataController = WMFActivityTabDataController(coreDataStore: emptyStore)
+        let noReads = try await emptyDataController.getMostRecentReadDateTime()
+        #expect(noReads == nil, "No reads means no date, not the epoch or now.")
+    }
+
+    /// Deleting through a timeline item has to resolve the project from the item's projectID string
+    /// and remove the underlying page view, so the row does not reappear on the next fetch.
+    @Test
+    func deletePageViewForTimelineItemRemovesOnlyThatArticle() async throws {
+        let store = try await fixture.makeTemporaryCoreDataStore()
+        let pageViewsDataController = try WMFPageViewsDataController(coreDataStore: store)
+
+        let timestamp = try #require(Calendar.current.date(byAdding: .day, value: -1, to: Date()))
+        _ = try await pageViewsDataController.addPageView(title: "Cat", namespaceID: 0, project: enProject, previousPageViewObjectID: nil, timestamp: timestamp)
+        _ = try await pageViewsDataController.addPageView(title: "Dog", namespaceID: 0, project: enProject, previousPageViewObjectID: nil, timestamp: timestamp)
+
+        let dataController = WMFActivityTabDataController(coreDataStore: store)
+        try await dataController.deletePageView(for: timelineItem(pageTitle: "Cat", projectID: enProject.id, date: timestamp))
+
+        let remaining = try await dataController.fetchTimelineReadArticles().values.flatMap { $0 }
+        #expect(remaining.map(\.pageTitle) == ["Dog"])
+    }
+
+    /// A timeline item whose projectID does not parse must be a no-op rather than deleting the wrong
+    /// row or throwing into the caller.
+    @Test
+    func deletePageViewForItemWithUnparseableProjectDoesNothing() async throws {
+        let store = try await fixture.makeTemporaryCoreDataStore()
+        let pageViewsDataController = try WMFPageViewsDataController(coreDataStore: store)
+
+        let timestamp = try #require(Calendar.current.date(byAdding: .day, value: -1, to: Date()))
+        _ = try await pageViewsDataController.addPageView(title: "Cat", namespaceID: 0, project: enProject, previousPageViewObjectID: nil, timestamp: timestamp)
+
+        #expect(WMFProject(id: "not-a-project") == nil, "Premise of this test: the identifier does not resolve.")
+
+        let dataController = WMFActivityTabDataController(coreDataStore: store)
+        try await dataController.deletePageView(for: timelineItem(pageTitle: "Cat", projectID: "not-a-project", date: timestamp))
+
+        let remaining = try await dataController.fetchTimelineReadArticles().values.flatMap { $0 }
+        #expect(remaining.map(\.pageTitle) == ["Cat"], "The read should survive an unresolvable project.")
+    }
+
+    /// TimelineItem identity is the id alone. The timeline merges read, saved and edit entries for
+    /// the same article, so two entries that differ in every other field are still the same item.
+    @Test
+    func timelineItemEqualityUsesTheIdentifierAlone() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let read = TimelineItem(id: "shared-id", date: date, titleHtml: "Cat", projectID: "wikipedia~en", pageTitle: "Cat", url: nil, namespaceID: 0, itemType: .read)
+        let saved = TimelineItem(id: "shared-id", date: date.addingTimeInterval(3600), titleHtml: "Dog", projectID: "wikipedia~de", pageTitle: "Dog", url: nil, namespaceID: 14, itemType: .saved)
+        let other = TimelineItem(id: "other-id", date: date, titleHtml: "Cat", projectID: "wikipedia~en", pageTitle: "Cat", url: nil, namespaceID: 0, itemType: .read)
+
+        #expect(read == saved)
+        #expect(read != other)
+    }
+
+    /// An edit becomes a timeline item that keeps both revision identifiers, which the diff link
+    /// needs, and is typed .edit so the row draws its icon.
+    @Test
+    func timelineItemFromArticleEditCarriesRevisionIdentifiers() throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let url = try #require(URL(string: "https://en.wikipedia.org/wiki/Cat"))
+        let edit = ArticleEdit(pageID: 42, revisionID: 7, parentRevisionID: 6, title: "Cat", date: date, projectID: enProject.id, url: url)
+
+        let item = TimelineItem(articleEdit: edit)
+
+        #expect(item.id == "42-7")
+        #expect(item.itemType == .edit)
+        #expect(item.revisionID == 7)
+        #expect(item.parentRevisionID == 6)
+        #expect(item.pageTitle == "Cat")
+        #expect(item.titleHtml == "Cat")
+        #expect(item.namespaceID == 0, "Contributions are article space.")
+        #expect(item.url == url)
+    }
+
+    private func timelineItem(pageTitle: String, projectID: String, date: Date) -> TimelineItem {
+        TimelineItem(
+            id: "read~\(projectID)~\(pageTitle)~\(date.timeIntervalSince1970)",
+            date: date,
+            titleHtml: pageTitle,
+            projectID: projectID,
+            pageTitle: pageTitle,
+            url: nil,
+            namespaceID: 0,
+            itemType: .read
+        )
+    }
 }


### PR DESCRIPTION
`WMFActivityTabDataController` was the least-covered data controller in WMFData at **5.44% (26/478 lines)**, despite owning the Activity tab's reading windows, timeline grouping and customization toggles. This takes it to **61.92% (296/478)**, and the WMFData target from 69.61% to 71.88%.

Test-only change — no production code is touched.

### Core-data-backed tests

These extend the existing suite, which already injects a temporary store.

- `getArticlesRead` counts a read from 29 days ago but not one from 31, pinning the rolling thirty-day window.
- `getWeeklyReadsThisMonth` returns its four buckets **oldest first**. The function builds them newest-first and reverses at the end, so the ordering is easy to invert without noticing.
- `fetchTimelineReadArticles` collapses repeat reads of one article on one day into a single entry, and keeps the **first** visit of that day rather than the most recent. That behaviour was previously only described in a comment.
- `getMostRecentReadDateTime` returns the newest page view, and `nil` rather than a placeholder date when nothing has been read.
- Both `deletePageView` paths, including that a `TimelineItem` whose `projectID` does not parse is a no-op instead of deleting some other row.
- `TimelineItem` equality is identifier-only, and `TimelineItem(articleEdit:)` carries both revision identifiers.

### Environment-backed tests

A second suite leases the global environment via `fixture.withConfiguredEnvironment`, because the toggles read through `WMFDataEnvironment.current.userDefaultsStore` rather than an injected store.

- All four customization toggles default to on, round-trip in both directions, and stay **independent of one another**. They are four near-identical accessors over four different keys, which is the shape a copy-paste mistake hides in.
- `hasSeenActivityTab` defaults to false and round-trips.
- The survey gate, and its hardcoded end date.
- `getGlobalEditCount` and `getUserImpactData` throw rather than crash when no app language is configured.

### One thing worth a maintainer's eye

`shouldShowSurvey()` can no longer return `true` for anyone: `surveyEndDate` is hardcoded to **2026-04-15**, and that date has passed, so the third gate always fails regardless of visit count or dismissal state. The test pins both the date and that consequence, so if the window is ever reopened the test fails and explains why. Happy to split this out if you would rather track it separately.

### Deliberately out of scope

`getTimelineItems`, `fetchTimelineSavedArticles`, `deduplicatedSavedItems`, `getTopCategories` and `fetchTopCategories` construct `WMFSavedArticlesDataController()` and `WMFCategoriesDataController()` with no arguments, so those instances resolve their store from `WMFDataEnvironment.current.coreDataStore`. Both classes do accept an injected `coreDataStore` (it simply defaults to the environment's), but the call sites here pass nothing, so covering these paths *through the Activity tab* means swapping the global store. That is a wider blast radius than this change wants, so it is left for a follow-up (~137 further lines).

### Verification

Run locally on iPhone 17 Pro / iOS 26.5, Xcode 26.6:

- `xcodebuild test -scheme WMFData` → `** TEST SUCCEEDED **` (220 XCTest, 0 failures; 194 Swift Testing across 22 suites)
- `swiftlint lint --config .swiftlint.yml --strict` on both files → `0 violations, 0 serious`
- No new compiler warnings naming either file

I do not have a Phabricator ticket for this one — let me know if you would like it filed before review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012v3afKtgngYevBdzmfGasK
