### PR TITLE
T434895: Add a fundraising date override to the developer settings

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
@@ -52,24 +52,45 @@ struct WMFDeveloperSettingsView: View {
 
             Section {
                 Toggle("Bypass Reminder Daily Limit", isOn: $viewModel.bypassDonationReminderDailyLimit)
-                Toggle("Force Fundraising Campaign Banner", isOn: $viewModel.forceFundraisingCampaignBanner)
-                Toggle("Use Test Wiki Donate Configs", isOn: $viewModel.useTestWikiDonateConfigs)
-                Toggle("Use Hardcoded Payment Methods", isOn: $viewModel.useHardcodedPaymentMethods)
-                Picker("Force Reminder Experiment Group", selection: $viewModel.forceDonationReminderExperimentAssignment) {
-                    Text("Off").tag(WMFDonationReminderDataController.ExperimentAssignment?.none)
-                    Text("Control (A)").tag(WMFDonationReminderDataController.ExperimentAssignment?.some(.control))
-                    Text("Group B").tag(WMFDonationReminderDataController.ExperimentAssignment?.some(.groupB))
-                    Text("Group C").tag(WMFDonationReminderDataController.ExperimentAssignment?.some(.groupC))
+                fundraisingRow(caption: "Changes the date the donation reminder end gate treats as today; reading progress, the daily limit, and networking keep using the real device date.") {
+                    Toggle("Override Current Date", isOn: $viewModel.overrideFundraisingCurrentDate)
                 }
-                Button {
-                    viewModel.clearFundraisingCampaignPersistence()
-                } label: {
-                    Text("Clear banner prompt state and donation history")
+                if viewModel.overrideFundraisingCurrentDate {
+                    DatePicker(
+                        "Overridden current date",
+                        selection: $viewModel.fundraisingCurrentDate,
+                        in: viewModel.fundraisingOverrideDateRange,
+                        displayedComponents: .date
+                    )
+                    .datePickerStyle(.graphical)
+                    .labelsHidden()
+                }
+                fundraisingRow(caption: "Ignores country and language settings. Only works if there is an active campaign.") {
+                    Toggle("Force Fundraising Campaign Banner", isOn: $viewModel.forceFundraisingCampaignBanner)
+                }
+                fundraisingRow(caption: "Fetches the donate and campaign configs from test.wikipedia.org instead of donate.wikimedia.org; toggling clears the cached configs and refetches immediately.") {
+                    Toggle("Use Test Wiki Donate Configs", isOn: $viewModel.useTestWikiDonateConfigs)
+                }
+                fundraisingRow(caption: "Skips the getPaymentMethods API call and enables Apple Pay with the standard card networks; use it when the payments API rate limits the device.") {
+                    Toggle("Use Hardcoded Payment Methods", isOn: $viewModel.useHardcodedPaymentMethods)
+                }
+                fundraisingRow(caption: "Overrides the persisted A/B/C bucket at read time; switching it back to Off restores the persisted bucket.") {
+                    Picker("Force Reminder Experiment Group", selection: $viewModel.forceDonationReminderExperimentAssignment) {
+                        Text("Off").tag(WMFDonationReminderDataController.ExperimentAssignment?.none)
+                        Text("Control (A)").tag(WMFDonationReminderDataController.ExperimentAssignment?.some(.control))
+                        Text("Group B").tag(WMFDonationReminderDataController.ExperimentAssignment?.some(.groupB))
+                        Text("Group C").tag(WMFDonationReminderDataController.ExperimentAssignment?.some(.groupC))
+                    }
+                }
+                fundraisingRow(caption: "Resets \"maybe later\" / \"already donated\", the local donation history, the saved donation reminder, the experiment bucket, and the wrap-up card, so the banner can show again and the next Maybe Later re-rolls the A/B/C assignment.") {
+                    Button {
+                        viewModel.clearFundraisingCampaignPersistence()
+                    } label: {
+                        Text("Clear banner prompt state and donation history")
+                    }
                 }
             } header: {
                 Text("Fundraising")
-            } footer: {
-                Text("Force ignores country and language settings. Only works if there is an active campaign. Clear resets \"maybe later\" / \"already donated\", the local donation history, the saved donation reminder, and the experiment bucket, so the banner can show again and the next Maybe Later re-rolls the A/B/C assignment. Force Reminder Experiment Group overrides the persisted A/B/C bucket at read time; switching it back to Off restores the persisted bucket. Use Test Wiki fetches the donate and campaign configs from test.wikipedia.org instead of donate.wikimedia.org; toggling clears the cached configs and refetches immediately. Use Hardcoded Payment Methods skips the getPaymentMethods API call and enables Apple Pay with the standard card networks; use it when the payments API rate limits the device.")
             }
 
             ForEach(viewModel.formViewModel.sections) { section in
@@ -81,5 +102,14 @@ struct WMFDeveloperSettingsView: View {
         }
         .listStyle(InsetGroupedListStyle())
         .listBackgroundColor(Color(theme.baseBackground))
+    }
+
+    private func fundraisingRow(caption: String, @ViewBuilder control: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            control()
+            Text(caption)
+                .font(Font(WMFFont.for(.caption1)))
+                .foregroundStyle(Color(theme.secondaryText))
+        }
     }
 }

--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -79,6 +79,25 @@ import WMFData
         }
     }
 
