### PR TITLE
Add the instrumentation for the donation reminder wrap-up cards

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Donate Form/WMFDonateViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Donate Form/WMFDonateViewModel.swift
@@ -619,8 +619,9 @@ extension WMFDonateViewModel: PKPaymentAuthorizationControllerDelegate {
 
         // Wait for payment sheet to dismiss
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.75, execute: { [weak self] in
-            self?.coordinatorDelegate?.handleDonateAction(.nativeFormDidTriggerPaymentSuccess)
-            self?.loggingDelegate?.handleDonateLoggingAction(.nativeFormDidTriggerPaymentSuccess)
+            guard let self else { return }
+            self.coordinatorDelegate?.handleDonateAction(.nativeFormDidTriggerPaymentSuccess)
+            self.loggingDelegate?.handleDonateLoggingAction(.nativeFormDidTriggerPaymentSuccess(recurringMonthlyIsSelected: self.monthlyRecurringViewModel.isSelected))
         })
     }
 

--- a/WMFComponents/Sources/WMFComponents/LoggingDelegate/DonateLoggingDelegate.swift
+++ b/WMFComponents/Sources/WMFComponents/LoggingDelegate/DonateLoggingDelegate.swift
@@ -10,7 +10,7 @@ public enum WMFDonateLoggingAction {
     case nativeFormDidEnterAmountInTextfield
     case nativeFormDidTapApplePayButton(transactionFeeIsSelected: Bool, recurringMonthlyIsSelected: Bool, emailOptInIsSelected: NSNumber?)
     case nativeFormDidAuthorizeApplePayPaymentSheet(amount: Decimal, presetIsSelected: Bool, recurringMonthlyIsSelected: Bool, donorEmail: String?, metricsID: String?)
-    case nativeFormDidTriggerPaymentSuccess
+    case nativeFormDidTriggerPaymentSuccess(recurringMonthlyIsSelected: Bool)
     case nativeFormDidTapProblemsDonating
     case nativeFormDidTapOtherWaysToGive
     case nativeFormDidTapFAQ

--- a/Wikipedia/Code/ArticleViewController+DonationReminder.swift
+++ b/Wikipedia/Code/ArticleViewController+DonationReminder.swift
@@ -233,7 +233,7 @@ extension ArticleViewController {
             self?.presentedViewController?.dismiss(animated: true)
         }, submitAction: { [weak self] selectedOptions, otherText in
             if let project {
-                let score = selectedOptions.first.flatMap(Int.init)
+                let score = selectedOptions.compactMap { Int($0) }.first
                 DonateFunnel.shared.logDonationReminderFeedbackDidSubmit(score: score, text: otherText, project: project)
             }
 

--- a/Wikipedia/Code/ArticleViewController+DonationReminder.swift
+++ b/Wikipedia/Code/ArticleViewController+DonationReminder.swift
@@ -6,7 +6,12 @@ import WMFNativeLocalizations
 extension ArticleViewController {
     func showDonationReminderCardIfNeeded() {
         if let wrapUpCard = WMFDonationReminderDataController.shared.claimWrapUpCardImpression() {
-            isShowingWrapUpCard = true
+            shownWrapUpCard = wrapUpCard
+
+            if let project, let metricsID = DonateCoordinator.donationReminderMetricsID(articleURL: articleURL) {
+                DonateFunnel.shared.logDonationReminderWrapUpImpression(card: wrapUpCard, project: project, metricsID: metricsID)
+            }
+
             switch wrapUpCard {
             case .feedbackSurvey:
                 messagingController.injectDonationReminderCard(cardHTML: Self.wrapUpFeedbackCardHTML(theme: theme)) { _ in }
@@ -42,10 +47,10 @@ extension ArticleViewController {
         let didCompleteDonationDuringFlow = isShowingDonateFlowFromDonationReminderCard && localDonationCount() > localDonationCountBeforeDonateFlow
         isShowingDonateFlowFromDonationReminderCard = false
 
-        guard !isShowingWrapUpCard else {
+        guard shownWrapUpCard == nil else {
             if didCompleteDonationDuringFlow {
                 messagingController.removeDonationReminderCard()
-                isShowingWrapUpCard = false
+                shownWrapUpCard = nil
             }
             return
         }
@@ -88,7 +93,7 @@ extension ArticleViewController {
         }
 
         if href.hasSuffix("#wmf-donation-reminder-wrap-up-no-thanks") {
-            messagingController.removeDonationReminderCard()
+            didTapWrapUpNoThanks()
             return true
         }
 
@@ -113,9 +118,21 @@ extension ArticleViewController {
     }
 
     private func didTapWrapUpGiveMonthly() {
-        guard let reminder = WMFDonationReminderDataController.shared.loadReminder() else { return }
+        guard case .recurringDonorPrompt(let pledgeAmount, let currencyCode) = shownWrapUpCard else { return }
 
-        startDonateFlowFromReminderCard(source: .donationReminderWrapUp(articleURL, pledgeAmount: reminder.amount, currencyCode: reminder.currencyCode))
+        if let project {
+            DonateFunnel.shared.logDonationReminderWrapUpDidTapGiveMonthly(project: project)
+        }
+
+        startDonateFlowFromReminderCard(source: .donationReminderWrapUp(articleURL, pledgeAmount: pledgeAmount, currencyCode: currencyCode))
+    }
+
+    private func didTapWrapUpNoThanks() {
+        if let shownWrapUpCard, let project {
+            DonateFunnel.shared.logDonationReminderWrapUpDidTapNoThanks(card: shownWrapUpCard, project: project)
+        }
+
+        messagingController.removeDonationReminderCard()
     }
 
     private func startDonateFlowFromReminderCard(source: DonateCoordinator.Source) {
@@ -178,6 +195,12 @@ extension ArticleViewController {
     }
 
     private func didTapWrapUpShareFeedback() {
+        let project = self.project
+
+        if let project {
+            DonateFunnel.shared.logDonationReminderWrapUpDidTapShareFeedback(project: project)
+        }
+
         let surveyIntro = WMFLocalizedString("donation-reminder-wrap-up-survey-intro", value: "A quick question about donation reminders", comment: "Introduction line of the feedback survey shown at the end of the donation reminder experiment.")
         let surveyQuestion = WMFLocalizedString("donation-reminder-wrap-up-survey-subtitle", value: "Should donation reminders based on articles you read become a permanent feature?", comment: "Question of the feedback survey shown at the end of the donation reminder experiment.")
         let surveyPlaceholder = WMFLocalizedString("donation-reminder-wrap-up-survey-placeholder", value: "Anything else? (Optional)", comment: "Placeholder of the optional free-form text field of the donation reminder feedback survey.")
@@ -197,14 +220,23 @@ extension ArticleViewController {
         )
 
         let surveyOptions = [
-            WMFSurveyViewModel.OptionViewModel(text: surveyOptionKeep, apiIdentifer: "keep"),
-            WMFSurveyViewModel.OptionViewModel(text: surveyOptionRemove, apiIdentifer: "remove"),
-            WMFSurveyViewModel.OptionViewModel(text: CommonStrings.notSureButtonTitle, apiIdentifer: "notsure")
+            WMFSurveyViewModel.OptionViewModel(text: surveyOptionKeep, apiIdentifer: "1"),
+            WMFSurveyViewModel.OptionViewModel(text: surveyOptionRemove, apiIdentifer: "2"),
+            WMFSurveyViewModel.OptionViewModel(text: CommonStrings.notSureButtonTitle, apiIdentifer: "3")
         ]
 
         let surveyView = WMFSurveyView(viewModel: WMFSurveyViewModel(localizedStrings: surveyLocalizedStrings, options: surveyOptions, selectionType: .single, shouldShowMultilineText: true, otherTextCharacterLimit: 250), cancelAction: { [weak self] in
+            if let project {
+                DonateFunnel.shared.logDonationReminderFeedbackDidTapCancel(project: project)
+            }
+
             self?.presentedViewController?.dismiss(animated: true)
-        }, submitAction: { [weak self] _, _ in
+        }, submitAction: { [weak self] selectedOptions, otherText in
+            if let project {
+                let score = selectedOptions.first.flatMap(Int.init)
+                DonateFunnel.shared.logDonationReminderFeedbackDidSubmit(score: score, text: otherText, project: project)
+            }
+
             self?.presentedViewController?.dismiss(animated: true, completion: {
                 self?.messagingController.removeDonationReminderCard()
                 let toastTitle = WMFLocalizedString("donation-reminder-wrap-up-survey-toast", value: "Thanks for your feedback. Your answer helps us decide what to build next.", comment: "Toast shown after the user submits the donation reminder feedback survey.")

--- a/Wikipedia/Code/ArticleViewController.swift
+++ b/Wikipedia/Code/ArticleViewController.swift
@@ -177,7 +177,7 @@ class ArticleViewController: ThemeableViewController, UIScrollViewDelegate, WMFN
 
     var isShowingDonateFlowFromDonationReminderCard = false
 
-    var isShowingWrapUpCard = false
+    var shownWrapUpCard: WMFDonationReminderDataController.WrapUpCard?
 
     var localDonationCountBeforeDonateFlow = 0
 

--- a/Wikipedia/Code/DonateCoordinator.swift
+++ b/Wikipedia/Code/DonateCoordinator.swift
@@ -772,8 +772,8 @@ extension DonateCoordinator: WMFDonateLoggingDelegate {
             logNativeFormDidTapApplePayButton(transactionFeeIsSelected: transactionFeeIsSelected, recurringMonthlyIsSelected: recurringMonthlyIsSelected, emailOptInIsSelected: emailOptInIsSelected)
         case .nativeFormDidAuthorizeApplePayPaymentSheet(let amount, let presetIsSelected, let recurringMonthlyIsSelected, let donorEmail, let metricsID):
             logNativeFormDidAuthorizeApplePayPaymentSheet(amount: amount, presetIsSelected: presetIsSelected, recurringMonthlyIsSelected: recurringMonthlyIsSelected, donorEmail: donorEmail, metricsID: metricsID)
-        case .nativeFormDidTriggerPaymentSuccess:
-            logNativeFormDidTriggerPaymentSuccess()
+        case .nativeFormDidTriggerPaymentSuccess(let recurringMonthlyIsSelected):
+            logNativeFormDidTriggerPaymentSuccess(recurringMonthlyIsSelected: recurringMonthlyIsSelected)
         case .nativeFormDidTapProblemsDonating:
             logNativeFormDidTapProblemsDonating()
         case .nativeFormDidTapOtherWaysToGive:
@@ -869,7 +869,11 @@ extension DonateCoordinator: WMFDonateLoggingDelegate {
         DonateFunnel.shared.logDonateFormNativeApplePayDidAuthorizeApplePay(amount: amount, presetIsSelected: presetIsSelected, recurringMonthlyIsSelected: recurringMonthlyIsSelected, metricsID: metricsID, donorEmail: donorEmail, project: wikimediaProject)
     }
 
-    private func logNativeFormDidTriggerPaymentSuccess() {
+    private func logNativeFormDidTriggerPaymentSuccess(recurringMonthlyIsSelected: Bool) {
+        if recurringMonthlyIsSelected, case .donationReminderWrapUp = source {
+            DonateFunnel.shared.logDonationReminderRecurringDonationConfirmed(project: wikimediaProject)
+        }
+
         guard let metricsID else {
             return
         }

--- a/Wikipedia/Code/DonateCoordinator.swift
+++ b/Wikipedia/Code/DonateCoordinator.swift
@@ -147,6 +147,17 @@ class DonateCoordinator: Coordinator {
         return String(originalMetricsID[..<iosRange.lowerBound]) + "_" + suffix + "_iOS"
     }
 
+    static func donationReminderMetricsID(articleURL: ArticleURL) -> String? {
+        guard let languageCode = articleURL.wmf_languageCode,
+              let countryCode = Locale.current.region?.identifier else {
+            return nil
+        }
+
+        // donation reminder metrics IDs need appmenu
+        let originalMetricsID = "\(languageCode)\(countryCode)_appmenu_iOS"
+        return donationReminderMetricsID(originalMetricsID: originalMetricsID)
+    }
+
     static func metricsID(for donateSource: Source, languageCode: String?) -> String? {
         switch donateSource {
         case .articleCampaignModal(_, let metricsID, _):
@@ -154,18 +165,7 @@ class DonateCoordinator: Coordinator {
         case .donationReminderCampaignModal(_, let metricsID, _):
             return donationReminderMetricsID(originalMetricsID: metricsID)
         case .donationReminderArticle(let articleURL, _, _), .donationReminderWrapUp(let articleURL, _, _):
-            
-            guard let languageCode = articleURL.wmf_languageCode,
-                  let countryCode = Locale.current.region?.identifier else {
-                return nil
-            }
-            
-            // donation reminder metrics IDs need appmenu
-            let originalMetricsID = "\(languageCode)\(countryCode)_appmenu_iOS"
-            let resolvedMetricsID = Self.donationReminderMetricsID(originalMetricsID: originalMetricsID)
-            
-            return resolvedMetricsID
-            
+            return donationReminderMetricsID(articleURL: articleURL)
         case .articleProfile, .exploreProfile, .settingsProfile, .placesProfile, .savedProfile, .searchProfile:
             guard let languageCode,
                   let countryCode = Locale.current.region?.identifier else {
@@ -300,13 +300,11 @@ class DonateCoordinator: Coordinator {
             case .activityTabProfile:
                 DonateFunnel.shared.logActivityProfileDonateCancel(metricsID: metricsID)
             case .donationReminderArticle:
-                
                 guard let project = self.wikimediaProject else {
                     return
                 }
 
-                 DonateFunnel.shared.logArticleDidTapCancel(project: project, metricsID: metricsID)
-                
+                DonateFunnel.shared.logArticleDidTapCancel(project: project, metricsID: metricsID)
             case .donationReminderWrapUp:
                 break
             }
@@ -338,8 +336,12 @@ class DonateCoordinator: Coordinator {
             let action = UIAlertAction(title: pledgeButtonTitle, style: .default, handler: { [weak self] _ in
                 guard let self else { return }
 
-                if !isWrapUpSource, let project = self.wikimediaProject {
-                    DonateFunnel.shared.logDonationReminderMilestoneDidTapApplePay(project: project, metricsID: metricsID)
+                if let project = self.wikimediaProject {
+                    if isWrapUpSource {
+                        DonateFunnel.shared.logDonationReminderRecurringEndDidTapApplePay(project: project, metricsID: metricsID)
+                    } else {
+                        DonateFunnel.shared.logDonationReminderMilestoneDidTapApplePay(project: project, metricsID: metricsID)
+                    }
                 }
 
                 donateViewModel.preselectAmount(pledgeSource.pledgeAmount)
@@ -390,7 +392,13 @@ class DonateCoordinator: Coordinator {
                     }
                 }
             case .donationReminderWrapUp:
-                break
+                if let project = self.wikimediaProject {
+                    if showsPledgeOption {
+                        DonateFunnel.shared.logDonationReminderRecurringEndDidTapOtherApplePay(project: project, metricsID: metricsID)
+                    } else {
+                        DonateFunnel.shared.logDonationReminderRecurringEndDidTapApplePay(project: project, metricsID: metricsID)
+                    }
+                }
             }
             if isWrapUpSource {
                 donateViewModel.preselectRecurringMonthly()
@@ -433,7 +441,9 @@ class DonateCoordinator: Coordinator {
                     DonateFunnel.shared.logDonationReminderMilestoneDidTapOtherMethod(project: project, metricsID: metricsID)
                 }
             case .donationReminderWrapUp:
-                break
+                if let project = self.wikimediaProject {
+                    DonateFunnel.shared.logDonationReminderRecurringEndDidTapOtherMethod(project: project, metricsID: metricsID)
+                }
             }
             navigateToOtherPaymentMethod()
         }))
@@ -887,12 +897,10 @@ extension DonateCoordinator: WMFDonateLoggingDelegate {
             DonateFunnel.shared.logSearchProfileDidSeeApplePayDonateSuccessToast(metricsID: metricsID)
         case .activityTabProfile:
             DonateFunnel.shared.logActivityProfileDidSeeApplePayDonateSuccessToast(metricsID: metricsID)
-        case .donationReminderArticle:
+        case .donationReminderArticle, .donationReminderWrapUp:
             if let wikimediaProject = self.wikimediaProject {
                 DonateFunnel.shared.logArticleCampaignDidSeeApplePayDonateSuccessToast(project: wikimediaProject, metricsID: metricsID)
             }
-        case .donationReminderWrapUp:
-            break
         }
     }
 
@@ -966,14 +974,12 @@ extension DonateCoordinator: WMFDonateLoggingDelegate {
             DonateFunnel.shared.logDonateFormInAppWebViewDidTapArticleReturnButton(project: wikimediaProject, metricsID: metricsID)
         case .exploreProfile, .settingsProfile, .yearInReview, .placesProfile, .savedProfile, .searchProfile, .activityTabProfile:
             DonateFunnel.shared.logDonateFormInAppWebViewDidTapReturnButton(metricsID: metricsID)
-        case .donationReminderArticle:
+        case .donationReminderArticle, .donationReminderWrapUp:
             guard let wikimediaProject else {
                 return
             }
 
             DonateFunnel.shared.logDonateFormInAppWebViewDidTapArticleReturnButton(project: wikimediaProject, metricsID: metricsID)
-        case .donationReminderWrapUp:
-            break
         }
     }
 
@@ -1016,14 +1022,12 @@ extension DonateCoordinator: WMFDonateLoggingDelegate {
                 DonateFunnel.shared.logSearchProfileDidSeeApplePayDonateSuccessToast(metricsID: metricsID)
             case .activityTabProfile:
                 DonateFunnel.shared.logActivityProfileDidSeeApplePayDonateSuccessToast(metricsID: metricsID)
-            case .donationReminderArticle:
+            case .donationReminderArticle, .donationReminderWrapUp:
                 guard let wikimediaProject else {
                     return
                 }
 
                 DonateFunnel.shared.logArticleCampaignDidSeeApplePayDonateSuccessToast(project: wikimediaProject, metricsID: metricsID)
-            case .donationReminderWrapUp:
-                break
             }
         }
     }

--- a/Wikipedia/Code/DonateFunnel.swift
+++ b/Wikipedia/Code/DonateFunnel.swift
@@ -28,6 +28,9 @@ import WMFData
         case reminderOverflow = "reminder_overflow"
         case globalSetting = "global_setting"
         case reminderMilestone = "reminder_milestone"
+        case reminderEnd = "reminder_end"
+        case reminderRecurringEnd = "reminder_recur_end"
+        case reminderFeedback = "reminder_feedback"
     }
     
     private enum Action: String {
@@ -87,6 +90,8 @@ import WMFData
         case notNowClick = "notnow_click"
         case otherApplePayClick = "other_applepay_click"
         case otherMethodClick = "other_method_click"
+        case feedbackStartClick = "feedback_start_click"
+        case recurringStartClick = "recurring_start_click"
     }
     
     private struct Event: EventInterface {
@@ -669,5 +674,64 @@ import WMFData
         case .groupC: group = "ios_remind_c"
         }
         logEvent(activeInterface: .articleBanner, action: .groupAssigned, actionData: ["group": group], project: project)
+    }
+
+    // MARK: - Donation Reminder Wrap-up
+
+    func logDonationReminderWrapUpImpression(card: WMFDonationReminderDataController.WrapUpCard, project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: card.activeInterface, action: .impression, actionData: ["campaign_id": metricsID], project: project)
+    }
+
+    func logDonationReminderWrapUpDidTapNoThanks(card: WMFDonationReminderDataController.WrapUpCard, project: WikimediaProject) {
+        logEvent(activeInterface: card.activeInterface, action: .noThanksClick, project: project)
+    }
+
+    func logDonationReminderWrapUpDidTapShareFeedback(project: WikimediaProject) {
+        logEvent(activeInterface: .reminderEnd, action: .feedbackStartClick, project: project)
+    }
+
+    func logDonationReminderWrapUpDidTapGiveMonthly(project: WikimediaProject) {
+        logEvent(activeInterface: .reminderRecurringEnd, action: .recurringStartClick, project: project)
+    }
+
+    func logDonationReminderFeedbackDidTapCancel(project: WikimediaProject) {
+        logEvent(activeInterface: .reminderFeedback, action: .cancelClick, project: project)
+    }
+
+    func logDonationReminderFeedbackDidSubmit(score: Int?, text: String, project: WikimediaProject) {
+        var actionData: [String: String] = [:]
+
+        if let score {
+            actionData["score"] = "\(score)"
+        }
+
+        if !text.isEmpty {
+            actionData["text"] = text.replacingOccurrences(of: ",", with: "&comma;")
+        }
+
+        logEvent(activeInterface: .reminderFeedback, action: .feedbackSubmitClick, actionData: actionData, project: project)
+    }
+
+    func logDonationReminderRecurringEndDidTapApplePay(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .reminderRecurringEnd, action: .applePayClick, actionData: ["campaign_id": metricsID], project: project)
+    }
+
+    func logDonationReminderRecurringEndDidTapOtherApplePay(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .reminderRecurringEnd, action: .otherApplePayClick, actionData: ["campaign_id": metricsID], project: project)
+    }
+
+    func logDonationReminderRecurringEndDidTapOtherMethod(project: WikimediaProject, metricsID: String) {
+        logEvent(activeInterface: .reminderRecurringEnd, action: .otherMethodClick, actionData: ["campaign_id": metricsID], project: project)
+    }
+}
+
+private extension WMFDonationReminderDataController.WrapUpCard {
+    var activeInterface: DonateFunnel.ActiveInterface {
+        switch self {
+        case .feedbackSurvey:
+            return .reminderEnd
+        case .recurringDonorPrompt:
+            return .reminderRecurringEnd
+        }
     }
 }

--- a/Wikipedia/Code/DonateFunnel.swift
+++ b/Wikipedia/Code/DonateFunnel.swift
@@ -31,6 +31,7 @@ import WMFData
         case reminderEnd = "reminder_end"
         case reminderRecurringEnd = "reminder_recur_end"
         case reminderFeedback = "reminder_feedback"
+        case reminderRecurringConfirmed = "reminder_recur_confirmed"
     }
     
     private enum Action: String {
@@ -722,6 +723,10 @@ import WMFData
 
     func logDonationReminderRecurringEndDidTapOtherMethod(project: WikimediaProject, metricsID: String) {
         logEvent(activeInterface: .reminderRecurringEnd, action: .otherMethodClick, actionData: ["campaign_id": metricsID], project: project)
+    }
+
+    func logDonationReminderRecurringDonationConfirmed(project: WikimediaProject?) {
+        logEvent(activeInterface: .reminderRecurringConfirmed, action: .impression, project: project)
     }
 }
 


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T437378

### Notes
* Adds the "end of test" instrumentation for the Donation Reminder V3 wrap-up cards shipped in #6158 and #6160, stream `app_donor_experience`.
* Per Shay, the iOS slides of the instrumentation deck were not remade 1:1, so this follows the Android implementation where the deck is incomplete.
* Events:
  * `reminder_end`: `impression` (campaign_id), `feedback_start_click`, `nothanks_click`
  * `reminder_feedback`: `cancel_click`, `feedback_submit_click` (action_data `score` 1-3 and `text`)
  * `reminder_recur_end`: `impression` (campaign_id), `recurring_start_click`, `nothanks_click`, `applepay_click`, `other_applepay_click`, `other_method_click`
  * `reminder_recur_confirmed`: `impression` after a successful monthly donation started from the wrap-up card, no action_data
  * Payment flow events started from the wrap-up card carry the campaign ID with the experiment group, e.g. `enNL_appmenu_reminderC_iOS`
* Survey interface is `reminder_feedback` for both cancel and submit, matching Android. The deck shows `remind_feedback` on submit.
* Score mapping matches Android: Keep it = 1, Remove it = 2, Not sure = 3.
* `reminder_recur_confirmed` fires only when the payment started from the wrap-up card, confirmed with Shay on Slack. Donations from the profile menu and Settings do not count.
* `WMFDonateLoggingAction.nativeFormDidTriggerPaymentSuccess` gained a `recurringMonthlyIsSelected` value so the coordinator knows whether the successful donation was monthly.

### Test Steps
1. Set the device region to the Netherlands.
2. Developer Settings → Fundraising → "Clear banner prompt state and donation history".
3. Set "Force Reminder Experiment Group" to Group B.
4. Turn on "Override Current Date" and pick a day between Nov 10 and Nov 15, 2026.
5. Open an article. Filter the Xcode console by `EPC`. Expect `impression` on `reminder_end` with `campaign_id: enNL_appmenu_reminderB_iOS`.
6. Tap Share feedback. Expect `feedback_start_click` on `reminder_end`. Tap Cancel. Expect `cancel_click` on `reminder_feedback`.
7. Repeat steps 2-5, tap Share feedback, pick Remove it, type a text with a comma, tap Submit. Expect `feedback_submit_click` on `reminder_feedback` with `score:2` and the text with `&comma;`.
8. Repeat steps 2-5 and tap No thanks. Expect `nothanks_click` on `reminder_end`.
9. Repeat step 2, set the group to Group C, turn "Override Current Date" off, go to Settings → Donation reminders and set up a reminder, then turn "Override Current Date" on again.
10. Open an article. Expect `impression` on `reminder_recur_end` with `campaign_id: enNL_appmenu_reminderC_iOS`.
11. Tap Give monthly. Expect `recurring_start_click` on `reminder_recur_end`. In the prompt, each option logs `applepay_click`, `other_applepay_click` or `other_method_click` on `reminder_recur_end` with the campaign_id. Cancel logs nothing.
12. Complete an Apple Pay donation with Monthly on. Expect `applepay_ui_confirm` with `recurring:true`, then `impression` on `reminder_recur_confirmed`, then `success_toast_article`.
13. Repeat step 9-10 and tap No thanks. Expect `nothanks_click` on `reminder_recur_end`.
14. Make a monthly donation from the profile menu. Expect no `reminder_recur_confirmed`.

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
group B logs
<img width="2343" height="718" alt="group-b-instrumentation" src="https://github.com/user-attachments/assets/33747626-a810-483e-805d-821cd2cf48f2" />

group C logs
<img width="3143" height="1112" alt="group-c-instrumentation" src="https://github.com/user-attachments/assets/dbf36c80-10c4-448d-be90-9b60a63f2122" />
