### PR TITLE
Run database housekeeping on launch, off the main thread

### DIFF
--- a/WMFData/Sources/WMFData/Store/WMFCoreDataStore.swift
+++ b/WMFData/Sources/WMFData/Store/WMFCoreDataStore.swift
@@ -153,6 +153,9 @@ public final class WMFCoreDataStore: @unchecked Sendable {
         }
     }
 
+    /// The maximum number of records that one housekeeping step deletes.
+    private static let housekeepingFetchLimit = 2000
+
     public func performDatabaseHousekeeping() async throws {
 
         let currentYear = Calendar.current.component(.year, from: Date())
@@ -175,12 +178,10 @@ public final class WMFCoreDataStore: @unchecked Sendable {
                 // Delete CDPageViews that were added > one year ago
                 let timestamp = NSPredicate(format: "timestamp < %@", argumentArray: [oneYearAgoDate])
 
-                guard let pageViewsToDelete = try self.fetch(entityType: CDPageView.self, predicate: timestamp, fetchLimit: 2000, in: backgroundContext) else {
-                    return
-                }
-
-                for pageView in pageViewsToDelete {
-                    backgroundContext.delete(pageView)
+                if let pageViewsToDelete = try self.fetch(entityType: CDPageView.self, predicate: timestamp, fetchLimit: Self.housekeepingFetchLimit, in: backgroundContext) {
+                    for pageView in pageViewsToDelete {
+                        backgroundContext.delete(pageView)
+                    }
                 }
 
                 let emptyPageViewsPredicate = NSPredicate(format: "pageViews.@count == 0")
@@ -193,32 +194,26 @@ public final class WMFCoreDataStore: @unchecked Sendable {
                 let compoundPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [timestamp, emptyPageViewsPredicate, emptyArticleTabItemsPredicate, savedPageInfoPredicate, pageInterestPredicate])
 
                 // Delete CDPages that have no page views, no article tab items, no saved info, no interest, and were added > one year ago
-                guard let pagesToDelete = try self.fetch(entityType: CDPage.self, predicate: compoundPredicate, fetchLimit: 2000, in: backgroundContext) else {
-                    return
-                }
-
-                for page in pagesToDelete {
-                    backgroundContext.delete(page)
+                if let pagesToDelete = try self.fetch(entityType: CDPage.self, predicate: compoundPredicate, fetchLimit: Self.housekeepingFetchLimit, in: backgroundContext) {
+                    for page in pagesToDelete {
+                        backgroundContext.delete(page)
+                    }
                 }
 
                 // Delete CDPageInterests that lost their page. These are unreachable to callers, and leaving one behind would fail every future save
                 let orphanedPagePredicate = NSPredicate(format: "page == nil")
-                guard let interestsToDelete = try self.fetch(entityType: CDPageInterest.self, predicate: orphanedPagePredicate, fetchLimit: nil, in: backgroundContext) else {
-                    return
-                }
-
-                for interest in interestsToDelete {
-                    backgroundContext.delete(interest)
+                if let interestsToDelete = try self.fetch(entityType: CDPageInterest.self, predicate: orphanedPagePredicate, fetchLimit: Self.housekeepingFetchLimit, in: backgroundContext) {
+                    for interest in interestsToDelete {
+                        backgroundContext.delete(interest)
+                    }
                 }
 
                 // Delete CDCategorys that have empty pages
                 let emptyPagesPredicate = NSPredicate(format: "pages.@count == 0")
-                guard let categoriesToDelete = try self.fetch(entityType: CDCategory.self, predicate: emptyPagesPredicate, fetchLimit: nil, in: backgroundContext) else {
-                    return
-                }
-
-                for category in categoriesToDelete {
-                    backgroundContext.delete(category)
+                if let categoriesToDelete = try self.fetch(entityType: CDCategory.self, predicate: emptyPagesPredicate, fetchLimit: Self.housekeepingFetchLimit, in: backgroundContext) {
+                    for category in categoriesToDelete {
+                        backgroundContext.delete(category)
+                    }
                 }
 
                 try self.saveIfNeeded(moc: backgroundContext)

--- a/Wikipedia/Code/AppDelegate.swift
+++ b/Wikipedia/Code/AppDelegate.swift
@@ -121,28 +121,54 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func registerBackgroundTasks() {
 
         BGTaskScheduler.shared.register(forTaskWithIdentifier: Self.backgroundAppRefreshTaskIdentifier, using: .main) { [weak self] task in
+            let completion = BackgroundTaskCompletion(task: task)
+
+            // iOS stops the app if the task uses all of its time and reports no completion.
+            task.expirationHandler = {
+                completion.complete(success: false)
+            }
+
             self?.appViewController.performBackgroundFetch { [weak self] result in
-                switch result {
-                case .failed:
-                    task.setTaskCompleted(success: false)
-                default:
-                    task.setTaskCompleted(success: true)
-                }
-                
+                completion.complete(success: result != .failed)
                 self?.scheduleBackgroundAppRefreshTask()
             }
         }
         
         BGTaskScheduler.shared.register(forTaskWithIdentifier: Self.backgroundDatabaseHousekeeperTaskIdentifier, using: .main) { [weak self] task in
+            let completion = BackgroundTaskCompletion(task: task)
+
+            // iOS stops the app if the task uses all of its time and reports no completion.
+            task.expirationHandler = { [weak self] in
+                self?.appViewController.cancelDatabaseHousekeeping()
+                completion.complete(success: false)
+            }
+
             self?.appViewController.performDatabaseHousekeeping { error in
-                
-                if error != nil {
-                    task.setTaskCompleted(success: false)
-                } else {
-                    task.setTaskCompleted(success: true)
-                }
+                completion.complete(success: error == nil)
             }
         }
+    }
+}
+
+/// Reports the completion of a background task one time only.
+///
+/// iOS stops the app if the code reports completion two times. Both the expiration handler
+/// and the work of the task can report completion, thus the code must count the reports.
+/// The task uses the main queue, therefore this class needs no lock.
+private final class BackgroundTaskCompletion {
+    private let task: BGTask
+    private var isComplete = false
+
+    init(task: BGTask) {
+        self.task = task
+    }
+
+    func complete(success: Bool) {
+        guard !isComplete else {
+            return
+        }
+        isComplete = true
+        task.setTaskCompleted(success: success)
     }
 }
 #endif

--- a/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
+++ b/Wikipedia/Code/NSUserDefaults+WMFExtensions.swift
@@ -39,6 +39,10 @@ public let WMFAlwaysDisplayEditNotices = "WMFAlwaysDisplayEditNotices"
 let WMFSessionBackgroundDate =  "WMFSessionBackgroundDate"
 let WMFSessionStartDate =  "WMFSessionStartDate"
 let WMFYearToSessionSecondsMapping =  "WMFYearToSessionSecondsMapping"
+let WMFLastDatabaseHousekeepingDate = "WMFLastDatabaseHousekeepingDate"
+
+/// The minimum time between two database housekeeping passes.
+public let WMFDatabaseHousekeepingInterval: TimeInterval = 60 * 60 * 12
 
 @objc public enum WMFAppDefaultTabType: Int {
     case explore
@@ -495,6 +499,24 @@ let WMFYearToSessionSecondsMapping =  "WMFYearToSessionSecondsMapping"
         }
     }
     
+    /// The time of the last completed database housekeeping pass.
+    @objc var wmf_lastDatabaseHousekeepingDate: Date? {
+        get {
+            return object(forKey: WMFLastDatabaseHousekeepingDate) as? Date
+        }
+        set {
+            set(newValue, forKey: WMFLastDatabaseHousekeepingDate)
+        }
+    }
+
+    /// True if sufficient time went by after the last completed pass.
+    @objc var wmf_shouldPerformDatabaseHousekeeping: Bool {
+        guard let lastDate = wmf_lastDatabaseHousekeepingDate else {
+            return true
+        }
+        return Date().timeIntervalSince(lastDate) >= WMFDatabaseHousekeepingInterval
+    }
+
     @objc var wmf_sessionStartTimestamp: Date? {
         get {
             return object(forKey: WMFSessionStartDate) as? Date

--- a/Wikipedia/Code/SettingsCoordinator.swift
+++ b/Wikipedia/Code/SettingsCoordinator.swift
@@ -205,12 +205,13 @@ final class SettingsCoordinator: Coordinator, SettingsCoordinatorDelegate {
 
         let databaseHousekeeper = WMFDatabaseHousekeeper()
         let navigationStateController = NavigationStateController(dataStore: dataStore)
+        let excludedArticleKeys = databaseHousekeeper.articleKeysToPreserve(in: dataStore, navigationStateController: navigationStateController)
 
         var cleanupError: Error? = nil
 
         self.dataStore.performBackgroundCoreDataOperation { moc in
             do {
-                try databaseHousekeeper.performHousekeepingOnManagedObjectContext(moc, navigationStateController: navigationStateController, cleanupLevel: .high)
+                try databaseHousekeeper.performHousekeeping(on: moc, excludedArticleKeys: excludedArticleKeys, cleanupLevel: .high)
 
             } catch {
                 cleanupError = error

--- a/Wikipedia/Code/SettingsCoordinator.swift
+++ b/Wikipedia/Code/SettingsCoordinator.swift
@@ -207,9 +207,9 @@ final class SettingsCoordinator: Coordinator, SettingsCoordinatorDelegate {
         let navigationStateController = NavigationStateController(dataStore: dataStore)
         let excludedArticleKeys = databaseHousekeeper.articleKeysToPreserve(in: dataStore, navigationStateController: navigationStateController)
 
-        var cleanupError: Error? = nil
-
         self.dataStore.performBackgroundCoreDataOperation { moc in
+            var cleanupError: Error?
+
             do {
                 try databaseHousekeeper.performHousekeeping(on: moc, excludedArticleKeys: excludedArticleKeys, cleanupLevel: .high)
 
@@ -217,23 +217,24 @@ final class SettingsCoordinator: Coordinator, SettingsCoordinatorDelegate {
                 cleanupError = error
                 DDLogError("Error on cleanup: \(error)")
             }
-        }
 
-        SharedContainerCacheHousekeeping.deleteStaleCachedItems(
-            in: SharedContainerCacheCommonNames.talkPageCache,
-            cleanupLevel: .high
-        )
-        SharedContainerCacheHousekeeping.deleteStaleCachedItems(
-            in: SharedContainerCacheCommonNames.didYouKnowCache,
-            cleanupLevel: .high
-        )
+            // These functions read and delete files. Keep them off the main thread.
+            SharedContainerCacheHousekeeping.deleteStaleCachedItems(
+                in: SharedContainerCacheCommonNames.talkPageCache,
+                cleanupLevel: .high
+            )
+            SharedContainerCacheHousekeeping.deleteStaleCachedItems(
+                in: SharedContainerCacheCommonNames.didYouKnowCache,
+                cleanupLevel: .high
+            )
 
-        Task {
-            try await Task.sleep(nanoseconds: 1_000_000_000)
-            if cleanupError != nil {
-                self.showClearCacheErrorBanner()
+            // Show the result after the work ends. A delay is not a signal of completion.
+            Task { @MainActor [weak self] in
+                if cleanupError != nil {
+                    self?.showClearCacheErrorBanner()
+                }
+                self?.showClearCacheComplete()
             }
-            self.showClearCacheComplete()
         }
     }
 

--- a/Wikipedia/Code/WMFAppViewController+Extensions.swift
+++ b/Wikipedia/Code/WMFAppViewController+Extensions.swift
@@ -885,25 +885,32 @@ extension WMFAppViewController {
         WMFDataEnvironment.current.appData = WMFAppData(appLanguages: languages)
     }
 
-    @objc func performWMFDataHousekeeping() {
-        let coreDataStore = WMFDataEnvironment.current.coreDataStore
-        Task {
-            do {
-                try await coreDataStore?.performDatabaseHousekeeping()
-            } catch {
-                DDLogError("Error pruning WMFData database: \(error)")
-            }
+    /// Deletes the old WMFData records. Returns the first error, or nil after success.
+    func performWMFDataHousekeeping() async -> Error? {
+        var firstError: Error?
 
-            do {
-                let pageViewsDataController = try WMFPageViewsDataController()
-                let clampedCount = try await pageViewsDataController.clampInflatedPageViewSecondsIfNeeded()
-                if clampedCount > 0 {
-                    DDLogInfo("Clamped inflated reading time on \(clampedCount) page views.")
-                }
-            } catch {
-                DDLogError("Error clamping inflated page view seconds: \(error)")
-            }
+        let coreDataStore = WMFDataEnvironment.current.coreDataStore
+        do {
+            try await coreDataStore?.performDatabaseHousekeeping()
+        } catch {
+            firstError = error
+            DDLogError("Error pruning WMFData database: \(error)")
         }
+
+        do {
+            let pageViewsDataController = try WMFPageViewsDataController()
+            let clampedCount = try await pageViewsDataController.clampInflatedPageViewSecondsIfNeeded()
+            if clampedCount > 0 {
+                DDLogInfo("Clamped inflated reading time on \(clampedCount) page views.")
+            }
+        } catch {
+            if firstError == nil {
+                firstError = error
+            }
+            DDLogError("Error clamping inflated page view seconds: \(error)")
+        }
+
+        return firstError
     }
 
     @objc func deleteYearInReviewPersonalizedNetworkData() {

--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -79,6 +79,9 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
     
     private var isWaitingToResumeApp: Bool = false
     private var isMigrationComplete: Bool = false
+
+    /// The task that prunes the WMFData database. Keep it, to let the caller stop it.
+    private var wmfDataHousekeepingTask: Task<Error?, Never>?
     private var isMigrationActive: Bool = false
     private var isResumeComplete: Bool = false
     private var isCheckingRemoteConfig: Bool = false
@@ -763,6 +766,11 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
     /// The time to wait after the app becomes active.
     private static let databaseHousekeepingLaunchDelay: UInt64 = 5 * NSEC_PER_SEC
 
+    /// Stops the WMFData prune. The legacy pass has no stop point, thus it runs to the end.
+    func cancelDatabaseHousekeeping() {
+        wmfDataHousekeepingTask?.cancel()
+    }
+
     func performDatabaseHousekeeping(completion: @escaping (Error?) -> Void) {
         let housekeeper = WMFDatabaseHousekeeper()
 
@@ -784,13 +792,23 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
             SharedContainerCacheHousekeeping.deleteStaleCachedItems(in: SharedContainerCacheCommonNames.didYouKnowCache, cleanupLevel: .low)
 
             Task { @MainActor [weak self] in
-                if housekeepingError == nil {
+                guard let self else {
+                    completion(housekeepingError)
+                    return
+                }
+
+                // Wait for the WMFData prune. The caller must not report completion before it ends.
+                let wmfDataTask = Task { await self.performWMFDataHousekeeping() }
+                self.wmfDataHousekeepingTask = wmfDataTask
+                let wmfDataError = await wmfDataTask.value
+                self.wmfDataHousekeepingTask = nil
+
+                let error = housekeepingError ?? wmfDataError
+                if error == nil {
                     UserDefaults.standard.wmf_lastDatabaseHousekeepingDate = Date()
                 }
 
-                self?.performWMFDataHousekeeping()
-
-                completion(housekeepingError)
+                completion(error)
             }
         }
     }

--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -745,18 +745,33 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
     func performDatabaseHousekeeping(completion: @escaping (Error?) -> Void) {
         let housekeeper = WMFDatabaseHousekeeper()
 
-        do {
-            try housekeeper.performHousekeepingOnManagedObjectContext(dataStore.viewContext, navigationStateController: navigationStateController, cleanupLevel: .low)
-        } catch {
-            DDLogError("Error on cleanup: \(error)")
+        // Read the view context on the main thread. A background context cannot find these articles.
+        let excludedArticleKeys = housekeeper.articleKeysToPreserve(in: dataStore, navigationStateController: navigationStateController)
+
+        dataStore.performBackgroundCoreDataOperation { moc in
+            var housekeepingError: Error?
+
+            do {
+                try housekeeper.performHousekeeping(on: moc, excludedArticleKeys: excludedArticleKeys, cleanupLevel: .low)
+            } catch {
+                housekeepingError = error
+                DDLogError("Error on cleanup: \(error)")
+            }
+
+            // These functions read and delete files. Keep them off the main thread.
+            SharedContainerCacheHousekeeping.deleteStaleCachedItems(in: SharedContainerCacheCommonNames.talkPageCache, cleanupLevel: .low)
+            SharedContainerCacheHousekeeping.deleteStaleCachedItems(in: SharedContainerCacheCommonNames.didYouKnowCache, cleanupLevel: .low)
+
+            Task { @MainActor [weak self] in
+                if housekeepingError == nil {
+                    UserDefaults.standard.wmf_lastDatabaseHousekeepingDate = Date()
+                }
+
+                self?.performWMFDataHousekeeping()
+
+                completion(housekeepingError)
+            }
         }
-
-        SharedContainerCacheHousekeeping.deleteStaleCachedItems(in: SharedContainerCacheCommonNames.talkPageCache, cleanupLevel: .low)
-        SharedContainerCacheHousekeeping.deleteStaleCachedItems(in: SharedContainerCacheCommonNames.didYouKnowCache, cleanupLevel: .low)
-
-        performWMFDataHousekeeping()
-
-        completion(nil)
     }
 
     // MARK: - Background Tasks

--- a/Wikipedia/Code/WMFAppViewController.swift
+++ b/Wikipedia/Code/WMFAppViewController.swift
@@ -473,6 +473,7 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
         savedArticlesFetcher?.start()
         assignMoreDynamicTabsV2ExperimentIfNeeded()
         AppIconUtility.shared.checkAndRevertIfExpired()
+        performDatabaseHousekeepingIfNeeded()
     }
 
     func performTasksThatShouldOccurAfterAnnouncementsUpdated() {
@@ -741,6 +742,26 @@ final class WMFAppViewController: UITabBarController, AppTabBarDelegate {
     }
 
     // MARK: - Background Processing
+
+    /// Does a housekeeping pass on a background context if sufficient time went by after the last pass.
+    func performDatabaseHousekeepingIfNeeded() {
+        guard isMigrationComplete else {
+            return
+        }
+
+        guard UserDefaults.standard.wmf_shouldPerformDatabaseHousekeeping else {
+            return
+        }
+
+        // Let the first screen appear first. The pass uses the same SQLite store.
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: Self.databaseHousekeepingLaunchDelay)
+            self?.performDatabaseHousekeeping { _ in }
+        }
+    }
+
+    /// The time to wait after the app becomes active.
+    private static let databaseHousekeepingLaunchDelay: UInt64 = 5 * NSEC_PER_SEC
 
     func performDatabaseHousekeeping(completion: @escaping (Error?) -> Void) {
         let housekeeper = WMFDatabaseHousekeeper()

--- a/Wikipedia/Code/WMFDatabaseHousekeeper.swift
+++ b/Wikipedia/Code/WMFDatabaseHousekeeper.swift
@@ -2,16 +2,45 @@ import Foundation
 import WMF
 
 @objc class WMFDatabaseHousekeeper : NSObject {
-    
+
+    /// The maximum number of articles that one pass deletes.
+    private static let articleDeletionLimit = 2000
+
+    /// The number of managed objects that Core Data reads from the store at one time.
+    private static let fetchBatchSize = 100
+
+    /// Gets the keys of the articles that are in use. Call this on the main thread.
+    @objc func articleKeysToPreserve(in dataStore: MWKDataStore, navigationStateController: NavigationStateController) -> Set<String> {
+        assert(Thread.isMainThread, "Read the view context on the main thread.")
+
+        let viewContext = dataStore.viewContext
+
+        var keys = Set<String>()
+
+        for object in viewContext.registeredObjects {
+            guard let article = object as? WMFArticle, !article.isFault, let key = article.key else {
+                continue
+            }
+            keys.insert(key)
+        }
+
+        if let preservedArticleKeys = navigationStateController.allPreservedArticleKeys(in: viewContext) {
+            keys.formUnion(preservedArticleKeys)
+        }
+
+        return keys
+    }
+
     // Returns deleted URLs
     // Note: A cleanupLevel of high will attempt to do additional scrubbing in the case of vandalism.
-    @discardableResult @objc func performHousekeepingOnManagedObjectContext(_ moc: NSManagedObjectContext, navigationStateController: NavigationStateController, cleanupLevel: WMFCleanupLevel) throws -> [URL] {
+    // The caller must own the queue of the context. Do not use the main queue view context.
+    @discardableResult @objc func performHousekeeping(on moc: NSManagedObjectContext, excludedArticleKeys: Set<String>, cleanupLevel: WMFCleanupLevel) throws -> [URL] {
         
         if cleanupLevel == .high {
             moc.navigationState = nil
         }
         
-        let urls = try deleteStaleUnreferencedArticles(moc, navigationStateController: navigationStateController, cleanupLevel: cleanupLevel)
+        let urls = try deleteStaleUnreferencedArticles(moc, excludedArticleKeys: excludedArticleKeys, cleanupLevel: cleanupLevel)
 
         try deleteStaleAnnouncements(moc)
 
@@ -37,7 +66,7 @@ import WMF
         }
     }
 
-    private func deleteStaleUnreferencedArticles(_ moc: NSManagedObjectContext, navigationStateController: NavigationStateController, cleanupLevel: WMFCleanupLevel = .low) throws -> [URL] {
+    private func deleteStaleUnreferencedArticles(_ moc: NSManagedObjectContext, excludedArticleKeys: Set<String>, cleanupLevel: WMFCleanupLevel = .low) throws -> [URL] {
         
         /**
  
@@ -53,9 +82,12 @@ import WMF
         }
         
         let allContentGroupFetchRequest = WMFContentGroup.fetchRequest()
+        // Read all of the groups in batches. Each group can hold the only reference to an article.
+        allContentGroupFetchRequest.fetchBatchSize = Self.fetchBatchSize
         
         let allContentGroups = try moc.fetch(allContentGroupFetchRequest)
         var referencedArticleKeys = Set<String>(minimumCapacity: allContentGroups.count * 5 + 1)
+        referencedArticleKeys.formUnion(excludedArticleKeys)
         
         for group in allContentGroups {
             if cleanupLevel == .high && (group.midnightUTCDate?.compare(oldestFeedDateMidnightUTC) == .orderedAscending ||
@@ -139,25 +171,26 @@ import WMF
             - Items with `isExcludedFromFeed == YES` need to stay in the database so that they will continue to be excluded from the feed
         */
         
+        var urls: [URL] = []
+
+        // The high level deletes no articles. The earlier `isFault` test gave the same result.
+        guard cleanupLevel != .high else {
+            if moc.hasChanges {
+                try moc.save()
+            }
+            postDidCompleteNotification()
+            return urls
+        }
+
         let articlesToDeleteFetchRequest = WMFArticle.fetchRequest()
         // savedDate == NULL && isDownloaded == YES will be picked up by SavedArticlesFetcher for deletion
-        let articlesToDeletePredicate = cleanupLevel == .high ? NSPredicate(format: "savedDate == NULL && isDownloaded == NO && placesSortOrder == 0 && isExcludedFromFeed == NO") : NSPredicate(format: "viewedDate == NULL && savedDate == NULL && isDownloaded == NO && placesSortOrder == 0 && isExcludedFromFeed == NO")
-        
-        if let preservedArticleKeys = navigationStateController.allPreservedArticleKeys(in: moc) {
-            referencedArticleKeys.formUnion(preservedArticleKeys)
-        }
-        
-        articlesToDeleteFetchRequest.propertiesToFetch = ["key"]
-        articlesToDeleteFetchRequest.predicate = articlesToDeletePredicate
+        articlesToDeleteFetchRequest.predicate = NSPredicate(format: "viewedDate == NULL && savedDate == NULL && isDownloaded == NO && placesSortOrder == 0 && isExcludedFromFeed == NO")
+        articlesToDeleteFetchRequest.fetchLimit = Self.articleDeletionLimit
+        articlesToDeleteFetchRequest.fetchBatchSize = Self.fetchBatchSize
 
         let articlesToDelete = try moc.fetch(articlesToDeleteFetchRequest)
         
-        var urls: [URL] = []
         for obj in articlesToDelete {
-            guard cleanupLevel != .high && obj.isFault else { // only delete articles that are faults. prevents deletion of articles that are being actively viewed. repro steps: open disambiguation pages view -> exit app -> re-enter app
-                continue
-            }
-            
             guard let key = obj.key, !referencedArticleKeys.contains(key) else {
                 continue
             }
@@ -173,8 +206,15 @@ import WMF
             try moc.save()
         }
         
-        NotificationCenter.default.post(name: .databaseHousekeeperDidComplete, object: nil)
+        postDidCompleteNotification()
         
         return urls
+    }
+
+    private func postDidCompleteNotification() {
+        // The observers change the UI, therefore send the notification on the main actor.
+        Task { @MainActor in
+            NotificationCenter.default.post(name: .databaseHousekeeperDidComplete, object: nil)
+        }
     }
 }

--- a/Wikipedia/Code/WMFSettingsViewController.m
+++ b/Wikipedia/Code/WMFSettingsViewController.m
@@ -412,10 +412,11 @@ static NSString *const WMFSettingsURLDonation = @"https://donate.wikimedia.org/?
 
     WMFDatabaseHousekeeper *databaseHousekeeper = [WMFDatabaseHousekeeper new];
     WMFNavigationStateController *navigationStateController = [[WMFNavigationStateController alloc] initWithDataStore:self.dataStore];
+    NSSet<NSString *> *excludedArticleKeys = [databaseHousekeeper articleKeysToPreserveIn:self.dataStore navigationStateController:navigationStateController];
 
     [self.dataStore performBackgroundCoreDataOperationOnATemporaryContext:^(NSManagedObjectContext *_Nonnull moc) {
         NSError *housekeepingError = nil;
-        [databaseHousekeeper performHousekeepingOnManagedObjectContext:moc navigationStateController:navigationStateController cleanupLevel:WMFCleanupLevelHigh error:&housekeepingError];
+        [databaseHousekeeper performHousekeepingOn:moc excludedArticleKeys:excludedArticleKeys cleanupLevel:WMFCleanupLevelHigh error:&housekeepingError];
         if (housekeepingError) {
             DDLogError(@"Error on cleanup: %@", housekeepingError);
             housekeepingError = nil;

--- a/WikipediaUnitTests/Code/WMFDatabaseHousekeeperTests.swift
+++ b/WikipediaUnitTests/Code/WMFDatabaseHousekeeperTests.swift
@@ -1,7 +1,17 @@
 import XCTest
 import WMF
+@testable import Wikipedia
 
 class WMFDatabaseHousekeeperTests: XCTestCase {
+
+    var dataStore: MWKDataStore!
+
+    override func setUp(completion: @escaping (Error?) -> Void) {
+        MWKDataStore.createTemporaryDataStore { dataStore in
+            self.dataStore = dataStore
+            completion(nil)
+        }
+    }
 
     override func tearDown() {
         UserDefaults.standard.wmf_lastDatabaseHousekeepingDate = nil
@@ -24,6 +34,44 @@ class WMFDatabaseHousekeeperTests: XCTestCase {
         XCTAssertTrue(UserDefaults.standard.wmf_shouldPerformDatabaseHousekeeping)
     }
 
+    // MARK: - Excluded article keys
+
+    /// A pass deletes a preview article that has no user state and no reference.
+    func testUnreferencedArticleIsDeleted() throws {
+        let moc = dataStore.viewContext
+        let article = try XCTUnwrap(dataStore.fetchOrCreateArticle(with: URL(string: "https://en.wikipedia.org/wiki/Stale")!))
+        let key = try XCTUnwrap(article.key)
+        try moc.save()
+
+        let deletedURLs = try WMFDatabaseHousekeeper().performHousekeeping(on: moc, excludedArticleKeys: [], cleanupLevel: .low)
+
+        XCTAssertEqual(deletedURLs.count, 1)
+        XCTAssertNil(dataStore.fetchArticle(withKey: key))
+    }
+
+    /// A pass keeps an article that the caller gives in the excluded keys.
+    func testExcludedArticleIsNotDeleted() throws {
+        let moc = dataStore.viewContext
+        let article = try XCTUnwrap(dataStore.fetchOrCreateArticle(with: URL(string: "https://en.wikipedia.org/wiki/InUse")!))
+        let key = try XCTUnwrap(article.key)
+        try moc.save()
+
+        let deletedURLs = try WMFDatabaseHousekeeper().performHousekeeping(on: moc, excludedArticleKeys: [key], cleanupLevel: .low)
+
+        XCTAssertTrue(deletedURLs.isEmpty)
+        XCTAssertNotNil(dataStore.fetchArticle(withKey: key))
+    }
+
+    /// The preserved keys hold an article that is realized in the view context.
+    func testArticleKeysToPreserveIncludesRealizedArticles() throws {
+        let article = try XCTUnwrap(dataStore.fetchOrCreateArticle(with: URL(string: "https://en.wikipedia.org/wiki/Realized")!))
+        let key = try XCTUnwrap(article.key)
+        try dataStore.viewContext.save()
+
+        let keys = WMFDatabaseHousekeeper().articleKeysToPreserve(in: dataStore, navigationStateController: NavigationStateController(dataStore: dataStore))
+
+        XCTAssertTrue(keys.contains(key))
+    }
     
     func testDaysBefore() {        
         let formatter = DateFormatter()

--- a/WikipediaUnitTests/Code/WMFDatabaseHousekeeperTests.swift
+++ b/WikipediaUnitTests/Code/WMFDatabaseHousekeeperTests.swift
@@ -2,6 +2,28 @@ import XCTest
 import WMF
 
 class WMFDatabaseHousekeeperTests: XCTestCase {
+
+    override func tearDown() {
+        UserDefaults.standard.wmf_lastDatabaseHousekeepingDate = nil
+    }
+
+    // MARK: - Throttle
+
+    func testHousekeepingRunsWhenItNeverRan() {
+        UserDefaults.standard.wmf_lastDatabaseHousekeepingDate = nil
+        XCTAssertTrue(UserDefaults.standard.wmf_shouldPerformDatabaseHousekeeping)
+    }
+
+    func testHousekeepingDoesNotRunAgainImmediately() {
+        UserDefaults.standard.wmf_lastDatabaseHousekeepingDate = Date()
+        XCTAssertFalse(UserDefaults.standard.wmf_shouldPerformDatabaseHousekeeping)
+    }
+
+    func testHousekeepingRunsAgainAfterTheInterval() {
+        UserDefaults.standard.wmf_lastDatabaseHousekeepingDate = Date(timeIntervalSinceNow: -WMFDatabaseHousekeepingInterval - 1)
+        XCTAssertTrue(UserDefaults.standard.wmf_shouldPerformDatabaseHousekeeping)
+    }
+
     
     func testDaysBefore() {        
         let formatter = DateFormatter()


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T428661

### Notes per commit

1. Add a throttle for the database housekeeping pass. Stores the time of the last completed pass. The minimum interval between two passes is 12 hours.

2. Do the pass on a background context. Uses the performBackgroundCoreDataOperation helper. The two Settings → Clear cache paths already used this helper. The disk cache functions also move off the main thread. Gives a batch size to both fetches, and a limit of 2000 to the article fetch. The completion notification now goes out on the main actor, because ExploreViewController uses it to refresh the feed.

3. Start a pass after launch. The trigger is in performTasksThatShouldOccurAfterBecomeActiveAndResume. It runs only if the migration is complete. It waits 5 seconds, to let the first screen appear first. The throttle also applies. The background task is now a second trigger, and it uses the same throttle.

4. Give a limit to each WMFData housekeeping step. The CDPageInterest step and the CDCategory step used no limit. Each step also used a guard statement with a return. Thus an empty step stopped the steps after it. Each step now uses the same limit and an if statement.

5. Report housekeeping completion after the WMFData prune ends. The function reported completion before the prune was complete. Thus the system could suspend the app during the prune. The error value was also always nil, thus the task always reported success. The function now waits for the prune and returns the first error.

6. Add an expiration handler to each background task. No task had a handler. If a task used all of its time, iOS stopped the app. The handler for the housekeeper task also stops the WMFData prune. A new class reports completion one time only, because iOS stops the app after two reports.

7. Remove the data race from the clear cache code. The function read cleanupError on the main thread after a delay of 1 second. The background block wrote the same value. The error value now stays in the background block. The block shows the result after the work ends. This change also moves the file deletes off the main thread.

### Test Steps
1. Smoke testing

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
