### PR TITLE
T436967: Remove the donation reminder feature flag

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
@@ -51,7 +51,6 @@ struct WMFDeveloperSettingsView: View {
             }
 
             Section {
-                Toggle("Enable Donation Reminder", isOn: $viewModel.enableDonationReminder)
                 Toggle("Bypass Reminder Daily Limit", isOn: $viewModel.bypassDonationReminderDailyLimit)
                 Toggle("Force Fundraising Campaign Banner", isOn: $viewModel.forceFundraisingCampaignBanner)
                 Toggle("Use Test Wiki Donate Configs", isOn: $viewModel.useTestWikiDonateConfigs)

--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -67,12 +67,6 @@ import WMFData
         }
     }
 
-    @Published public var enableDonationReminder: Bool = WMFDeveloperSettingsDataController.shared.enableDonationReminder {
-        didSet {
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = enableDonationReminder
-        }
-    }
-
     @Published public var forceDonationReminderExperimentAssignment: WMFDonationReminderDataController.ExperimentAssignment? = WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment {
         didSet {
             WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = forceDonationReminderExperimentAssignment

--- a/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
@@ -201,12 +201,6 @@ public protocol WMFDeveloperSettingsDataControlling: AnyObject {
         WMFDonationReminderDataController.shared.clearExperimentAssignment()
     }
 
-    /// Feature flag for the Donation Reminder experiment
-    public var enableDonationReminder: Bool {
-        get { (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.developerSettingsEnableDonationReminder.rawValue)) ?? false }
-        set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.developerSettingsEnableDonationReminder.rawValue, value: newValue) }
-    }
-
     /// Debugging convenience: overrides the persisted donation reminder experiment bucket at read
     /// time without re-rolling it. Nil means no override.
     public var forceDonationReminderExperimentAssignment: WMFDonationReminderDataController.ExperimentAssignment? {

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
@@ -138,10 +138,6 @@ public final class WMFDonationReminderDataController {
     }
 
     public func isReminderSettingsEntryAvailable(currentDate: Date = Date()) -> Bool {
-        guard WMFDeveloperSettingsDataController.shared.enableDonationReminder else {
-            return false
-        }
-
         switch experimentAssignment {
         case .groupB, .groupC:
             break
@@ -164,8 +160,7 @@ public final class WMFDonationReminderDataController {
     }
 
     public func shouldShowFollowUpReminder(currentDate: Date = Date()) async throws -> Bool {
-        guard WMFDeveloperSettingsDataController.shared.enableDonationReminder,
-              let reminder = loadReminder(),
+        guard let reminder = loadReminder(),
               reminder.isEnabled,
               currentDate < Self.reminderEndDate,
               case .articlesRead(count: let articlesReadGoal) = reminder.trigger else {

--- a/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Donor Experience/WMFDonationReminderDataController.swift
@@ -95,7 +95,7 @@ public final class WMFDonationReminderDataController {
 
     public static let shared = WMFDonationReminderDataController()
 
-    public static let experimentCampaignID = "NL_2026_08"
+    public static let experimentCampaignID = "NL_2026_09"
 
     public static let experimentPresetAmounts: [Decimal] = [1, 3, 5]
 

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -46,7 +46,6 @@ public enum WMFUserDefaultsKey: String {
     case developerSettingsForceFundraisingCampaignBanner = "dev-settings-force-fundraising-campaign-banner"
     case developerSettingsUseTestWikiDonateConfigs = "dev-settings-use-test-wiki-donate-configs"
     case developerSettingsUseHardcodedPaymentMethods = "dev-settings-use-hardcoded-payment-methods"
-    case developerSettingsEnableDonationReminder = "dev-settings-enable-donation-reminder"
     case developerSettingsForceDonationReminderExperimentAssignment = "dev-settings-force-donation-reminder-experiment-assignment"
     case developerSettingsBypassDonationReminderDailyLimit = "dev-settings-bypass-donation-reminder-daily-limit"
     case donationReminder = "donation-reminder"

--- a/WMFData/Tests/WMFDataTests/WMFDonationReminderDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFDonationReminderDataControllerTests.swift
@@ -92,21 +92,17 @@ final class WMFDonationReminderDataControllerTests {
     }
 
     @Test
-    func shouldShowFollowUpReminderRequiresFeatureFlagEnabledReminderAndGoal() async throws {
+    func shouldShowFollowUpReminderRequiresReminderAndGoal() async throws {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironmentWithCoreData) {
             let createdDate = Date(timeIntervalSince1970: 1_755_600_000)
             let currentDate = createdDate.addingTimeInterval(1_000)
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 2), amount: 3, currencyCode: "EUR", createdDate: createdDate, isEnabled: true))
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
 
             try await addQualifyingPageView(title: "First", timestamp: createdDate.addingTimeInterval(100))
             #expect(try await controller.shouldShowFollowUpReminder(currentDate: currentDate) == false)
 
             try await addQualifyingPageView(title: "Second", timestamp: createdDate.addingTimeInterval(200))
             #expect(try await controller.shouldShowFollowUpReminder(currentDate: currentDate) == true)
-
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = false
-            #expect(try await controller.shouldShowFollowUpReminder(currentDate: currentDate) == false)
         }
     }
 
@@ -115,7 +111,6 @@ final class WMFDonationReminderDataControllerTests {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironmentWithCoreData) {
             let createdDate = Date(timeIntervalSince1970: 1_755_600_000)
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 1), amount: 3, currencyCode: "EUR", createdDate: createdDate, isEnabled: false))
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
 
             try await addQualifyingPageView(title: "First", timestamp: createdDate.addingTimeInterval(100))
 
@@ -128,7 +123,6 @@ final class WMFDonationReminderDataControllerTests {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironmentWithCoreData) {
             let createdDate = Date(timeIntervalSince1970: 1_755_600_000)
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 1), amount: 3, currencyCode: "EUR", createdDate: createdDate, isEnabled: true))
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
 
             try await addQualifyingPageView(title: "First", timestamp: createdDate.addingTimeInterval(100))
             #expect(try await controller.shouldShowFollowUpReminder(currentDate: createdDate.addingTimeInterval(1_000)) == true)
