### PR TITLE
Lock the evergreen account creation flow to portrait

### DIFF
--- a/Wikipedia/Code/EvergreenAccountCreationCoordinator.swift
+++ b/Wikipedia/Code/EvergreenAccountCreationCoordinator.swift
@@ -95,6 +95,10 @@ final class EvergreenAccountCreationCoordinator: NSObject, Coordinator {
         let viewController = WMFSlideshowViewController(viewModel: viewModel)
         let promptNavigationController = WMFComponentNavigationController(rootViewController: viewController, modalPresentationStyle: .fullScreen)
 
+        // The slides are laid out for portrait, and this navigation controller is thrown away on
+        // dismissal, so the lock needs no unwinding.
+        promptNavigationController.turnOnForcePortrait()
+
         // Full screen cannot be swiped away, so the close button is the only way out. The delegate
         // stays as a safety net for a dismissal from anywhere else.
         promptNavigationController.presentationController?.delegate = self
@@ -138,7 +142,9 @@ final class EvergreenAccountCreationCoordinator: NSObject, Coordinator {
             navigationController: navigationController,
             theme: theme,
             loggingCategory: loggingCategory,
-            startsOnAccountCreation: true
+            startsOnAccountCreation: true,
+            // Keeps the orientation the prompt was locked to across the hand-off.
+            forcePortrait: true
         )
 
         loginCoordinator.createAccountSuccessCustomDismissBlock = { [weak self] in

--- a/Wikipedia/Code/LoginCoordinator.swift
+++ b/Wikipedia/Code/LoginCoordinator.swift
@@ -17,13 +17,17 @@ final class LoginCoordinator: Coordinator {
 
     private let startsOnAccountCreation: Bool
 
+    /// For callers whose own flow is locked to portrait, so the orientation carries across to here.
+    private let forcePortrait: Bool
+
     // MARK: Lifecycle
 
-    init(navigationController: UINavigationController, theme: Theme, loggingCategory: EventCategoryMEP? = nil, startsOnAccountCreation: Bool = false) {
+    init(navigationController: UINavigationController, theme: Theme, loggingCategory: EventCategoryMEP? = nil, startsOnAccountCreation: Bool = false, forcePortrait: Bool = false) {
         self.navigationController = navigationController
         self.theme = theme
         self.loggingCategory = loggingCategory
         self.startsOnAccountCreation = startsOnAccountCreation
+        self.forcePortrait = forcePortrait
     }
 
     @discardableResult
@@ -69,6 +73,10 @@ final class LoginCoordinator: Coordinator {
     }
 
     private func present(_ viewController: UIViewController) {
+        if forcePortrait {
+            (viewController as? WMFComponentNavigationController)?.turnOnForcePortrait()
+        }
+
         if let presentedVC = navigationController.presentedViewController {
             presentedVC.present(viewController, animated: true)
         } else {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T434847

### Notes
* Locks flow in portrait 

### Test Steps
1. Honestly let's rely on QA because triggering this is hard

### Checklist
- [ ] Checked against Swift 6 strict concurrency

### Screenshots/Videos
