### PR TITLE
T436036: Show the reminder settings entry once bucketed and apply design review fixes

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupView.swift
@@ -82,7 +82,7 @@ struct WMFDonationReminderSetupView: View {
     private var triggerGroup: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 6) {
-                if let booksImage = WMFSFSymbolIcon.for(symbol: .booksVerticalFill, font: WMFFont.subheadline) {
+                if let booksImage = WMFSFSymbolIcon.for(symbol: .booksVertical, font: WMFFont.subheadline) {
                     Image(uiImage: booksImage)
                         .foregroundColor(Color(theme.secondaryText))
                 }

--- a/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupView.swift
@@ -60,7 +60,7 @@ struct WMFDonationReminderSetupView: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 24) {
             Text(viewModel.localizedStrings.subtitle)
                 .font(Font(WMFFont.for(.subheadline)))
                 .foregroundColor(Color(theme.text))

--- a/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupView.swift
@@ -130,6 +130,7 @@ struct WMFDonationReminderSetupView: View {
                 WMFSelectablePillButton(label: triggerOption.label, isSelected: viewModel.selectedTriggerOptionIdentifier == triggerOption.id) {
                     viewModel.selectedTriggerOptionIdentifier = triggerOption.id
                 }
+                .accessibilityLabel("\(triggerOption.label) \(viewModel.localizedStrings.triggerUnitLabel)")
             }
         }
     }