@@ -147,7 +141,6 @@ final class WMFDonationReminderDataControllerTests {
             let createdDate = Date(timeIntervalSince1970: 1_755_600_000)
             let nextDay = createdDate.addingTimeInterval(100_000)
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 1), amount: 3, currencyCode: "EUR", createdDate: createdDate, isEnabled: true))
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
 
             controller.recordFollowUpReminderShown(currentDate: createdDate.addingTimeInterval(1_000))
 
@@ -170,7 +163,6 @@ final class WMFDonationReminderDataControllerTests {
             let secondDay = createdDate.addingTimeInterval(100_000)
             let thirdDay = createdDate.addingTimeInterval(200_000)
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 1), amount: 3, currencyCode: "EUR", createdDate: createdDate, isEnabled: true))
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
 
             controller.recordFollowUpReminderShown(currentDate: createdDate.addingTimeInterval(1_000))
             controller.recordFollowUpReminderShown(currentDate: secondDay)
@@ -218,7 +210,6 @@ final class WMFDonationReminderDataControllerTests {
             let createdDate = Date(timeIntervalSince1970: 1_755_600_000)
             let nextDay = createdDate.addingTimeInterval(100_000)
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 1), amount: 3, currencyCode: "EUR", createdDate: createdDate, isEnabled: true))
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
 
             let firstShownDate = createdDate.addingTimeInterval(1_000)
             controller.recordFollowUpReminderShown(currentDate: firstShownDate)
@@ -244,7 +235,6 @@ final class WMFDonationReminderDataControllerTests {
             let secondDay = createdDate.addingTimeInterval(100_000)
             let thirdDay = createdDate.addingTimeInterval(200_000)
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 1), amount: 3, currencyCode: "EUR", createdDate: createdDate, isEnabled: true))
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
 
             controller.recordFollowUpReminderShown(currentDate: createdDate.addingTimeInterval(1_000))
             controller.recordFollowUpReminderShown(currentDate: secondDay)
@@ -260,7 +250,6 @@ final class WMFDonationReminderDataControllerTests {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironmentWithCoreData) {
             let createdDate = Date(timeIntervalSince1970: 1_755_600_000)
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 1), amount: 3, currencyCode: "EUR", createdDate: createdDate, isEnabled: true))
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
 
             try await addQualifyingPageView(title: "First", timestamp: createdDate.addingTimeInterval(100))
 
