### PR TITLE
T437359: Add the semantic search experiment and its developer settings

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsView.swift
@@ -43,7 +43,7 @@ struct WMFDeveloperSettingsView: View {
 
             Section {
                 Toggle("Bypass Reminder Daily Limit", isOn: $viewModel.bypassDonationReminderDailyLimit)
-                fundraisingRow(caption: "Changes the date the donation reminder end gate treats as today; reading progress, the daily limit, and networking keep using the real device date.") {
+                captionedRow(caption: "Changes the date the donation reminder end gate treats as today; reading progress, the daily limit, and networking keep using the real device date.") {
                     Toggle("Override Current Date", isOn: $viewModel.overrideFundraisingCurrentDate)
                 }
                 if viewModel.overrideFundraisingCurrentDate {
@@ -56,16 +56,16 @@ struct WMFDeveloperSettingsView: View {
                     .datePickerStyle(.graphical)
                     .labelsHidden()
                 }
-                fundraisingRow(caption: "Ignores country and language settings. Only works if there is an active campaign.") {
+                captionedRow(caption: "Ignores country and language settings. Only works if there is an active campaign.") {
                     Toggle("Force Fundraising Campaign Banner", isOn: $viewModel.forceFundraisingCampaignBanner)
                 }
-                fundraisingRow(caption: "Fetches the donate and campaign configs from test.wikipedia.org instead of donate.wikimedia.org; toggling clears the cached configs and refetches immediately.") {
+                captionedRow(caption: "Fetches the donate and campaign configs from test.wikipedia.org instead of donate.wikimedia.org; toggling clears the cached configs and refetches immediately.") {
                     Toggle("Use Test Wiki Donate Configs", isOn: $viewModel.useTestWikiDonateConfigs)
                 }
-                fundraisingRow(caption: "Skips the getPaymentMethods API call and enables Apple Pay with the standard card networks; use it when the payments API rate limits the device.") {
+                captionedRow(caption: "Skips the getPaymentMethods API call and enables Apple Pay with the standard card networks; use it when the payments API rate limits the device.") {
                     Toggle("Use Hardcoded Payment Methods", isOn: $viewModel.useHardcodedPaymentMethods)
                 }
-                fundraisingRow(caption: "Overrides the persisted A/B/C bucket at read time; switching it back to Off restores the persisted bucket.") {
+                captionedRow(caption: "Overrides the persisted A/B/C bucket at read time; switching it back to Off restores the persisted bucket.") {
                     Picker("Force Reminder Experiment Group", selection: $viewModel.forceDonationReminderExperimentAssignment) {
                         Text("Off").tag(WMFDonationReminderDataController.ExperimentAssignment?.none)
                         Text("Control (A)").tag(WMFDonationReminderDataController.ExperimentAssignment?.some(.control))
@@ -73,7 +73,7 @@ struct WMFDeveloperSettingsView: View {
                         Text("Group C").tag(WMFDonationReminderDataController.ExperimentAssignment?.some(.groupC))
                     }
                 }
-                fundraisingRow(caption: "Resets \"maybe later\" / \"already donated\", the local donation history, the saved donation reminder, the experiment bucket, and the wrap-up card, so the banner can show again and the next Maybe Later re-rolls the A/B/C assignment.") {
+                captionedRow(caption: "Resets \"maybe later\" / \"already donated\", the local donation history, the saved donation reminder, the experiment bucket, and the wrap-up card, so the banner can show again and the next Maybe Later re-rolls the A/B/C assignment.") {
                     Button {
                         viewModel.clearFundraisingCampaignPersistence()
                     } label: {
@@ -82,6 +82,28 @@ struct WMFDeveloperSettingsView: View {
                 }
             } header: {
                 Text("Fundraising")
+            }
+
+            Section {
+                captionedRow(caption: "Keeps the semantic search entry point hidden in production. Without this, no gate below is evaluated.") {
+                    Toggle("Enable Semantic Search", isOn: $viewModel.enableSemanticSearch)
+                }
+                captionedRow(caption: "Overrides the persisted A/B bucket at read time and bypasses the target language gate; switching it back to Off restores the persisted bucket.") {
+                    Picker("Force Experiment Group", selection: $viewModel.forceSemanticSearchExperimentAssignment) {
+                        Text("Off").tag(WMFSemanticSearchDataController.ExperimentAssignment?.none)
+                        Text("Control (A)").tag(WMFSemanticSearchDataController.ExperimentAssignment?.some(.control))
+                        Text("Group B").tag(WMFSemanticSearchDataController.ExperimentAssignment?.some(.groupB))
+                    }
+                }
+                captionedRow(caption: "Removes the persisted bucket so the next eligible search re-rolls the A/B assignment.") {
+                    Button {
+                        viewModel.clearSemanticSearchExperimentAssignment()
+                    } label: {
+                        Text("Clear experiment assignment")
+                    }
+                }
+            } header: {
+                Text("Semantic Search")
             }
 
             ForEach(viewModel.formViewModel.sections) { section in
@@ -95,7 +117,7 @@ struct WMFDeveloperSettingsView: View {
         .listBackgroundColor(Color(theme.baseBackground))
     }
 
-    private func fundraisingRow(caption: String, @ViewBuilder control: () -> some View) -> some View {
+    private func captionedRow(caption: String, @ViewBuilder control: () -> some View) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             control()
             Text(caption)

--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -190,9 +190,15 @@ import WMFData
     }
 
     public func clearSemanticSearchExperimentAssignment() {
-        WMFSemanticSearchDataController.shared.clearExperimentAssignment()
+        let title: String
+        do {
+            try WMFSemanticSearchDataController.shared.clearExperimentAssignment()
+            title = "Semantic search bucket cleared. The next eligible search re-rolls the assignment."
+        } catch {
+            title = "Could not clear the semantic search bucket: \(error)"
+        }
         Task { @MainActor in
-            WMFToastPresenter.shared.show(WMFToastConfig(title: .init("Semantic search bucket cleared. The next eligible search re-rolls the assignment.")))
+            WMFToastPresenter.shared.show(WMFToastConfig(title: .init(title)))
         }
     }
 

--- a/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
+++ b/WMFComponents/Sources/WMFComponents/Components/Developer Settings/WMFDeveloperSettingsViewModel.swift
@@ -86,6 +86,18 @@ import WMFData
         }
     }
 
+    @Published public var enableSemanticSearch: Bool = WMFDeveloperSettingsDataController.shared.enableSemanticSearch {
+        didSet {
+            WMFDeveloperSettingsDataController.shared.enableSemanticSearch = enableSemanticSearch
+        }
+    }
+
+    @Published public var forceSemanticSearchExperimentAssignment: WMFSemanticSearchDataController.ExperimentAssignment? = WMFDeveloperSettingsDataController.shared.forceSemanticSearchExperimentAssignment {
+        didSet {
+            WMFDeveloperSettingsDataController.shared.forceSemanticSearchExperimentAssignment = forceSemanticSearchExperimentAssignment
+        }
+    }
+
     var fundraisingOverrideDateRange: ClosedRange<Date> {
         let lowerBound = WMFDonationReminderDataController.reminderEndDate.addingTimeInterval(-86_400)
         let upperBound = WMFDonationReminderDataController.wrapUpEndDate.addingTimeInterval(86_400)
@@ -174,6 +186,13 @@ import WMFData
         WMFDeveloperSettingsDataController.shared.clearFundraisingCampaignPersistence()
         Task { @MainActor in
             WMFToastPresenter.shared.show(WMFToastConfig(title: .init("Fundraising state cleared. The campaign banner can show again.")))
+        }
+    }
+
+    public func clearSemanticSearchExperimentAssignment() {
+        WMFSemanticSearchDataController.shared.clearExperimentAssignment()
+        Task { @MainActor in
+            WMFToastPresenter.shared.show(WMFToastConfig(title: .init("Semantic search bucket cleared. The next eligible search re-rolls the assignment.")))
         }
     }
 

--- a/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Developer Settings/WMFDeveloperSettingsDataController.swift
@@ -244,6 +244,31 @@ public protocol WMFDeveloperSettingsDataControlling: AnyObject {
         fundraisingOverriddenCurrentDate ?? Date()
     }
 
+    // MARK: - Semantic Search
+
+    public var enableSemanticSearch: Bool {
+        get { (try? userDefaultsStore?.load(key: WMFUserDefaultsKey.developerSettingsEnableSemanticSearch.rawValue)) ?? false }
+        set { try? userDefaultsStore?.save(key: WMFUserDefaultsKey.developerSettingsEnableSemanticSearch.rawValue, value: newValue) }
+    }
+
+    /// Debugging convenience: overrides the persisted semantic search experiment bucket at read
+    /// time without re-rolling it, and bypasses the target language gate. Nil means no override.
+    public var forceSemanticSearchExperimentAssignment: WMFSemanticSearchDataController.ExperimentAssignment? {
+        get {
+            guard let rawValue: String = try? userDefaultsStore?.load(key: WMFUserDefaultsKey.developerSettingsForceSemanticSearchExperimentAssignment.rawValue) else {
+                return nil
+            }
+            return WMFSemanticSearchDataController.ExperimentAssignment(rawValue: rawValue)
+        }
+        set {
+            if let newValue {
+                try? userDefaultsStore?.save(key: WMFUserDefaultsKey.developerSettingsForceSemanticSearchExperimentAssignment.rawValue, value: newValue.rawValue)
+            } else {
+                try? userDefaultsStore?.remove(key: WMFUserDefaultsKey.developerSettingsForceSemanticSearchExperimentAssignment.rawValue)
+            }
+        }
+    }
+
     // MARK: - Remote Feature Flags
 
     /// Comes from `iosv1.visualEditorEnabled` in the remote feature config. A missing key or a

--- a/WMFData/Sources/WMFData/Data Controllers/Experiments/WMFExperimentsDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Experiments/WMFExperimentsDataController.swift
@@ -22,6 +22,7 @@ final class WMFExperimentsDataController {
         case yirLoginPrompt
         case homeTab
         case donationReminder
+        case semanticSearch
 
         var config: ExperimentConfig {
             switch self {
@@ -33,6 +34,8 @@ final class WMFExperimentsDataController {
                 return WMFExperimentsDataController.homeTabConfig
             case .donationReminder:
                 return WMFExperimentsDataController.donationReminderConfig
+            case .semanticSearch:
+                return WMFExperimentsDataController.semanticSearchConfig
             }
         }
     }
@@ -42,6 +45,7 @@ final class WMFExperimentsDataController {
         case yirLoginPromptPercent
         case homeTabPercent
         case donationReminderPercent
+        case semanticSearchPercent
     }
 
     enum BucketFileName: String {
@@ -49,6 +53,7 @@ final class WMFExperimentsDataController {
         case yirLoginPromptBucket
         case homeTabBucket
         case donationReminderBucket
+        case semanticSearchBucket
     }
 
     public enum BucketValue: String {
@@ -60,6 +65,8 @@ final class WMFExperimentsDataController {
         case donationReminderControl = "DonationReminder_Control"
         case donationReminderGroupB = "DonationReminder_GroupB"
         case donationReminderGroupC = "DonationReminder_GroupC"
+        case semanticSearchControl = "SemanticSearch_Control"
+        case semanticSearchGroupB = "SemanticSearch_GroupB"
     }
     
     // MARK: Properties
@@ -73,6 +80,8 @@ final class WMFExperimentsDataController {
     private static let homeTabConfig = ExperimentConfig(experiment: .homeTab, percentageFileName: .homeTabPercent, bucketFileName: .homeTabBucket, bucketValueControl: .homeTabControl, bucketValueTest: .homeTabGroupB, bucketValueTest2: nil)
 
     private static let donationReminderConfig = ExperimentConfig(experiment: .donationReminder, percentageFileName: .donationReminderPercent, bucketFileName: .donationReminderBucket, bucketValueControl: .donationReminderControl, bucketValueTest: .donationReminderGroupB, bucketValueTest2: .donationReminderGroupC)
+
+    private static let semanticSearchConfig = ExperimentConfig(experiment: .semanticSearch, percentageFileName: .semanticSearchPercent, bucketFileName: .semanticSearchBucket, bucketValueControl: .semanticSearchControl, bucketValueTest: .semanticSearchGroupB, bucketValueTest2: nil)
 
     private let store: WMFKeyValueStore
     
@@ -135,6 +144,13 @@ final class WMFExperimentsDataController {
                     bucket = .donationReminderGroupB
                 } else {
                     bucket = .donationReminderGroupC
+                }
+
+            case .semanticSearch:
+                if randomInt <= percentage {
+                    bucket = .semanticSearchControl
+                } else {
+                    bucket = .semanticSearchGroupB
                 }
             }
         }

--- a/WMFData/Sources/WMFData/Data Controllers/Semantic Search/WMFSemanticSearchDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Semantic Search/WMFSemanticSearchDataController.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+public final class WMFSemanticSearchDataController {
+
+    public enum ExperimentAssignment: String, Sendable {
+        case control
+        case groupB
+    }
+
+    public enum ExperimentError: Error {
+        case missingExperimentStore
+        case unexpectedBucketValue
+    }
+
+    public static let shared = WMFSemanticSearchDataController()
+
+    // TODO: Remove when the `iosv1.semanticSearchLanguages` in the remote feature config is available.
+    public static let defaultTargetLanguageCodes = ["fr", "ar", "ja"]
+
+    private static let experimentControlPercentage = 50
+
+    private var experimentStore: WMFKeyValueStore? { WMFDataEnvironment.current.sharedCacheStore }
+
+    private let stateLock = NSLock()
+
+    private init() {}
+
+    // MARK: - Availability
+
+    /// True when the semantic search entry point can render for a search in `languageCode`.
+    /// The developer toggle, the target language gate and the experiment bucket must all pass.
+    public func isEntryPointAvailable(languageCode: String) -> Bool {
+        guard isEligible(languageCode: languageCode) else {
+            return false
+        }
+
+        return experimentAssignment == .groupB
+    }
+
+    /// True when a search in `languageCode` can enroll the reader in the experiment.
+    public func isEligible(languageCode: String) -> Bool {
+        guard WMFDeveloperSettingsDataController.shared.enableSemanticSearch else {
+            return false
+        }
+
+        if developerSettingsForcedAssignment != nil {
+            return true
+        }
+
+        return isTargetLanguage(languageCode: languageCode)
+    }
+
+    public func isTargetLanguage(languageCode: String) -> Bool {
+        targetLanguageCodes.contains(languageCode)
+    }
+
+    public var targetLanguageCodes: [String] {
+        WMFDeveloperSettingsDataController.shared.loadFeatureConfig()?.ios.semanticSearchLanguages ?? Self.defaultTargetLanguageCodes
+    }
+
+    // MARK: - Experiment Assignment
+
+    /// Rolls the experiment bucket the first time a reader runs an eligible search, and returns
+    /// the persisted bucket after that. Returns nil when the search is not eligible.
+    @discardableResult
+    public func assignExperimentIfNeeded(languageCode: String) throws -> ExperimentAssignment? {
+        guard let experimentStore else {
+            throw ExperimentError.missingExperimentStore
+        }
+
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        guard isEligible(languageCode: languageCode) else {
+            return nil
+        }
+
+        let experimentsDataController = WMFExperimentsDataController(store: experimentStore)
+        let bucketValue = try experimentsDataController.determineBucketForExperiment(.semanticSearch, withPercentage: Self.experimentControlPercentage)
+
+        guard let assignment = ExperimentAssignment(bucketValue: bucketValue) else {
+            throw ExperimentError.unexpectedBucketValue
+        }
+
+        return developerSettingsForcedAssignment ?? assignment
+    }
+
+    public var experimentAssignment: ExperimentAssignment? {
+        if let developerSettingsForcedAssignment {
+            return developerSettingsForcedAssignment
+        }
+
+        guard let experimentStore else {
+            return nil
+        }
+
+        let experimentsDataController = WMFExperimentsDataController(store: experimentStore)
+        guard let bucketValue = experimentsDataController.bucketForExperiment(.semanticSearch) else {
+            return nil
+        }
+
+        return ExperimentAssignment(bucketValue: bucketValue)
+    }
+
+    public func clearExperimentAssignment() {
+        guard let experimentStore else {
+            return
+        }
+
+        let experimentsDataController = WMFExperimentsDataController(store: experimentStore)
+        try? experimentsDataController.resetExperiment(.semanticSearch)
+    }
+
+    // Overrides assignment at read time only, so the persisted bucket survives
+    // turning the developer setting back off.
+    private var developerSettingsForcedAssignment: ExperimentAssignment? {
+        WMFDeveloperSettingsDataController.shared.forceSemanticSearchExperimentAssignment
+    }
+}
+
+private extension WMFSemanticSearchDataController.ExperimentAssignment {
+    init?(bucketValue: WMFExperimentsDataController.BucketValue) {
+        switch bucketValue {
+        case .semanticSearchControl:
+            self = .control
+        case .semanticSearchGroupB:
+            self = .groupB
+        default:
+            return nil
+        }
+    }
+}

--- a/WMFData/Sources/WMFData/Data Controllers/Semantic Search/WMFSemanticSearchDataController.swift
+++ b/WMFData/Sources/WMFData/Data Controllers/Semantic Search/WMFSemanticSearchDataController.swift
@@ -54,8 +54,11 @@ public final class WMFSemanticSearchDataController {
         targetLanguageCodes.contains(languageCode)
     }
 
+    /// The languages from `iosv1.semanticSearchLanguages` in the remote feature config. Until the
+    /// remote config has the key, the default target languages apply.
     public var targetLanguageCodes: [String] {
-        WMFDeveloperSettingsDataController.shared.loadFeatureConfig()?.ios.semanticSearchLanguages ?? Self.defaultTargetLanguageCodes
+        let remoteLanguageCodes = WMFDeveloperSettingsDataController.shared.loadFeatureConfig()?.ios.semanticSearchLanguages ?? []
+        return remoteLanguageCodes.isEmpty ? Self.defaultTargetLanguageCodes : remoteLanguageCodes
     }
 
     // MARK: - Experiment Assignment
@@ -64,15 +67,15 @@ public final class WMFSemanticSearchDataController {
     /// the persisted bucket after that. Returns nil when the search is not eligible.
     @discardableResult
     public func assignExperimentIfNeeded(languageCode: String) throws -> ExperimentAssignment? {
-        guard let experimentStore else {
-            throw ExperimentError.missingExperimentStore
-        }
-
         stateLock.lock()
         defer { stateLock.unlock() }
 
         guard isEligible(languageCode: languageCode) else {
             return nil
+        }
+
+        guard let experimentStore else {
+            throw ExperimentError.missingExperimentStore
         }
 
         let experimentsDataController = WMFExperimentsDataController(store: experimentStore)
@@ -102,13 +105,13 @@ public final class WMFSemanticSearchDataController {
         return ExperimentAssignment(bucketValue: bucketValue)
     }
 
-    public func clearExperimentAssignment() {
+    public func clearExperimentAssignment() throws {
         guard let experimentStore else {
-            return
+            throw ExperimentError.missingExperimentStore
         }
 
         let experimentsDataController = WMFExperimentsDataController(store: experimentStore)
-        try? experimentsDataController.resetExperiment(.semanticSearch)
+        try experimentsDataController.resetExperiment(.semanticSearch)
     }
 
     // Overrides assignment at read time only, so the persisted bucket survives

--- a/WMFData/Sources/WMFData/Models/Developer Settings/WMFFeatureConfigResponse.swift
+++ b/WMFData/Sources/WMFData/Models/Developer Settings/WMFFeatureConfigResponse.swift
@@ -106,6 +106,7 @@ public struct WMFFeatureConfigResponse: Codable {
     public struct IOS: Codable {
         public let hCaptcha: HCaptcha?
         public let visualEditorEnabled: Bool?
+        public let semanticSearchLanguages: [String]?
         
         public struct HCaptcha: Codable {
             public let baseURL: String
@@ -118,9 +119,10 @@ public struct WMFFeatureConfigResponse: Codable {
             public let apiKey: String
         }
 
-        public init(hCaptcha: HCaptcha?, visualEditorEnabled: Bool? = nil) {
+        public init(hCaptcha: HCaptcha?, visualEditorEnabled: Bool? = nil, semanticSearchLanguages: [String]? = nil) {
             self.hCaptcha = hCaptcha
             self.visualEditorEnabled = visualEditorEnabled
+            self.semanticSearchLanguages = semanticSearchLanguages
         }
     }
     

--- a/WMFData/Sources/WMFData/Models/Developer Settings/WMFFeatureConfigResponse.swift
+++ b/WMFData/Sources/WMFData/Models/Developer Settings/WMFFeatureConfigResponse.swift
@@ -106,7 +106,7 @@ public struct WMFFeatureConfigResponse: Codable {
     public struct IOS: Codable {
         public let hCaptcha: HCaptcha?
         public let visualEditorEnabled: Bool?
-        public let semanticSearchLanguages: [String]?
+        public let semanticSearchLanguages: [String]
         
         public struct HCaptcha: Codable {
             public let baseURL: String
@@ -119,10 +119,23 @@ public struct WMFFeatureConfigResponse: Codable {
             public let apiKey: String
         }
 
-        public init(hCaptcha: HCaptcha?, visualEditorEnabled: Bool? = nil, semanticSearchLanguages: [String]? = nil) {
+        public init(hCaptcha: HCaptcha?, visualEditorEnabled: Bool? = nil, semanticSearchLanguages: [String] = []) {
             self.hCaptcha = hCaptcha
             self.visualEditorEnabled = visualEditorEnabled
             self.semanticSearchLanguages = semanticSearchLanguages
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case hCaptcha
+            case visualEditorEnabled
+            case semanticSearchLanguages
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            hCaptcha = try container.decodeIfPresent(HCaptcha.self, forKey: .hCaptcha)
+            visualEditorEnabled = try container.decodeIfPresent(Bool.self, forKey: .visualEditorEnabled)
+            semanticSearchLanguages = try container.decodeIfPresent([String].self, forKey: .semanticSearchLanguages) ?? []
         }
     }
     

--- a/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
+++ b/WMFData/Sources/WMFData/Store/WMFUserDefaultsKey.swift
@@ -108,4 +108,8 @@ public enum WMFUserDefaultsKey: String {
 
     // Evergreen account creation prompt
     case evergreenAccountCreationState = "evergreen-account-creation-state"
+
+    // Semantic search
+    case developerSettingsEnableSemanticSearch = "dev-settings-enable-semantic-search"
+    case developerSettingsForceSemanticSearchExperimentAssignment = "dev-settings-force-semantic-search-experiment-assignment"
 }

--- a/WMFData/Tests/WMFDataTests/WMFSemanticSearchDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFSemanticSearchDataControllerTests.swift
@@ -23,9 +23,25 @@ final class WMFSemanticSearchDataControllerTests {
     }
 
     @Test
+    func defaultTargetLanguagesApplyWithoutRemoteTargetLanguages() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.enableSemanticSearch = true
+
+            #expect(controller.targetLanguageCodes == WMFSemanticSearchDataController.defaultTargetLanguageCodes)
+            #expect(controller.isEligible(languageCode: "fr"))
+            #expect(controller.isEligible(languageCode: "en") == false)
+
+            try saveRemoteTargetLanguages([])
+
+            #expect(controller.targetLanguageCodes == WMFSemanticSearchDataController.defaultTargetLanguageCodes)
+        }
+    }
+
+    @Test
     func searchesOutsideTheTargetLanguagesDoNotEnroll() async throws {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             WMFDeveloperSettingsDataController.shared.enableSemanticSearch = true
+            try saveRemoteTargetLanguages(["fr", "ar", "ja"])
 
             #expect(controller.isEligible(languageCode: "en") == false)
             let assignment = try controller.assignExperimentIfNeeded(languageCode: "en")
@@ -39,8 +55,9 @@ final class WMFSemanticSearchDataControllerTests {
     func targetLanguageSearchEnrollsOnceAndKeepsTheBucket() async throws {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             WMFDeveloperSettingsDataController.shared.enableSemanticSearch = true
+            try saveRemoteTargetLanguages(["fr", "ar", "ja"])
 
-            for languageCode in WMFSemanticSearchDataController.defaultTargetLanguageCodes {
+            for languageCode in ["fr", "ar", "ja"] {
                 #expect(controller.isEligible(languageCode: languageCode))
             }
 
@@ -73,6 +90,7 @@ final class WMFSemanticSearchDataControllerTests {
     func forcedAssignmentBypassesTheLanguageGateAndOverridesTheBucket() async throws {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             WMFDeveloperSettingsDataController.shared.enableSemanticSearch = true
+            try saveRemoteTargetLanguages(["fr"])
             let store = try #require(WMFDataEnvironment.current.sharedCacheStore)
             let experimentsDataController = WMFExperimentsDataController(store: store)
             _ = try experimentsDataController.determineBucketForExperiment(.semanticSearch, withPercentage: 50, randomIntProvider: { 1 })
@@ -97,10 +115,11 @@ final class WMFSemanticSearchDataControllerTests {
     func clearingTheAssignmentAllowsANewRoll() async throws {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
             WMFDeveloperSettingsDataController.shared.enableSemanticSearch = true
+            try saveRemoteTargetLanguages(["ja"])
             _ = try controller.assignExperimentIfNeeded(languageCode: "ja")
             #expect(controller.experimentAssignment != nil)
 
-            controller.clearExperimentAssignment()
+            try controller.clearExperimentAssignment()
 
             #expect(controller.experimentAssignment == nil)
             #expect(controller.isEntryPointAvailable(languageCode: "ja") == false)
@@ -108,14 +127,9 @@ final class WMFSemanticSearchDataControllerTests {
     }
 
     @Test
-    func remoteFeatureConfigReplacesTheTargetLanguages() async throws {
+    func remoteFeatureConfigProvidesTheTargetLanguages() async throws {
         try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
-            #expect(controller.targetLanguageCodes == WMFSemanticSearchDataController.defaultTargetLanguageCodes)
-
-            let sharedCacheStore = try #require(WMFDataEnvironment.current.sharedCacheStore)
-            let ios = WMFFeatureConfigResponse.IOS(hCaptcha: nil, semanticSearchLanguages: ["en", "pt"])
-            let config = WMFFeatureConfigResponse(common: WMFFeatureConfigResponse.Common(yir: []), ios: ios, cachedDate: Date())
-            try sharedCacheStore.save(key: "Developer Settings", "AppsFeatureConfig", value: config)
+            try saveRemoteTargetLanguages(["en", "pt"])
 
             #expect(controller.targetLanguageCodes == ["en", "pt"])
             #expect(controller.isTargetLanguage(languageCode: "pt"))
@@ -126,12 +140,32 @@ final class WMFSemanticSearchDataControllerTests {
     @Test
     func featureConfigDecodesWithoutTheSemanticSearchKey() throws {
         let json = Data("""
-        {"commonv1": {"yir": []}, "iosv1": {}}
+        {"commonv1": {"yir": []}, "iosv1": {"visualEditorEnabled": true}}
         """.utf8)
 
         let config = try JSONDecoder().decode(WMFFeatureConfigResponse.self, from: json)
 
-        #expect(config.ios.semanticSearchLanguages == nil)
+        #expect(config.ios.semanticSearchLanguages.isEmpty)
+        #expect(config.ios.visualEditorEnabled == true)
+        #expect(config.ios.hCaptcha == nil)
+    }
+
+    @Test
+    func featureConfigDecodesTheSemanticSearchLanguages() throws {
+        let json = Data("""
+        {"commonv1": {"yir": []}, "iosv1": {"semanticSearchLanguages": ["fr", "ar", "ja"]}}
+        """.utf8)
+
+        let config = try JSONDecoder().decode(WMFFeatureConfigResponse.self, from: json)
+
+        #expect(config.ios.semanticSearchLanguages == ["fr", "ar", "ja"])
+    }
+
+    private func saveRemoteTargetLanguages(_ languageCodes: [String]) throws {
+        let sharedCacheStore = try #require(WMFDataEnvironment.current.sharedCacheStore)
+        let ios = WMFFeatureConfigResponse.IOS(hCaptcha: nil, semanticSearchLanguages: languageCodes)
+        let config = WMFFeatureConfigResponse(common: WMFFeatureConfigResponse.Common(yir: []), ios: ios, cachedDate: Date())
+        try sharedCacheStore.save(key: "Developer Settings", "AppsFeatureConfig", value: config)
     }
 
     private func configureEnvironment() async {

--- a/WMFData/Tests/WMFDataTests/WMFSemanticSearchDataControllerTests.swift
+++ b/WMFData/Tests/WMFDataTests/WMFSemanticSearchDataControllerTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+import WMFDataTestSupport
+@testable import WMFData
+@testable import WMFDataMocks
+
+@Suite(.serialized)
+final class WMFSemanticSearchDataControllerTests {
+
+    private let fixture = WMFDataTestFixture()
+    private let controller = WMFSemanticSearchDataController.shared
+
+    @Test
+    func entryPointIsHiddenWhileTheDeveloperToggleIsOff() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.forceSemanticSearchExperimentAssignment = .groupB
+
+            #expect(controller.isEligible(languageCode: "fr") == false)
+            #expect(controller.isEntryPointAvailable(languageCode: "fr") == false)
+            let assignment = try controller.assignExperimentIfNeeded(languageCode: "fr")
+            #expect(assignment == nil)
+        }
+    }
+
+    @Test
+    func searchesOutsideTheTargetLanguagesDoNotEnroll() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.enableSemanticSearch = true
+
+            #expect(controller.isEligible(languageCode: "en") == false)
+            let assignment = try controller.assignExperimentIfNeeded(languageCode: "en")
+            #expect(assignment == nil)
+            #expect(controller.experimentAssignment == nil)
+            #expect(controller.isEntryPointAvailable(languageCode: "en") == false)
+        }
+    }
+
+    @Test
+    func targetLanguageSearchEnrollsOnceAndKeepsTheBucket() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.enableSemanticSearch = true
+
+            for languageCode in WMFSemanticSearchDataController.defaultTargetLanguageCodes {
+                #expect(controller.isEligible(languageCode: languageCode))
+            }
+
+            let firstAssignment = try #require(try controller.assignExperimentIfNeeded(languageCode: "fr"))
+            let secondAssignment = try #require(try controller.assignExperimentIfNeeded(languageCode: "ar"))
+
+            #expect(secondAssignment == firstAssignment)
+            #expect(controller.experimentAssignment == firstAssignment)
+            #expect(controller.isEntryPointAvailable(languageCode: "fr") == (firstAssignment == .groupB))
+            #expect(controller.isEntryPointAvailable(languageCode: "en") == false)
+        }
+    }
+
+    @Test
+    func bucketRollFollowsTheControlPercentage() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            let store = try #require(WMFDataEnvironment.current.sharedCacheStore)
+            let experimentsDataController = WMFExperimentsDataController(store: store)
+
+            let controlBucket = try experimentsDataController.determineBucketForExperiment(.semanticSearch, withPercentage: 50, randomIntProvider: { 50 })
+            try experimentsDataController.resetExperiment(.semanticSearch)
+            let groupBBucket = try experimentsDataController.determineBucketForExperiment(.semanticSearch, withPercentage: 50, randomIntProvider: { 51 })
+
+            #expect(controlBucket == .semanticSearchControl)
+            #expect(groupBBucket == .semanticSearchGroupB)
+        }
+    }
+
+    @Test
+    func forcedAssignmentBypassesTheLanguageGateAndOverridesTheBucket() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.enableSemanticSearch = true
+            let store = try #require(WMFDataEnvironment.current.sharedCacheStore)
+            let experimentsDataController = WMFExperimentsDataController(store: store)
+            _ = try experimentsDataController.determineBucketForExperiment(.semanticSearch, withPercentage: 50, randomIntProvider: { 1 })
+            #expect(controller.experimentAssignment == .control)
+
+            WMFDeveloperSettingsDataController.shared.forceSemanticSearchExperimentAssignment = .groupB
+
+            #expect(controller.isEligible(languageCode: "en"))
+            #expect(controller.experimentAssignment == .groupB)
+            #expect(controller.isEntryPointAvailable(languageCode: "en"))
+            let forcedAssignment = try controller.assignExperimentIfNeeded(languageCode: "en")
+            #expect(forcedAssignment == .groupB)
+
+            WMFDeveloperSettingsDataController.shared.forceSemanticSearchExperimentAssignment = nil
+
+            #expect(controller.experimentAssignment == .control)
+            #expect(controller.isEntryPointAvailable(languageCode: "fr") == false)
+        }
+    }
+
+    @Test
+    func clearingTheAssignmentAllowsANewRoll() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            WMFDeveloperSettingsDataController.shared.enableSemanticSearch = true
+            _ = try controller.assignExperimentIfNeeded(languageCode: "ja")
+            #expect(controller.experimentAssignment != nil)
+
+            controller.clearExperimentAssignment()
+
+            #expect(controller.experimentAssignment == nil)
+            #expect(controller.isEntryPointAvailable(languageCode: "ja") == false)
+        }
+    }
+
+    @Test
+    func remoteFeatureConfigReplacesTheTargetLanguages() async throws {
+        try await fixture.withConfiguredEnvironment(configure: configureEnvironment) {
+            #expect(controller.targetLanguageCodes == WMFSemanticSearchDataController.defaultTargetLanguageCodes)
+
+            let sharedCacheStore = try #require(WMFDataEnvironment.current.sharedCacheStore)
+            let ios = WMFFeatureConfigResponse.IOS(hCaptcha: nil, semanticSearchLanguages: ["en", "pt"])
+            let config = WMFFeatureConfigResponse(common: WMFFeatureConfigResponse.Common(yir: []), ios: ios, cachedDate: Date())
+            try sharedCacheStore.save(key: "Developer Settings", "AppsFeatureConfig", value: config)
+
+            #expect(controller.targetLanguageCodes == ["en", "pt"])
+            #expect(controller.isTargetLanguage(languageCode: "pt"))
+            #expect(controller.isTargetLanguage(languageCode: "fr") == false)
+        }
+    }
+
+    @Test
+    func featureConfigDecodesWithoutTheSemanticSearchKey() throws {
+        let json = Data("""
+        {"commonv1": {"yir": []}, "iosv1": {}}
+        """.utf8)
+
+        let config = try JSONDecoder().decode(WMFFeatureConfigResponse.self, from: json)
+
+        #expect(config.ios.semanticSearchLanguages == nil)
+    }
+
+    private func configureEnvironment() async {
+        WMFDataEnvironment.current.userDefaultsStore = WMFMockKeyValueStore()
+        WMFDataEnvironment.current.sharedCacheStore = WMFMockKeyValueStore()
+    }
+}


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T437359

### Notes
* It adds the experiment and the developer settings, and no UI.
* `WMFExperimentsDataController` gets the `semanticSearch` experiment: a 50/50 split between `SemanticSearch_Control` and `SemanticSearch_GroupB`. The bucket names still need to be aligned with Android and with the TestKitchen instrument.
* `WMFSemanticSearchDataController` assigns the bucket on the first eligible search, not on launch, so readers who never search in a target language stay out of the denominator. The entry point is available when four gates pass: the developer toggle, the target language, and the Group B bucket.
* The target languages come from `iosv1.semanticSearchLanguages` in the remote feature config. The key does not exist yet, so the controller falls back to `fr`, `ar` and `ja` (will we use the existing hybridSearch?). When we turn the feature on, the fallback goes away, an empty or missing array means off, and the developer settings below are removed.
* The "Enable Semantic Search" developer toggle keeps everything hidden in production. Without it no gate is evaluated and no bucket is assigned.
* The "Force Experiment Group" picker overrides the persisted bucket at read time and bypasses the language gate, so we can test in English. Switching it back to Off restores the persisted bucket.

### Test Steps
1. Not much to test, since this is an enabler PR.

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
<img width="40%" alt="Simulator Screenshot - iPhone 17 - 2026-09-11 at 09 14 01" src="https://github.com/user-attachments/assets/6ae0fb59-fe6d-43de-aae4-eb94c95ef632" />