+    @Published public var overrideFundraisingCurrentDate: Bool = WMFDeveloperSettingsDataController.shared.fundraisingOverriddenCurrentDate != nil {
+        didSet {
+            WMFDeveloperSettingsDataController.shared.fundraisingOverriddenCurrentDate = overrideFundraisingCurrentDate ? fundraisingCurrentDate : nil
+        }
+    }
+
+    @Published public var fundraisingCurrentDate: Date = WMFDeveloperSettingsDataController.shared.fundraisingOverriddenCurrentDate ?? WMFDonationReminderDataController.reminderEndDate {
+        didSet {
+            guard overrideFundraisingCurrentDate else { return }
+            WMFDeveloperSettingsDataController.shared.fundraisingOverriddenCurrentDate = fundraisingCurrentDate
+        }
+    }
+
+    var fundraisingOverrideDateRange: ClosedRange<Date> {
+        let lowerBound = WMFDonationReminderDataController.reminderEndDate.addingTimeInterval(-86_400)
+        let upperBound = WMFDonationReminderDataController.wrapUpEndDate.addingTimeInterval(86_400)
+        return lowerBound...upperBound
+    }
+
 
     @objc public init(localizedStrings: WMFDeveloperSettingsLocalizedStrings) {
         self.localizedStrings = localizedStrings

--- a/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
@@ -226,6 +226,23 @@ public protocol WMFDeveloperSettingsDataControlling: AnyObject {
         set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.developerSettingsBypassDonationReminderDailyLimit.rawValue, value: newValue) }
     }
 
+    /// Debugging convenience: overrides the date that the fundraising features treat as today, so we
+    /// can test the campaign and reminder date windows.
+    public var fundraisingOverriddenCurrentDate: Date? {
+        get { try? userDefaultsStore?.load(key: WMFUserDefaultsKey.developerSettingsFundraisingOverriddenCurrentDate.rawValue) }
+        set {
+            if let newValue {
+                try? userDefaultsStore?.save(key: WMFUserDefaultsKey.developerSettingsFundraisingOverriddenCurrentDate.rawValue, value: newValue)
+            } else {
+                try? userDefaultsStore?.remove(key: WMFUserDefaultsKey.developerSettingsFundraisingOverriddenCurrentDate.rawValue)
+            }
+        }
+    }
+
+    public var fundraisingCurrentDate: Date {
+        fundraisingOverriddenCurrentDate ?? Date()
+    }
+
     public var enableVisualEditingJourney: Bool {
         get { (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.developerSettingsEnableVisualEditingJourney.rawValue)) ?? false }
         set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.developerSettingsEnableVisualEditingJourney.rawValue, value: newValue) }

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
@@ -145,7 +145,7 @@ public final class WMFDonationReminderDataController {
             return false
         }
 
-        return currentDate < Self.reminderEndDate
+        return (WMFDeveloperSettingsDataController.shared.fundraisingOverriddenCurrentDate ?? currentDate) < Self.reminderEndDate
     }
 
     // MARK: - Follow-up Reminder Cycle
