### PR TITLE
Resign the first responder before WMFComponents screens disappear

### DIFF
--- a/WMFComponents/Sources/WMFComponents/Base/Component Base Classes/WMFComponentHostingController.swift
+++ b/WMFComponents/Sources/WMFComponents/Base/Component Base Classes/WMFComponentHostingController.swift
@@ -52,6 +52,13 @@ open class WMFComponentHostingController<HostedView: View>: UIHostingController<
             .store(in: &cancellables)
     }
 
+    // MARK: - Lifecycle
+
+    open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        view.endEditing(true)
+    }
+
     // MARK: - Subclass Overrides
 
     public func appEnvironmentDidChange() {

--- a/WMFComponents/Sources/WMFComponents/Base/Component Base Classes/WMFComponentViewController.swift
+++ b/WMFComponents/Sources/WMFComponents/Base/Component Base Classes/WMFComponentViewController.swift
@@ -46,6 +46,13 @@ open class WMFComponentViewController: UIViewController {
         .store(in: &cancellables)
     }
 
+    // MARK: - Lifecycle
+
+    open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        view.endEditing(true)
+    }
+
     // MARK: - Subclass Overrides
 
     public func appEnvironmentDidChange() {


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T437739

### Notes
* Root cause of T437739, and also of T435878 (#6117) and T436962 (#6163): when a SwiftUI `TextField` hosted in a `UIHostingController` is still first responder while its view controller is popped or dismissed, the keyboard disappears without the normal hide notifications, and SwiftUI keeps the last keyboard frame. Every SwiftUI hosting view created afterwards is laid out with that stale keyboard safe area inset. In the "Choose how to edit" sheet, the inset clips the `ScrollView` background and the system sheet material shows through in the system appearance.
* The fix calls `view.endEditing(true)` in `viewWillDisappear` of `WMFComponentHostingController` and `WMFComponentViewController`, so the keyboard closes through the normal notification cycle regardless of how a screen is left (pop, dismiss, swipe down). This replaces the per screen `.ignoresSafeArea(.keyboard)` approach; the two existing workarounds are left in place and can be removed in a follow up.
* Verified with an automated UI test that measures the sheet background pixels in the simulator (iOS 26.5): the same run that reproduced the bug renders the sheet correctly with this change. UIKit text fields (login screen) were tested with both modal dismiss and pop and do not trigger the bug, so the legacy base classes are intentionally left untouched.
* Not covered: view controllers that do not inherit from these base classes (plain `UIViewController` subclasses and direct `UIHostingController` usages). No screen with text input was found in that group.

### Test Steps
1. Set the device system appearance to Light and the app theme to Dark. This only makes the bug visible.
2. Open any article.
3. Tap the profile button, then Donate, then "Donate with Apple Pay".
4. Tap the custom amount field so the keyboard appears.
5. With the keyboard still visible, go back to the article.
6. Tap the edit pencil of a section, then "Edit introduction".
7. The "Choose how to edit" sheet body is painted with the dark theme background and the "Don't show this again" row is readable. Before this change, the body below the options card shows the light system material and the text is unreadable.
8. Repeat steps 3 to 6 and return to Home or open Settings instead of the sheet: the screens are not clipped (regressions from T435878 and T436962).

### Checklist
- [x] Checked against Swift 6 strict concurrency

### Screenshots/Videos
<img width="40%" alt="keyboard-safe-area-sheet-before-fix" src="https://github.com/user-attachments/assets/905b0b68-45bd-42f3-93e6-7dd6bd7e0f03" /><img width="40%" alt="keyboard-safe-area-sheet-after-fix" src="https://github.com/user-attachments/assets/b65616bb-39ed-4ff9-abad-7c0eda55eece" />