@@ -192,11 +193,15 @@ struct WMFDonationReminderSetupView: View {
     private var footerButtons: some View {
         VStack(spacing: 12) {
             if viewModel.isReminderEnabled {
-                WMFLargeButton(style: .primary, title: viewModel.primaryButtonTitle) {
+                WMFLargeButton(
+                    style: .primary,
+                    title: viewModel.primaryButtonTitle,
+                    forceBackgroundColor: viewModel.isConfirmButtonEnabled ? nil : theme.baseBackground,
+                    forceForegroundColor: viewModel.isConfirmButtonEnabled ? nil : theme.secondaryText
+                ) {
                     viewModel.confirm()
                 }
                 .disabled(!viewModel.isConfirmButtonEnabled)
-                .opacity(viewModel.isConfirmButtonEnabled ? 1 : 0.5)
             }
 
             if viewModel.origin == .banner {

--- a/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupView.swift
@@ -111,17 +111,34 @@ struct WMFDonationReminderSetupView: View {
                 }
             }
 
-            HStack(spacing: 12) {
-                ForEach(viewModel.configuration.triggerOptions) { triggerOption in
-                    WMFSelectablePillButton(label: triggerOption.label, isSelected: viewModel.selectedTriggerOptionIdentifier == triggerOption.id) {
-                        viewModel.selectedTriggerOptionIdentifier = triggerOption.id
-                    }
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 12) {
+                    triggerOptionButtons
+                    triggerUnitLabel
                 }
-                Text(viewModel.localizedStrings.triggerUnitLabel)
-                    .font(Font(WMFFont.for(.callout)))
-                    .foregroundColor(Color(theme.text))
+                VStack(alignment: .leading, spacing: 12) {
+                    triggerOptionButtons
+                    triggerUnitLabel
+                }
             }
         }
+    }
+
+    private var triggerOptionButtons: some View {
+        HStack(spacing: 12) {
+            ForEach(viewModel.configuration.triggerOptions) { triggerOption in
+                WMFSelectablePillButton(label: triggerOption.label, isSelected: viewModel.selectedTriggerOptionIdentifier == triggerOption.id) {
+                    viewModel.selectedTriggerOptionIdentifier = triggerOption.id
+                }
+            }
+        }
+    }
+
+    private var triggerUnitLabel: some View {
+        Text(viewModel.localizedStrings.triggerUnitLabel)
+            .font(Font(WMFFont.for(.callout)))
+            .foregroundColor(Color(theme.text))
+            .fixedSize(horizontal: true, vertical: false)
     }
 
     private var amountGroup: some View {
@@ -191,4 +208,3 @@ struct WMFDonationReminderSetupView: View {
         }
     }
 }
-

--- a/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupViewModel.swift
@@ -255,7 +255,7 @@ public final class WMFDonationReminderSetupViewModel: ObservableObject {
         formatter.currencyCode = configuration.currencyCode
         let formattedAmount = formatter.string(from: finalAmount as NSNumber) ?? "\(finalAmount)"
         let toastTitle = String.localizedStringWithFormat(localizedStrings.confirmationToastFormat, formattedAmount, selectedTriggerOption.label)
-        WMFToastPresenter.shared.show(WMFToastConfig(title: toastTitle, icon: WMFSFSymbolIcon.for(symbol: .checkmarkCircleFill)))
+        WMFToastPresenter.shared.show(WMFToastConfig(title: toastTitle))
 
         didConfirmReminder?(reminder)
     }

--- a/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupViewModel.swift
@@ -149,7 +149,7 @@ public final class WMFDonationReminderSetupViewModel: ObservableObject {
     }
 
     var primaryButtonTitle: String {
-        origin == .settings ? localizedStrings.updateButtonTitle : localizedStrings.confirmButtonTitle
+        initialReminder == nil ? localizedStrings.confirmButtonTitle : localizedStrings.updateButtonTitle
     }
 
     var hasPendingChanges: Bool {

--- a/WMFComponents/Sources/WMFComponents/Components/Settings/WMFSettingsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Settings/WMFSettingsView.swift
@@ -25,9 +25,8 @@ struct SettingsRow: View {
                     .font(Font(WMFFont.for(.body)))
                 if let subtitle = item.subtitle {
                     Text(subtitle)
-                        .font(Font(WMFFont.for(.subheadline)))
+                        .font(Font(WMFFont.for(.footnote)))
                         .foregroundColor(Color(uiColor: theme.secondaryText))
-                        .lineLimit(2)
                 }
             }
             Spacer()

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/WMFBetaBadge.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/WMFBetaBadge.swift
@@ -17,7 +17,7 @@ public struct WMFBetaBadge: View {
             Text(betaLabel)
                 .font(Font(WMFFont.for(.caption1)))
         }
-        .foregroundColor(Color(appEnvironment.theme.secondaryText))
+        .foregroundColor(Color(appEnvironment.theme.text))
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(Capsule().stroke(Color(appEnvironment.theme.baseBackground), lineWidth: 1))

--- a/WMFComponents/Sources/WMFComponents/Style/WMFIcon.swift
+++ b/WMFComponents/Sources/WMFComponents/Style/WMFIcon.swift
@@ -136,7 +136,7 @@ public enum WMFSFSymbolIcon {
     case textPage
     case leave
     case gear
-    case booksVerticalFill
+    case booksVertical
     case creditCard
     case flask
     case gearShape
@@ -367,8 +367,8 @@ public enum WMFSFSymbolIcon {
             image = UIImage(systemName: "rectangle.portrait.and.arrow.right", withConfiguration: configuration)
         case .gear:
             image = UIImage(systemName: "gear", withConfiguration: configuration)
-        case .booksVerticalFill:
-            image = UIImage(systemName: "books.vertical.fill", withConfiguration: configuration)
+        case .booksVertical:
+            image = UIImage(systemName: "books.vertical", withConfiguration: configuration)
         case .creditCard:
             image = UIImage(systemName: "creditcard", withConfiguration: configuration)
         case .flask:

--- a/WMFComponents/Tests/WMFComponentsTests/WMFDonationReminderSetupViewModelTests.swift
+++ b/WMFComponents/Tests/WMFComponentsTests/WMFDonationReminderSetupViewModelTests.swift
@@ -362,13 +362,18 @@ final class WMFDonationReminderSetupViewModelTests {
     }
 
     @Test
-    func primaryButtonTitleFollowsOrigin() async {
+    func primaryButtonTitleFollowsSavedReminder() async {
         await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let bannerViewModel = makeViewModel(origin: .banner)
-            let settingsViewModel = makeViewModel(origin: .settings)
+            let settingsWithoutReminderViewModel = makeViewModel(origin: .settings)
 
             #expect(bannerViewModel.primaryButtonTitle == bannerViewModel.localizedStrings.confirmButtonTitle)
-            #expect(settingsViewModel.primaryButtonTitle == settingsViewModel.localizedStrings.updateButtonTitle)
+            #expect(settingsWithoutReminderViewModel.primaryButtonTitle == settingsWithoutReminderViewModel.localizedStrings.confirmButtonTitle)
+
+            WMFDonationReminderDataController.shared.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 5), amount: 1, currencyCode: "EUR", createdDate: Date(), isEnabled: true))
+            let settingsWithReminderViewModel = makeViewModel(origin: .settings)
+
+            #expect(settingsWithReminderViewModel.primaryButtonTitle == settingsWithReminderViewModel.localizedStrings.updateButtonTitle)
         }
     }
 

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
@@ -116,8 +116,6 @@ public final class WMFDonationReminderDataController {
 
     private static let maximumIgnoredReminderImpressions = 2
 
-    private static let experimentCurrencyCodeKey = "donation-reminder-experiment-currency"
-
     private var userDefaultsStore: WMFKeyValueStore? { WMFDataEnvironment.current.userDefaultsStore }
     private var experimentStore: WMFKeyValueStore? { WMFDataEnvironment.current.sharedCacheStore }
 
@@ -263,7 +261,7 @@ public final class WMFDonationReminderDataController {
     // MARK: - Experiment Assignment
 
     public func clearExperimentAssignment() {
-        try? userDefaultsStore?.remove(key: Self.experimentCurrencyCodeKey)
+        try? userDefaultsStore?.remove(key: WMFUserDefaultsKey.donationReminderExperimentCurrency.rawValue)
 
         guard let experimentStore else {
             return
@@ -296,14 +294,14 @@ public final class WMFDonationReminderDataController {
 
         let resolvedAssignment = forcedAssignment ?? assignment
         if resolvedAssignment != .control {
-            try? userDefaultsStore?.save(key: Self.experimentCurrencyCodeKey, value: campaignCurrencyCode)
+            try? userDefaultsStore?.save(key: WMFUserDefaultsKey.donationReminderExperimentCurrency.rawValue, value: campaignCurrencyCode)
         }
 
         return resolvedAssignment
     }
 
     public var experimentCurrencyCode: String? {
-        try? userDefaultsStore?.load(key: Self.experimentCurrencyCodeKey)
+        try? userDefaultsStore?.load(key: WMFUserDefaultsKey.donationReminderExperimentCurrency.rawValue)
     }
 
     public var reminderSetupCurrencyCode: String? {

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
@@ -95,6 +95,8 @@ public final class WMFDonationReminderDataController {
 
     public static let shared = WMFDonationReminderDataController()
 
+    public static let experimentCampaignID = "NL_2026_08"
+
     public static let experimentPresetAmounts: [Decimal] = [1, 3, 5]
 
     // The reminders outlive the remote campaign end date. The experiment plan sets these fixed dates.
@@ -113,6 +115,8 @@ public final class WMFDonationReminderDataController {
     #endif
 
     private static let maximumIgnoredReminderImpressions = 2
+
+    private static let experimentCurrencyCodeKey = "donation-reminder-experiment-currency"
 
     private var userDefaultsStore: WMFKeyValueStore? { WMFDataEnvironment.current.userDefaultsStore }
     private var experimentStore: WMFKeyValueStore? { WMFDataEnvironment.current.sharedCacheStore }
@@ -144,10 +148,6 @@ public final class WMFDonationReminderDataController {
         case .groupB, .groupC:
             break
         default:
-            return false
-        }
-
-        guard loadReminder() != nil else {
             return false
         }
 
@@ -263,6 +263,8 @@ public final class WMFDonationReminderDataController {
     // MARK: - Experiment Assignment
 
     public func clearExperimentAssignment() {
+        try? userDefaultsStore?.remove(key: Self.experimentCurrencyCodeKey)
+
         guard let experimentStore else {
             return
         }
@@ -272,13 +274,18 @@ public final class WMFDonationReminderDataController {
     }
 
     @discardableResult
-    public func assignExperimentIfNeeded() throws -> ExperimentAssignment {
+    public func assignExperimentIfNeeded(campaignID: String, campaignCurrencyCode: String) throws -> ExperimentAssignment? {
         guard let experimentStore else {
             throw ExperimentError.missingExperimentStore
         }
 
         stateLock.lock()
         defer { stateLock.unlock() }
+
+        let forcedAssignment = developerSettingsForcedAssignment
+        guard campaignID == Self.experimentCampaignID || forcedAssignment != nil else {
+            return nil
+        }
 
         let experimentsDataController = WMFExperimentsDataController(store: experimentStore)
         let bucketValue = try experimentsDataController.determineBucketForExperiment(.donationReminder, withPercentage: Self.experimentGroupPercentage)
@@ -287,7 +294,20 @@ public final class WMFDonationReminderDataController {
             throw ExperimentError.unexpectedBucketValue
         }
 
-        return developerSettingsForcedAssignment ?? assignment
+        let resolvedAssignment = forcedAssignment ?? assignment
+        if resolvedAssignment != .control {
+            try? userDefaultsStore?.save(key: Self.experimentCurrencyCodeKey, value: campaignCurrencyCode)
+        }
+
+        return resolvedAssignment
+    }
+
+    public var experimentCurrencyCode: String? {
+        try? userDefaultsStore?.load(key: Self.experimentCurrencyCodeKey)
+    }
+
+    public var reminderSetupCurrencyCode: String? {
+        loadReminder()?.currencyCode ?? experimentCurrencyCode ?? Locale.current.currency?.identifier
     }
 
     public var experimentAssignment: ExperimentAssignment? {

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -49,6 +49,7 @@ public enum WMFUserDefaultsKey: String {
     case developerSettingsForceDonationReminderExperimentAssignment = "dev-settings-force-donation-reminder-experiment-assignment"
     case developerSettingsBypassDonationReminderDailyLimit = "dev-settings-bypass-donation-reminder-daily-limit"
     case donationReminder = "donation-reminder"
+    case donationReminderExperimentCurrency = "donation-reminder-experiment-currency"
 
     case allowGestureZoomArticleWebview = "allow-gesture-zoom-article-webview"
     // Reading Challenge 2026 (feature removed, see WMFReadingChallengeCompletionDataController)

--- a/WMFData/Tests/WMFDataTests/WMFDonationReminderDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFDonationReminderDataControllerTests.swift
@@ -369,12 +369,94 @@ final class WMFDonationReminderDataControllerTests {
     @Test
     func assignExperimentPersistsAssignment() async throws {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
-            let assignment = try controller.assignExperimentIfNeeded()
+            let assignment = try assignExperiment()
 
             #expect(controller.experimentAssignment == assignment)
 
-            let repeatedAssignment = try controller.assignExperimentIfNeeded()
+            let repeatedAssignment = try assignExperiment()
             #expect(repeatedAssignment == assignment)
+        }
+    }
+
+    @Test
+    func assignExperimentReturnsNilForAnotherCampaign() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let assignment = try controller.assignExperimentIfNeeded(campaignID: "BR_2026_08", campaignCurrencyCode: "BRL")
+
+            #expect(assignment == nil)
+            #expect(controller.experimentAssignment == nil)
+            #expect(controller.experimentCurrencyCode == nil)
+        }
+    }
+
+    @Test
+    func assignExperimentSavesTheCampaignCurrencyForTreatmentGroups() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .groupB
+
+            let assignment = try assignExperiment(campaignCurrencyCode: "EUR")
+
+            #expect(assignment == .groupB)
+            #expect(controller.experimentCurrencyCode == "EUR")
+
+            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = nil
+        }
+    }
+
+    @Test
+    func assignExperimentDoesNotSaveTheCampaignCurrencyForControl() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .control
+
+            let assignment = try assignExperiment(campaignCurrencyCode: "EUR")
+
+            #expect(assignment == .control)
+            #expect(controller.experimentCurrencyCode == nil)
+
+            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = nil
+        }
+    }
+
+    @Test
+    func forcedAssignmentBypassesTheCampaignGate() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .groupC
+
+            let assignment = try controller.assignExperimentIfNeeded(campaignID: "BR_2026_08", campaignCurrencyCode: "BRL")
+
+            #expect(assignment == .groupC)
+            #expect(controller.experimentCurrencyCode == "BRL")
+
+            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = nil
+        }
+    }
+
+    @Test
+    func reminderSetupCurrencyPrefersThePledgeOverTheExperimentCurrency() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .groupB
+            try assignExperiment(campaignCurrencyCode: "EUR")
+            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = nil
+
+            #expect(controller.reminderSetupCurrencyCode == "EUR")
+
+            controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 5), amount: 1, currencyCode: "USD", createdDate: Date(), isEnabled: true))
+
+            #expect(controller.reminderSetupCurrencyCode == "USD")
+        }
+    }
+
+    @Test
+    func clearExperimentAssignmentClearsTheCampaignCurrency() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .groupB
+            try assignExperiment(campaignCurrencyCode: "EUR")
+            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = nil
+            #expect(controller.experimentCurrencyCode == "EUR")
+
+            controller.clearExperimentAssignment()
+
+            #expect(controller.experimentCurrencyCode == nil)
         }
     }
 
