### PR TITLE
T434895: Update the shared survey view for the donation reminder feedback survey

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Settings/WMFSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Settings/WMFSettingsViewModel.swift
@@ -75,7 +75,7 @@ final public class WMFSettingsViewModel: ObservableObject {
         let safetyTitle: String
 
         let donationsHeader = WMFLocalizedString("settings-donations-header", value: "Donations", comment: "Header of the donations section on the settings screen.")
-        let donationRemindersTitle = WMFLocalizedString("settings-donation-reminders-title", value: "Donation reminders", comment: "Title of the donation reminders row on the settings screen.")
+        let donationRemindersTitle = CommonStrings.donationRemindersTitle
         let donationRemindersSubtitleFormat = WMFLocalizedString("settings-donation-reminders-subtitle", value: "Wikipedia will remind you to donate %1$@ every %2$@ articles you read.", comment: "Subtitle of the donation reminders row on the settings screen. %1$@ is the donation amount, %2$@ is the number of articles.")
         let clearDonationHistoryTitle = WMFLocalizedString("settings-clear-donation-history", value: "Clear donation history", comment: "Title of the row on the settings screen that deletes the locally saved donation history.")
 

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Survey/WMFSurveyView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Survey/WMFSurveyView.swift
@@ -48,27 +48,7 @@ public struct WMFSurveyView: View {
 
     public var body: some View {
         NavigationView {
-            VStack(alignment: .leading, spacing: 0) {
-                VStack(alignment: .leading, spacing: 8) {
-                    if let heading = viewModel.localizedStrings.heading {
-                        Text(heading)
-                            .font(Font(WMFFont.for(.semiboldHeadline)))
-                            .foregroundColor(Color(theme.text))
-                    }
-                    Text(viewModel.localizedStrings.subtitle)
-                        .font(Font(WMFFont.for(.callout)))
-                        .foregroundColor(Color(theme.secondaryText))
-                    if let instructions = viewModel.localizedStrings.instructions {
-                        Text(instructions)
-                            .font(Font(WMFFont.for(.italicCallout)))
-                            .foregroundColor(Color(theme.secondaryText))
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 16)
-                .padding(.top, 24)
-
-                List {
+            List {
                 Section {
                     ForEach(viewModel.options) { optionViewModel in
                         HStack {
@@ -99,6 +79,27 @@ public struct WMFSurveyView: View {
                     }
                     .listRowBackground(Color(theme.paperBackground))
                     .listRowSeparatorTint(Color(theme.newBorder))
+                } header: {
+                    VStack(alignment: .leading, spacing: 8) {
+                        if let heading = viewModel.localizedStrings.heading {
+                            Text(heading)
+                                .font(Font(WMFFont.for(.semiboldHeadline)))
+                                .foregroundColor(Color(theme.text))
+                        }
+                        Text(viewModel.localizedStrings.subtitle)
+                            .font(Font(WMFFont.for(.callout)))
+                            .foregroundColor(Color(theme.secondaryText))
+                        if let instructions = viewModel.localizedStrings.instructions {
+                            Text(instructions)
+                                .font(Font(WMFFont.for(.italicCallout)))
+                                .foregroundColor(Color(theme.secondaryText))
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textCase(nil)
+                    .listRowInsets(EdgeInsets())
+                    .padding(.top, 24)
+                    .padding(.bottom, 24)
                 }
                 .listSectionSeparator(.hidden)
 
@@ -134,9 +135,8 @@ public struct WMFSurveyView: View {
                 .listCustomSectionSpacing(16)
                 .listRowSeparator(.hidden)
             }
-                .listBackgroundColor(Color(theme.baseBackground))
-                .listStyle(.insetGrouped)
-            }
+            .listBackgroundColor(Color(theme.baseBackground))
+            .listStyle(.insetGrouped)
             .background(Color(theme.baseBackground))
             .navigationTitle(viewModel.localizedStrings.title)
             .navigationBarTitleDisplayMode(.inline)

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Survey/WMFSurveyView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Survey/WMFSurveyView.swift
@@ -17,6 +17,15 @@ public struct WMFSurveyView: View {
         return !selectedOptions.isEmpty || !otherOptionText.isEmpty
     }
 
+    private var isOverCharacterLimit: Bool {
+        guard let characterLimit = viewModel.otherTextCharacterLimit else { return false }
+        return otherOptionText.count > characterLimit
+    }
+
+    private var canSubmit: Bool {
+        userHasSelectedReasons && !isOverCharacterLimit
+    }
+
     @FocusState var otherOptionTextFieldSelected: Bool
 
     @State var otherOptionText = ""
@@ -39,22 +48,27 @@ public struct WMFSurveyView: View {
 
     public var body: some View {
         NavigationView {
-            List {
-                Section {
-                    VStack(alignment: .leading) {
-                        Text(viewModel.localizedStrings.subtitle)
-                            .font(Font(WMFFont.for(.callout)))
-                        if let instructions = viewModel.localizedStrings.instructions {
-                            Text(instructions)
-                                .font(Font(WMFFont.for(.italicCallout)))
-                        }
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 8) {
+                    if let heading = viewModel.localizedStrings.heading {
+                        Text(heading)
+                            .font(Font(WMFFont.for(.semiboldHeadline)))
+                            .foregroundColor(Color(theme.text))
+                    }
+                    Text(viewModel.localizedStrings.subtitle)
+                        .font(Font(WMFFont.for(.callout)))
+                        .foregroundColor(Color(theme.secondaryText))
+                    if let instructions = viewModel.localizedStrings.instructions {
+                        Text(instructions)
+                            .font(Font(WMFFont.for(.italicCallout)))
+                            .foregroundColor(Color(theme.secondaryText))
                     }
                 }
-                .foregroundColor(Color(theme.secondaryText))
-                .listRowBackground(Color.clear)
-                .listRowSeparator(.hidden)
-                .listCustomSectionSpacing(0)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+                .padding(.top, 24)
 
+                List {
                 Section {
                     ForEach(viewModel.options) { optionViewModel in
                         HStack {
@@ -103,20 +117,44 @@ public struct WMFSurveyView: View {
                         .listRowBackground(Color(theme.paperBackground))
                     }
 
+                } footer: {
+                    if let characterLimit = viewModel.otherTextCharacterLimit {
+                        HStack {
+                            if isOverCharacterLimit, let characterLimitErrorText = viewModel.localizedStrings.characterLimitErrorText {
+                                Text(characterLimitErrorText)
+                                    .foregroundColor(Color(theme.destructive))
+                            }
+                            Spacer()
+                            Text("\(otherOptionText.count)/\(characterLimit)")
+                                .foregroundColor(Color(isOverCharacterLimit ? theme.destructive : theme.secondaryText))
+                        }
+                        .font(Font(WMFFont.for(.caption1)))
+                    }
                 }
                 .listCustomSectionSpacing(16)
                 .listRowSeparator(.hidden)
             }
-            .listBackgroundColor(Color(theme.baseBackground))
-            .listStyle(.insetGrouped)
+                .listBackgroundColor(Color(theme.baseBackground))
+                .listStyle(.insetGrouped)
+            }
+            .background(Color(theme.baseBackground))
             .navigationTitle(viewModel.localizedStrings.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button(viewModel.localizedStrings.cancel) {
-                        cancelAction?()
+                    if #available(iOS 26.0, *) {
+                        Button(role: .close) {
+                            cancelAction?()
+                        }
+                    } else {
+                        Button {
+                            cancelAction?()
+                        } label: {
+                            Image(uiImage: WMFSFSymbolIcon.for(symbol: .close) ?? UIImage())
+                        }
+                        .foregroundStyle(Color(theme.link))
+                        .accessibilityLabel(viewModel.localizedStrings.cancel)
                     }
-                    .foregroundStyle(Color(theme.link))
                 }
 
                 ToolbarItem(placement: .topBarTrailing) {
@@ -126,8 +164,8 @@ public struct WMFSurveyView: View {
                         }
                         submitAction?(Array(selectedOptions), otherOptionText)
                     }
-                    .disabled(!userHasSelectedReasons)
-                    .foregroundStyle(Color(userHasSelectedReasons ? theme.link : theme.secondaryText))
+                    .disabled(!canSubmit)
+                    .foregroundStyle(Color(canSubmit ? theme.link : theme.secondaryText))
                 }
             }
             }

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/Survey/WMFSurveyViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/Survey/WMFSurveyViewModel.swift
@@ -2,59 +2,80 @@ import Foundation
 
 public final class WMFSurveyViewModel {
 
-	public struct LocalizedStrings {
-		let title: String
-		let cancel: String
-		let submit: String
-		let subtitle: String
-		let instructions: String?
+    public struct LocalizedStrings {
+        let title: String
+        let cancel: String
+        let submit: String
+        let heading: String?
+        let subtitle: String
+        let instructions: String?
 
-		let otherPlaceholder: String
+        let otherPlaceholder: String
+        let characterLimitErrorText: String?
 
-        public init(title: String, cancel: String, submit: String, subtitle: String, instructions: String?, otherPlaceholder: String) {
-			self.title = title
-			self.cancel = cancel
-			self.submit = submit
-			self.subtitle = subtitle
-			self.instructions = instructions
-			self.otherPlaceholder = otherPlaceholder
-		}
-	}
-    
+        public init(
+            title: String,
+            cancel: String,
+            submit: String,
+            heading: String? = nil,
+            subtitle: String,
+            instructions: String?,
+            otherPlaceholder: String,
+            characterLimitErrorText: String? = nil
+        ) {
+            self.title = title
+            self.cancel = cancel
+            self.submit = submit
+            self.heading = heading
+            self.subtitle = subtitle
+            self.instructions = instructions
+            self.otherPlaceholder = otherPlaceholder
+            self.characterLimitErrorText = characterLimitErrorText
+        }
+    }
+
     public struct OptionViewModel: Hashable, Identifiable {
         public let id = UUID()
         public let text: String
         public let apiIdentifer: String
-        
+
         public func hash(into hasher: inout Hasher) {
             hasher.combine(apiIdentifer)
         }
-        
+
         public static func == (lhs: WMFSurveyViewModel.OptionViewModel, rhs: WMFSurveyViewModel.OptionViewModel) -> Bool {
             return lhs.apiIdentifer == rhs.apiIdentifer
         }
-        
+
         public init(text: String, apiIdentifer: String) {
             self.text = text
             self.apiIdentifer = apiIdentifer
         }
     }
-    
+
     public enum SelectionType {
         case multi
         case single
     }
 
-	let localizedStrings: LocalizedStrings
+    let localizedStrings: LocalizedStrings
     let options: [OptionViewModel]
     let selectionType: SelectionType
     let shouldShowMultilineText: Bool
+    let otherTextCharacterLimit: Int?
 
-    public init(localizedStrings: LocalizedStrings, options: [OptionViewModel], selectionType: SelectionType, shouldShowMultilineText: Bool = false) {
-		self.localizedStrings = localizedStrings
+    public init(
+        localizedStrings: LocalizedStrings,
+        options: [OptionViewModel],
+        selectionType: SelectionType,
+        shouldShowMultilineText: Bool = false,
+        otherTextCharacterLimit: Int? = nil
+    ) {
+        self.localizedStrings = localizedStrings
         self.options = options
         self.selectionType = selectionType
         self.shouldShowMultilineText = shouldShowMultilineText
-	}
+        self.otherTextCharacterLimit = otherTextCharacterLimit
+    }
 
 }

--- a/WMFComponents/Sources/WMFComponents/Components/Shared/WMFBetaBadge.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Shared/WMFBetaBadge.swift
@@ -5,8 +5,6 @@ public struct WMFBetaBadge: View {
 
     @ObservedObject var appEnvironment = WMFAppEnvironment.current
 
-    private let betaLabel = WMFLocalizedString("beta-badge-label", value: "Beta", comment: "Label indicating a feature is in beta.")
-
     public init() {}
 
     public var body: some View {
@@ -14,7 +12,7 @@ public struct WMFBetaBadge: View {
             if let betaImage = WMFSFSymbolIcon.for(symbol: .flask, font: WMFFont.caption1) {
                 Image(uiImage: betaImage)
             }
-            Text(betaLabel)
+            Text(CommonStrings.betaLabel)
                 .font(Font(WMFFont.for(.caption1)))
         }
         .foregroundColor(Color(appEnvironment.theme.text))

--- a/WMFLocalizations/Sources/WMFNativeLocalizations/CommonStrings.swift
+++ b/WMFLocalizations/Sources/WMFNativeLocalizations/CommonStrings.swift
@@ -693,6 +693,8 @@ public class CommonStrings: NSObject {
     public static let joinLoginTitle = WMFLocalizedString("profile-page-join-title", value: "Log in / Join Wikipedia", comment: "Link to sign up or sign in")
 
     public static let noThanksTitle = WMFLocalizedString("variants-alert-dismiss-button", value: "No thanks", comment: "Dismiss button on alert used to inform users about variant support.")
+    public static let betaLabel = WMFLocalizedString("beta-badge-label", value: "Beta", comment: "Label indicating a feature is in beta.")
+    public static let donationRemindersTitle = WMFLocalizedString("settings-donation-reminders-title", value: "Donation reminders", comment: "Title of the donation reminders row on the settings screen.")
     public static let continueWithoutLoggingIn = WMFLocalizedString("ip-account-cta-bottom", value: "Continue without logging in", comment: "Continue without logging in button title")
 
     public static func takeSurveyTitle(languageCode: String?) -> String {


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T434895

### Notes
* Prepares the shared `WMFSurveyView` for the donation reminder wrap-up feedback survey (next PR in the stack), with changes that also benefit the existing surveys:
  * New optional `heading` field, shown bold above the subtitle. Only rendered when a caller provides it — no existing survey changes.
  * New optional character limit for the free-form text field: a live `x/N` counter and a "limit exceeded" error render in the section footer, and Submit is disabled while over the limit. Only active when a caller passes a limit — no existing survey changes.
  * The subtitle/instructions header moved out of the `List` and now aligns with the leading edge of the cards, with proper spacing between the two lines.
  * The Cancel text button is now a close button: `Button(role: .close)` on iOS 26 (liquid glass) with an `xmark` fallback on earlier versions, keeping "Cancel" as the accessibility label.
* Moves two reused strings to `CommonStrings` so the wrap-up cards can share them: `beta-badge-label` (from `WMFBetaBadge`) and `settings-donation-reminders-title` (from the Settings row). Keys are unchanged, so existing translations carry over.
* The `WMFSurveyViewModel` diff looks larger than it is — most of it is tabs-to-spaces whitespace normalization. "Hide whitespace" shows the real change.

### Test Steps
1. Open one of the existing surveys (for example Article Tabs → overflow → survey, or the image recommendations "No" survey). The question header now aligns with the card edges, and the top-left close button is an X instead of "Cancel". Everything else is unchanged: no heading, no character counter.
2. The new heading and character limit have no consumer yet — they are exercised by the wrap-up feedback survey in the next PR of this stack.
3. Settings → the "Donation reminders" row title still renders (now sourced from CommonStrings), and the reminder setup screen's Beta badge is unchanged.

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos

<img width="50%" alt="Simulator Screenshot - iPhone 17 - 2026-09-02 at 11 43 02" src="https://github.com/user-attachments/assets/aa49ee8c-ce4d-4af0-8f56-612ca4b1206a" />