@@ -278,7 +267,6 @@ final class WMFDonationReminderDataControllerTests {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironmentWithCoreData) {
             let createdDate = Date(timeIntervalSince1970: 1_755_600_000)
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 1), amount: 3, currencyCode: "EUR", createdDate: createdDate, isEnabled: true))
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
 
             try await addQualifyingPageView(title: "First", timestamp: createdDate.addingTimeInterval(100))
 
@@ -289,21 +277,6 @@ final class WMFDonationReminderDataControllerTests {
             let secondClaim = try await controller.claimFollowUpReminderImpression(currentDate: claimedDate.addingTimeInterval(100))
             #expect(secondClaim == nil)
             #expect(controller.loadReminder()?.timesReminderShown == 1)
-        }
-    }
-
-    @Test
-    func claimReturnsNilWhenTheFeatureFlagIsDisabled() async throws {
-        try await fixture.withConfiguredEnvironment(configure: configureEnvironmentWithCoreData) {
-            let createdDate = Date(timeIntervalSince1970: 1_755_600_000)
-            controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 1), amount: 3, currencyCode: "EUR", createdDate: createdDate, isEnabled: true))
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = false
-
-            try await addQualifyingPageView(title: "First", timestamp: createdDate.addingTimeInterval(100))
-
-            let claim = try await controller.claimFollowUpReminderImpression(currentDate: createdDate.addingTimeInterval(1_000))
-            #expect(claim == nil)
-            #expect(controller.loadReminder()?.timesReminderShown == 0)
         }
     }
 
@@ -524,21 +497,8 @@ final class WMFDonationReminderDataControllerTests {
     }
 
     @Test
-    func settingsEntryUnavailableWhenFeatureFlagIsOff() async {
-        await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
-            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .groupB
-            controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 5), amount: 1, currencyCode: "EUR", createdDate: Date(), isEnabled: true))
-
-            #expect(controller.isReminderSettingsEntryAvailable() == false)
-
-            WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = nil
-        }
-    }
-
-    @Test
     func settingsEntryUnavailableForControlAssignment() async {
         await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
             WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .control
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 5), amount: 1, currencyCode: "EUR", createdDate: Date(), isEnabled: true))
 
@@ -551,7 +511,6 @@ final class WMFDonationReminderDataControllerTests {
     @Test
     func settingsEntryAvailableWithoutSavedReminder() async {
         await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
             WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .groupB
 
             #expect(controller.isReminderSettingsEntryAvailable())
@@ -563,7 +522,6 @@ final class WMFDonationReminderDataControllerTests {
     @Test
     func settingsEntryAvailableForTreatmentGroupWithSavedReminder() async {
         await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
             WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .groupB
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 5), amount: 1, currencyCode: "EUR", createdDate: Date(), isEnabled: true))
 
@@ -576,7 +534,6 @@ final class WMFDonationReminderDataControllerTests {
     @Test
     func settingsEntryStopsAtReminderEndDate() async {
         await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
             WMFDeveloperSettingsDataController.shared.forceDonationReminderExperimentAssignment = .groupC
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 5), amount: 1, currencyCode: "EUR", createdDate: Date(timeIntervalSince1970: 1_700_000_000), isEnabled: true))
 
