### PR TITLE
Games: Optimize Which Came First layout and text size for iPad

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Games/Splash Screen/WMFGamesSplashScreenView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Splash Screen/WMFGamesSplashScreenView.swift
@@ -4,6 +4,7 @@ public struct WMFGamesSplashScreenView: View {
 
     @ObservedObject var appEnvironment = WMFAppEnvironment.current
     @ObservedObject public var viewModel: WMFGamesSplashScreenViewModel
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     public init(viewModel: WMFGamesSplashScreenViewModel) {
         self.viewModel = viewModel
@@ -24,18 +25,18 @@ public struct WMFGamesSplashScreenView: View {
                         Image(uiImage: viewModel.icon ?? UIImage())
                             .resizable()
                             .scaledToFit()
-                            .frame(width: 44, height: 44)
+                            .frame(width: horizontalSizeClass == .regular ? 72 : 44, height: horizontalSizeClass == .regular ? 72 : 44)
                             .foregroundColor(Color(uiColor: WMFColor.white))
                             .padding(.bottom, 24)
 
                         Text(viewModel.title)
-                            .font(Font(WMFFont.for(.georgiaTitle1)))
+                            .font(horizontalSizeClass == .regular ? Font.custom("Georgia", size: 44) : Font(WMFFont.for(.georgiaTitle1)))
                             .foregroundColor(.white)
                             .multilineTextAlignment(.center)
                             .padding(.bottom, 8)
 
                         Text(viewModel.subtitle)
-                            .font(Font(WMFFont.for(.body)))
+                            .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .title2 : .body)))
                             .foregroundColor(Color(uiColor: WMFColor.white))
                             .multilineTextAlignment(.center)
                             .padding(.horizontal, 32)
@@ -63,6 +64,8 @@ public struct WMFGamesSplashScreenView: View {
                     .padding(.bottom, 24)
                 }
                 .frame(minHeight: UIScreen.main.bounds.height - 100)
+                .frame(maxWidth: horizontalSizeClass == .regular ? 750 : .infinity)
+                .frame(maxWidth: .infinity)
             }
         }
     }