@@ -387,7 +469,7 @@ final class WMFDonationReminderDataControllerTests {
             var seenAssignments = Set<WMFDonationReminderDataController.ExperimentAssignment>()
             for _ in 1...200 {
                 try experimentsDataController.resetExperiment(.donationReminder)
-                seenAssignments.insert(try controller.assignExperimentIfNeeded())
+                seenAssignments.insert(try assignExperiment())
                 if seenAssignments.count == 3 {
                     break
                 }
@@ -400,7 +482,7 @@ final class WMFDonationReminderDataControllerTests {
     @Test
     func clearExperimentAssignmentAllowsANewRoll() async throws {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
-            try controller.assignExperimentIfNeeded()
+            try assignExperiment()
             #expect(controller.experimentAssignment != nil)
 
             controller.clearExperimentAssignment()
@@ -414,23 +496,24 @@ final class WMFDonationReminderDataControllerTests {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             let createdDate = Date(timeIntervalSince1970: 1_755_600_000)
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 5), amount: 3, currencyCode: "EUR", createdDate: createdDate, isEnabled: true))
-            try controller.assignExperimentIfNeeded()
+            try assignExperiment()
 
             WMFDeveloperSettingsDataController.shared.clearFundraisingCampaignPersistence()
 
             #expect(controller.loadReminder() == nil)
             #expect(controller.experimentAssignment == nil)
+            #expect(controller.experimentCurrencyCode == nil)
         }
     }
 
     @Test
     func developerSettingsForceOverridesAssignmentAtReadTimeOnly() async throws {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
-            let persistedAssignment = try controller.assignExperimentIfNeeded()
+            let persistedAssignment = try assignExperiment()
 
             WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .groupC
             #expect(controller.experimentAssignment == .groupC)
-            #expect(try controller.assignExperimentIfNeeded() == .groupC)
+            #expect(try assignExperiment() == .groupC)
 
             WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .control
             #expect(controller.experimentAssignment == .control)
@@ -466,12 +549,12 @@ final class WMFDonationReminderDataControllerTests {
     }
 
     @Test
-    func settingsEntryUnavailableWithoutSavedReminder() async {
+    func settingsEntryAvailableWithoutSavedReminder() async {
         await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
             WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .groupB
 
-            #expect(controller.isReminderSettingsEntryAvailable() == false)
+            #expect(controller.isReminderSettingsEntryAvailable())
 
             WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = nil
         }
@@ -518,6 +601,11 @@ final class WMFDonationReminderDataControllerTests {
             #expect(showsBeforeEndDate)
             #expect(showsAtEndDate == false)
         }
+    }
+
+    @discardableResult
+    private func assignExperiment(campaignID: String = WMFDonationReminderDataController.experimentCampaignID, campaignCurrencyCode: String = "EUR") throws -> WMFDonationReminderDataController.ExperimentAssignment {
+        try #require(try controller.assignExperimentIfNeeded(campaignID: campaignID, campaignCurrencyCode: campaignCurrencyCode))
     }
 
     private func addQualifyingPageView(title: String, timestamp: Date) async throws {

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -123,7 +123,11 @@ extension ArticleViewController {
             case .maybeLater:
                 let experimentAssignment: WMFDonationReminderDataController.ExperimentAssignment?
                 if WMFDeveloperSettingsDataController.shared.enableDonationReminder {
-                    experimentAssignment = try? WMFDonationReminderDataController.shared.assignExperimentIfNeeded()
+                    experimentAssignment = try? WMFDonationReminderDataController.shared.assignExperimentIfNeeded(
+                        campaignID: asset.id,
+                        campaignCurrencyCode: asset.currencyCode
+                    )
+
                     #if DEBUG
                     if let experimentAssignment {
                         self.showDebugExperimentAssignmentToast(experimentAssignment)

--- a/Wikipedia/Code/SettingsCoordinator.swift
+++ b/Wikipedia/Code/SettingsCoordinator.swift
@@ -362,12 +362,12 @@ final class SettingsCoordinator: Coordinator, SettingsCoordinatorDelegate {
 
     private func showDonationReminderSetup() {
         guard let settingsNav = settingsNavigationController,
-              let savedReminder = WMFDonationReminderDataController.shared.loadReminder()
+              let currencyCode = WMFDonationReminderDataController.shared.reminderSetupCurrencyCode
         else { return }
 
         let coordinator = DonationReminderSetupCoordinator(
             navigationController: settingsNav,
-            currencyCode: savedReminder.currencyCode,
+            currencyCode: currencyCode,
             theme: theme,
             origin: .settings
         )


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T436036

### Notes
* Shows the "Donation reminders" Settings row as soon as the user is bucketed in group B/C, without requiring a saved pledge (PM-approved). The setup screen resolves its currency from the pledge, then the stored experiment currency, then the device locale.
* Gates experiment enrollment by campaign ID (`NL_2026_08`) and stores the campaign currency at assignment time. The developer settings forced assignment bypasses the campaign gate for QA.
* Design review fixes: settings row subtitle uses the footnote font without truncation, outline books symbol, darker beta badge, 24pt header spacing, no icon on the confirmation toast, "Articles" label never breaks mid-word (stacks below the pills when needed), VoiceOver reads "5 Articles, button", and the disabled confirm button uses gray theme tokens instead of opacity.
* Known follow-up (no ticket yet): `CapsuleButtonStyle` has no disabled visual state, so call sites hack it with `.opacity`. This PR fixes only the reminder setup screen.

### Test Steps
1. In Developer Settings, enable **Enable Donation Reminder** and set **Force Reminder Experiment Group** to B or C.
2. Open Settings → the "Donation reminders" row shows "Off" even with no saved reminder. Tap it → the setup screen opens with the toggle off and a "Confirm reminder" button.
3. Confirm a reminder → the row shows "On" with the pledge subtitle in the smaller font, and reopening the screen shows "Update reminder".
4. Check the setup screen in light/sepia/dark/black and at accessibility text sizes.

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