@@ -591,7 +548,6 @@ final class WMFDonationReminderDataControllerTests {
     @Test
     func followUpReminderStopsAtReminderEndDate() async throws {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironmentWithCoreData) {
-            WMFDeveloperSettingsDataController.shared.enableDonationReminder = true
             let endDate = WMFDonationReminderDataController.reminderEndDate
             let progress = WMFDonationReminder.Progress(currentCycleStartDate: endDate.addingTimeInterval(-172_800), timesReminderShown: 1)
             controller.saveReminder(WMFDonationReminder(trigger: .articlesRead(count: 5), amount: 1, currencyCode: "EUR", createdDate: endDate.addingTimeInterval(-864_000), isEnabled: true, progress: progress))

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -49,7 +49,7 @@ extension ArticleViewController {
                     #endif
                 }
 
-                if WMFDonationReminderDataController.shared.experimentAssignment != nil {
+                if experimentAssignment != nil {
                     donateSource = .donationReminderCampaignModal(articleURL, activeCampaignAsset.metricsID, donateURL)
                 }
             }

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -117,7 +117,7 @@ extension ArticleViewController {
                 return
             }
 
-            if WMFDeveloperSettingsDataController.shared.enableDonationReminder {
+            if case .donationReminderCampaignModal = source {
                 DonateFunnel.shared.logDonationReminderCampaignModalDidTapDonate(project: project, metricsID: metricsID)
             } else {
                 DonateFunnel.shared.logFundraisingCampaignModalDidTapDonate(project: project, metricsID: metricsID)
@@ -161,7 +161,7 @@ extension ArticleViewController {
                 dataController.markAssetAsPermanentlyHidden(asset: asset)
             case .maybeLater:
                 let experimentAssignment: WMFDonationReminderDataController.ExperimentAssignment?
-                if WMFDeveloperSettingsDataController.shared.enableDonationReminder {
+                if case .donationReminderCampaignModal = source {
                     experimentAssignment = WMFDonationReminderDataController.shared.experimentAssignment
                 } else {
                     experimentAssignment = nil
@@ -180,7 +180,11 @@ extension ArticleViewController {
                     coordinator.start()
                 } else {
                     dataController.markAssetAsMaybeLater(asset: asset, currentDate: Date())
-                    self.donateDidSetMaybeLater(metricsID: metricsID)
+                    var isDonationReminderCampaign = false
+                    if case .donationReminderCampaignModal = source {
+                        isDonationReminderCampaign = true
+                    }
+                    self.donateDidSetMaybeLater(metricsID: metricsID, isDonationReminderCampaign: isDonationReminderCampaign)
                 }
             case .donate, .alreadyDonated, .other:
                 break
@@ -197,14 +201,14 @@ extension ArticleViewController {
     }
     #endif
 
-    func donateDidSetMaybeLater(metricsID: String) {
+    func donateDidSetMaybeLater(metricsID: String, isDonationReminderCampaign: Bool) {
 
         let project = WikimediaProject(siteURL: articleURL)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             let title = WMFLocalizedString("donate-later-title", value: "We will remind you again tomorrow.", comment: "Title for toast shown when user clicks remind me later on fundraising banner")
 
             if let project {
-                if WMFDeveloperSettingsDataController.shared.enableDonationReminder {
+                if isDonationReminderCampaign {
                     DonateFunnel.shared.logDonationReminderMaybeLaterToastImpression(project: project, metricsID: metricsID)
                 } else {
                     DonateFunnel.shared.logArticleDidSeeReminderToast(project: project, metricsID: metricsID)

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -67,7 +67,7 @@ extension ArticleViewController {
             }
 
             let isFirstAppSession = UserDefaults.standard.wmf_appResignActiveDate() == nil
-            let hasDonationReminderOutcome = WMFDeveloperSettingsDataController.shared.enableDonationReminder && WMFDonationReminderDataController.shared.loadReminder() != nil
+            let hasDonationReminderOutcome = WMFDonationReminderDataController.shared.loadReminder() != nil && Date() < WMFDonationReminderDataController.reminderEndDate
 
             guard (isOptedIn && !userDonatedWithinLast250Days() && !isFirstAppSession && !hasDonationReminderOutcome) || isForcingBannerForDevelopment else {
                 willDisplayCampaignModal = false

--- a/Wikipedia/Code/ArticleViewController+Announcements.swift
+++ b/Wikipedia/Code/ArticleViewController+Announcements.swift
@@ -29,20 +29,18 @@ extension ArticleViewController {
             }
             
             guard let donateURL =  activeCampaignAsset.actions[0].url else {
+                willDisplayCampaignModal = false
+                onNothingShown?()
                 return
             }
-            
+
             var donateSource: DonateCoordinator.Source = .articleCampaignModal(articleURL, activeCampaignAsset.metricsID, donateURL)
-            
+
             // Setup donation reminder experiment if needed
-            if WMFDeveloperSettingsDataController.shared.enableDonationReminder {
-                
-                guard activeCampaignAsset.id == WMFDonationReminderDataController.experimentCampaignID else {
-                    return
-                }
-                
+            if activeCampaignAsset.id == WMFDonationReminderDataController.experimentCampaignID {
+
                 let neededAssignment = WMFDonationReminderDataController.shared.needsExperimentAssignment
-                
+
                 let experimentAssignment = try? WMFDonationReminderDataController.shared.assignExperimentIfNeeded(campaignID: activeCampaignAsset.id, campaignCurrencyCode: activeCampaignAsset.currencyCode)
                 if let experimentAssignment, neededAssignment {
                     DonateFunnel.shared.logDonationReminderGroupAssigned(experimentAssignment, project: wikimediaProject)
@@ -50,14 +48,15 @@ extension ArticleViewController {
                     showDebugExperimentAssignmentToast(experimentAssignment)
                     #endif
                 }
-                
-                if WMFDeveloperSettingsDataController.shared.enableDonationReminder,
-                   activeCampaignAsset.id == WMFDonationReminderDataController.experimentCampaignID {
+
+                if WMFDonationReminderDataController.shared.experimentAssignment != nil {
                     donateSource = .donationReminderCampaignModal(articleURL, activeCampaignAsset.metricsID, donateURL)
                 }
             }
-            
+
             guard let metricsID = DonateCoordinator.metricsID(for: donateSource, languageCode: nil) else {
+                willDisplayCampaignModal = false
+                onNothingShown?()
                 return
             }
 

--- a/Wikipedia/Code/ArticleViewController+DonationReminder.swift
+++ b/Wikipedia/Code/ArticleViewController+DonationReminder.swift
@@ -30,7 +30,7 @@ extension ArticleViewController {
     func removeDonationReminderCardIfNeeded() {
         isShowingDonateFlowFromDonationReminderCard = false
 
-        if !WMFDeveloperSettingsDataController.shared.enableDonationReminder || WMFDonationReminderDataController.shared.isFollowUpReminderWindowClosed {
+        if WMFDonationReminderDataController.shared.isFollowUpReminderWindowClosed {
             messagingController.removeDonationReminderCard()
         }
     }

--- a/Wikipedia/Code/DonationReminderSetupCoordinator.swift
+++ b/Wikipedia/Code/DonationReminderSetupCoordinator.swift
@@ -30,7 +30,7 @@ final class DonationReminderSetupCoordinator: Coordinator {
             guard let languageCode else {
                 return nil
             }
-            return WikimediaProject(wmfProject: WMFProject.wikipedia(WMFLanguage(languageCode: languageCode, languageVariantCode: languageCode)))
+            return WikimediaProject(wmfProject: WMFProject.wikipedia(WMFLanguage(languageCode: languageCode, languageVariantCode: nil)))
         case .settings:
             return nil
         }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T436967

### Notes
* Removes the `enableDonationReminder` developer settings flag. There is no remote flag, so this is what turns the experiment on in production — the campaign config (id + date window) becomes the only gate.
* Updates `experimentCampaignID` to `NL_2026_09`
* Campaigns outside the experiment now fall through to the regular banner flow instead of being suppressed (follow-up to the #6161 review discussion). The donate source only switches to the experiment flow when an assignment exists, so a failed assignment still shows the regular banner.
* The banner suppression for experiment participants is now bounded by `reminderEndDate`. Without this, anyone who took part in the experiment (including opt-outs, since "No thanks" also saves a reminder) would never see a campaign banner again after the experiment ends.
* Event logging that used the flag to pick between experiment and legacy events now picks by donate source. Same events, updated condition: a post-experiment campaign logs the legacy events instead of the experiment ones.
* Also fixes the language variant passed to the setup event project (was the language code). No behavior change.

### Test Steps
1. Turn on **Use Test Wiki Donate Configs** and **Force Fundraising Campaign Banner**, then open an article: the NL_2026_09 banner shows, the experiment assigns once (`group_assigned`), and banner events carry `..._reminderX_iOS` campaign IDs. (only works after the campaign exists - 2 days from now?)
2. Point `experimentCampaignID` at a non-experiment campaign locally and repeat: the regular banner flow shows and the legacy events log with the plain campaign ID.


### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
n/a