--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/Cards/WMFWhichCameFirstCardView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/Cards/WMFWhichCameFirstCardView.swift
@@ -104,7 +104,7 @@ public struct WMFWhichCameFirstCardView: View {
     private var eventText: some View {
         ScrollView(.vertical, showsIndicators: true) {
             Text(viewModel.event.text)
-                .font(Font(WMFFont.for(.footnote)))
+                .font(Font(WMFFont.for(sizeClass == .regular ? .title2 : .footnote)))
                 .foregroundColor(Color(uiColor: theme.text))
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.trailing, 2)
@@ -122,12 +122,12 @@ public struct WMFWhichCameFirstCardView: View {
                 Image(uiImage: uiImage)
                     .resizable()
                     .scaledToFill()
-                    .frame(width: 100, height: 100)
+                    .frame(width: sizeClass == .regular ? 160 : 100, height: sizeClass == .regular ? 160 : 100)
                     .clipShape(RoundedRectangle(cornerRadius: 2))
             } else {
                 RoundedRectangle(cornerRadius: 2)
                     .fill(Color(uiColor: theme.midBackground))
-                    .frame(width: 100, height: 100)
+                    .frame(width: sizeClass == .regular ? 160 : 100, height: sizeClass == .regular ? 160 : 100)
                     .overlay(ProgressView().scaleEffect(0.7))
             }
         }
@@ -150,7 +150,7 @@ public struct WMFWhichCameFirstCardView: View {
         Text(viewModel.event.dateString)
             .accessibilityHidden(true)
             .minimumScaleFactor(0.3)
-            .font(Font(WMFFont.for(.subheadline)))
+            .font(Font(WMFFont.for(sizeClass == .regular ? .headline : .subheadline)))
             .foregroundColor(Color(uiColor: theme.paperBackground))
             .padding(.horizontal, 8)
             .padding(.vertical, 2)
@@ -167,7 +167,7 @@ private struct CardHeightModifier: ViewModifier {
     func body(content: Content) -> some View {
         if isRegular {
             content
-                .containerRelativeFrame(.vertical, count: 3, spacing: 16)
+                .frame(height: 300)
         } else {
             content
                 .frame(height: cardHeight)

--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Core/WMFWhichCameFirstView.swift
@@ -5,6 +5,7 @@ public struct WMFWhichCameFirstView: View {
 
     @ObservedObject var viewModel: WMFWhichCameFirstViewModel
     @ObservedObject var appEnvironment = WMFAppEnvironment.current
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     private var theme: WMFTheme { appEnvironment.theme }
 
@@ -86,7 +87,7 @@ public struct WMFWhichCameFirstView: View {
                     if viewModel.showTitle {
                         Text(viewModel.localizedStrings.title)
                             .minimumScaleFactor(0.3)
-                            .font(Font(WMFFont.for(.georgiaTitle1)))
+                            .font(horizontalSizeClass == .regular ? Font.custom("Georgia", size: 44) : Font(WMFFont.for(.georgiaTitle1)))
                             .foregroundColor(Color(uiColor: theme.baseBackground))
                             .multilineTextAlignment(.center)
                             .layoutPriority(1)
@@ -128,6 +129,7 @@ public struct WMFWhichCameFirstView: View {
                     
                     footerArea
                 }
+                .frame(maxWidth: horizontalSizeClass == .regular ? 750 : .infinity)
                 .padding(.top, viewModel.cardViewModelA?.isRevealed == true ? -96 : -16)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 .background(Color(uiColor: theme.midBackground))
@@ -161,12 +163,12 @@ public struct WMFWhichCameFirstView: View {
 
                         Text(viewModel.localizedStrings.submitButton)
                             .minimumScaleFactor(0.2)
-                            .font(Font(WMFFont.for(.semiboldSubheadline)))
+                            .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .semiboldHeadline : .semiboldSubheadline)))
                             .multilineTextAlignment(.center)
 
                         if let image = WMFSFSymbolIcon.for(
                             symbol: .chevronForward,
-                            font: .semiboldSubheadline,
+                            font: horizontalSizeClass == .regular ? .semiboldHeadline : .semiboldSubheadline,
                             compatibleWith: .wmfCappedForSFSymbols
                         ) {
                             Image(uiImage: image)
@@ -196,12 +198,12 @@ public struct WMFWhichCameFirstView: View {
                             : viewModel.localizedStrings.nextButton
                         )
                         .minimumScaleFactor(0.2)
-                        .font(Font(WMFFont.for(.semiboldSubheadline)))
+                        .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .semiboldHeadline : .semiboldSubheadline)))
                         .multilineTextAlignment(.center)
 
                         if let image = WMFSFSymbolIcon.for(
                             symbol: .chevronForward,
-                            font: .semiboldSubheadline,
+                            font: horizontalSizeClass == .regular ? .semiboldHeadline : .semiboldSubheadline,
                             compatibleWith: .wmfCappedForSFSymbols
                         ) {
                             Image(uiImage: image)
@@ -291,9 +293,11 @@ private struct ProgressDotsView: View {
 
     @ScaledMetric(relativeTo: .title3) private var scaledDotSize: CGFloat = 20
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     private var dotSize: CGFloat {
-        dynamicTypeSize <= .xLarge ? scaledDotSize : scaledDotSize(for: .xLarge)
+        let size = dynamicTypeSize <= .xLarge ? scaledDotSize : scaledDotSize(for: .xLarge)
+        return horizontalSizeClass == .regular ? size * 1.5 : size
     }
 
     private func scaledDotSize(for size: DynamicTypeSize) -> CGFloat {
@@ -302,7 +306,7 @@ private struct ProgressDotsView: View {
     }
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: horizontalSizeClass == .regular ? 12 : 8) {
             ForEach(Array(progressResults.enumerated()), id: \.offset) { index, result in
                 ZStack {
                     if let result = result {

--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Results/Articles View/WMFWhichCameFirstArticlesView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Results/Articles View/WMFWhichCameFirstArticlesView.swift
@@ -28,7 +28,7 @@ public struct WMFWhichCameFirstArticlesView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text(viewModel.sectionTitle)
-                .font(Font(WMFFont.for(.semiboldHeadline)))
+                .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .semiboldTitle3 : .semiboldHeadline)))
                 .foregroundStyle(Color(uiColor: theme.text))
 
             LazyVGrid(
@@ -165,7 +165,7 @@ private struct WMFWhichCameFirstArticleCardView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     private var imageHeight: CGFloat {
-        horizontalSizeClass == .regular ? 110 : 95
+        horizontalSizeClass == .regular ? 160 : 95
     }
 
     var body: some View {
@@ -173,7 +173,7 @@ private struct WMFWhichCameFirstArticleCardView: View {
             thumbnailArea
 
             Text(item.title)
-                .font(Font(WMFFont.for(.georgiaCallout)))
+                .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .georgiaTitle3 : .georgiaCallout)))
                 .foregroundStyle(Color(uiColor: theme.text))
                 .lineLimit(2)
                 .padding(.horizontal, 10)
@@ -182,7 +182,7 @@ private struct WMFWhichCameFirstArticleCardView: View {
 
             if let snippet = item.snippetText {
                 Text(snippet)
-                    .font(Font(WMFFont.for(.caption1)))
+                    .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .subheadline : .caption1)))
                     .foregroundStyle(Color(uiColor: theme.secondaryText))
                     .lineLimit(3)
                     .lineSpacing(1.4)

--- a/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Results/WMFWhichCameFirstResultsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Games/Which Came First/Results/WMFWhichCameFirstResultsView.swift
@@ -8,6 +8,7 @@ public struct WMFWhichCameFirstResultsView: View {
     @ObservedObject var viewModel: WMFWhichCameFirstResultsViewModel
     @ObservedObject var appEnvironment = WMFAppEnvironment.current
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     
     public init(viewModel: WMFWhichCameFirstResultsViewModel) {
         self.viewModel = viewModel
@@ -55,8 +56,10 @@ public struct WMFWhichCameFirstResultsView: View {
                             .padding(.horizontal, 16)
                         WMFWhichCameFirstArticlesView(viewModel: viewModel.articlesViewModel)
                     }
+                    .frame(maxWidth: horizontalSizeClass == .regular ? 750 : .infinity)
                     .padding(.top, headerHeight(for: height) - 123)
                     .padding(.bottom, 24)
+                    .frame(maxWidth: .infinity)
                 }
                 .zIndex(1)
             }
@@ -108,7 +111,7 @@ public struct WMFWhichCameFirstResultsView: View {
     private var scoreCard: some View {
         VStack(alignment: .center, spacing: 12) {
             Text(viewModel.scoreLabel(viewModel.score, of: viewModel.totalQuestions))
-                .font(Font(WMFFont.for(.georgiaTitle1)))
+                .font(horizontalSizeClass == .regular ? Font.custom("Georgia", size: 44) : Font(WMFFont.for(.georgiaTitle1)))
             // Specifically left as hardcoded color
                 .foregroundStyle(Color.black)
                 .multilineTextAlignment(.center)
@@ -116,14 +119,14 @@ public struct WMFWhichCameFirstResultsView: View {
                 .fixedSize(horizontal: false, vertical: true)
             
             HStack(spacing: 6) {
-                if let image = WMFSFSymbolIcon.for(symbol: .clock, font: .body) {
+                if let image = WMFSFSymbolIcon.for(symbol: .clock, font: horizontalSizeClass == .regular ? .title3 : .body) {
                     Image(uiImage: image)
                     // Specifically left as hardcoded color
                         .foregroundStyle(Color.black)
                         .accessibilityHidden(true)
                 }
                 Text(viewModel.countdownLabel(from: viewModel.nextGameCountdownString))
-                    .font(Font(WMFFont.for(.callout)).monospacedDigit())
+                    .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .title3 : .callout)).monospacedDigit())
                 // Specifically left as hardcoded color
                     .foregroundStyle(Color.black)
                     .minimumScaleFactor(0.8)
@@ -134,12 +137,12 @@ public struct WMFWhichCameFirstResultsView: View {
                 viewModel.shareScore?()
             } label: {
                 HStack(alignment: .center, spacing: 4) {
-                    if let image = WMFSFSymbolIcon.for(symbol: .squareAndArrowUp, font: .semiboldSubheadline) {
+                    if let image = WMFSFSymbolIcon.for(symbol: .squareAndArrowUp, font: horizontalSizeClass == .regular ? .semiboldHeadline : .semiboldSubheadline) {
                         Image(uiImage: image)
                             .accessibilityHidden(true)
                     }
                     Text(viewModel.shareScoreButton)
-                        .font(Font(WMFFont.for(.semiboldSubheadline)))
+                        .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .semiboldHeadline : .semiboldSubheadline)))
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 // Specifically left as hardcoded color
@@ -167,7 +170,7 @@ public struct WMFWhichCameFirstResultsView: View {
     private var statsSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text(viewModel.yourStatsTitle)
-                .font(Font(WMFFont.for(.semiboldSubheadline)))
+                .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .semiboldTitle3 : .semiboldSubheadline)))
                 .foregroundColor(Color(uiColor: theme.text))
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, 16)
@@ -253,11 +256,11 @@ public struct WMFWhichCameFirstResultsView: View {
             }
             VStack(alignment: .leading, spacing: 2) {
                 Text(value)
-                    .font(Font(WMFFont.for(.boldCallout)))
+                    .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .boldTitle1 : .boldCallout)))
                     .foregroundColor(Color(uiColor: theme.text))
                     .minimumScaleFactor(0.8)
                 Text(label)
-                    .font(Font(WMFFont.for(.caption1)))
+                    .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .body : .caption1)))
                     .foregroundColor(Color(uiColor: theme.text))
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -270,13 +273,13 @@ public struct WMFWhichCameFirstResultsView: View {
     private var loggedOutStats: some View {
         VStack(spacing: 8) {
             Text(viewModel.logInToViewStatsTitle)
-                .font(Font(WMFFont.for(.semiboldSubheadline)))
+                .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .semiboldTitle3 : .semiboldSubheadline)))
                 .foregroundColor(Color(uiColor: theme.text))
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
             
             Text(viewModel.logInToViewStatsBody)
-                .font(Font(WMFFont.for(.subheadline)))
+                .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .title3 : .subheadline)))
                 .foregroundColor(Color(uiColor: theme.text))
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
@@ -285,12 +288,12 @@ public struct WMFWhichCameFirstResultsView: View {
                 viewModel.onLogIn?()
             } label: {
                 HStack(spacing: 4) {
-                    if let image = WMFSFSymbolIcon.for(symbol: .personFilled, font: .semiboldSubheadline) {
+                    if let image = WMFSFSymbolIcon.for(symbol: .personFilled, font: horizontalSizeClass == .regular ? .semiboldTitle3 : .semiboldSubheadline) {
                         Image(uiImage: image)
                             .accessibilityHidden(true)
                     }
                     Text(viewModel.logInButton)
-                        .font(Font(WMFFont.for(.semiboldSubheadline)))
+                        .font(Font(WMFFont.for(horizontalSizeClass == .regular ? .semiboldTitle3 : .semiboldSubheadline)))
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 .foregroundColor(Color(uiColor: theme.paperBackground))


### PR DESCRIPTION
### Bug: T436776

**Phabricator:** https://phabricator.wikimedia.org/T436776

### Notes
* **Summary:** Optimizes the "Which Came First" game layout and text sizes specifically for iPad screens. Previously, text and image elements appeared too small, making the game difficult to read on larger displays.
* **Implementation:** Utilizes the `horizontalSizeClass` environment variable to conditionally scale fonts, image frames, dynamic progress dots, and view containers when rendered in a `.regular` size class.
* Retains the original `.compact` sizing constraints to ensure the iPhone baseline layout remains completely unaffected.

### Test Steps
1. Build and run the app on an iPhone simulator. Navigate to the "Which Came First" game and verify the layout remains completely unchanged.
2. Build and run the app on an iPad simulator (e.g., 11-inch or 13-inch).
3. Navigate to the "Which Came First" game.
4. Verify that the Splash Screen, Game Cards, and Results View all utilize the larger screen space with properly scaled text, buttons, and image frames.

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots

<details>
<summary><b>iPhone (No change)</b></summary>
<br>

| Before | After |
| :---: | :---: |
| <img width="350" alt="Screenshot 2026-09-03 at 3 01 11 PM" src="https://github.com/user-attachments/assets/b929847e-4cf8-461f-b487-e29b90745306" /> | <img width="350" alt="Screenshot 2026-09-03 at 3 01 11 PM" src="https://github.com/user-attachments/assets/2c5f6847-f34b-40bd-b4e3-a13a5caeabcf" /> |
| <img width="350" alt="Screenshot 2026-09-03 at 3 01 27 PM" src="https://github.com/user-attachments/assets/305a70e9-a8f2-4ebe-a327-4490f4517925" /> | <img width="350" alt="Screenshot 2026-09-03 at 3 01 27 PM" src="https://github.com/user-attachments/assets/305a70e9-a8f2-4ebe-a327-4490f4517925" /> |
| <img width="350" alt="Screenshot 2026-09-03 at 3 02 51 PM" src="https://github.com/user-attachments/assets/9bceee70-10ef-4b9d-ad56-2ac7847fe746" /> | <img width="350" alt="Screenshot 2026-09-03 at 3 02 51 PM" src="https://github.com/user-attachments/assets/9bceee70-10ef-4b9d-ad56-2ac7847fe746" /> |
| <img width="350" alt="Screenshot 2026-09-03 at 3 11 38 PM" src="https://github.com/user-attachments/assets/23984a18-22a9-47ee-91e2-c4ec441c6853" /> | <img width="350" alt="Screenshot 2026-09-03 at 3 11 38 PM" src="https://github.com/user-attachments/assets/23984a18-22a9-47ee-91e2-c4ec441c6853" /> |

</details>


<details>
<summary><b>iPad mini</b></summary>
<br>

| Before | After |
| :---: | :---: |
| <img width="350" alt="Screenshot 2026-09-03 at 5 08 37 PM" src="https://github.com/user-attachments/assets/6ce0851e-aea3-4d3b-a6ec-02b37fda416b" /> | <img width="350" alt="Screenshot 2026-09-03 at 4 51 22 PM" src="https://github.com/user-attachments/assets/96ba7d87-3764-492f-90c8-cf47b442f624" /> |
| <img width="350" alt="Screenshot 2026-09-03 at 5 08 42 PM" src="https://github.com/user-attachments/assets/8e1f2b8e-0713-4e65-9688-8d5e5e86a46f" /> | <img width="350" alt="Screenshot 2026-09-03 at 4 51 25 PM" src="https://github.com/user-attachments/assets/32ed9d4e-9555-4991-931e-e3b0406ff359" /> |
| <img width="350" alt="Screenshot 2026-09-03 at 5 08 48 PM" src="https://github.com/user-attachments/assets/4a54abee-e9bb-4205-ade3-5d9634284a74" /> | <img width="350" alt="Screenshot 2026-09-03 at 4 51 32 PM" src="https://github.com/user-attachments/assets/d9f8b742-02dc-4cd6-bbca-4b61f72b6afe" /> |
| <img width="350" alt="Screenshot 2026-09-03 at 5 09 09 PM" src="https://github.com/user-attachments/assets/a0882604-cb59-4dc7-9d9b-68d8162d6c01" /> | <img width="350" alt="Screenshot 2026-09-03 at 4 51 54 PM" src="https://github.com/user-attachments/assets/2a4ab0b3-e37f-475f-a9c0-b200775c30d3" /> |

</details>


<details>
<summary><b>iPad 11-inch</b></summary>
<br>

| Before | After |
| :---: | :---: |
| <img width="350" alt="Screenshot 2026-09-03 at 4 40 00 PM" src="https://github.com/user-attachments/assets/680b0258-54b4-45c4-aa7a-3d007a9aae75" /> | <img width="350" alt="Screenshot 2026-09-03 at 3 01 04 PM" src="https://github.com/user-attachments/assets/513659be-9277-4c7a-b1a9-f8529d5b7810" /> |
| <img width="350" alt="Screenshot 2026-09-03 at 4 40 09 PM" src="https://github.com/user-attachments/assets/b7714fa3-f82d-4ede-942b-be3abfffa851" /> | <img width="350" alt="Screenshot 2026-09-03 at 3 01 20 PM" src="https://github.com/user-attachments/assets/7af1f63a-2de6-4240-8dcb-3cb0dc26e310" /> |
| <img width="350" alt="Screenshot 2026-09-03 at 4 40 46 PM" src="https://github.com/user-attachments/assets/cfe66150-735b-49d9-a28f-33a3818ae0b4" /> | <img width="350" alt="Screenshot 2026-09-03 at 3 02 43 PM" src="https://github.com/user-attachments/assets/38dd8be6-a2b8-4a66-ad5a-fd4f7d6cd2ae" /> |
| <img width="350" alt="Screenshot 2026-09-03 at 4 41 05 PM" src="https://github.com/user-attachments/assets/bc990fc9-1776-4ddf-84b3-40c056f707b1" /> | <img width="350" alt="Screenshot 2026-09-03 at 3 11 35 PM" src="https://github.com/user-attachments/assets/240d42d4-7d28-4ba8-9be6-d351059ec88d" /> |

</details>


<details>
<summary><b>iPad 13-inch</b></summary>
<br>

| Before | After |
| :---: | :---: |
| <img width="350" alt="Screenshot 2026-09-03 at 4 39 57 PM" src="https://github.com/user-attachments/assets/768e1656-e396-455a-b4f2-3cc23b3bfc12" /> | <img width="350" alt="Screenshot 2026-09-03 at 3 01 02 PM" src="https://github.com/user-attachments/assets/59b47a64-5ba5-4c50-9814-7ca6e6f801cb" /> |
| <img width="350" alt="Screenshot 2026-09-03 at 4 40 06 PM" src="https://github.com/user-attachments/assets/b318b57c-b388-42b4-b95d-f3b6e96533f3" /> | <img width="350" alt="Screenshot 2026-09-03 at 3 01 16 PM" src="https://github.com/user-attachments/assets/e2fed5a6-7f29-49e8-8ebd-10fd0302ec28" /> |
| <img width="350" alt="Screenshot 2026-09-03 at 4 40 43 PM" src="https://github.com/user-attachments/assets/5de3f19d-88f3-4aff-bbcb-650a1d338572" /> | <img width="350" alt="Screenshot 2026-09-03 at 3 02 40 PM" src="https://github.com/user-attachments/assets/9403f3d6-08b0-455d-96a2-91f0140327c9" /> |
| <img width="350" alt="Screenshot 2026-09-03 at 4 41 03 PM" src="https://github.com/user-attachments/assets/de4c9371-d10c-436a-9ef0-20578aea63f6" /> | <img width="350" alt="Screenshot 2026-09-03 at 3 11 22 PM" src="https://github.com/user-attachments/assets/64b4604b-867a-4ea2-ae5a-c65ec949da3a" /> |

</details>