### PR TITLE
T436987: Size the reminder setup tooltip to its text on iPad

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupView.swift
@@ -9,6 +9,8 @@ struct WMFDonationReminderSetupView: View {
 
     private let customAmountErrorIdentifier = "custom-amount-error"
 
+    @ScaledMetric private var triggerDetailPopoverWidth: CGFloat = 240
+
     var body: some View {
         VStack(spacing: 0) {
             ScrollViewReader { scrollProxy in
@@ -105,7 +107,7 @@ struct WMFDonationReminderSetupView: View {
                         .multilineTextAlignment(.leading)
                         .fixedSize(horizontal: false, vertical: true)
                         .padding()
-                        .frame(maxWidth: 240)
+                        .frame(width: triggerDetailPopoverWidth)
                         .presentationCompactAdaptation(.popover)
                         .presentationBackground(Color(theme.popoverBackground))
                 }

--- a/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Donation Reminder/WMFDonationReminderSetupView.swift
@@ -9,7 +9,12 @@ struct WMFDonationReminderSetupView: View {
 
     private let customAmountErrorIdentifier = "custom-amount-error"
 
-    @ScaledMetric private var triggerDetailPopoverWidth: CGFloat = 240
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @ScaledMetric private var scaledTriggerDetailPopoverWidth: CGFloat = 240
+
+    private var triggerDetailPopoverWidth: CGFloat {
+        horizontalSizeClass == .regular ? scaledTriggerDetailPopoverWidth : 240
+    }
 
     var body: some View {
         VStack(spacing: 0) {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T436987

### Notes
* The info popover next to "Whenever I read" clipped its text on iPad at accessibility text sizes. The content used `.frame(maxWidth: 240)`, so the popover measured the text as a single line and got a one-line height while the text wrapped inside it.
* The popover now uses a fixed width, so the text wraps at a known width and the popover height follows it.
* In the regular horizontal size class (iPad in full screen) the width is a `@ScaledMetric` (240pt at the default text size) that grows with Dynamic Type, which keeps long words from breaking mid-word at the larger accessibility sizes.
* In the compact size class (iPhone, and iPad in Split View) the width stays at 240pt, so it never exceeds the screen. The size class is read on the parent view, since the popover content itself always reports compact on iPad.

### Test Steps
1. In Developer settings, turn on **Use Test Wiki Donate Configs** and **Force Fundraising Campaign Banner**, and set **Force Reminder Experiment Group** to Group B.
2. On an iPad simulator, open an English article, tap **Maybe later**, then tap the ⓘ next to "Whenever I read". The popover shows the full text.
3. Set the simulator text size to the largest accessibility size (`xcrun simctl ui <udid> content_size accessibility-extra-extra-extra-large`) and tap ⓘ again. Before this change the text was cut off; now the popover is wider and shows all of it.
4. Repeat on iPhone at the largest accessibility size: the popover keeps its 240pt width, wraps into more lines, and is not clipped horizontally.
5. Set both simulators back to the default size (`content_size large`) and confirm the popover looks the same as before the change.

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
<img width="40%" alt="Simulator Screenshot - iPad Air 11-inch (M3) - 2026-09-03 at 16 46 39" src="https://github.com/user-attachments/assets/48ffcc1a-11a4-43e7-9524-d4a7fc386cb6" />
<img width="40%" alt="Simulator Screenshot - iPhone 17 - 2026-09-03 at 16 46 44" src="https://github.com/user-attachments/assets/a6333bdc-e6e6-4ab5-bb4e-c3ec94538d71" />