@@ -162,8 +162,9 @@ public final class WMFDonationReminderDataController {
     public func shouldShowFollowUpReminder(currentDate: Date = Date()) async throws -> Bool {
         guard let reminder = loadReminder(),
               reminder.isEnabled,
-              currentDate < Self.reminderEndDate,
-              case .articlesRead(count: let articlesReadGoal) = reminder.trigger else {
+              (WMFDeveloperSettingsDataController.shared.fundraisingOverriddenCurrentDate ?? currentDate) < Self.reminderEndDate,
+              case .articlesRead(count: let articlesReadGoal) = reminder.trigger
+        else {
             return false
         }
 

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -43,6 +43,7 @@ public enum WMFUserDefaultsKey: String {
     case openAppOnSearchTab = "open-app-on-search-tab"
     case isSubscribedToEchoNotifications = "is-subscribed-to-echo-notifications"
     case forceHCaptchaChallenge = "force-hcaptcha-challenge"
+    case developerSettingsFundraisingOverriddenCurrentDate = "dev-settings-fundraising-overridden-current-date"
     case developerSettingsForceFundraisingCampaignBanner = "dev-settings-force-fundraising-campaign-banner"
     case developerSettingsUseTestWikiDonateConfigs = "dev-settings-use-test-wiki-donate-configs"
     case developerSettingsUseHardcodedPaymentMethods = "dev-settings-use-hardcoded-payment-methods"

--- a/WMFData/Tests/WMFDataTests/WMFDonationReminderDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFDonationReminderDataControllerTests.swift
@@ -564,6 +564,28 @@ final class WMFDonationReminderDataControllerTests {
         try #require(try controller.assignExperimentIfNeeded(campaignID: campaignID, campaignCurrencyCode: campaignCurrencyCode))
     }
 
+    @Test
+    func overriddenCurrentDateWinsTheReminderEndGate() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .groupB
+            let progress = WMFDonationReminder.Progress(currentCycleStartDate: Date(timeIntervalSince1970: 1_755_600_000), timesReminderShown: 1)
+            controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 5), amount: 1, currencyCode: "EUR", createdDate: Date(timeIntervalSince1970: 1_700_000_000), isEnabled: true, progress: progress))
+            let beforeEndDate = WMFDonationReminderDataController.reminderEndDate.addingTimeInterval(-86_400)
+
+            let showsWithoutOverride = try await controller.shouldShowFollowUpReminder(currentDate: beforeEndDate)
+            #expect(controller.isReminderSettingsEntryAvailable(currentDate: beforeEndDate))
+            #expect(showsWithoutOverride)
+
+            WMFDeveloperSettingsDataController.shared.fundraisingOverriddenCurrentDate = WMFDonationReminderDataController.reminderEndDate
+            let showsWithOverride = try await controller.shouldShowFollowUpReminder(currentDate: beforeEndDate)
+            #expect(controller.isReminderSettingsEntryAvailable(currentDate: beforeEndDate) == false)
+            #expect(showsWithOverride == false)
+
+            WMFDeveloperSettingsDataController.shared.fundraisingOverriddenCurrentDate = nil
+            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = nil
+        }
+    }
+
     private func addQualifyingPageView(title: String, timestamp: Date) async throws {
         try await addPageView(title: title, timestamp: timestamp, numberOfSeconds: Double(WMFDonationReminderDataController.minimumSecondsForArticleRead))
     }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T434895

### Notes
* Adds an **Override Current Date** developer setting to the Fundraising section: a toggle plus a calendar (limited to Nov 8–16) that changes the date the donation reminder end gate treats as today.
* Why: changing the actual device date breaks TLS certificate validation and stops all networking, so QA had no way to test the Nov 9 cutoff. The override moves only the date gate, and networking keeps using the real device date.
* Scope note: reading progress and the once-per-day limit intentionally stay on the real clock — article reads are recorded with real timestamps, so overriding those dates would make reminders look broken. Use real time + the existing "Bypass Reminder Daily Limit" toggle to test the reminder cycle, and the date override to test the date windows. The upcoming wrap-up card window will consume the same override in a follow-up PR.
* Also reorganizes the Fundraising developer settings rows so each control has its explanation right below it, replacing the long footer paragraph. 

### Test Steps
1. Developer Settings → Fundraising → turn on **Override Current Date**. A calendar appears, limited to Nov 8–16.
2. With Enable Donation Reminder on, a forced experiment group, and a saved reminder: pick **Nov 8** → the in-article reminder and the Settings → Donation reminders entry still show. Pick **Nov 9** → both stop showing.
3. Turn the override off → today's real date applies again and reminders come back.

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
<img width="60%" alt="Simulator Screenshot - iPhone 17 - 2026-09-02 at 10 01 26" src="https://github.com/user-attachments/assets/5e64feaa-e78f-40d4-93af-6b59a8510de7" />
